### PR TITLE
Add supervised configuration profile installs

### DIFF
--- a/pymobiledevice3/cli/profile.py
+++ b/pymobiledevice3/cli/profile.py
@@ -37,6 +37,21 @@ def profile_install(lockdown: LockdownClient, profiles):
         service.install_profile(profile.read())
 
 
+@profile_group.command('install-silent', cls=Command)
+@click.option('--keystore', type=click.File('rb'), required=True,
+              help="A PKCS#12 keystore containing the certificate and private key which can supervise the device.")
+@click.option('--keystore-password', prompt=True, required=True, hide_input=True,
+              help="The password for the PKCS#12 keystore.")
+@click.argument('profiles', nargs=-1, type=click.File('rb'))
+def profile_install_silent(lockdown: LockdownClient, profiles, keystore, keystore_password):
+    """ install given profiles without user interaction (requires the device to be supervised) """
+    service = MobileConfigService(lockdown=lockdown)
+    for profile in profiles:
+        logger.info(f'installing {profile.name}')
+        service.install_profile_silent(
+            profile.read(), keystore.read(), keystore_password)
+
+
 @profile_group.command('cloud-configuration', cls=Command)
 @click.option('--color/--no-color', default=True)
 def profile_cloud_configuration(lockdown: LockdownClient, color):

--- a/pymobiledevice3/services/mobile_config.py
+++ b/pymobiledevice3/services/mobile_config.py
@@ -5,6 +5,10 @@ from typing import Mapping
 from pymobiledevice3.exceptions import ProfileError
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.services.base_service import BaseService
+from cryptography.hazmat.primitives.serialization.pkcs12 import load_pkcs12
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.hazmat.primitives.serialization.pkcs7 import PKCS7SignatureBuilder
+from cryptography.hazmat.primitives import hashes
 
 
 class Purpose(Enum):
@@ -22,6 +26,18 @@ class MobileConfigService(BaseService):
 
     def flush(self) -> None:
         self._send_recv({'RequestType': 'Flush'})
+
+    def escalate(self, pkcs12: bytes, password: str) -> None:
+        decrypted_p12 = load_pkcs12(pkcs12, password.encode('utf-8'))
+
+        escalate_response = self._send_recv({
+            'RequestType': 'Escalate',
+            'SupervisorCertificate': decrypted_p12.cert.certificate.public_bytes(Encoding.DER)
+        })
+        signed_challenge = PKCS7SignatureBuilder().set_data(escalate_response['Challenge']).add_signer(
+            decrypted_p12.cert.certificate, decrypted_p12.key, hashes.SHA256()).sign(Encoding.DER, [])
+        self._send_recv({'RequestType': 'EscalateResponse', 'SignedRequest': signed_challenge})
+        self._send_recv({'RequestType': 'ProceedWithKeybagMigration'})
 
     def get_stored_profile(self, purpose: Purpose = Purpose.PostSetupInstallation) -> Mapping:
         return self._send_recv({'RequestType': 'GetStoredProfile', 'Purpose': purpose.value})
@@ -53,6 +69,10 @@ class MobileConfigService(BaseService):
 
     def install_profile(self, payload: bytes) -> None:
         self._send_recv({'RequestType': 'InstallProfile', 'Payload': payload})
+
+    def install_profile_silent(self, profile: bytes, pkcs12: bytes, password: str) -> None:
+        self.escalate(pkcs12, password)
+        self._send_recv({'RequestType': 'InstallProfileSilent', 'Payload': profile})
 
     def remove_profile(self, identifier: str) -> None:
         profiles = self.get_profile_list()


### PR DESCRIPTION
I am trying to install configuration profiles without user interaction, mainly to install and certificate authorities automatically. In my research (https://github.com/tweaselORG/appstraction/issues/44#issuecomment-1545880084), I stumbled over device supervision and noticed your library was missing that functionality. However, https://github.com/danielpaulus/go-ios managed to [implement it](https://github.com/danielpaulus/go-ios/blob/main/ios/mcinstall/mcinstall.go), so using their research, I implemented the `InstallProfileSilent` request into `pymobiledevice3`.

This way, you can now install configuration profiles on the device silently, if the device has been supervised and you have access to the supervising certificate and key. If you don’t want to reset your device, but have jailbroken it, you can also refer to the linked issue for how to set up supervision.

I tested this on iOS 16.4.1 on an iPhone X.