### PR TITLE
house_arrest: fix shell functionality

### DIFF
--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -675,7 +675,7 @@ class AfcLsStub(LsStub):
 
 
 class AfcShell(Cmd):
-    def __init__(self, lockdown: LockdownClient, service_name='com.apple.afc', completekey='tab'):
+    def __init__(self, lockdown: LockdownClient, service_name='com.apple.afc', completekey='tab', afc_service=None):
         # bugfix: prevent the Cmd instance from trying to parse click's arguments
         sys.argv = sys.argv[:1]
 
@@ -685,7 +685,7 @@ class AfcShell(Cmd):
         self.logger = logging.getLogger(__name__)
         self.lockdown = lockdown
         self.service_name = service_name
-        self.afc = AfcService(self.lockdown, service_name=service_name)
+        self.afc = afc_service or AfcService(self.lockdown, service_name=service_name)
         self.curdir = '/'
         self.complete_edit = self._complete_first_arg
         self.complete_cd = self._complete_first_arg

--- a/pymobiledevice3/services/house_arrest.py
+++ b/pymobiledevice3/services/house_arrest.py
@@ -25,4 +25,4 @@ class HouseArrestService(AfcService):
     def shell(self, application_id, cmd='VendContainer'):
         res = self.send_command(application_id, cmd)
         if res:
-            AfcShell(self.lockdown).cmdloop()
+            AfcShell(self.lockdown, afc_service=self).cmdloop()


### PR DESCRIPTION
Fix shell functionality in HouseArrestService to use itself instead of standard AfcService.

```shell
pymobiledevice3 apps afc BUNDLE_ID
```
The directory listing shown belongs to /var/mobile/Media.
After the change the directory listing is correct (app container).