### PR TITLE
cli: lockdown: add short option to `info` command

### DIFF
--- a/pymobiledevice3/cli/lockdown.py
+++ b/pymobiledevice3/cli/lockdown.py
@@ -48,9 +48,13 @@ def lockdown_developer_service(service_provider: LockdownServiceProvider, servic
 
 
 @lockdown_group.command('info', cls=Command)
-def lockdown_info(service_provider: LockdownServiceProvider):
+@click.option('-s', '--short-info', is_flag=True, default=False, help='short info for lockdown service')
+def lockdown_info(service_provider: LockdownServiceProvider, short_info: bool) -> None:
     """ query all lockdown values """
-    print_json(service_provider.all_values)
+    if short_info:
+        print_json(service_provider.short_info)
+    else:
+        print_json(service_provider.all_values)
 
 
 @lockdown_group.command('get', cls=Command)


### PR DESCRIPTION
QOL improvement. Expose the `short_info` property from `LockdownClient`.

I can't speak for everyone, but I usually need just this information when using this command.

![Screenshot 2024-05-19 at 10 14 52 PM](https://github.com/doronz88/pymobiledevice3/assets/45926479/6204ad96-86c7-4c58-aa45-2d59258bda95)