### PR TITLE
diagnostics: fix `get_wifi()` on older models (#1284)

### DIFF
--- a/pymobiledevice3/services/diagnostics.py
+++ b/pymobiledevice3/services/diagnostics.py
@@ -1029,4 +1029,7 @@ class DiagnosticsService(LockdownService):
         return self.ioregistry(ioclass='IOPMPowerSource')
 
     def get_wifi(self) -> dict:
-        return self.ioregistry(name='AppleBCMWLANSkywalkInterface')
+        result = self.ioregistry(name='AppleBCMWLANSkywalkInterface')
+        if result:
+            return result
+        return self.ioregistry(ioclass='IO80211Interface')


### PR DESCRIPTION
Close #1284

<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
