### PR TITLE
Get Developer Mode status in amfi cls and from cli

### DIFF
--- a/pymobiledevice3/cli/amfi.py
+++ b/pymobiledevice3/cli/amfi.py
@@ -24,3 +24,10 @@ def amfi():
 def enable_developer_mode(lockdown: LockdownClient):
     """ enable developer mode """
     AmfiService(lockdown).enable_developer_mode()
+
+
+@amfi.command('status-developer-mode', cls=Command)
+def status_developer_mode(lockdown: LockdownClient):
+    """ get developer mode status """
+    state = 'Activated' if AmfiService(lockdown).status_developer_mode() else 'Deactivated'
+    print(state)

--- a/pymobiledevice3/services/amfi.py
+++ b/pymobiledevice3/services/amfi.py
@@ -64,3 +64,7 @@ class AmfiService:
         resp = service.send_recv_plist({'action': 2})
         if not resp.get('success'):
             raise DeveloperModeError(f'enable_developer_mode_post_restart() failed: {resp}')
+
+    def status_developer_mode(self) -> bool:
+        return self._lockdown.get_value('com.apple.security.mac.amfi', 'DeveloperModeStatus')
+


### PR DESCRIPTION
Query Developer Mode state from amfi class and cli. 

```shell
❯ pymobiledevice3 amfi 
Usage: pymobiledevice3 amfi [OPTIONS] COMMAND [ARGS]...

  amfi options

Options:
  -h, --help  Show this message and exit.

Commands:
  enable-developer-mode  enable developer mode
  status-developer-mode  get developer mode status

```