### PR TITLE
utils: handle `get_remoted_process()` return None

### DIFF
--- a/pymobiledevice3/remote/utils.py
+++ b/pymobiledevice3/remote/utils.py
@@ -27,6 +27,9 @@ def stop_remoted_if_required() -> None:
         return
 
     remoted = get_remoted_process()
+    if remoted is None:
+        yield
+        return
     if remoted.status() == 'stopped':
         # process already stopped, we don't need to do anything
         return

--- a/pymobiledevice3/remote/utils.py
+++ b/pymobiledevice3/remote/utils.py
@@ -28,7 +28,6 @@ def stop_remoted_if_required() -> None:
 
     remoted = get_remoted_process()
     if remoted is None:
-        yield
         return
     if remoted.status() == 'stopped':
         # process already stopped, we don't need to do anything
@@ -46,6 +45,8 @@ def resume_remoted_if_required() -> None:
         return
 
     remoted = get_remoted_process()
+    if remoted is None:
+        return
     if remoted.status() == 'running':
         # process already running, we don't need to do anything
         return


### PR DESCRIPTION
Hey,I'm getting some crash logs and it looks like get_remoted_process() is returning None.
I made the change and it looks work.
The crash log:
```
Traceback (most recent call last):
  File "pymobiledevice3/__main__.py", line 115, in <module>
  File "pymobiledevice3/__main__.py", line 70, in cli
  File "click/core.py", line 1157, in __call__
  File "click/core.py", line 1078, in main
  File "click/core.py", line 1688, in invoke
  File "click/core.py", line 1688, in invoke
  File "click/core.py", line 1434, in invoke
  File "click/core.py", line 783, in invoke
  File "pymobiledevice3/cli/remote.py", line 112, in cli_start_quic_tunnel
  File "pymobiledevice3/cli/remote.py", line 28, in get_device_list
  File "contextlib.py", line 137, in __enter__
  File "pymobiledevice3/remote/utils.py", line 32, in stop_remoted
AttributeError: 'NoneType' object has no attribute 'status'
```