### PR TITLE
core_device_tunnel_service: fix start tunnel issue

### DIFF
--- a/pymobiledevice3/remote/core_device_tunnel_service.py
+++ b/pymobiledevice3/remote/core_device_tunnel_service.py
@@ -575,6 +575,11 @@ class CoreDeviceTunnelService(RemoteService):
                                                     'startNewSession': True})
 
         data = self.decode_tlv(PairingDataComponentTLVBuf.parse(response))
+
+        if PairingDataComponentType.ERROR in data:
+            self._send_pair_verify_failed()
+            return False
+
         peer_public_key = X25519PublicKey.from_public_bytes(data[PairingDataComponentType.PUBLIC_KEY])
         self.encryption_key = self.x25519_private_key.exchange(peer_public_key)
 


### PR DESCRIPTION
in function CoreDeviceTunnelService._validate_pairing(), expect a PUBLIC_KEY response,
but some device will response an error instead of PUBLIC_KEY, 
we trust this as verify failed and continue to pair.

this work fine on my device,  I think this can fix issue #663