### PR TITLE
HeartbeatService: remove `LockdownService` inheritance

### DIFF
--- a/pymobiledevice3/services/heartbeat.py
+++ b/pymobiledevice3/services/heartbeat.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
+import logging
 import time
 
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
-from pymobiledevice3.services.lockdown_service import LockdownService
 
 
-class HeartbeatService(LockdownService):
+class HeartbeatService:
     """
     Use to keep an active connection with lockdowd
     """
@@ -14,12 +14,15 @@ class HeartbeatService(LockdownService):
     RSD_SERVICE_NAME = 'com.apple.mobile.heartbeat.shim.remote'
 
     def __init__(self, lockdown: LockdownServiceProvider):
-        if isinstance(lockdown, LockdownClient):
-            super().__init__(lockdown, self.SERVICE_NAME)
-        else:
-            super().__init__(lockdown, self.RSD_SERVICE_NAME)
+        self.logger = logging.getLogger(__name__)
+        self.lockdown = lockdown
 
-    def start(self, interval=None):
+        if isinstance(lockdown, LockdownClient):
+            self.service_name = self.SERVICE_NAME
+        else:
+            self.service_name = self.RSD_SERVICE_NAME
+
+    def start(self, interval: float = None) -> None:
         start = time.time()
         service = self.lockdown.start_lockdown_service(self.service_name)
 


### PR DESCRIPTION
The service usage requires to re-establish a connection on every `start()`, making the first service start redundant