### PR TITLE
ci: update python-app workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,11 +20,14 @@ jobs:
       matrix:
         python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        # Python <3.10 not available for macos-latest (macos-14-arm64)
+        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
         exclude:
-          - os: macos-latest
-            python-version: 3.8
-          - os: macos-latest
-            python-version: 3.9
+          - { python-version: 3.8, os: macos-latest }
+          - { python-version: 3.9, os: macos-latest }
+        include:
+          - { python-version: 3.8, os: macos-13 }
+          - { python-version: 3.9, os: macos-13 }
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Use macos-13 runner for python 3.8 & 3.9.

Re: https://github.com/actions/setup-python/issues/696#issuecomment-1637587760.

I've referenced https://github.com/python/peps/pull/3763.  The 3.8 and 3.9 checks on macos-13 appear at the end. Workflow can be modified to keep all 3.8 and 3.9 checks together.

Any preferences?



