### PR TITLE
cli: sysdiagnose allow directory path

### DIFF
--- a/pymobiledevice3/cli/crash.py
+++ b/pymobiledevice3/cli/crash.py
@@ -71,7 +71,7 @@ def crash_mover_watch(service_provider: LockdownClient, name, raw):
 
 
 @crash.command('sysdiagnose', cls=Command)
-@click.argument('out', type=click.Path(exists=False, dir_okay=False, file_okay=True))
+@click.argument('out', type=click.Path(exists=False, dir_okay=True, file_okay=True))
 @click.option('-e', '--erase', is_flag=True, help='erase file after pulling')
 @click.option('-t', '--timeout', default=None, show_default=True, type=click.FLOAT,
               help='Maximum time in seconds to wait for the completion of sysdiagnose archive')


### PR DESCRIPTION
`CrashReportsManager.get_new_sysdiagnose` allows a directory output. I think the equivalent CLI command should allow that as well.

Tested passing dir and file path.
![Screenshot 2024-04-27 at 11 50 27 PM](https://github.com/doronz88/pymobiledevice3/assets/45926479/b0f15e58-7636-484e-98ef-3ab7ddd4f4e0)
![Screenshot 2024-04-27 at 11 50 38 PM](https://github.com/doronz88/pymobiledevice3/assets/45926479/9086eb6f-8ca9-4ccf-a55a-3cacf426fdd1)
