### PR TITLE
Fix ciphers suite being missing on LibreSSL/macOS

### DIFF
--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -45,7 +45,7 @@ def parse_plist(payload):
 
 def create_context(keyfile, certfile):
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    context.set_ciphers('ALL:@SECLEVEL=0')
+    context.set_ciphers('ALL:!aNULL:!eNULL')
     context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE
     context.load_cert_chain(certfile, keyfile)


### PR DESCRIPTION
The `SECLEVEL` command was apparently removed from LibreSSL, which is the default cryptography suite on macOS. It breaks any service connection. Changing the ciphers suite to "everything" (which is equivalent to the previous setting) fixes the issue