### PR TITLE
syslog live cli: Updates to regex search and no colour output to file

### DIFF
--- a/pymobiledevice3/cli/syslog.py
+++ b/pymobiledevice3/cli/syslog.py
@@ -138,7 +138,7 @@ def syslog_live(service_provider: LockdownClient, out, pid, process_name, match,
         if match_regex:
             skip = True
             for r in match_regex:
-                if not r.findall(line):
+                if not r.findall(line_no_style):
                     continue
                 line = re.sub(r, replace, line)
                 skip = False

--- a/pymobiledevice3/cli/syslog.py
+++ b/pymobiledevice3/cli/syslog.py
@@ -105,6 +105,7 @@ def syslog_live(service_provider: LockdownClient, out, pid, process_name, match,
             if posixpath.basename(syslog_entry.filename) != process_name:
                 continue
 
+        line_no_style = format_line(False, pid, syslog_entry, include_label)
         line = format_line(user_requested_colored_output(), pid, syslog_entry, include_label)
 
         skip = False
@@ -148,7 +149,10 @@ def syslog_live(service_provider: LockdownClient, out, pid, process_name, match,
         print(line, flush=True)
 
         if out:
-            print(line, file=out, flush=True)
+            if user_requested_colored_output():
+                print(line, file=out, flush=True)
+            else:
+                print(line_no_style, file=out, flush=True)
 
 
 @syslog.command('collect', cls=Command)


### PR DESCRIPTION
Before I get into it, the syslog live command is a hidden gem, thank you!

This PR is addressing two things I think are bugs.  For the first one, maybe I’m not aware of some useful log viewing tools where color output is beneficial?

1. print unstyled line to file when using regex options with `--no-color` option.  Left console output alone since the regex styling is a nice touch.
    * Example : `pymobiledevice3 syslog live -ei "backboardd{corebrightness}" -o "$HOME/syslog_live_debug.txt" --no-color` 
    * before
        1. `2024-04-25 23:54:48.918659 [1m[4mbackboardd{CoreBrightness}[0m[65] <DEBUG>: [2]: ALSIntegrationMode`
    * after
        1. `2024-04-25 23:58:28.923438 backboardd{CoreBrightness}[65] <DEBUG>: [2]: ALSIntegrationMode`
2. Run regex on unstyled string. It wasn't immediately clear to pass `--no-color` in combination with regex options.  
    * Change is a little dangerous as it's breaking existing behaviour when color is enabled. 

Below examples are based on existing behaviour for 2nd point:
* no match
    * `pymobiledevice3 syslog live -ei "backboardd{corebrightness}"`
* match
    * `pymobiledevice3 syslog live -ei "backboardd.?\[0m{.?\[35mcorebrightness.?\[0m}"`
    * `pymobiledevice3 syslog live -ei "backboardd.*?{.*?corebrightness.*?}"`
    * `pymobiledevice3 syslog live -ei "backboardd{corebrightness}" --no-color`