### PR TITLE
ci: use concurrency in GitHub workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,10 @@ on:
   schedule:
     - cron: '24 3 * * 6'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: '! github.event.pull_request.draft'


### PR DESCRIPTION
Reference: https://docs.github.com/en/actions/using-jobs/using-concurrency

Reason for change:
I've used this in other projects.  It conserves resources, even though GitHub isn't charging this project for minutes used ... (I hope) 🙂

TL;DR
With this change, each push to a PR branch cancels in-progress workflows, for that particular branch. Only the workflow for the latest set of changes runs to completion.