### PR TITLE
tests: add cli unit-tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,32 +43,6 @@ jobs:
       - name: Test install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -U .
+          python -m pip install -U '.[test]'
       - name: Test show usage
-        run: |
-          python -m pymobiledevice3 --help
-          python -m pymobiledevice3 activation --help
-          python -m pymobiledevice3 afc --help
-          python -m pymobiledevice3 amfi --help
-          python -m pymobiledevice3 apps --help
-          python -m pymobiledevice3 backup2 --help
-          python -m pymobiledevice3 bonjour --help
-          python -m pymobiledevice3 companion --help
-          python -m pymobiledevice3 crash --help
-          python -m pymobiledevice3 developer --help
-          python -m pymobiledevice3 diagnostics --help
-          python -m pymobiledevice3 lockdown --help
-          python -m pymobiledevice3 mounter --help
-          python -m pymobiledevice3 notification --help
-          python -m pymobiledevice3 pcap --help
-          python -m pymobiledevice3 power-assertion --help
-          python -m pymobiledevice3 processes --help
-          python -m pymobiledevice3 profile --help
-          python -m pymobiledevice3 provision --help
-          python -m pymobiledevice3 remote --help
-          python -m pymobiledevice3 restore --help
-          python -m pymobiledevice3 springboard --help
-          python -m pymobiledevice3 syslog --help
-          python -m pymobiledevice3 usbmux --help
-          python -m pymobiledevice3 webinspector --help
-          python -m pymobiledevice3 version --help
+        run: pytest -m cli

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 filterwarnings =
     error
     error::ResourceWarning
+markers =
+    cli: tests for cli interface

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,0 +1,31 @@
+import shlex
+import subprocess
+
+import pytest
+from click.testing import CliRunner
+
+from pymobiledevice3 import __main__
+
+pytestmark = [pytest.mark.cli]
+
+
+def test_cli_main_interface():
+    runner = CliRunner()
+    r1 = runner.invoke(__main__.cli, ['--help'])
+    assert r1.exit_code == 0
+
+    r2 = runner.invoke(__main__.cli)
+    assert r2.exit_code == 0
+
+
+@pytest.mark.parametrize('group', __main__.CLI_GROUPS.keys())
+def test_cli_groups(group):
+    runner = CliRunner()
+    group_help_result = runner.invoke(__main__.cli, [group, '--help'])
+    assert group_help_result.exit_code == 0
+
+
+@pytest.mark.parametrize('group', __main__.CLI_GROUPS.keys())
+def test_cli_from_python_m_flag(group):
+    cmd = shlex.split(f'python -m pymobiledevice3 {group} --help')
+    subprocess.run(cmd, check=True)


### PR DESCRIPTION
Was doing some other work with CLI an noticed an improvement for unit-test coverage.

Any new groups would automatically be picked up without having to update the workflow.