### PR TITLE
Requirements: temporarily add setuptools dependency for py>=312

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,7 @@ pytun-pmd3>=2.0.5
 aiofiles
 prompt_toolkit
 sslpsk-pmd3>=1.0.3
+
+# TODO: temporary workaround until python-editor, sub-dep of inquirer3, is 3.12 friendly
+# https://github.com/python/cpython/issues/92584
+setuptools>=66.1; python_version >= '3.12'


### PR DESCRIPTION
For those who take the blue pill, this fixes the recent workflow failures and python 3.12 compatibility.

---

For those who are brave enough to take the red pill, let's take a trip down the rabbit hole.

## Problem
Recent failures in workflow runs.
```
  File "/home/runner/work/pymobiledevice3/pymobiledevice3/pymobiledevice3/__main__.py", line 167, in <module>
    main()
...
  File "/home/runner/work/pymobiledevice3/pymobiledevice3/pymobiledevice3/cli/amfi.py", line 5, in <module>
    from pymobiledevice3.cli.cli_common import Command, print_json
  File "/home/runner/work/pymobiledevice3/pymobiledevice3/pymobiledevice3/cli/cli_common.py", line 12, in <module>
    import inquirer3
...
  File "/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/inquirer3/render/console/__init__.py", line 11, in <module>
    from inquirer3.render.console._editor import Editor
  File "/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/inquirer3/render/console/_editor.py", line 1, in <module>
    import editor
  File "/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/editor.py", line 11, in <module>
    from distutils.spawn import find_executable
ModuleNotFoundError: No module named 'distutils'
```

This also affects local use and not just limited to CI.
```
python3.12 -m venv venv
source venv/bin/activate
pip install '.[test]'
python -m pymobiledevice3
```

## Debugging
Comparing venvs
working: https://github.com/doronz88/pymobiledevice3/actions/runs/9107543130/job/25036614685
not working: https://github.com/doronz88/pymobiledevice3/actions/runs/9130844502/job/25108700098

| Package         | Working Version        | Non-Working Version        |
|-----------------|------------------------|----------------------------|
| readchar        | 4.0.6                  | 4.1.0                      |
| setuptools      | 69.5.1                 | Not listed                 |

readchar 4.1.0 moved from setup.cfg to pyproject.toml. In doing so, also dropped setuptools from install requirements.
https://github.com/magmax/python-readchar/compare/v4.0.6...v4.1.0#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L41

This exposed an issue with a sub-dependency of `inquirer3`, `python-editor`. A fix was pushed to `python-editor` mainline 7 months ago, but not released yet.  https://github.com/fmoo/python-editor/pull/39

Testing:
* https://github.com/StephenGemin/pymobiledevice3/pull/5

## Solution
Both are temporary workarounds
1.  `setuptools>=66.1` for py>=312
    * * https://github.com/pypa/setuptools/blob/main/NEWS.rst#v6610
3. `readchar<4.1`
