### PR TITLE
Set the mtime for generated files by afcservice

### DIFF
--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -234,6 +234,7 @@ class AfcService(LockdownService):
                 dst = os.path.join(dst, os.path.basename(relative_src))
             with open(dst, 'wb') as f:
                 f.write(self.get_file_contents(src))
+            os.utime(dst, (os.stat(dst).st_atime, self.stat(src)['st_mtime'].timestamp()))
         else:
             # directory
             dst_path = pathlib.Path(dst) / os.path.basename(relative_src)


### PR DESCRIPTION
After using the "afc pull" command, the mtime (modified time) of the original file is copied to the destination file using "utime".
It would also be possible to change the atime, but this value isn't passed over by the afc service.
