### PR TITLE
service_connection: treat `SSLError` from `recv()` as disconnection

### DIFF
--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -177,7 +177,10 @@ class ServiceConnection:
         :param length: The maximum amount of data to receive.
         :return: The received data.
         """
-        return self.socket.recv(length)
+        try:
+            return self.socket.recv(length)
+        except ssl.SSLError:
+            raise ConnectionAbortedError()
 
     def sendall(self, data: bytes) -> None:
         """


### PR DESCRIPTION
Raise `ConnectionAbortedError` instead of `SSLError`. This fixes broken `amfi enable-developer-mode` for python3.13.