### PR TITLE
Maintenance/remove python38 support

### DIFF
--- a/pymobiledevice3/bonjour.py
+++ b/pymobiledevice3/bonjour.py
@@ -1,6 +1,5 @@
 import asyncio
 import dataclasses
-import sys
 from socket import AF_INET, AF_INET6, inet_ntop
 from typing import Optional
 
@@ -8,7 +7,6 @@ from ifaddr import get_adapters
 from zeroconf import IPVersion, ServiceListener, ServiceStateChange, Zeroconf
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
-from pymobiledevice3.exceptions import FeatureNotSupportedError
 from pymobiledevice3.osu.os_utils import get_os_utils
 
 REMOTEPAIRING_SERVICE_NAMES = ['_remotepairing._tcp.local.']
@@ -82,13 +80,7 @@ def query_bonjour(service_names: list[str], ip: str) -> BonjourQuery:
 
 async def browse(service_names: list[str], ips: list[str], timeout: float = DEFAULT_BONJOUR_TIMEOUT) \
         -> list[BonjourAnswer]:
-    try:
-        bonjour_queries = [query_bonjour(service_names, adapter) for adapter in ips]
-    except ValueError as e:
-        if sys.version_info.major == 3 and sys.version_info.minor == 8:
-            raise FeatureNotSupportedError('python3.8', 'IPv6 link-local bonjour browse') from e
-        else:
-            raise e
+    bonjour_queries = [query_bonjour(service_names, adapter) for adapter in ips]
     answers = []
     await asyncio.sleep(timeout)
     for bonjour_query in bonjour_queries:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pymobiledevice3"
 description = "Pure python3 implementation for working with iDevices (iPhone, etc...)"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007" }
 keywords = ["ios", "protocol", "lockdownd", "instruments", "automation", "cli", "afc"]
 authors = [
@@ -17,7 +17,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Follow up from https://github.com/doronz88/pymobiledevice3/commit/5400ff7926d6b4a75a8bcba4632bc13dd31d6368, need to bump `requires-python`. 

Note:
Since it's still possible to install pymobiledevice3 on 3.8, some may see the following error.

```
/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pymobiledevice3/exceptions.py:306: in <module>
    class InspectorEvaluateError(PyMobileDevice3Exception):
/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pymobiledevice3/exceptions.py:308: in InspectorEvaluateError
    stack: Optional[list[str]] = None):
E   TypeError: 'type' object is not subscriptable
``