### PR TITLE
lockdown: async contextmanager for LockdownClient

### DIFF
--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -152,10 +152,16 @@ class LockdownClient(ABC, LockdownServiceProvider):
         return f'<{self.__class__.__name__} ID:{self.identifier} VERSION:{self.product_version} ' \
                f'TYPE:{self.product_type} PAIRED:{self.paired}>'
 
-    def __enter__(self):
+    def __enter__(self) -> 'LockdownClient':
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    async def __aenter__(self) -> 'LockdownClient':
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         self.close()
 
     @property


### PR DESCRIPTION
Quality of life improvement to be able to use async context manager regardless of the `LockdownServiceProvider`.

Example:
```python
async def get_service_provider(udid):
  service_provider = await async_get_tunneld_devices()
  # get RSD for udid
  if not service_provider:
     # most likely for <iOS17
     service_provider = create_using_usbmux(serial=udid)
  return service_provider

async def func(udid):
    service_provider = await get_service_provider(udid)
    async with service_provider as service:
        await auto_mount(service)
        # etc.
```