### PR TITLE
process_control: fix hanlding OSError on Windows (#803)

### DIFF
--- a/pymobiledevice3/services/dvt/instruments/process_control.py
+++ b/pymobiledevice3/services/dvt/instruments/process_control.py
@@ -20,7 +20,7 @@ class OutputReceivedEvent:
                 date = datetime.datetime.fromtimestamp(message[2].value / 1000)
             else:
                 date = datetime.datetime.fromtimestamp(message[2].value)
-        except ValueError:
+        except (ValueError, OSError):
             date = None
 
         return cls(pid=message[1].value, date=date, message=message[0].value)


### PR DESCRIPTION
Output before changes:

    (venv) D:\repos\...>pymobiledevice3 developer dvt launch com.my.app --stream 
        Process launched with pid 6299
        Traceback (most recent call last):
        File "C:\Users\...\...\Python310\lib\runpy.py", line 196, in _run_module_as_main
          return _run_code(code, main_globals, None,
        File "C:\Users\...\...\Python310\lib\runpy.py", line 86, in _run_code
          exec(code, run_globals)
        File "D:\repos\...\venv\Scripts\pymobiledevice3.exe\__main__.py", line 7, in <module>
          sys.exit(main())
        File "D:\repos\...\venv\lib\site-packages\pymobiledevice3\__main__.py", line 98, in main
          cli()
        File "D:\repos\...\venv\lib\site-packages\click\core.py", line 1157, in __call__
          return self.main(*args, **kwargs)
        File "D:\repos\...\venv\lib\site-packages\click\core.py", line 1078, in main
          rv = self.invoke(ctx)
        File "D:\repos\...\venv\lib\site-packages\click\core.py", line 1688, in invoke
          return _process_result(sub_ctx.command.invoke(sub_ctx))
        File "D:\repos\...\venv\lib\site-packages\click\core.py", line 1688, in invoke
          return _process_result(sub_ctx.command.invoke(sub_ctx))
        File "D:\repos\...\venv\lib\site-packages\click\core.py", line 1688, in invoke
          return _process_result(sub_ctx.command.invoke(sub_ctx))
        File "D:\repos\...\venv\lib\site-packages\click\core.py", line 1434, in invoke
          return ctx.invoke(self.callback, **ctx.params)
        File "D:\repos\...\venv\lib\site-packages\click\core.py", line 783, in invoke
          return __callback(*args, **kwargs)
        File "D:\repos\...\venv\lib\site-packages\pymobiledevice3\cli\cli_common.py", line 159, in wrap_callback_calling
          callback(service_provider=service_provider, **kwargs)
        File "D:\repos\...\venv\lib\site-packages\pymobiledevice3\cli\developer.py", line 203, in launch
          for output_received in process_control:
        File "D:\repos\...\venv\lib\site-packages\pymobiledevice3\services\dvt\instruments\process_control.py", line 77, in __iter__
          yield OutputReceivedEvent.create(value)
        File "D:\repos\...\venv\lib\site-packages\pymobiledevice3\services\dvt\instruments\process_control.py", line 18, in create
          date = datetime.datetime.fromtimestamp(message[2].value)
        OSError: [Errno 22] Invalid argument

-----------------------------------------------------------------------------------------------------------------------------------------
Output after changes

      (venv) D:\repos\...>pymobiledevice3 developer dvt launch com.my.app --stream 
            Process launched with pid 6289
            2024-02-02 16:09:10 RS1-WW-283 PID:6289[16728] INFO AK Info: Number of detected and configured output channels: 2
            2024-02-02 16:09:10 RS1-WW-283 PID:6289[16728] INFO AK Info: Using output port: Speaker of type Speaker with 2 output channel(s)
