### PR TITLE
Filter <=iOS17 from start-tunnel, use --udid to trim queries on other devices

### DIFF
--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -14,6 +14,7 @@ from abc import ABC, abstractmethod
 from asyncio import CancelledError, StreamReader, StreamWriter
 from collections import namedtuple
 from contextlib import asynccontextmanager, suppress
+
 from packaging.version import Version
 
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider

--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -16,7 +16,6 @@ from collections import namedtuple
 from contextlib import asynccontextmanager, suppress
 from packaging.version import Version
 
-from pymobiledevice3.exceptions import InvalidServiceError
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.services.lockdown_service import LockdownService
 
@@ -815,6 +814,7 @@ class CoreDeviceTunnelService(RemotePairingProtocol, RemoteService):
         return self.service.send_request({
             'mangledTypeName': 'RemotePairing.ControlChannelMessageEnvelope', 'value': data})
 
+
 class RemotePairingTunnelService(RemotePairingProtocol):
     def __init__(self, remote_identifier: str, hostname: str, port: int) -> None:
         RemotePairingProtocol.__init__(self)
@@ -968,7 +968,8 @@ async def start_tunnel(
         raise Exception(f'Bad value for protocol_handler: {protocol_handler}')
 
 
-async def get_core_device_tunnel_services(bonjour_timeout: float = DEFAULT_BONJOUR_TIMEOUT,
+async def get_core_device_tunnel_services(
+        bonjour_timeout: float = DEFAULT_BONJOUR_TIMEOUT,
         udid: Optional[str] = None) -> List[CoreDeviceTunnelService]:
     result = []
     for rsd in await get_rsds(bonjour_timeout=bonjour_timeout, udid=udid):
@@ -985,7 +986,8 @@ async def get_core_device_tunnel_services(bonjour_timeout: float = DEFAULT_BONJO
     return result
 
 
-async def get_remote_pairing_tunnel_services(bonjour_timeout: float = DEFAULT_BONJOUR_TIMEOUT,
+async def get_remote_pairing_tunnel_services(
+        bonjour_timeout: float = DEFAULT_BONJOUR_TIMEOUT,
         udid: Optional[str] = None) -> List[RemotePairingTunnelService]:
     result = []
     for answer in await browse_remotepairing(timeout=bonjour_timeout):

--- a/pymobiledevice3/remote/utils.py
+++ b/pymobiledevice3/remote/utils.py
@@ -1,7 +1,7 @@
 import contextlib
 import platform
 import sys
-from typing import Generator, List
+from typing import Generator, List, Optional
 
 import psutil
 
@@ -12,7 +12,8 @@ from pymobiledevice3.remote.remote_service_discovery import RSD_PORT, RemoteServ
 REMOTED_PATH = '/usr/libexec/remoted'
 
 
-async def get_rsds(bonjour_timeout: float = DEFAULT_BONJOUR_TIMEOUT) -> List[RemoteServiceDiscoveryService]:
+async def get_rsds(bonjour_timeout: float = DEFAULT_BONJOUR_TIMEOUT, udid: Optional[str] = None) -> \
+        List[RemoteServiceDiscoveryService]:
     result = []
     with stop_remoted():
         for answer in await browse_remoted(timeout=bonjour_timeout):
@@ -24,7 +25,10 @@ async def get_rsds(bonjour_timeout: float = DEFAULT_BONJOUR_TIMEOUT) -> List[Rem
                     continue
                 except OSError:
                     continue
-                result.append(rsd)
+                if udid is None or rsd.udid == udid:
+                    result.append(rsd)
+                else:
+                    rsd.close()
     return result
 
 


### PR DESCRIPTION
Happy to take a second pass at this if you'd like something significantly different.

Once filtering out <=iOS17, the only reason I can see for InvalidServiceError on iOS17+ is that Apple really has removed it (or the developer image isn't mounted), either of which would be worth seeing as an error and continuing on with properly-configured devices. So I've jumped through some hoops to save the first such exception, and raise it only if all attached iOS17 devices fail on the same error.  I would understand if you didn't like that approach.

Thank you for your consideration.

====
Version <=17.x devices now filtered out from get_core_device_tunnel_services() UNLESS called with the --udid argument.   This allows the user to still force a connection attempt against any single device regardless of iOS version.  If iOS 16.8, for example, functions, then the version check can be lowered from 17.0. (no ios16.8 device available at the time of testing).

get_rsds() now takes an optional udid argument.  When specified, will only returns rsds that match.

For consistency, same done to get_remote_pairing_tunnel_services().

Various functions that call get_rsds() and get_remote_pairing_tunnel_services() and previously post-filtered on udid have had that filtering code removed.

rsd.close() and remotepairing.close() now called when "ip" is specified and does not match.  This seemed correct, but if this has undesired effects, needs to be reverted.