### PR TITLE
Don't fail restores if booting RestoreSEP fails

### DIFF
--- a/pymobiledevice3/restore/recovery.py
+++ b/pymobiledevice3/restore/recovery.py
@@ -380,8 +380,11 @@ class Recovery(BaseRestore):
         self.send_component_and_command('RestoreDeviceTree', 'devicetree')
 
         if self.build_identity.has_component('RestoreSEP'):
-            # send rsepfirmware and load it
-            self.send_component_and_command('RestoreSEP', 'rsepfirmware')
+            # attempt to send rsepfirmware and load it, otherwise continue
+            try:
+                self.send_component_and_command('RestoreSEP', 'rsepfirmware')
+            except USBError:
+                pass
 
         self.send_kernelcache()
 


### PR DESCRIPTION
Tested on an iPod7,1. Would like others to test to confirm this doesn't create any other issues before it's merged.

This closes issue #231.