### PR TITLE
cli_common: Fix wait_return availability on Windows

### DIFF
--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import logging
 import os
-import signal
 import sys
 import uuid
 from typing import Callable, List, Mapping, Optional, Tuple
@@ -94,9 +93,13 @@ def get_last_used_terminal_formatting(buf: str) -> str:
     return '\x1b' + buf.rsplit('\x1b', 1)[1].split('m')[0] + 'm'
 
 
-def wait_return():
-    print("Press Ctrl+C to send a SIGINT or use 'kill' command to send a SIGTERM")
-    signal.sigwait([signal.SIGINT, signal.SIGTERM])
+def wait_return() -> None:
+    if sys.platform != 'win32':
+        import signal
+        print("Press Ctrl+C to send a SIGINT or use 'kill' command to send a SIGTERM")
+        signal.sigwait([signal.SIGINT, signal.SIGTERM])
+    else:
+        input('Press ENTER to exit>')
 
 
 UDID_ENV_VAR = 'PYMOBILEDEVICE3_UDID'


### PR DESCRIPTION
As [sigwait](https://docs.python.org/3/library/signal.html#signal.sigwait) is only available on Unix, running some services on Windows can result in errors like [this comment](https://github.com/doronz88/pymobiledevice3/issues/569#issuecomment-1891269679)

It's more common to use Enter to exit processes instead of Ctrl+C on Windows, so I reverted the behavior on Windows to what it was before #680

This PR needs to be tested along with #797 for now since Windows support is not yet on master.