### PR TITLE
cli: add --color/--no-color option to profile list

### DIFF
--- a/pymobiledevice3/cli/profile.py
+++ b/pymobiledevice3/cli/profile.py
@@ -22,9 +22,10 @@ def profile_group():
 
 
 @profile_group.command('list', cls=Command)
-def profile_list(service_provider: LockdownClient):
+@click.option('--color/--no-color', default=True)
+def profile_list(service_provider: LockdownClient, color):
     """ list installed profiles """
-    print_json(MobileConfigService(lockdown=service_provider).get_profile_list())
+    print_json(MobileConfigService(lockdown=service_provider).get_profile_list(), colored=color)
 
 
 @profile_group.command('install', cls=Command)


### PR DESCRIPTION
Adding support for `color/no-color` in pymobiledevice3 profile list command