### PR TITLE
requirements: pyimg4 == 0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ wsproto
 nest_asyncio>=1.5.5
 Pillow
 inquirer3>=0.1.0
-pyimg4>=0.8
+pyimg4==0.8
 ipsw_parser>=1.1.2
 remotezip
 zeroconf


### PR DESCRIPTION
PyIMG4 0.8.2+ currently has a bug where it generates invalid kernelcaches, preventing a device from entering restore mode successfully. A temporary solution is to pin the PyIMG4 version used by 0.8 (0.8.1 was never pushed to PyPI).