### PR TITLE
Revert "usbmux: improve `get_device_list()` error handling"

### DIFF
--- a/pymobiledevice3/usbmux.py
+++ b/pymobiledevice3/usbmux.py
@@ -352,15 +352,15 @@ class PlistMuxConnection(BinaryMuxConnection):
     def get_device_list(self, timeout: float = None) -> None:
         """ get device list synchronously without waiting the timeout """
         self.devices = []
-        response = self._send_receive({'MessageType': 'ListDevices'})
-        for device in response['DeviceList']:
-            if device['MessageType'] == 'Attached':
-                super()._add_device(MuxDevice(device['DeviceID'], device['Properties']['SerialNumber'],
-                                              device['Properties']['ConnectionType']))
-            elif device['MessageType'] == 'Detached':
-                super()._remove_device(device['DeviceID'])
+        self._send({'MessageType': 'ListDevices'})
+        for response in self._receive(self._tag - 1)['DeviceList']:
+            if response['MessageType'] == 'Attached':
+                super()._add_device(MuxDevice(response['DeviceID'], response['Properties']['SerialNumber'],
+                                              response['Properties']['ConnectionType']))
+            elif response['MessageType'] == 'Detached':
+                super()._remove_device(response['DeviceID'])
             else:
-                raise MuxException(f'Invalid packet type received: {device}')
+                raise MuxException(f'Invalid packet type received: {response}')
 
     def get_buid(self) -> str:
         """ get SystemBUID """
@@ -392,14 +392,13 @@ class PlistMuxConnection(BinaryMuxConnection):
             raise MuxException(f'Received non-plist type {response}')
         return plistlib.loads(response.data)
 
-    def _send_receive(self, data: Mapping) -> Mapping:
+    def _send_receive(self, data: Mapping):
         self._send(data)
         response = self._receive(self._tag - 1)
         if response['MessageType'] != 'Result':
             raise MuxException(f'got an invalid message: {response}')
         if response['Number'] != 0:
             raise self._raise_mux_exception(response['Number'], f'got an error message: {response}')
-        return response
 
 
 def create_mux(usbmux_address: Optional[str] = None) -> MuxConnection:


### PR DESCRIPTION
This reverts commit fe3b92c8d40e581c87575bd447cd49d0424eb321.

Testing
---
Tested after revert
OS: Mac Sonoma 14.0
python 3.9

```shell
(pymob3) --- pymobiledevice3 % pymobiledevice3 usbmux list
[
    {
        "BuildVersion": "20F66",
        "ConnectionType": "USB",
        "DeviceClass": "iPhone",
        "DeviceName": "IPODIAP2",
        "Identifier": "cab4353b973913cce793aa8ba894d5033ceb84b2",
        "ProductType": "iPhone10,4",
        "ProductVersion": "16.5"
    }
]

```


Details
---
The above commit appears to have introduced a breaking change.

```shell
(pymob3) --- pymobiledevice3 % pymobiledevice3 usbmux list
Traceback (most recent call last):
File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/bin/pymobiledevice3", line 8, in <module>
sys.exit(cli())
File "/Users/stephen/repos/public/pymobiledevice3/pymobiledevice3/main.py", line 77, in cli
cli_commands()
File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1157, in call
return self.main(*args, **kwargs)
File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1078, in main
rv = self.invoke(ctx)
File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
return ctx.invoke(self.callback, **ctx.params)
File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 783, in invoke
return __callback(*args, **kwargs)
File "/Users/stephen/repos/public/pymobiledevice3/pymobiledevice3/cli/usbmux.py", line 57, in usbmux_list
for device in usbmux.list_devices(usbmux_address=usbmux_address):
File "/Users/stephen/repos/public/pymobiledevice3/pymobiledevice3/usbmux.py", line 411, in list_devices
mux.get_device_list(0.1)
File "/Users/stephen/repos/public/pymobiledevice3/pymobiledevice3/usbmux.py", line 355, in get_device_list
response = self._send_receive({'MessageType': 'ListDevices'})
File "/Users/stephen/repos/public/pymobiledevice3/pymobiledevice3/usbmux.py", line 398, in _send_receive
if response['MessageType'] != 'Result':
KeyError: 'MessageType'
```

The response from `PlistMuxConnection._send({'MessageType': 'ListDevices'})` is shown below.  
 
![Screenshot 2023-11-27 at 9 00 06 PM](https://github.com/doronz88/pymobiledevice3/assets/45926479/3cf8aa22-7406-446b-93c6-5f0d6978771b)