### PR TITLE
[build_manifest] build_major: Properly get build_major

### DIFF
--- a/pymobiledevice3/restore/ipsw/build_manifest.py
+++ b/pymobiledevice3/restore/ipsw/build_manifest.py
@@ -13,7 +13,14 @@ class BuildManifest:
 
     @cached_property
     def build_major(self):
-        return int(self._manifest['ProductBuildVersion'][:2])
+        build_major = str()
+        for i in self._manifest['ProductBuildVersion']:
+            if i.isdigit():
+                build_major += i
+            else:
+                break
+
+        return int(build_major)
 
     @cached_property
     def supported_product_types(self):


### PR DESCRIPTION
With the current implementation, it attempts to parse the first 2 characters in the buildid as an integer. For older iOS builds, such as iOS 5.1.1 (9B206), this would fail.

This implementation mimicks C's `strtoul()` function, which idevicerestore uses to get the build major.