### PR TITLE
cli_common: add `PYMOBILEDEVICE3_TUNNEL` envvar

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -1,10 +1,12 @@
 import logging
+import os
 import sys
 import traceback
 
 import click
 import coloredlogs
 
+from pymobiledevice3.cli.cli_common import TUNNEL_ENV_VAR
 from pymobiledevice3.exceptions import AccessDeniedError, CloudConfigurationAlreadyPresentError, \
     ConnectionFailedToUsbmuxdError, DeprecationError, DeveloperModeError, DeveloperModeIsNotEnabledError, \
     DeviceHasPasscodeSetError, DeviceNotFoundError, FeatureNotSupportedError, InternalError, InvalidServiceError, \
@@ -145,13 +147,8 @@ def main() -> None:
             logger.warning('Got an InvalidServiceError. Trying again over tunneld since it is a developer command')
             should_retry_over_tunneld = True
         if should_retry_over_tunneld:
-            if '--' in sys.argv:
-                escape_sequence = sys.argv.index('--')
-                before = sys.argv[:escape_sequence]
-                after = sys.argv[escape_sequence:]
-                sys.argv = before + ['--tunnel', e.identifier] + after
-            else:
-                sys.argv += ['--tunnel', e.identifier]
+            # use a single space because click will ignore envvars of empty strings
+            os.environ[TUNNEL_ENV_VAR] = ' '
             return main()
         logger.error(INVALID_SERVICE_MESSAGE)
     except PasswordRequiredError:

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -26,6 +26,7 @@ from pymobiledevice3.usbmux import select_devices_by_connection_type
 USBMUX_OPTION_HELP = 'usbmuxd listener address (in the form of either /path/to/unix/socket OR HOST:PORT'
 COLORED_OUTPUT = True
 UDID_ENV_VAR = 'PYMOBILEDEVICE3_UDID'
+TUNNEL_ENV_VAR = 'PYMOBILEDEVICE3_TUNNEL'
 OSUTILS = get_os_utils()
 
 
@@ -217,11 +218,12 @@ class RSDCommand(BaseServiceProviderCommand):
                       help='\b\n'
                            'RSD hostname and port number (as provided by a `start-tunnel` subcommand).'),
             RSDOption(('rsd_service_provider_using_tunneld', '--tunnel'), callback=self.tunneld,
-                      mutually_exclusive=['rsd_service_provider_manually'],
+                      mutually_exclusive=['rsd_service_provider_manually'], envvar=TUNNEL_ENV_VAR,
                       help='\b\n'
                            'Either an empty string to force tunneld device selection, or a UDID of a tunneld '
                            'discovered device.\n'
-                           'The string may be suffixed with :PORT in case tunneld is not serving at the default port.')
+                           'The string may be suffixed with :PORT in case tunneld is not serving at the default port.\n'
+                           f'This option may also be transferred as an environment variable: {TUNNEL_ENV_VAR}')
         ]
 
     def rsd(self, ctx, param: str, value: Optional[Tuple[str, int]]) -> Optional[RemoteServiceDiscoveryService]:
@@ -235,6 +237,7 @@ class RSDCommand(BaseServiceProviderCommand):
         if udid is None:
             return
 
+        udid = udid.strip()
         port = TUNNELD_DEFAULT_ADDRESS[1]
         if ':' in udid:
             udid, port = udid.split(':')


### PR DESCRIPTION
This will allow better handling for re-running commands using the `--tunnel` option. Also, this can be used to force all commands to use a given tunnel without the need to specify this option manually each time.