### PR TITLE
ci: add concurrency to Python Package workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: '! github.event.pull_request.draft'


### PR DESCRIPTION
Reference: https://docs.github.com/en/actions/using-jobs/using-concurrency

Before:
* Each push to a PR branch triggers a new workflow and each workflow runs to completion.

Now:
* Each push to a PR branch cancels in-progress workflows, for that particular branch.  Only the workflow for the latest set of changes runs to completion.