### PR TITLE
common: fix `get_home_folder()` to always return the non-sudo homedir

### DIFF
--- a/pymobiledevice3/common.py
+++ b/pymobiledevice3/common.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-_HOMEFOLDER = Path.home() / '.pymobiledevice3'
+from pymobiledevice3.osu.os_utils import get_os_utils
+
+_HOMEFOLDER = get_os_utils().get_homedir() / '.pymobiledevice3'
 
 
 def get_home_folder() -> Path:

--- a/pymobiledevice3/osu/os_utils.py
+++ b/pymobiledevice3/osu/os_utils.py
@@ -76,6 +76,9 @@ class OsUtils:
     def wait_return(self):
         raise FeatureNotSupportedError(self._os_name, inspect.currentframe().f_code.co_name)
 
+    def get_homedir(self) -> Path:
+        return Path.home()
+
 
 def get_os_utils() -> OsUtils:
     return OsUtils.create()

--- a/pymobiledevice3/osu/posix_util.py
+++ b/pymobiledevice3/osu/posix_util.py
@@ -83,6 +83,9 @@ class Linux(Posix):
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, interval_sec)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, max_fails)
 
+    def get_homedir(self) -> Path:
+        return Path('~' + os.environ.get('SUDO_USER', ''))
+
 
 class Cygwin(Posix):
     @property


### PR DESCRIPTION
The linux's `sudo` makes `Path.home()` return the root user's homedir, while the darwin's return the non-sudo's