### PR TITLE
changes to accessibility list-items

### DIFF
--- a/pymobiledevice3/cli/developer.py
+++ b/pymobiledevice3/cli/developer.py
@@ -860,7 +860,7 @@ def accessibility_notifications(service_provider: LockdownClient):
 
 @accessibility.command('list-items', cls=Command)
 def accessibility_list_items(service_provider: LockdownClient):
-    """ list items available in currently shown menu """
+    """List items available in the currently shown menu."""
 
     service = AccessibilityAudit(service_provider)
     iterator = service.iter_events()
@@ -869,6 +869,7 @@ def accessibility_list_items(service_provider: LockdownClient):
     service.move_focus_next()
 
     first_item = None
+    items = []
 
     for event in iterator:
         if event.name != 'hostInspectorCurrentElementChanged:':
@@ -880,13 +881,12 @@ def accessibility_list_items(service_provider: LockdownClient):
 
         if first_item is None:
             first_item = current_item
-        else:
-            if first_item.caption == current_item.caption:
-                return
+        elif first_item.caption == current_item.caption:
+            return  # Break if we encounter the first item again (loop)
 
-        print(f'{current_item.caption}: {current_item.element.identifier}')
+        items.append(current_item.to_dict())
+        print_json(items)
         service.move_focus_next()
-
 
 @developer.group('condition')
 def condition():

--- a/pymobiledevice3/services/accessibilityaudit.py
+++ b/pymobiledevice3/services/accessibilityaudit.py
@@ -37,7 +37,7 @@ class AXAuditElement_v1(SerializedObject):
 
     @property
     def identifier(self) -> bytes:
-        return self._fields['PlatformElementValue_v1'].NSdata
+        return self._fields['PlatformElementValue_v1']
 
     def __repr__(self):
         return f'<Element: {self.identifier}>'

--- a/pymobiledevice3/services/accessibilityaudit.py
+++ b/pymobiledevice3/services/accessibilityaudit.py
@@ -24,8 +24,52 @@ class AXAuditInspectorFocus_v1(SerializedObject):
         return self._fields.get('CaptionTextValue_v1')
 
     @property
+    def spoken_description(self) -> str:
+        return self._fields.get('SpokenDescriptionValue_v1')
+
+    @property
     def element(self) -> bytes:
         return self._fields.get('ElementValue_v1')
+
+    @property
+    def platform_identifier(self) -> str:
+        """Converts the element bytes to a hexadecimal string."""
+        return self.element.identifier.hex().upper()
+
+    @property
+    def estimated_uid(self) -> str:
+        """Generates a UID from the platform identifier."""
+        hex_value = self.platform_identifier
+
+        if len(hex_value) % 2 != 0:
+            raise ValueError("Hex value length must be even.")
+
+        hex_bytes = bytes.fromhex(hex_value)
+
+        if len(hex_bytes) < 16:
+            raise ValueError("Hex value must contain at least 16 bytes.")
+
+        # Extract TimeLow bytes (indexes 12 to 15)
+        time_low_bytes = hex_bytes[12:16]
+        time_low = time_low_bytes.hex().upper()
+
+        # Extract ClockSeq bytes (indexes 0 to 1)
+        clock_seq_bytes = hex_bytes[0:2]
+        clock_seq = clock_seq_bytes.hex().upper()
+
+        # Construct UID with placeholder values for unused parts
+        uid = f"{time_low}-0000-0000-{clock_seq}-000000000000"
+
+        return uid
+
+    def to_dict(self) -> dict:
+        """Serializes the focus element into a dictionary."""
+        return {
+            'platform_identifier': self.platform_identifier,
+            'estimated_uid': self.estimated_uid,
+            'caption': self.caption,
+            'spoken_description': self.spoken_description
+        }
 
     def __str__(self):
         return f'<Focused ElementCaption: {self.caption}>'


### PR DESCRIPTION
adds spoken_description property and changes response type to json with below keys 
```
 {
            'platform_identifier': hexadecimal string of raw bytes obtained from apple API 
            'estimated_uid': element UID as returned and used by appium and WDA
            'caption': as as previous API response
            'spoken_description': mostly same as caption except for certain cases such as latin languages which are not spoken like english such as Portuguese etc.
        }
```
output of list-items - https://app.warp.dev/block/ThOGg6XvGEZBJwvseWPwKN 
corresponding screens accessibility tree as obtained using WDA for reference - https://app.warp.dev/block/oMlvxORH9aJpb7CA8U0rkR 

the added `estimated_uid` allows 1:1 mapping