### PR TITLE
Change the print_json to return object to be used

### DIFF
--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -72,8 +72,10 @@ def print_json(buf, colored=True, default=default_json_encoder):
         colorful_json = highlight(formatted_json, lexers.JsonLexer(),
                                   formatters.TerminalTrueColorFormatter(style='stata-dark'))
         print(colorful_json)
+        return(colorful_json)
     else:
         print(formatted_json)
+        return(formatted_json)
 
 
 def print_hex(data, colored=True):

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -72,10 +72,10 @@ def print_json(buf, colored=True, default=default_json_encoder):
         colorful_json = highlight(formatted_json, lexers.JsonLexer(),
                                   formatters.TerminalTrueColorFormatter(style='stata-dark'))
         print(colorful_json)
-        return(colorful_json)
+        return colorful_json
     else:
         print(formatted_json)
-        return(formatted_json)
+        return formatted_json
 
 
 def print_hex(data, colored=True):


### PR DESCRIPTION
Change the print_json method in the cli_common.py to return an  object to be used in the code elsewhere  instead of just printing the formatted json to the stdout