### PR TITLE
[Recovery] enter_restore: Support <A10

### DIFF
--- a/pymobiledevice3/restore/recovery.py
+++ b/pymobiledevice3/restore/recovery.py
@@ -5,6 +5,7 @@ from io import BytesIO
 
 from usb import USBError
 
+from pymobiledevice3.exceptions import PyMobileDevice3Exception
 from pymobiledevice3.irecv import IRecv, Mode
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.restore.device import Device
@@ -268,7 +269,9 @@ class Recovery:
 
     def dfu_enter_recovery(self):
         self.send_component('iBSS')
-        self.reconnect_irecv(is_recovery=True)
+        self.reconnect_irecv()
+        if 'SRTG' in self.device.irecv._device_info:
+            raise PyMobileDevice3Exception('Device failed to enter recovery')
 
         if self.build_identity.build_manifest.build_major > 8:
             old_nonce = self.device.irecv.ap_nonce


### PR DESCRIPTION
\<A10 boot process differs from >=A10, in that the device will not boot into recovery mode until after iBEC is sent.
This causes `Recovery.boot_ramdisk()` to not work on <A10 devices.

TODO:
- [x] Fix `Recovery.dfu_enter_recovery()`
    - `Recovery.boot_ramdisk()` attempts to reconnect to the device in recovery mode, when on <A10, the device will still be in DFU mode.
        - We can just reconnect to the device without expecting it to be in recovery mode, and check that the `SRTG` tag is no longer in the device serial number, which confirms iBSS was booted.
- [x] Fix `Recovery.send_ibec()`
    - When sending iBEC, `IRecv.send_buffer()` fails on <A10.
        - I believe this is due to [this](https://github.com/doronz88/pymobiledevice3/blob/master/pymobiledevice3/irecv.py#L181-L192) code running, which it shouldn't as the device has already booted into recovery mode at this point. I'm currently unsure of how to go about fixing this, and would love input.
    - **UPDATE**: I believe this was a local issue, as it seems to be working for me now.
- [ ] Fix `Recovery.enter_restore()`
    - When sending RestoreSEP, `IRecv.send_command()` fails on <A9: #231.
        - I still need to do some more research to find the cause of this.



Sorry for duplicate PR, I changed the branch I was merging from.