### PR TITLE
service_connection: use `OP_LEGACY_SERVER_CONNECT` for legacy iOS devices

### DIFF
--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -57,7 +57,7 @@ def create_context(certfile, keyfile=None):
         context.set_ciphers('ALL:!aNULL:!eNULL:@SECLEVEL=0')
     else:
         context.set_ciphers('ALL:!aNULL:!eNULL')
-    context.options |= 0x4 #OPENSSL OP_LEGACY_SERVER_CONNECT (required for legacy iOS devices)
+    context.options |= 0x4 # OPENSSL OP_LEGACY_SERVER_CONNECT (required for legacy iOS devices)
     context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE
     context.load_cert_chain(certfile, keyfile)

--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -57,7 +57,7 @@ def create_context(certfile, keyfile=None):
         context.set_ciphers('ALL:!aNULL:!eNULL:@SECLEVEL=0')
     else:
         context.set_ciphers('ALL:!aNULL:!eNULL')
-    context.options |= 0x4 # OPENSSL OP_LEGACY_SERVER_CONNECT (required for legacy iOS devices)
+    context.options |= 0x4  # OPENSSL OP_LEGACY_SERVER_CONNECT (required for legacy iOS devices)
     context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE
     context.load_cert_chain(certfile, keyfile)

--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -57,6 +57,7 @@ def create_context(certfile, keyfile=None):
         context.set_ciphers('ALL:!aNULL:!eNULL:@SECLEVEL=0')
     else:
         context.set_ciphers('ALL:!aNULL:!eNULL')
+    context.options |= 0x4
     context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE
     context.load_cert_chain(certfile, keyfile)

--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -57,7 +57,7 @@ def create_context(certfile, keyfile=None):
         context.set_ciphers('ALL:!aNULL:!eNULL:@SECLEVEL=0')
     else:
         context.set_ciphers('ALL:!aNULL:!eNULL')
-    context.options |= 0x4
+    context.options |= 0x4 #OPENSSL OP_LEGACY_SERVER_CONNECT (required for legacy iOS devices)
     context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE
     context.load_cert_chain(certfile, keyfile)


### PR DESCRIPTION
Allow legacy openssl handshake.
This allows connecting to legacy devices (AppleTV 3, older iPods) with the "OP_LEGACY_SERVER_CONNECT" flag set.