### PR TITLE
afc: use `try_decode` in `cat`

### DIFF
--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -839,7 +839,7 @@ class AfcShell:
                 print(posixpath.join(root, name))
 
     def _do_cat(self, filename: str):
-        print(self.afc.get_file_contents(self.relative_path(filename)))
+        print(try_decode(self.afc.get_file_contents(self.relative_path(filename))))
 
     def _do_rm(self, file: Annotated[List[str], Arg(nargs='+', completer=path_completer)]):
         for filename in file:


### PR DESCRIPTION
when reading text files it makes them pretty hard to read otherwise especially crash reports