### PR TITLE
service_connection: fix handling of the `timeout` option

### DIFF
--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -79,8 +79,9 @@ class ServiceConnection:
 
     @staticmethod
     def create_using_tcp(hostname: str, port: int, keep_alive: bool = True,
-                         timeout: int = DEFAULT_TIMEOUT) -> 'ServiceConnection':
-        sock = socket.create_connection((hostname, port), timeout=timeout)
+                         create_connection_timeout: int = DEFAULT_TIMEOUT) -> 'ServiceConnection':
+        sock = socket.create_connection((hostname, port), timeout=create_connection_timeout)
+        sock.settimeout(None)
         if keep_alive:
             OSUTIL.set_keepalive(sock)
         return ServiceConnection(sock)


### PR DESCRIPTION
Refactor it into `create_connection_timeout` option, so that it will only affect the TCP-handshake

Relates to issue reported in #1086