### PR TITLE
amfi: fix Windows behaviour during autoenable dev mode (#428)

### DIFF
--- a/pymobiledevice3/services/amfi.py
+++ b/pymobiledevice3/services/amfi.py
@@ -53,7 +53,7 @@ class AmfiService:
             try:
                 self._lockdown = create_using_usbmux(self._lockdown.udid)
                 break
-            except (NoDeviceConnectedError, ConnectionFailedError, BadDevError, construct.core.StreamError):
+            except (NoDeviceConnectedError, ConnectionFailedError, BadDevError, OSError, construct.core.StreamError):
                 pass
 
         self.enable_developer_mode_post_restart()


### PR DESCRIPTION
Fixes Windows error

> OSError: [WinError 10048] Only one usage of each socket address (protocol/network address/port) is normally permitted

It happens durung enabling dev mode, while waiting device reboot to accept dev mode popup

Tested: Win10,11 with > 30 devices