### PR TITLE
Add missing requirements for Python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,8 @@ tqdm
 cached-property
 requests
 cmd2
+gnureadline
+pyreadline3
 packaging
 pygnuutils>=0.0.5
 cryptography>=35.0.0


### PR DESCRIPTION
When switching from Python 3.9 to Python 3.10, a warning appears:
```
Readline features including tab completion have been disabled because
no supported version of readline was found. To resolve this, install
pyreadline3 on Windows or gnureadline on Linux/Mac.
```
After locating the string in the dependancies and adding a `traceback.print_stack()` call, it seems that this appears when a user imports either `services/afc.py` or `services/crash_reports.py`, which in turn imports `cmd2` and triggers this warning.
Installing both `pyreadline3` and `gnureadline` seems to fix the issue.