### PR TITLE
lockdown: remove `all_domains` property

### DIFF
--- a/pymobiledevice3/cli/lockdown.py
+++ b/pymobiledevice3/cli/lockdown.py
@@ -44,10 +44,9 @@ def lockdown_developer_service(service_provider: LockdownServiceProvider, servic
 
 
 @lockdown_group.command('info', cls=Command)
-@click.option('-a', '--all', is_flag=True, help='include all domain information')
-def lockdown_info(service_provider: LockdownServiceProvider, all):
+def lockdown_info(service_provider: LockdownServiceProvider):
     """ query all lockdown values """
-    print_json(service_provider.all_domains if all else service_provider.all_values)
+    print_json(service_provider.all_values)
 
 
 @lockdown_group.command('get', cls=Command)

--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -28,39 +28,6 @@ from pymobiledevice3.service_connection import LockdownServiceConnection
 from pymobiledevice3.usbmux import PlistMuxConnection
 
 SYSTEM_BUID = '30142955-444094379208051516'
-DOMAINS = ['com.apple.disk_usage',
-           'com.apple.disk_usage.factory',
-           'com.apple.mobile.battery',
-           # FIXME: For some reason lockdownd segfaults on this, works sometimes tho
-           # 'com.apple.mobile.debug',
-           'com.apple.iqagent',
-           'com.apple.purplebuddy',
-           'com.apple.PurpleBuddy',
-           'com.apple.mobile.chaperone',
-           'com.apple.mobile.third_party_termination',
-           'com.apple.mobile.lockdownd',
-           'com.apple.mobile.lockdown_cache',
-           'com.apple.xcode.developerdomain',
-           'com.apple.international',
-           'com.apple.mobile.data_sync',
-           'com.apple.mobile.tethered_sync',
-           'com.apple.mobile.mobile_application_usage',
-           'com.apple.mobile.backup',
-           'com.apple.mobile.nikita',
-           'com.apple.mobile.restriction',
-           'com.apple.mobile.user_preferences',
-           'com.apple.mobile.sync_data_class',
-           'com.apple.mobile.software_behavior',
-           'com.apple.mobile.iTunes.SQLMusicLibraryPostProcessCommands',
-           'com.apple.mobile.iTunes.accessories',
-           'com.apple.mobile.internal',  # < iOS 4.0+
-           'com.apple.mobile.wireless_lockdown',  # < iOS 4.0+
-           'com.apple.fairplay',
-           'com.apple.iTunes',
-           'com.apple.mobile.iTunes.store',
-           'com.apple.mobile.iTunes',
-           'com.apple.fmip',
-           'com.apple.Accessibility', ]
 
 DEFAULT_LABEL = 'pymobiledevice3'
 SERVICE_PORT = 62078
@@ -194,15 +161,6 @@ class LockdownClient(ABC, LockdownServiceProvider):
     @property
     def wifi_mac_address(self) -> str:
         return self.all_values.get('WiFiAddress')
-
-    @property
-    def all_domains(self) -> Mapping:
-        result = self.all_values
-
-        for domain in DOMAINS:
-            result.update({domain: self.get_value(domain)})
-
-        return result
 
     @property
     def short_info(self) -> Dict:

--- a/pymobiledevice3/remote/remote_service_discovery.py
+++ b/pymobiledevice3/remote/remote_service_discovery.py
@@ -33,7 +33,6 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         self.peer_info: Optional[Mapping] = None
         self.lockdown: Optional[LockdownClient] = None
         self.all_values: Optional[Mapping] = None
-        self.all_domains: Optional[Mapping] = None
 
     @property
     def product_version(self) -> str:
@@ -58,7 +57,6 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
             self.lockdown = create_using_remote(
                 self.start_lockdown_service('com.apple.mobile.lockdown.remote.untrusted'))
         self.all_values = self.lockdown.all_values
-        self.all_domains = self.lockdown.all_domains
 
     def get_value(self, domain: str = None, key: str = None):
         return self.lockdown.get_value(domain, key)


### PR DESCRIPTION
It seems on some devices querying all lockdownd domain might take large amounts of time and this causes the RSD handshake to become quite slow randomly.

We remove this propert entirely since it's not very helpful and causing maintenance issues.