### PR TITLE
pcap: use `python-pcapng` to generate metadata for each packet

### DIFF
--- a/pymobiledevice3/services/pcapd.py
+++ b/pymobiledevice3/services/pcapd.py
@@ -2,10 +2,11 @@
 
 import enum
 import socket
-import struct
 from typing import Generator, Optional
 
+import pcapng.blocks as blocks
 from construct import Byte, Bytes, Container, CString, Int16ub, Int32ub, Int32ul, Padded, Seek, Struct, this
+from pcapng import FileWriter
 
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
@@ -294,8 +295,6 @@ typedef struct pcaprec_hdr_s {
 LINKTYPE_ETHERNET = 1
 LINKTYPE_RAW = 101
 
-PCAP_HEADER = struct.pack('<LHHLLLL', 0xa1b2c3d4, 2, 4, 0, 0, 65535, LINKTYPE_ETHERNET)
-PACKET_HEADER = '<LLLL'
 ETHERNET_HEADER = b'\xBE\xEF' * 6 + b'\x08\x00'
 
 device_packet_struct = Struct(
@@ -367,11 +366,29 @@ class PcapdService(LockdownService):
 
             packet_index += 1
 
-    @staticmethod
-    def write_to_pcap(out, packet_generator):
-        out.write(PCAP_HEADER)
+    def write_to_pcap(self, out, packet_generator) -> None:
+        shb = blocks.SectionHeader(
+            options={
+                'shb_hardware': 'artificial',
+                'shb_os': 'iOS',
+                'shb_userappl': 'pymobiledevice3',
+            }
+        )
+        shb.new_member(
+            blocks.InterfaceDescription,
+            link_type=1,
+            options={
+                'if_description': 'iOS Packet Capture',
+                'if_os': f'iOS {self.lockdown.product_version}'
+            },
+        )
+        writer = FileWriter(out, shb)
+
         for packet in packet_generator:
-            length = len(packet.data)
-            pkthdr = struct.pack(PACKET_HEADER, packet.seconds, packet.microseconds, length, length)
-            data = pkthdr + packet.data
-            out.write(data)
+            enhanced_packet = shb.new_member(blocks.EnhancedPacket, options={
+                'opt_comment': f'PID: {packet.pid}, ProcName: {packet.comm}, EPID: {packet.epid}, '
+                               f'EProcName: {packet.ecomm}, SVC: {packet.svc}'
+            })
+
+            enhanced_packet.packet_data = packet.data
+            writer.write_block(enhanced_packet)

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ pytun-pmd3>=2.0.5
 aiofiles
 prompt_toolkit
 sslpsk-pmd3>=1.0.3
+python-pcapng>=2.1.1
 
 # TODO: temporary workaround until python-editor, sub-dep of inquirer3, is 3.12 friendly
 # https://github.com/python/cpython/issues/92584


### PR DESCRIPTION
Update pymobiledevice3/services/pcapd.py to use python-pcapng library for writing pcap output. This is for pcapng support, which allows frame comments to be added on each packet. 

In the frame comments, I added the process ID, process name, E Process ID, E Process Name, and SVC to the frame comment. This significantly enhances investigation of network traffic captured via pcap in various tools.

 This is what now appears for each packet when viewed in Wireshark:
![pcapng_comment](https://github.com/doronz88/pymobiledevice3/assets/96144967/637fa7a7-00f7-46d6-9363-4d67573073c0)

Also removed code that constructed PCAP file header and other PCAP file generation code, as its now being handled by python-pcapng

Also updated requirements.txt to pull python-pcapng>=2.1.1 .