### PR TITLE
bonjour: skip browsing on tunnel interfaces

### DIFF
--- a/pymobiledevice3/bonjour.py
+++ b/pymobiledevice3/bonjour.py
@@ -103,6 +103,9 @@ async def browse_ipv6(service_names: List[str], timeout: float = DEFAULT_BONJOUR
 def get_ipv4_addresses() -> List[str]:
     ips = []
     for adapter in get_adapters():
+        if adapter.nice_name.startswith('tun'):
+            # skip browsing on already established tunnels
+            continue
         for ip in adapter.ips:
             if ip.ip == '127.0.0.1':
                 continue

--- a/pymobiledevice3/osu/posix_util.py
+++ b/pymobiledevice3/osu/posix_util.py
@@ -35,7 +35,7 @@ class Posix(OsUtils):
 
     def get_ipv6_ips(self) -> List[str]:
         return [f'{adapter.ips[0].ip[0]}%{adapter.nice_name}' for adapter in get_adapters() if
-                adapter.ips[0].is_IPv6]
+                adapter.ips[0].is_IPv6 and not adapter.nice_name.startswith('tun')]
 
     def chown_to_non_sudo_if_needed(self, path: Path) -> None:
         if os.getenv('SUDO_UID') is None:


### PR DESCRIPTION
this is a working solution fixing issue https://github.com/doronz88/pymobiledevice3/issues/966
which makes tunnel task creation to timeout , which causes fastapi to timeout as well for 2minutes straight in a loop.