### PR TITLE
lockdown: added methods to set timezone and use 24h clock

### DIFF
--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -299,6 +299,12 @@ class LockdownClient(ABC, LockdownServiceProvider):
     def set_locale(self, locale: str) -> None:
         self.set_value(locale, key='Locale', domain='com.apple.international')
 
+    def set_timezone(self, timezone: str) -> None:
+        self.set_value(timezone, key='TimeZone')
+
+    def set_uses24hClock(self, value: bool) -> None:
+        self.set_value(value, key='Uses24HourClock')
+
     @_reconnect_on_remote_close
     def enter_recovery(self):
         return self._request('EnterRecovery')


### PR DESCRIPTION
Added 2 methods to lockdown service to set timezone and to use or not 24h clock