### PR TITLE
lockdown: add property: assistive_touch

### DIFF
--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -219,6 +219,16 @@ class LockdownClient(ABC, LockdownServiceProvider):
         return self.get_value('com.apple.MobileDeviceCrashCopy', 'ShouldSubmit')
 
     @property
+    def assistive_touch(self) -> bool:
+        """AssistiveTouch (the on-screen software home button)"""
+        return bool(self.get_value('com.apple.Accessibility').get('AssistiveTouchEnabledByiTunes', 0))
+
+    @assistive_touch.setter
+    def assistive_touch(self, value: bool) -> None:
+        """AssistiveTouch (the on-screen software home button)"""
+        self.set_value(int(value), 'com.apple.Accessibility', 'AssistiveTouchEnabledByiTunes')
+
+    @property
     def voice_over(self) -> bool:
         return bool(self.get_value('com.apple.Accessibility').get('VoiceOverTouchEnabledByiTunes', 0))
 


### PR DESCRIPTION
Add the ability to get the Assistive Touch icon visibility as well as show / hide this icon.

```shell
(pymob3) --- pymobiledevice3 % pymobiledevice3 lockdown info -a | grep -E "Accessibility|Assistive"
    "com.apple.Accessibility": {
        "AssistiveTouchEnabledByiTunes": 0,
        "AccessibilityLanguages": [
        "SupportsAccessibility": true,

```

* Tested locally
  * single get / set&get (no issues)
  * setting same state multiple times (no issues)
  * getting and setting the state over many looped iterations, just seeing if things will break (no issues)

