### PR TITLE
pcap: include timestamp info into recorded packets

### DIFF
--- a/pymobiledevice3/services/pcapd.py
+++ b/pymobiledevice3/services/pcapd.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import time
 import enum
 from collections.abc import Generator
 from typing import Optional
@@ -391,10 +392,21 @@ class PcapdService(LockdownService):
         writer = FileWriter(out, shb)
 
         for packet in packet_generator:
+            if hasattr(packet, 'timestamp'):
+                packet_time = packet.timestamp
+            else:
+                packet_time = time.time()
+
+            timestamp_microseconds = int(packet_time * 1_000_000)
+            timestamp_high = (timestamp_microseconds >> 32) & 0xFFFFFFFF
+            timestamp_low = timestamp_microseconds & 0xFFFFFFFF
+
             enhanced_packet = shb.new_member(blocks.EnhancedPacket, options={
                 'opt_comment': f'PID: {packet.pid}, ProcName: {packet.comm}, EPID: {packet.epid}, '
                                f'EProcName: {packet.ecomm}, SVC: {packet.svc}'
             })
 
             enhanced_packet.packet_data = packet.data
+            enhanced_packet.timestamp_high = timestamp_high
+            enhanced_packet.timestamp_low = timestamp_low
             writer.write_block(enhanced_packet)

--- a/pymobiledevice3/services/pcapd.py
+++ b/pymobiledevice3/services/pcapd.py
@@ -8,6 +8,7 @@ from typing import Optional
 import pcapng.blocks as blocks
 from construct import Byte, Bytes, Container, CString, Int16ub, Int32ub, Int32ul, Padded, Seek, Struct, this
 from pcapng import FileWriter
+
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.services.lockdown_service import LockdownService

--- a/pymobiledevice3/services/pcapd.py
+++ b/pymobiledevice3/services/pcapd.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 
-import time
 import enum
+import time
 from collections.abc import Generator
 from typing import Optional
 
 import pcapng.blocks as blocks
 from construct import Byte, Bytes, Container, CString, Int16ub, Int32ub, Int32ul, Padded, Seek, Struct, this
 from pcapng import FileWriter
-
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.services.lockdown_service import LockdownService


### PR DESCRIPTION
Currently generated PCAP are having no timestamp. When opening in wireshark, time is always at 0.
This PR retrieve the current time and help timestamping pcap based on what pcapng wants. 