### PR TITLE
Use sysdiagnose notification for tarball readiness

### DIFF
--- a/tests/services/test_crash_reports.py
+++ b/tests/services/test_crash_reports.py
@@ -75,19 +75,6 @@ def test_pull(crash_manager, delete_test_dir):
 
 
 @pytest.mark.parametrize(
-    ('message', 'return_value'),
-    (
-            ('sysdiagnose (full) complete', True),
-            ('Sysdiagnose completed. File path: /foo/bar.tar.gz', True),
-            ('sysdiagnose', False),
-            ('', False),
-    )
-)
-def test_sysdiagnose_syslog_message_match_return_value(message, return_value):
-    assert CrashReportsManager._sysdiagnose_complete_syslog_match(message) is return_value
-
-
-@pytest.mark.parametrize(
     ('end_time', 'return_value'),
     ((-1, True), (0, True), (time.monotonic() + 1000, False), (None, False))
 )


### PR DESCRIPTION
On some iPhones, especially after multiple sysdiagnose collections, the sysdiagnose process stops outputting to syslog.  This behaviour is highly reproducible on iOS16 devices. I've only seen this on three iOS17 devices.

It's beyond my skills to root cause and I would need help to dig deeper.

Some observations:
  * Behaviour is consistent with each trigger method, volume button and accessibility icon.
  * The sysdiagnose process log cut-off is suspiciously close to the analytics toast message appearance on the iPhone.
  * A device reboot may help, but only for 1-2 sysdiagnose collect events.
---

I considered two options to fix the symptom, ***open to suggestions***
1. Attempt pull if file exists after timeout (current decision).
2. Change the search strategy.  Assume the tarball is ready to pull when the file size stops changing.  This is ~3-4s after sysdiagnose complete message in syslog, or the analytics toast message. This worked well on the devices I used for testing, but it's a more invasive change.  Not too elegant either.
    * Wait for file to exist
    * loop until the file reaches a stable size for X iterations

---

Below are two examples of sysdiagnose process logs stopping in syslog. Capture command: 
`pymobiledevice3 syslog live --no-color -o "..." -ei "sysdiagnose"`

## iOS17
"ProductType": "iPhone15,4", "ProductVersion": "17.4.1"

[syslog_sysdiag_ios17_04.txt](https://github.com/doronz88/pymobiledevice3/files/15329118/syslog_sysdiag_ios17_04.txt)

```shell
(pymob3) pymobiledevice3 $ pymobiledevice3 crash sysdiagnose -v -t 180 $TMPDIR
Press Power+VolUp+VolDown for 0.215 seconds
2024-05-15 20:10:35 macbook pymobiledevice3.services.crash_reports[88690] DEBUG Detected in progress sysdiagnose IN_PROGRESS_sysdiagnose_2024.05.15_20-10-35-0400_iPhone-OS_iPhone_21E236.tmp
2024-05-15 20:10:35 macbook pymobiledevice3.services.crash_reports[88690] INFO sysdiagnose tarball creation has been started
2024-05-15 20:13:32 macbook pymobiledevice3.services.crash_reports[88690] DEBUG Timeout waiting for sysdiagnose complete syslog entry, but file exists. Attempt pull.
```


## iOS16
"ProductType": "iPhone10,4", "ProductVersion": "16.5"

[syslog_sysdiag_ios16_03.txt](https://github.com/doronz88/pymobiledevice3/files/15329116/syslog_sysdiag_ios16_03.txt)

```shell
(pymob3) pymobiledevice3 $ pymobiledevice3 crash sysdiagnose -v -t 180 $TMPDIR
Press Power+VolUp+VolDown for 0.215 seconds
2024-05-15 20:04:39 macbook pymobiledevice3.services.crash_reports[88497] DEBUG Detected in progress sysdiagnose IN_PROGRESS_sysdiagnose_2024.05.15_20-04-38-0400_iPhone-OS_iPhone_20F66.tmp
2024-05-15 20:04:39 macbook pymobiledevice3.services.crash_reports[88497] INFO sysdiagnose tarball creation has been started
2024-05-15 20:07:33 macbook pymobiledevice3.services.crash_reports[88497] DEBUG Timeout waiting for sysdiagnose complete syslog entry, but file exists. Attempt pull.
```