### PR TITLE
requirements: remove pyimg4 & update ipsw-parser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ wsproto
 nest_asyncio>=1.5.5
 Pillow
 inquirer3>=0.1.0
-pyimg4==0.8
 ipsw_parser>=1.1.2
 remotezip
 zeroconf

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ wsproto
 nest_asyncio>=1.5.5
 Pillow
 inquirer3>=0.1.0
-ipsw_parser>=1.1.2
+ipsw_parser>=1.1.3
 remotezip
 zeroconf
 ifaddr


### PR DESCRIPTION
PyIMG4 hasn't been used by pymd3 since all IPSW-related code was exported to ipsw-parser. I am leaving this PR as a draft until https://github.com/doronz88/ipsw_parser/pull/16 is merged & an update for ipsw-parser has been pushed.