### PR TITLE
sysdiagnose: ignore old `IN_PROGRESS` files 

### DIFF
--- a/pymobiledevice3/services/crash_reports.py
+++ b/pymobiledevice3/services/crash_reports.py
@@ -161,7 +161,7 @@ class CrashReportsManager:
                         for ext in self.IN_PROGRESS_SYSDIAGNOSE_EXTENSIONS:
                             if filename.endswith(ext):
                                 delta = datetime.now() - self.afc.stat(posixpath.join(SYSDIAGNOSE_DIR,filename))['st_mtime']
-                                # Ignores IN_PROGRESS sysdiagnose files older than 30min
+                                # Ignores IN_PROGRESS sysdiagnose files older than 10min
                                 if delta.total_seconds() < 600:
                                     sysdiagnose_filename = filename.rsplit(ext)[0]
                                     sysdiagnose_filename = sysdiagnose_filename.replace('IN_PROGRESS_', '')

--- a/pymobiledevice3/services/crash_reports.py
+++ b/pymobiledevice3/services/crash_reports.py
@@ -1,6 +1,5 @@
 import logging
 import posixpath
-from datetime import datetime
 from typing import Generator, List
 
 from pycrashreport.crash_report import get_crash_report_from_buf
@@ -161,7 +160,8 @@ class CrashReportsManager:
                     if filename not in excluded_temp_files and 'IN_PROGRESS_' in filename:
                         for ext in self.IN_PROGRESS_SYSDIAGNOSE_EXTENSIONS:
                             if filename.endswith(ext):
-                                delta = self.lockdown.date - self.afc.stat(posixpath.join(SYSDIAGNOSE_DIR,filename))['st_mtime']
+                                delta = self.lockdown.date - \
+                                    self.afc.stat(posixpath.join(SYSDIAGNOSE_DIR, filename))['st_mtime']
                                 # Ignores IN_PROGRESS sysdiagnose files older than the defined time to live
                                 if delta.total_seconds() < SYSDIAGNOSE_IN_PROGRESS_MAX_TTL_SECS:
                                     sysdiagnose_filename = filename.rsplit(ext)[0]

--- a/pymobiledevice3/services/crash_reports.py
+++ b/pymobiledevice3/services/crash_reports.py
@@ -150,18 +150,22 @@ class CrashReportsManager:
 
     def _get_new_sysdiagnose_filename(self) -> str:
         sysdiagnose_filename = None
+        build_version = self.lockdown.short_info['BuildVersion']
 
         while sysdiagnose_filename is None:
             try:
                 for filename in self.afc.listdir(SYSDIAGNOSE_DIR):
                     # search for an IN_PROGRESS archive
                     if 'IN_PROGRESS_' in filename:
-                        for ext in self.IN_PROGRESS_SYSDIAGNOSE_EXTENSIONS:
-                            if filename.endswith(ext):
-                                sysdiagnose_filename = filename.rsplit(ext)[0]
-                                sysdiagnose_filename = sysdiagnose_filename.replace('IN_PROGRESS_', '')
-                                sysdiagnose_filename = f'{sysdiagnose_filename}.tar.gz'
-                                return posixpath.join(SYSDIAGNOSE_DIR,  sysdiagnose_filename)
+                            for ext in self.IN_PROGRESS_SYSDIAGNOSE_EXTENSIONS:
+                                if filename.endswith(ext):
+                                    if build_version in filename:
+                                        sysdiagnose_filename = filename.rsplit(ext)[0]
+                                        sysdiagnose_filename = sysdiagnose_filename.replace('IN_PROGRESS_', '')
+                                        sysdiagnose_filename = f'{sysdiagnose_filename}.tar.gz'
+                                        return posixpath.join(SYSDIAGNOSE_DIR,  sysdiagnose_filename)
+                                    else:
+                                        self.logger.warning(f"Existing old sysdiagnose temp file ignored {filename}")
             except AfcException:
                 pass
 

--- a/pymobiledevice3/services/crash_reports.py
+++ b/pymobiledevice3/services/crash_reports.py
@@ -1,5 +1,6 @@
 import logging
 import posixpath
+from datetime import datetime
 from typing import Generator, List
 
 from pycrashreport.crash_report import get_crash_report_from_buf
@@ -150,22 +151,25 @@ class CrashReportsManager:
 
     def _get_new_sysdiagnose_filename(self) -> str:
         sysdiagnose_filename = None
-        build_version = self.lockdown.short_info['BuildVersion']
+        excluded_temp_files = []
 
         while sysdiagnose_filename is None:
             try:
                 for filename in self.afc.listdir(SYSDIAGNOSE_DIR):
                     # search for an IN_PROGRESS archive
-                    if 'IN_PROGRESS_' in filename:
-                            for ext in self.IN_PROGRESS_SYSDIAGNOSE_EXTENSIONS:
-                                if filename.endswith(ext):
-                                    if build_version in filename:
-                                        sysdiagnose_filename = filename.rsplit(ext)[0]
-                                        sysdiagnose_filename = sysdiagnose_filename.replace('IN_PROGRESS_', '')
-                                        sysdiagnose_filename = f'{sysdiagnose_filename}.tar.gz'
-                                        return posixpath.join(SYSDIAGNOSE_DIR,  sysdiagnose_filename)
-                                    else:
-                                        self.logger.warning(f"Existing old sysdiagnose temp file ignored {filename}")
+                    if filename not in excluded_temp_files and 'IN_PROGRESS_' in filename:
+                        for ext in self.IN_PROGRESS_SYSDIAGNOSE_EXTENSIONS:
+                            if filename.endswith(ext):
+                                delta = datetime.now() - self.afc.stat(posixpath.join(SYSDIAGNOSE_DIR,filename))['st_mtime']
+                                # Ignores IN_PROGRESS sysdiagnose files older than 30min
+                                if delta.total_seconds() < 600:
+                                    sysdiagnose_filename = filename.rsplit(ext)[0]
+                                    sysdiagnose_filename = sysdiagnose_filename.replace('IN_PROGRESS_', '')
+                                    sysdiagnose_filename = f'{sysdiagnose_filename}.tar.gz'
+                                    return posixpath.join(SYSDIAGNOSE_DIR,  sysdiagnose_filename)
+                                else:
+                                    self.logger.warning(f"Old sysdiagnose temp file ignored {filename}")
+                                    excluded_temp_files.append(filename)
             except AfcException:
                 pass
 


### PR DESCRIPTION
If, for whatever reason, there are old temp (IN_PROGRESS) sysdiagnose files present in the device, the method  _get_new_sysdiagnose_filename(self) https://github.com/doronz88/pymobiledevice3/blob/aa0b3fe126157ce249526576cbd613ad68393c49/pymobiledevice3/services/crash_reports.py#L151

fails to monitor for the creation of new temp sysdiagnose files. This pull request tries to tackle that issue by discarding temp files not modified in the last 10 minutes.