### PR TITLE
Initial support for supervised pairing

### DIFF
--- a/pymobiledevice3/cli/lockdown.py
+++ b/pymobiledevice3/cli/lockdown.py
@@ -90,6 +90,13 @@ def lockdown_pair(service_provider: LockdownClient):
     """ pair device """
     service_provider.pair()
 
+@lockdown_group.command('pair-supervised', cls=CommandWithoutAutopair)
+@click.argument('p12file', type=click.File('rb'))
+@click.argument('password')
+def lockdown_pair_supervised(service_provider: LockdownClient, p12file, password):
+    """ pair supervised device """
+    service_provider.pair_supervised(p12file=p12file, password=password)
+
 
 @lockdown_group.command('save-pair-record', cls=CommandWithoutAutopair)
 @click.argument('output', type=click.File('wb'))

--- a/pymobiledevice3/cli/lockdown.py
+++ b/pymobiledevice3/cli/lockdown.py
@@ -90,6 +90,7 @@ def lockdown_pair(service_provider: LockdownClient):
     """ pair device """
     service_provider.pair()
 
+
 @lockdown_group.command('pair-supervised', cls=CommandWithoutAutopair)
 @click.argument('p12file', type=click.File('rb'))
 @click.argument('password')

--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -393,7 +393,8 @@ class LockdownClient(ABC, LockdownServiceProvider):
                        'SystemBUID': self.system_buid}
 
         pair_options = {'PairRecord': pair_record, 'ProtocolVersion': '2',
-                        'PairingOptions': {'SupervisorCertificate': decrypted_p12.cert.certificate.public_bytes(Encoding.DER), 'ExtendedPairingErrors': True}}
+                        'PairingOptions': {'SupervisorCertificate': decrypted_p12.cert.certificate.public_bytes(Encoding.DER),
+                                           'ExtendedPairingErrors': True}}
 
         # first pair with SupervisorCertificate as PairingOptions to get Challenge
         pair = self._request_pair(pair_options, timeout=timeout)
@@ -551,7 +552,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
         error = response.get('Error')
         if error is not None:
             # return response if supervisor cert challenge is required, to work with pair_supervisor
