### PR TITLE
Fix restores on <A10 devices.

### DIFF
--- a/pymobiledevice3/cli/restore.py
+++ b/pymobiledevice3/cli/restore.py
@@ -46,7 +46,7 @@ class Command(click.Command):
         logger.debug('searching among connected devices via lockdownd')
         for device in usbmux.list_devices():
             try:
-                lockdown = create_using_usbmux(serial=device.serial)
+                lockdown = create_using_usbmux(serial=device.serial, connection_type='USB')
             except IncorrectModeError:
                 continue
             if (ecid is None) or (lockdown.ecid == value):

--- a/pymobiledevice3/irecv.py
+++ b/pymobiledevice3/irecv.py
@@ -207,6 +207,7 @@ class IRecv:
     def reset(self):
         try:
             logger.debug('resetting usb device')
+            logger.info('If the restore hangs here, disconnect & reconnect the device')
             self._device.reset()
         except USBError:
             pass

--- a/pymobiledevice3/restore/asr.py
+++ b/pymobiledevice3/restore/asr.py
@@ -29,7 +29,7 @@ class ASRClient(object):
     SERVICE_PORT = ASR_PORT
 
     def __init__(self, udid: str):
-        self.service = LockdownServiceConnection.create_using_usbmux(udid, self.SERVICE_PORT)
+        self.service = LockdownServiceConnection.create_using_usbmux(udid, self.SERVICE_PORT, connection_type='USB')
 
         # receive Initiate command message
         data = self.recv_plist()

--- a/pymobiledevice3/restore/fdr.py
+++ b/pymobiledevice3/restore/fdr.py
@@ -48,10 +48,10 @@ class FDRClient:
         logger.debug('connecting to FDR')
 
         if type_ == fdr_type.FDR_CTRL:
-            self.service = LockdownServiceConnection.create_using_usbmux(device.serial, self.SERVICE_PORT)
+            self.service = LockdownServiceConnection.create_using_usbmux(device.serial, self.SERVICE_PORT, connection_type='USB')
             self.ctrl_handshake()
         else:
-            self.service = LockdownServiceConnection.create_using_usbmux(device.serial, conn_port)
+            self.service = LockdownServiceConnection.create_using_usbmux(device.serial, conn_port, connection_type='USB')
             self.sync_handshake()
 
         logger.debug('FDR connected')

--- a/pymobiledevice3/restore/fdr.py
+++ b/pymobiledevice3/restore/fdr.py
@@ -48,7 +48,9 @@ class FDRClient:
         logger.debug('connecting to FDR')
 
         if type_ == fdr_type.FDR_CTRL:
-            self.service = LockdownServiceConnection.create_using_usbmux(device.serial, self.SERVICE_PORT, connection_type='USB')
+            self.service = LockdownServiceConnection.create_using_usbmux(
+                device.serial, self.SERVICE_PORT, connection_type='USB'
+            )
             self.ctrl_handshake()
         else:
             self.service = LockdownServiceConnection.create_using_usbmux(device.serial, conn_port, connection_type='USB')

--- a/pymobiledevice3/restore/recovery.py
+++ b/pymobiledevice3/restore/recovery.py
@@ -390,10 +390,7 @@ class Recovery(BaseRestore):
 
     def dfu_enter_recovery(self):
         self.send_component('iBSS')
-        try:
-            self.reconnect_irecv()
-        except:
-            self.reconnect_irecv(is_recovery=True)
+        self.reconnect_irecv()
 
         if 'SRTG' in self.device.irecv._device_info:
             raise PyMobileDevice3Exception('Device failed to enter recovery')

--- a/pymobiledevice3/restore/recovery.py
+++ b/pymobiledevice3/restore/recovery.py
@@ -390,7 +390,9 @@ class Recovery(BaseRestore):
 
     def dfu_enter_recovery(self):
         self.send_component('iBSS')
-        self.reconnect_irecv(is_recovery=True)
+        self.reconnect_irecv()
+        if 'SRTG' in self.device.irecv._device_info:
+            raise PyMobileDevice3Exception('Device failed to enter recovery')
 
         if self.build_identity.build_manifest.build_major > 8:
             old_nonce = self.device.irecv.ap_nonce

--- a/pymobiledevice3/restore/recovery.py
+++ b/pymobiledevice3/restore/recovery.py
@@ -454,7 +454,7 @@ class Recovery(BaseRestore):
             self.logger.info('going into Recovery')
 
             # in case lockdown has disconnected while waiting for a ticket
-            self.device.lockdown = create_using_usbmux(serial=self.device.lockdown.udid)
+            self.device.lockdown = create_using_usbmux(serial=self.device.lockdown.udid, connection_type='USB')
             self.device.lockdown.enter_recovery()
 
             self.device.lockdown = None

--- a/pymobiledevice3/restore/recovery.py
+++ b/pymobiledevice3/restore/recovery.py
@@ -445,19 +445,7 @@ class Recovery(BaseRestore):
             self.logger.info('fetching TSS record')
             self.fetch_tss_record()
 
