### PR TITLE
diagnostics: handle MobileGestalt deprecation error on iOS 17.4

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -5,8 +5,8 @@ import traceback
 import click
 import coloredlogs
 
-from pymobiledevice3.exceptions import AccessDeniedError, ConnectionFailedToUsbmuxdError, DeveloperModeError, \
-    DeveloperModeIsNotEnabledError, DeviceHasPasscodeSetError, DeviceNotFoundError, InternalError, \
+from pymobiledevice3.exceptions import AccessDeniedError, ConnectionFailedToUsbmuxdError, DeprecationError, \
+    DeveloperModeError, DeveloperModeIsNotEnabledError, DeviceHasPasscodeSetError, DeviceNotFoundError, InternalError, \
     InvalidServiceError, MessageNotSupportedError, MissingValueError, NoDeviceConnectedError, NoDeviceSelectedError, \
     NotEnoughDiskSpaceError, NotPairedError, PairingDialogResponsePendingError, PasswordRequiredError, \
     RSDRequiredError, SetProhibitedError, TunneldConnectionError, UserDeniedPairingError
@@ -148,6 +148,8 @@ def main() -> None:
     except RSDRequiredError:
         logger.error('The requested operation requires an RSD instance. For more information see:\n'
                      'https://github.com/doronz88/pymobiledevice3?tab=readme-ov-file#working-with-developer-tools-ios--170')
+    except DeprecationError:
+        logger.error('failed to query MobileGestalt, MobileGestalt deprecated (iOS >= 17.4).')
 
 
 if __name__ == '__main__':

--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -346,6 +346,11 @@ class NotEnoughDiskSpaceError(PyMobileDevice3Exception):
     pass
 
 
+class DeprecationError(PyMobileDevice3Exception):
+    """ The requested action/service/method is deprecated """
+    pass
+
+
 class RSDRequiredError(PyMobileDevice3Exception):
     """ The requested action requires an RSD object """
     pass


### PR DESCRIPTION
MobileGestalt deprecated on iOS 17.4, added more clear exception message.
For history:
```C:\Users\Andrew>python -m pymobiledevice3 diagnostics mg
Traceback (most recent call last):
  File "C:\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\Andrew\AppData\Roaming\Python\Python310\site-packages\pymobiledevice3\__main__.py", line 154, in <module>
    main()
  File "C:\Users\Andrew\AppData\Roaming\Python\Python310\site-packages\pymobiledevice3\__main__.py", line 101, in main
    cli()
  File "C:\Python310\lib\site-packages\click\core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "C:\Python310\lib\site-packages\click\core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "C:\Python310\lib\site-packages\click\core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Python310\lib\site-packages\click\core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Python310\lib\site-packages\click\core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Python310\lib\site-packages\click\core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "C:\Users\Andrew\AppData\Roaming\Python\Python310\site-packages\pymobiledevice3\cli\cli_common.py", line 134, in wrap_callback_calling
    callback(service_provider=service_provider, **kwargs)
  File "C:\Users\Andrew\AppData\Roaming\Python\Python310\site-packages\pymobiledevice3\cli\diagnostics.py", line 66, in diagnostics_mg
    print_json(DiagnosticsService(lockdown=service_provider).mobilegestalt(keys=keys), colored=color)
  File "C:\Users\Andrew\AppData\Roaming\Python\Python310\site-packages\pymobiledevice3\services\diagnostics.py", line 977, in mobilegestalt
    raise PyMobileDevice3Exception('failed to query MobileGestalt, MobileGestalt Deprecated (iOS >= 17.4)')
pymobiledevice3.exceptions.PyMobileDevice3Exception: failed to query MobileGestalt, MobileGestalt Deprecated (iOS >= 17.4)
```

MG on iOS 17.4 dev preview(12 pro max) answers like
`{'Diagnostics': {'MobileGestalt': {'Status': 'MobileGestaltDeprecated'}}, 'Status': 'Success'}`