### PR TITLE
requirements: `pyimg4>=0.8`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ wsproto
 nest_asyncio>=1.5.5
 Pillow
 inquirer3>=0.1.0
-pyimg4>=0.7
+pyimg4>=0.8
 ipsw_parser>=1.1.2
 remotezip
 zeroconf


### PR DESCRIPTION
I have released a new PyIMG4 version that makes the compression libaries optional. pymobiledevice3 doesn't require any compression functionality, so updating the version requirement removes the need of a buildsystem for installing the compression libraries.