### PR TITLE
amfi: fix error parsing in `create_amfi_show_override_path_file()`

### DIFF
--- a/pymobiledevice3/services/amfi.py
+++ b/pymobiledevice3/services/amfi.py
@@ -20,7 +20,7 @@ class AmfiService:
         """ create an empty file at AMFIShowOverridePath """
         service = self._lockdown.start_lockdown_service(self.SERVICE_NAME)
         resp = service.send_recv_plist({'action': 0})
-        if not resp['status']:
+        if not resp.get('success'):
             raise PyMobileDevice3Exception(f'create_AMFIShowOverridePath() failed with: {resp}')
 
     def enable_developer_mode(self, enable_post_restart=True):


### PR DESCRIPTION
Seems that the field in resp is 'success' instead of 'status'.
I only have device with iPadOS 17 so if that's not case in older system, plz correct me.