### PR TITLE
requirements: use `inquirer3>=0.6.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ starlette
 wsproto
 nest_asyncio>=1.5.5
 Pillow
-inquirer3>=0.1.0
+inquirer3>=0.6.0
 ipsw_parser>=1.2.3
 remotezip
 zeroconf
@@ -41,7 +41,3 @@ aiofiles
 prompt_toolkit
 sslpsk-pmd3>=1.0.3
 python-pcapng>=2.1.1
-
-# TODO: temporary workaround until python-editor, sub-dep of inquirer3, is 3.12 friendly
-# https://github.com/python/cpython/issues/92584
-setuptools>=66.1; python_version >= '3.12'


### PR DESCRIPTION
avoid bug occuring on lower versions of inquirer3 in python3.12