### PR TITLE
add the missing _channelCanceled:

### DIFF
--- a/pymobiledevice3/services/remote_server.py
+++ b/pymobiledevice3/services/remote_server.py
@@ -373,6 +373,14 @@ class RemoteServer(LockdownService):
         self.perform_handshake()
         return self
 
+    def close(self):
+        aux = MessageAux()
+        for code in self.channel_messages.keys():
+            if code > 0:
+                aux.append_int(code)
+        self.send_message(self.BROADCAST_CHANNEL, '_channelCanceled:', aux, expects_reply=False)
+        super().close()
+
 
 class Tap:
     def __init__(self, dvt, channel_name: str, config: typing.Mapping):


### PR DESCRIPTION
From Wireshark capured data, client need to send message `_channelCanceled:` at last

Captured data:

![image](https://github.com/doronz88/pymobiledevice3/assets/3281689/b8b19ae3-d32a-4c4c-8b05-8247422e6778)
![image](https://github.com/doronz88/pymobiledevice3/assets/3281689/5afa932e-b799-4285-9ead-6d491df072cc)

The payload part extract is

```
Header Container: 
    magic = 524114809
    cb = 32
    fragmentId = 0
    fragmentCount = 1
    length = 201
    identifier = 8
    conversationIndex = 0
    channelCode = 0
    expectsReply = 0
Payload Container: 
    flags = 2
    auxiliaryLength = 28
    totalLength = 185
AUX Container: 
    magic = 496
    aux = ListContainer: 
        Container: 
            type = 3
            value = 2
Identifier: _channelCanceled:
```

with Code

```python
import io
from pymobiledevice3.services.remote_server import (
    message_aux_t_struct, dtx_message_payload_header_struct, dtx_message_header_struct)
from bpylist2.archiver import unarchive

def hex2stream(hex_stream: str) -> io.BytesIO:
    raw = bytes.fromhex(hex_stream)
    return io.BytesIO(raw)


def parse_and_print(stream: io.BytesIO):
    header = dtx_message_header_struct.parse_stream(stream)
    print("Header", header)

    payload = dtx_message_payload_header_struct.parse_stream(stream)
    print("Payload", payload)

    aux = message_aux_t_struct.parse(stream.read(payload.auxiliaryLength))
    print('AUX', aux)

    identifier_size = payload.totalLength - payload.auxiliaryLength
    identifier = stream.read(identifier_size)
    print("Identifier:", unarchive(identifier))



packet1 = "795b3d1f2000000000000100c900000008000000000000000000000000000000"
packet2 = "020000001c000000b900000000000000f0010000000000000c000000000000000a000000030000000200000062706c6973743030d4010203040506070a582476657273696f6e592461726368697665725424746f7058246f626a6563747312000186a05f100f4e534b657965644172636869766572d1080954726f6f748001a20b0c55246e756c6c5f10115f6368616e6e656c43616e63656c65643a08111a24293237494c5153565c0000000000000101000000000000000d00000000000000000000000000000070"
stream = hex2stream(packet1 + packet2)
parse_and_print(stream)
```

