### PR TITLE
added run-audit and list-supported-audit-type cli command

### DIFF
--- a/pymobiledevice3/cli/developer.py
+++ b/pymobiledevice3/cli/developer.py
@@ -773,6 +773,19 @@ def accessibility():
     """ accessibility options. """
     pass
 
+@accessibility.command('run-audit', cls=Command)
+@click.argument('test_types', nargs=-1)
+def accessibility_run_audit(service_provider: LockdownServiceProvider, test_types):
+    """ runs accessibility audit tests """
+    param = list(test_types)
+    audit_issues = AccessibilityAudit(service_provider).run_audit(param)
+    print_json([audit_issue.json() for audit_issue in audit_issues], False) 
+
+@accessibility.command('supported-audit-types', cls=Command)
+def accessibility_supported_audit_types(service_provider: LockdownServiceProvider):
+    """ lists supported accessibility audit test types """
+    print_json(AccessibilityAudit(service_provider).supported_audits_types())
+
 
 @accessibility.command('capabilities', cls=Command)
 def accessibility_capabilities(service_provider: LockdownClient):

--- a/pymobiledevice3/services/remote_server.py
+++ b/pymobiledevice3/services/remote_server.py
@@ -169,6 +169,12 @@ class NSMutableData:
         return archive_obj.decode('NS.data')
 
 
+class NSMutableString:
+    @staticmethod
+    def decode_archive(archive_obj: archiver.ArchivedObject):
+        return archive_obj.decode('NS.string')
+
+
 class XCTestConfiguration:
     _default = {
         # 'testBundleURL': UID(3),
@@ -235,6 +241,7 @@ archiver.update_class_map({'DTSysmonTapMessage': DTTapMessage,
                            'NSURL': NSURL,
                            'NSValue': NSValue,
                            'NSMutableData': NSMutableData,
+                           'NSMutableString': NSMutableString,
                            'XCTestConfiguration': XCTestConfiguration})
 
 archiver.Archive.inline_types = list(set(archiver.Archive.inline_types + [bytes]))


### PR DESCRIPTION
Added CLI command for 
**run-audit** -  To run the accessibility audit api and return the results
    sample response
          `[
    {
        "element_rect_value": "{{36, 123}, {342, 33.5}}",
        "font_size": 0.0,
        "issue_classification": "testTypeDynamicText",
        "ml_generated_description": null
    },
    {
        "element_rect_value": "{{36, 160}, {342, 16}}",
        "font_size": 0.0,
        "issue_classification": "testTypeDynamicText",
        "ml_generated_description": null
    }
]`


**supported-audits-types** - To list the support audit test types of the report
     sample response
           `[
    "testTypeSufficientElementDescription",
    "testTypeContrast",
    "testTypeHitRegion",
    "testTypeElementDetection",
    "testTypeTextClipped",
    "testTypeTrait",
    "testTypeDynamicText"
]`
     