### PR TITLE
Catch plistlib.InvalidFileException when loading file

### DIFF
--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -143,7 +143,7 @@ class LockdownClient(object):
         try:
             with open(filename, 'rb') as f:
                 pair_record = plistlib.load(f)
-        except (PermissionError, FileNotFoundError):
+        except (PermissionError, FileNotFoundError, plistlib.InvalidFileException):
             return None
         return pair_record
 


### PR DESCRIPTION
Hey doronz great library btw. Doing some tests with and iPad mini 6th generation sometimes I get the exception InvalidFileException. I think it could be resolved with this PR.

In this method
```python

    def get_itunes_pairing_record(self):
        platform_type = 'linux' if not sys.platform.startswith('linux') else sys.platform
        filename = LOCKDOWN_PATH[platform_type] / f'{self.identifier}.plist'
        try:
            with open(filename, 'rb') as f:
                pair_record = plistlib.load(f)
        except (PermissionError, FileNotFoundError):
            return None
        return pair_record

```
plistlib.load(f) could raise InvalidFileException and it is not captured. 

So here

```python
    def validate_pairing(self):
        pair_record = self.get_itunes_pairing_record()
        if pair_record is not None:
            self.logger.info(f'Using iTunes pair record: {self.identifier}.plist')
        elif Version(self.ios_version) >= Version('13.0'):
            pair_record = self.get_usbmux_pairing_record()
        else:
            pair_record = self.get_local_pairing_record()
```

validate_pairing breaks in the first line and will never try to pair with the other methods.