### PR TITLE
remote: use TCP as the default tunneling protocol on python3.13+

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -16,8 +16,8 @@ from pymobiledevice3.exceptions import AccessDeniedError, CloudConfigurationAlre
     ConnectionFailedToUsbmuxdError, DeprecationError, DeveloperModeError, DeveloperModeIsNotEnabledError, \
     DeviceHasPasscodeSetError, DeviceNotFoundError, FeatureNotSupportedError, InternalError, InvalidServiceError, \
     MessageNotSupportedError, MissingValueError, NoDeviceConnectedError, NotEnoughDiskSpaceError, NotPairedError, \
-    OSNotSupportedError, PairingDialogResponsePendingError, PasswordRequiredError, RSDRequiredError, \
-    SetProhibitedError, TunneldConnectionError, UserDeniedPairingError
+    OSNotSupportedError, PairingDialogResponsePendingError, PasswordRequiredError, QuicProtocolNotSupportedError, \
+    RSDRequiredError, SetProhibitedError, TunneldConnectionError, UserDeniedPairingError
 from pymobiledevice3.osu.os_utils import get_os_utils
 
 coloredlogs.install(level=logging.INFO)
@@ -244,6 +244,8 @@ def main() -> None:
         logger.error(
             f'Missing implementation of `{e.feature}` on `{e.os_name}`. To add support, consider contributing at '
             f'https://github.com/doronz88/pymobiledevice3.')
+    except QuicProtocolNotSupportedError as e:
+        logger.error(str(e))
 
 
 if __name__ == '__main__':

--- a/pymobiledevice3/cli/remote.py
+++ b/pymobiledevice3/cli/remote.py
@@ -68,7 +68,8 @@ def remote_cli() -> None:
 @click.option('--port', type=click.INT, default=TUNNELD_DEFAULT_ADDRESS[1])
 @click.option('-d', '--daemonize', is_flag=True)
 @click.option('-p', '--protocol', type=click.Choice([e.value for e in TunnelProtocol]),
-              default=TunnelProtocol.QUIC.value)
+              help='Transport protocol. If python version >= 3.13 will default to TCP. Otherwise will default to QUIC',
+              default=TunnelProtocol.DEFAULT.value)
 @click.option('--usb/--no-usb', default=True, help='Enable usb monitoring')
 @click.option('--wifi/--no-wifi', default=True, help='Enable wifi monitoring')
 @click.option('--usbmux/--no-usbmux', default=True, help='Enable usbmux monitoring')
@@ -112,7 +113,7 @@ def rsd_info(service_provider: RemoteServiceDiscoveryService):
 
 async def tunnel_task(
         service, secrets: Optional[TextIO] = None, script_mode: bool = False,
-        max_idle_timeout: float = MAX_IDLE_TIMEOUT, protocol: TunnelProtocol = TunnelProtocol.QUIC) -> None:
+        max_idle_timeout: float = MAX_IDLE_TIMEOUT, protocol: TunnelProtocol = TunnelProtocol.DEFAULT) -> None:
     async with start_tunnel(
             service, secrets=secrets, max_idle_timeout=max_idle_timeout, protocol=protocol) as tunnel_result:
         logger.info('tunnel created')
@@ -152,7 +153,7 @@ async def tunnel_task(
 
 async def start_tunnel_task(
         connection_type: ConnectionType, secrets: TextIO, udid: Optional[str] = None, script_mode: bool = False,
-        max_idle_timeout: float = MAX_IDLE_TIMEOUT, protocol: TunnelProtocol = TunnelProtocol.QUIC) -> None:
+        max_idle_timeout: float = MAX_IDLE_TIMEOUT, protocol: TunnelProtocol = TunnelProtocol.DEFAULT) -> None:
     if start_tunnel is None:
         raise NotImplementedError('failed to start the tunnel on your platform')
     get_tunnel_services = {
@@ -185,7 +186,7 @@ async def start_tunnel_task(
               help='Maximum QUIC idle time (ping interval)')
 @click.option('-p', '--protocol',
               type=click.Choice([e.value for e in TunnelProtocol], case_sensitive=False),
-              default=TunnelProtocol.QUIC.value)
+              default=TunnelProtocol.DEFAULT.value)
 @sudo_required
 def cli_start_tunnel(
         connection_type: ConnectionType, udid: Optional[str], secrets: TextIO, script_mode: bool,

--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -14,7 +14,7 @@ __all__ = [
     'LaunchingApplicationError', 'BadCommandError', 'BadDevError', 'ConnectionFailedError', 'CoreDeviceError',
     'AccessDeniedError', 'RSDRequiredError', 'SysdiagnoseTimeoutError', 'GetProhibitedError',
     'FeatureNotSupportedError', 'OSNotSupportedError', 'DeprecationError', 'NotEnoughDiskSpaceError',
-    'CloudConfigurationAlreadyPresentError'
+    'CloudConfigurationAlreadyPresentError', 'QuicProtocolNotSupportedError',
 ]
 
 from typing import Optional
@@ -390,3 +390,8 @@ class FeatureNotSupportedError(SupportError):
     def __init__(self, os_name, feature):
         super().__init__(os_name)
         self.feature = feature
+
+
+class QuicProtocolNotSupportedError(PyMobileDevice3Exception):
+    """ QUIC tunnel support was removed on iOS 18.2+ """
+    pass

--- a/pymobiledevice3/remote/common.py
+++ b/pymobiledevice3/remote/common.py
@@ -1,3 +1,4 @@
+import sys
 from enum import Enum
 
 
@@ -9,3 +10,6 @@ class ConnectionType(Enum):
 class TunnelProtocol(Enum):
     TCP = 'tcp'
     QUIC = 'quic'
+
+    # TODO: make only TCP the default once 3.12 becomes deprecated
+    DEFAULT = TCP if sys.version_info >= (3, 13) else QUIC

--- a/pymobiledevice3/tunneld.py
+++ b/pymobiledevice3/tunneld.py
@@ -53,7 +53,7 @@ class TunnelTask:
 
 
 class TunneldCore:
-    def __init__(self, protocol: TunnelProtocol = TunnelProtocol.QUIC, wifi_monitor: bool = True,
+    def __init__(self, protocol: TunnelProtocol = TunnelProtocol.DEFAULT, wifi_monitor: bool = True,
                  usb_monitor: bool = True, usbmux_monitor: bool = True, mobdev2_monitor: bool = True) -> None:
         self.protocol = protocol
         self.tasks: list[asyncio.Task] = []


### PR DESCRIPTION
iOS 18.2+ removed QUIC support for tunneling, so using TCP as the new default avoids this restriction.
In addition, we now verify and raise `QuicProtocolNotSupportedError` if we failed to establish a QUIC connection to the target.