-            if(error) == 'MCChallengeRequired':
+            if error == 'MCChallengeRequired':
                 return response
             exception_errors = {'PasswordProtected': PasswordRequiredError,
                                 'PairingDialogResponsePending': PairingDialogResponsePendingError,

--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -29,6 +29,11 @@ from pymobiledevice3.pair_records import create_pairing_records_cache_folder, ge
 from pymobiledevice3.service_connection import ServiceConnection
 from pymobiledevice3.usbmux import PlistMuxConnection
 
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.hazmat.primitives.serialization.pkcs7 import PKCS7SignatureBuilder
+from cryptography.hazmat.primitives.serialization.pkcs12 import load_pkcs12
+
 SYSTEM_BUID = '30142955-444094379208051516'
 
 DEFAULT_LABEL = 'pymobiledevice3'
@@ -358,6 +363,62 @@ class LockdownClient(ABC, LockdownServiceProvider):
         self.paired = True
 
     @_reconnect_on_remote_close
+    def pair_supervised(self, timeout: float = None, p12file: Path = None, password: str = None) -> None:
+
+        keystore_data = p12file.read()
+        try:
+            decrypted_p12 = load_pkcs12(
+                keystore_data, password.encode('utf-8'))
+        except Exception as pkcs12_error:
+            self.service.close()
+            raise Exception(f'load_pkcs12 error: {pkcs12_error}')
+
+        self.device_public_key = self.get_value('', 'DevicePublicKey')
+        if not self.device_public_key:
+            self.logger.error('Unable to retrieve DevicePublicKey')
+            self.service.close()
+            raise PairingError()
+
+        self.logger.info('Creating host key & certificate')
+        cert_pem, private_key_pem, device_certificate = ca_do_everything(
+            self.device_public_key)
+
+        pair_record = {'DevicePublicKey': self.device_public_key,
+                       'DeviceCertificate': device_certificate,
+                       'HostCertificate': cert_pem,
+                       'HostID': self.host_id,
+                       'RootCertificate': cert_pem,
+                       'RootPrivateKey': private_key_pem,
+                       'WiFiMACAddress': self.wifi_mac_address,
+                       'SystemBUID': self.system_buid}
+
+        pair_options = {'PairRecord': pair_record, 'ProtocolVersion': '2',
+                        'PairingOptions': {'SupervisorCertificate': decrypted_p12.cert.certificate.public_bytes(Encoding.DER), 'ExtendedPairingErrors': True}}
+
+        # first pair with SupervisorCertificate as PairingOptions to get Challenge
+        pair = self._request_pair(pair_options, timeout=timeout)
+        if pair.get('Error') == 'MCChallengeRequired':
+            extendedresponse = pair.get('ExtendedResponse')
+            if extendedresponse is not None:
+                pairingchallenge = extendedresponse.get('PairingChallenge')
+                signed_response = PKCS7SignatureBuilder().set_data(pairingchallenge).add_signer(
+                    decrypted_p12.cert.certificate, decrypted_p12.key, hashes.SHA256()).sign(Encoding.DER, [])
+                pair_options = {'PairRecord': pair_record, 'ProtocolVersion': '2', 'PairingOptions': {
+                    'ChallengeResponse': signed_response, 'ExtendedPairingErrors': True}}
+                # second pair with Response to Challenge
+                pair = self._request_pair(pair_options, timeout=timeout)
+
+        pair_record['HostPrivateKey'] = private_key_pem
+        escrow_bag = pair.get('EscrowBag')
+
+        if escrow_bag is not None:
+            pair_record['EscrowBag'] = pair.get('EscrowBag')
+
+        self.pair_record = pair_record
+        self.save_pair_record()
+        self.paired = True
+
+    @_reconnect_on_remote_close
     def unpair(self, host_id: str = None) -> None:
         pair_record = self.pair_record if host_id is None else {'HostID': host_id}
         self._request('Unpair', {'PairRecord': pair_record, 'ProtocolVersion': '2'}, verify_request=False)
@@ -489,6 +550,9 @@ class LockdownClient(ABC, LockdownServiceProvider):
 
         error = response.get('Error')
         if error is not None:
+            # return response if supervisor cert challenge is required, to work with pair_supervisor
+            if(error) == 'MCChallengeRequired':
+                return response
             exception_errors = {'PasswordProtected': PasswordRequiredError,
                                 'PairingDialogResponsePending': PairingDialogResponsePendingError,
                                 'UserDeniedPairing': UserDeniedPairingError,

--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -13,7 +13,11 @@ from pathlib import Path
 from ssl import SSLZeroReturnError
 from typing import Dict, Mapping, Optional
 
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.hazmat.primitives.serialization.pkcs7 import PKCS7SignatureBuilder
+from cryptography.hazmat.primitives.serialization.pkcs12 import load_pkcs12
 from packaging.version import Version
 
 from pymobiledevice3 import usbmux
@@ -28,11 +32,6 @@ from pymobiledevice3.pair_records import create_pairing_records_cache_folder, ge
     get_preferred_pair_record
 from pymobiledevice3.service_connection import ServiceConnection
 from pymobiledevice3.usbmux import PlistMuxConnection
-
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.serialization import Encoding
-from cryptography.hazmat.primitives.serialization.pkcs7 import PKCS7SignatureBuilder
-from cryptography.hazmat.primitives.serialization.pkcs12 import load_pkcs12
 
 SYSTEM_BUID = '30142955-444094379208051516'
 


### PR DESCRIPTION
When devices are supervised they can only be paired with the superviser certificate.

The pairing is done with two pair requests, to work as a challenge/response:
- pair request with SupervisorCertificate public key to get the Challenge back
- pair request with the Response signed with private key of the SupervisorCertificate

This PR to add initial support for these supervised devices.

`$ python3 -m pymobiledevice3 lockdown pair-supervised supervisor.p12 supersecretpass`
