### PR TITLE
Update network_monitor.py to fix ConnectionUpdateEvent struct

### DIFF
--- a/pymobiledevice3/services/dvt/instruments/network_monitor.py
+++ b/pymobiledevice3/services/dvt/instruments/network_monitor.py
@@ -55,6 +55,7 @@ class ConnectionDetectionEvent:
 class ConnectionUpdateEvent:
     rx_packets: int
     rx_bytes: int
+    tx_packets: int
     tx_bytes: int
     rx_dups: int
     rx000: int
@@ -62,8 +63,7 @@ class ConnectionUpdateEvent:
     min_rtt: int
     avg_rtt: int
     connection_serial: int
-    unknown0: int
-    unknown1: int
+    time: int
 
 
 class NetworkMonitor:


### PR DESCRIPTION
After:
ConnectionUpdateEvent(rx_packets=36571, rx_bytes=243753121, tx_packets=1, tx_bytes=389, rx_dups=187115, rx000=1131949, tx_retx=0, min_rtt=0.115125, avg_rtt=0.115125, connection_serial=7, time=-1) ConnectionUpdateEvent(rx_packets=67, rx_bytes=67, tx_packets=2, tx_bytes=8507, rx_dups=67, rx000=0, tx_retx=0, min_rtt=0.04309375, avg_rtt=0.04309375, connection_serial=6,  time=-1)
ConnectionUpdateEvent(rx_packets=69, rx_bytes=270, tx_packets=5, tx_bytes=13839, rx_dups=66, rx000=0, tx_retx=0, min_rtt=0.042, avg_rtt=0.042, connection_serial=5, time=-1)ConnectionUpdateEvent(rx_packets=4, rx_bytes=205, tx_packets=4, tx_bytes=13839, rx_dups=1, rx000=0, tx_retx=0, min_rtt=0.04228125, avg_rtt=0.04228125, connection_serial=4,  time=-1)
ConnectionUpdateEvent(rx_packets=1, rx_bytes=1, tx_packets=2, tx_bytes=8507, rx_dups=1, rx000=0, tx_retx=0, min_rtt=0.04196875, avg_rtt=0.04196875, connection_serial=3, time=-1) ConnectionUpdateEvent(rx_packets=3, rx_bytes=204, tx_packets=3, tx_bytes=13813, rx_dups=0, rx000=0, tx_retx=0, min_rtt=0.0370625, avg_rtt=0.0370625, connection_serial=2, time=-1) ConnectionUpdateEvent(rx_packets=3, rx_bytes=924, tx_packets=6, tx_bytes=7008, rx_dups=0, rx000=0, tx_retx=0, min_rtt=0.0386875, avg_rtt=0.0386875, connection_serial=1, time=-1)