### PR TITLE
service_connection: increase default timeout for tcp connections

### DIFF
--- a/pymobiledevice3/cli/developer.py
+++ b/pymobiledevice3/cli/developer.py
@@ -207,9 +207,11 @@ def launch(service_provider: LockdownClient, arguments: str, kill_existing: bool
                                      environment=dict(env))
         print(f'Process launched with pid {pid}')
         while stream:
-            for output_received in process_control:
-                logging.getLogger(f'PID:{output_received.pid}').info(output_received.message.strip())
-
+            try:
+                for output_received in process_control:
+                    logging.getLogger(f'PID:{output_received.pid}').info(output_received.message.strip())
+            except OSError:
+                break
 
 @dvt.command('shell', cls=Command)
 def dvt_shell(service_provider: LockdownClient):

--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -19,7 +19,7 @@ from pymobiledevice3.usbmux import MuxDevice, select_device
 DEFAULT_AFTER_IDLE_SEC = 3
 DEFAULT_INTERVAL_SEC = 3
 DEFAULT_MAX_FAILS = 3
-DEFAULT_TIMEOUT = 1
+DEFAULT_TIMEOUT = 1.5
 OSUTIL = get_os_utils()
 SHELL_USAGE = """
 # This shell allows you to communicate directly with every service layer behind the lockdownd daemon.


### PR DESCRIPTION
With the recent addition of a default timeout for all socket connections (bb80cfb89b31da6ecc540a45da2bf789478cd931), launching an app can raise a socket timeout error for iOS17. It takes longer than one second to wait for a response when using the "--stream" flag.

Since the timeout is a recent addition, I decided to increase the default value. Alternatively, I could provide a way to pass the timeout value to `ServiceConnection.create_using_tcp` where needed.

# With 2s default
```shell
(pymob3) ➜  pymobiledevice3 git:(bugfix/socket-default-timeout) ✗ pymobiledevice3 developer dvt launch com.facebook.WebDriverAgentRunner --stream
2024-06-22 20:59:44:976 macbook pymobiledevice3.__main__[77320] WARNING Got an InvalidServiceError. Trying again over tunneld since it is a developer command
Process launched with pid 2295
2024-06-22 20:59:46:932 macbook root[77320] INFO launched app
2024-06-22 20:59:48:247 macbook PID:2295[77320] INFO Test Suite 'All tests' started at 2024-06-22 20:59:48.344.
# --> ~1.3s

2024-06-22 20:59:48:247 macbook PID:2295[77320] INFO Test Suite 'WebDriverAgentRunner.xctest' started at 2024-06-22 20:59:48.344.
Test Suite 'UITestingUITests' started at 2024-06-22 20:59:48.344.
    t =      nans Suite Set Up
2024-06-22 20:59:48:274 macbook PID:2295[77320] INFO Test Case '-[UITestingUITests testRunner]' started.
2024-06-22 20:59:48:276 macbook PID:2295[77320] INFO t =     0.00s Start Test at 2024-06-22 20:59:48.373
2024-06-22 20:59:48:346 macbook PID:2295[77320] INFO t =     0.07s Set Up
2024-06-22 20:59:48:347 macbook PID:2295[77320] INFO 2024-06-22 20:59:48.443 WebDriverAgentRunner-Runner[2295:2318325] Built at Jun  1 2024 21:00:05
2024-06-22 20:59:48:368 macbook PID:2295[77320] INFO 2024-06-22 20:59:48.463 WebDriverAgentRunner-Runner[2295:2318325] ServerURLHere->http://192.168.2.69:8100<-ServerURLHere
```

# with 1s default
```shell
(pymob3) ➜  pymobiledevice3 git:(master) pymobiledevice3 developer dvt launch com.facebook.WebDriverAgentRunner --stream
2024-06-22 20:54:42 macbook pymobiledevice3.__main__[76759] WARNING Got an InvalidServiceError. Trying again over tunneld since it is a developer command
Process launched with pid 2292
Traceback (most recent call last):
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/__main__.py", line 100, in main
    cli()
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/cli/cli_common.py", line 147, in wrap_callback_calling
    callback(service_provider=service_provider, **kwargs)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/cli/developer.py", line 202, in launch
    with DvtSecureSocketProxyService(lockdown=service_provider) as dvt:
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/services/dvt/dvt_secure_socket_proxy.py", line 24, in __init__
    super().__init__(lockdown, service_name, remove_ssl_context=remove_ssl_context)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/services/remote_server.py", line 362, in __init__
    super().__init__(lockdown, service_name, is_developer_service=is_developer_service)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/services/lockdown_service.py", line 20, in __init__
    service = start_service(service_name, include_escrow_bag=include_escrow_bag)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/lockdown_service_provider.py", line 47, in start_lockdown_developer_service
    return self.start_lockdown_service(name, include_escrow_bag=include_escrow_bag)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/lockdown.py", line 67, in _inner_reconnect_on_remote_close
    return f(*args, **kwargs)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/lockdown.py", line 499, in start_lockdown_service
    attr = self.get_service_connection_attributes(name, include_escrow_bag=include_escrow_bag)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/lockdown.py", line 489, in get_service_connection_attributes
    response = self._request('StartService', options)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/lockdown.py", line 577, in _request
    raise exception_errors.get(error, LockdownError)(error, self.identifier)
pymobiledevice3.exceptions.InvalidServiceError: InvalidService

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/services/remote_server.py", line 466, in _recv_packet_fragments
    message = self.channel_messages[channel].get()
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/services/remote_server.py", line 294, in get
    return self._messages.get_nowait()
  File "/Users/stephen/.pyenv/versions/3.9.17/lib/python3.9/queue.py", line 199, in get_nowait
    return self.get(block=False)
  File "/Users/stephen/.pyenv/versions/3.9.17/lib/python3.9/queue.py", line 168, in get
    raise Empty
_queue.Empty

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/stephen/.pyenv/versions/pymob3/bin/pymobiledevice3", line 8, in <module>
    sys.exit(main())
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/__main__.py", line 145, in main
    return main()
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/__main__.py", line 100, in main
    cli()
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/stephen/.pyenv/versions/3.9.17/envs/pymob3/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/cli/cli_common.py", line 147, in wrap_callback_calling
    callback(service_provider=service_provider, **kwargs)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/cli/developer.py", line 210, in launch
    for output_received in process_control:
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/services/dvt/instruments/process_control.py", line 77, in __iter__
    key, value = self._channel.receive_key_value()
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/services/remote_server.py", line 258, in receive_key_value
    return self._service.recv_plist(self)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/services/remote_server.py", line 435, in recv_plist
    data, aux = self.recv_message(channel)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/services/remote_server.py", line 447, in recv_message
    packet_stream = self._recv_packet_fragments(channel)
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/services/remote_server.py", line 471, in _recv_packet_fragments
    data = self.service.recvall(dtx_message_header_struct.sizeof())
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/service_connection.py", line 137, in recvall
    chunk = self.recv(size - len(data))
  File "/Users/stephen/repos/public/StephenGemin/pymobiledevice3/pymobiledevice3/service_connection.py", line 118, in recv
    return self.socket.recv(length)
socket.timeout: timed out

```