### PR TITLE
crash_reports: fix sysdiagnose complete syslog match

### DIFF
--- a/pymobiledevice3/services/crash_reports.py
+++ b/pymobiledevice3/services/crash_reports.py
@@ -138,10 +138,14 @@ class CrashReportsManager:
         self._wait_for_sysdiagnose_to_finish()
         self.pull(out, entry=sysdiagnose_filename, erase=erase)
 
+    @staticmethod
+    def _sysdiagnose_complete_syslog_match(message: str) -> bool:
+        return message == 'sysdiagnose (full) complete' or 'Sysdiagnose completed' in message
+
     def _wait_for_sysdiagnose_to_finish(self) -> None:
         with OsTraceService(self.lockdown) as os_trace:
             for entry in os_trace.syslog():
-                if entry.message == 'sysdiagnose (full) complete':
+                if CrashReportsManager._sysdiagnose_complete_syslog_match(entry.message):
                     break
 
     def _get_new_sysdiagnose_filename(self) -> str:


### PR DESCRIPTION
Fix detecting sysdiagnose complete when triggered via accessibility icon.  Both devices have similar syslog entries
```python
SyslogEntry(
  pid=563, 
  timestamp=datetime.datetime(2024, 1, 7, 23, 22, 2, 150124), 
  level=<SyslogLogLevel.NOTICE: 0>,
  image_name='/System/Library/PrivateFrameworks/AccessibilityPhysicalInteraction.framework/AccessibilityPhysicalInteraction',
  filename='/System/Library/CoreServices/AssistiveTouch.app/assistivetouchd', 
  message='Sysdiagnose completed. File path: /private/var/mobile/Library/Logs/CrashReporter/DiagnosticLogs/sysdiagnose/sysdiagnose_2024.01.07_23-20-38-0500_iPhone-OS_iPhone_20F66.tar.gz', 
  label=SyslogLabel(category='AXPhysicalInteraction', subsystem='com.apple.Accessibility')
)
```

I'm wondering if the current implementation assumes sysdiagnose is triggered by pressing both volume buttons?  I wasn't able to trigger sysdiagnose using that method.

---

### Testing
[syslog_files.zip](https://github.com/doronz88/pymobiledevice3/files/13864447/syslog_files.zip)
* iphone8
  * ios16.5
* iphone14
  * ios17.0.2
