### PR TITLE
docs: Fix typo – missing `s` in `wifi-connections`

### DIFF
--- a/misc/understanding_idevice_protocol_layers.md
+++ b/misc/understanding_idevice_protocol_layers.md
@@ -121,10 +121,10 @@ this feature over USB:
 
 ```shell
 # Turn it on
-pymobiledevice3 lockdown wifi-connection on
+pymobiledevice3 lockdown wifi-connections on
 
 # Or off
-pymobiledevice3 lockdown wifi-connection off
+pymobiledevice3 lockdown wifi-connections off
 ```
 
 Now the device will use the [bonjour](https://en.wikipedia.org/wiki/Bonjour_(software)) protocol in order to announce


### PR DESCRIPTION
Adding an `s` to `wifi-connection` fixes this error:
```shell
❯ pymobiledevice3 lockdown wifi-connection on
Usage: pymobiledevice3 lockdown [OPTIONS] COMMAND [ARGS]...
Try 'pymobiledevice3 lockdown -h' for help.

Error: No such command 'wifi-connection'.
```
