### PR TITLE
cli: standalone scripts do not override cli coloredlogs

### DIFF
--- a/misc/remotexpc_sniffer.py
+++ b/misc/remotexpc_sniffer.py
@@ -18,8 +18,6 @@ from pymobiledevice3.remote.xpc_message import XpcWrapper, decode_xpc_object
 
 logger = logging.getLogger()
 
-coloredlogs.install(level=logging.DEBUG)
-
 FRAME_HEADER_SIZE = 9
 
 
@@ -204,4 +202,5 @@ def live(iface: str):
 
 
 if __name__ == '__main__':
+    coloredlogs.install(level=logging.DEBUG)
     cli()

--- a/pymobiledevice3/resources/dsc_uuid_map.py
+++ b/pymobiledevice3/resources/dsc_uuid_map.py
@@ -6,8 +6,6 @@ from uuid import UUID
 import click
 import coloredlogs
 
-coloredlogs.install(level=logging.DEBUG)
-
 MAGIC = b'\x0b\x10\x00\x00'
 DYLD_MAGIC = b'dyld_v1'
 MAP_FILENAME = os.path.join(os.path.dirname(__file__), 'dsc_uuid_map.json')
@@ -99,4 +97,5 @@ def main(dsc, dyld_uuid, force):
 
 
 if __name__ == '__main__':
+    coloredlogs.install(level=logging.DEBUG)
     main()

--- a/pymobiledevice3/resources/firmware_notifications.py
+++ b/pymobiledevice3/resources/firmware_notifications.py
@@ -8,8 +8,6 @@ import coloredlogs
 
 NOTIFICATIONS_FILENAME = os.path.join(os.path.dirname(__file__), 'notifications.txt')
 
-coloredlogs.install(level=logging.DEBUG)
-
 
 def get_notifications():
     with open(NOTIFICATIONS_FILENAME, 'rb') as f:
@@ -60,4 +58,5 @@ def main(root_fs):
 
 
 if __name__ == '__main__':
+    coloredlogs.install(level=logging.DEBUG)
     main()


### PR DESCRIPTION
importing from any of these three modules overrides the coloredlogs.install from `__main__.py`.

Only install colored logs when running these modules as standalone scripts.