### PR TITLE
Allow finding recovery/DFU mode devices without usbmuxd present

### DIFF
--- a/pymobiledevice3/cli/restore.py
+++ b/pymobiledevice3/cli/restore.py
@@ -44,16 +44,20 @@ class Command(click.Command):
 
         ecid = value
         logger.debug('searching among connected devices via lockdownd')
-        for device in usbmux.list_devices():
-            try:
-                lockdown = create_using_usbmux(serial=device.serial, connection_type='USB')
-            except (ConnectionFailedError, ConnectionFailedToUsbmuxdError, IncorrectModeError):
-                continue
-            if (ecid is None) or (lockdown.ecid == value):
-                logger.debug('found device')
-                return lockdown
-            else:
-                continue
+        try:
+            for device in usbmux.list_devices():
+                try:
+                    lockdown = create_using_usbmux(serial=device.serial, connection_type='USB')
+                except (ConnectionFailedError, IncorrectModeError):
+                    continue
+                if (ecid is None) or (lockdown.ecid == value):
+                    logger.debug('found device')
+                    return lockdown
+                else:
+                    continue
+        except ConnectionFailedToUsbmuxdError:
+            pass
+
         logger.debug('waiting for device to be available in Recovery mode')
         return IRecv(ecid=ecid)
 

--- a/pymobiledevice3/cli/restore.py
+++ b/pymobiledevice3/cli/restore.py
@@ -11,7 +11,7 @@ from remotezip import RemoteZip
 
 from pymobiledevice3 import usbmux
 from pymobiledevice3.cli.cli_common import print_json, set_verbosity
-from pymobiledevice3.exceptions import ConnectionFailedError, IncorrectModeError
+from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionFailedToUsbmuxdError, IncorrectModeError
 from pymobiledevice3.irecv import IRecv
 from pymobiledevice3.lockdown import LockdownClient, create_using_usbmux
 from pymobiledevice3.restore.device import Device
@@ -47,7 +47,7 @@ class Command(click.Command):
         for device in usbmux.list_devices():
             try:
                 lockdown = create_using_usbmux(serial=device.serial, connection_type='USB')
-            except (ConnectionFailedError, IncorrectModeError):
+            except (ConnectionFailedError, ConnectionFailedToUsbmuxdError, IncorrectModeError):
                 continue
             if (ecid is None) or (lockdown.ecid == value):
                 logger.debug('found device')


### PR DESCRIPTION
`pymobiledevice3`'s `cli.restore.Command` class expects `usbmuxd` to always be running, but on some Linux systems `usbmuxd` is only running whenever an iOS device is connected in normal mode (via udev) by default. This PR allows for devices to be found in recovery/DFU mode regardless of if usbmuxd is available on the system, fixing this issue.