### PR TITLE
process_control: fix handling timestamp errors during launch

### DIFF
--- a/pymobiledevice3/services/dvt/instruments/process_control.py
+++ b/pymobiledevice3/services/dvt/instruments/process_control.py
@@ -13,8 +13,12 @@ class OutputReceivedEvent:
 
     @classmethod
     def create(cls, message) -> 'OutputReceivedEvent':
-        return cls(pid=message[1].value, date=datetime.datetime.fromtimestamp(message[2].value),
-                   message=message[0].value)
+        try:
+            date = datetime.datetime.fromtimestamp(message[2].value)
+        except ValueError:
+            date = None
+
+        return cls(pid=message[1].value, date=date, message=message[0].value)
 
 
 class ProcessControl:


### PR DESCRIPTION
Regarding issue #727 (https://github.com/doronz88/pymobiledevice3/issues/727), in some cases, a ValueError was raised due to a year value being out of range. We would like to change this behavior so that the program continues to run even if this error occurs.