-        if self.device.irecv:
-            if self.device.irecv.mode == Mode.DFU_MODE:
-                # device is currently in DFU mode, place it into recovery mode
-                self.dfu_enter_recovery()
-            elif self.device.irecv.mode.is_recovery:
-                # now we load the iBEC
-                try:
-                    self.send_ibec()
-                except USBError:
-                    pass
-
-                self.reconnect_irecv()
-        elif self.device.lockdown:
+        if self.device.lockdown:
             # normal mode
             self.logger.info('going into Recovery')
 
@@ -469,13 +457,18 @@ class Recovery(BaseRestore):
             self.device.irecv = IRecv(self.device.ecid)
             self.reconnect_irecv()
 
+        if self.device.irecv.mode == Mode.DFU_MODE:
+            # device is currently in DFU mode, place it into recovery mode
+            self.dfu_enter_recovery()
+
+        elif self.device.irecv.mode.is_recovery:
             # now we load the iBEC
             try:
                 self.send_ibec()
             except USBError:
                 pass
 
-            self.reconnect_irecv()
+            self.reconnect_irecv(is_recovery=True)
 
         self.logger.info('device booted into recovery')
 

--- a/pymobiledevice3/restore/restore.py
+++ b/pymobiledevice3/restore/restore.py
@@ -633,7 +633,7 @@ class Restore(BaseRestore):
 
         while True:
             try:
-                client = LockdownServiceConnection.create_using_usbmux(self._restored.udid, data_port)
+                client = LockdownServiceConnection.create_using_usbmux(self._restored.udid, data_port, connection_type='USB')
                 break
             except ConnectionFailedError:
                 self.logger.debug('Retrying connection...')
@@ -1153,7 +1153,7 @@ class Restore(BaseRestore):
 
         while True:
             try:
-                client = LockdownServiceConnection.create_using_usbmux(self._restored.udid, data_port)
+                client = LockdownServiceConnection.create_using_usbmux(self._restored.udid, data_port, connection_type='USB')
                 break
             except ConnectionFailedError:
                 self.logger.debug('Retrying connection...')
@@ -1198,7 +1198,7 @@ class Restore(BaseRestore):
 
         if self._ignore_fdr:
             self.logger.info('Establishing a mock FDR listener')
-            self._fdr = LockdownServiceConnection.create_using_usbmux(self._restored.udid, FDRClient.SERVICE_PORT)
+            self._fdr = LockdownServiceConnection.create_using_usbmux(self._restored.udid, FDRClient.SERVICE_PORT, connection_type='USB')
         else:
             self.logger.info('Starting FDR listener thread')
             start_fdr_thread(fdr_type.FDR_CTRL)

--- a/pymobiledevice3/restore/restore.py
+++ b/pymobiledevice3/restore/restore.py
@@ -1198,7 +1198,9 @@ class Restore(BaseRestore):
 
         if self._ignore_fdr:
             self.logger.info('Establishing a mock FDR listener')
-            self._fdr = LockdownServiceConnection.create_using_usbmux(self._restored.udid, FDRClient.SERVICE_PORT, connection_type='USB')
+            self._fdr = LockdownServiceConnection.create_using_usbmux(
+                self._restored.udid, FDRClient.SERVICE_PORT, connection_type='USB'
+            )
         else:
             self.logger.info('Starting FDR listener thread')
             start_fdr_thread(fdr_type.FDR_CTRL)

--- a/pymobiledevice3/restore/restored_client.py
+++ b/pymobiledevice3/restore/restored_client.py
@@ -14,7 +14,7 @@ class RestoredClient(object):
     def __init__(self, udid=None, client_name=DEFAULT_CLIENT_NAME):
         self.logger = logging.getLogger(__name__)
         self.udid = self._get_or_verify_udid(udid)
-        self.service = LockdownServiceConnection.create_using_usbmux(self.udid, self.SERVICE_PORT)
+        self.service = LockdownServiceConnection.create_using_usbmux(self.udid, self.SERVICE_PORT, connection_type='USB')
         self.label = client_name
         self.query_type = self.service.send_recv_plist({'Request': 'QueryType'})
         self.version = self.query_type.get('RestoreProtocolVersion')


### PR DESCRIPTION
This PR is a continuation of #232 and #233.

\<A10 boot process differs from >=A10, in that the device will not boot into recovery mode until after iBEC is sent.
This causes `Recovery.dfu_enter_recovery()` to not work on <A10 devices when starting a restore from DFU mode.

~~Also, in `Recovery.boot_ramdisk()`, to boot iBEC on <A10, iBSS must be sent first.~~

I've also forced restores to only look for a device connected via USB, to prevent any devices connected over the network from interrupting the restore.

TODO:
- `Recovery.dfu_enter_recovery()`
  - [x] Don't expect the device to be in recovery mode after iBSS is sent
  - [x] Fix freeze when trying to reset device after iBEC is sent
    - Note: If you physically disconnect & reconnect the device, the restore will continue on as normal.
  - [x] Only send `go` command after sending iBEC if necessary
    - <A10 devices will load iBEC automatically after it's sent