### PR TITLE
[recovery] dfu_enter_recovery: Support <A10

### DIFF
--- a/pymobiledevice3/restore/recovery.py
+++ b/pymobiledevice3/restore/recovery.py
@@ -5,6 +5,7 @@ from io import BytesIO
 
 from usb import USBError
 
+from pymobiledevice3.exceptions import PyMobileDevice3Exception
 from pymobiledevice3.irecv import IRecv, Mode
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.restore.device import Device
@@ -268,7 +269,9 @@ class Recovery:
 
     def dfu_enter_recovery(self):
         self.send_component('iBSS')
-        self.reconnect_irecv(is_recovery=True)
+        self.reconnect_irecv()
+        if 'SRTG' in self.device.irecv._device_info:
+            raise PyMobileDevice3Exception('Device failed to enter recovery')
 
         if self.build_identity.build_manifest.build_major > 8:
             old_nonce = self.device.irecv.ap_nonce


### PR DESCRIPTION
On <A10, the device boots iBSS, but is still in DFU mode. We can detect whether or not the device booted the iBSS successfully by making sure SRTG isn't in the device's serial number.
Tested on iPod7,1 and iPhone6,1.