### PR TITLE
tunnel_service: raise exception upon successful pairing

### DIFF
--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -14,7 +14,7 @@ __all__ = [
     'LaunchingApplicationError', 'BadCommandError', 'BadDevError', 'ConnectionFailedError', 'CoreDeviceError',
     'AccessDeniedError', 'RSDRequiredError', 'SysdiagnoseTimeoutError', 'GetProhibitedError',
     'FeatureNotSupportedError', 'OSNotSupportedError', 'DeprecationError', 'NotEnoughDiskSpaceError',
-    'CloudConfigurationAlreadyPresentError', 'QuicProtocolNotSupportedError',
+    'CloudConfigurationAlreadyPresentError', 'QuicProtocolNotSupportedError', 'RemotePairingCompletedError',
 ]
 
 from typing import Optional
@@ -394,4 +394,14 @@ class FeatureNotSupportedError(SupportError):
 
 class QuicProtocolNotSupportedError(PyMobileDevice3Exception):
     """ QUIC tunnel support was removed on iOS 18.2+ """
+    pass
+
+
+class RemotePairingCompletedError(PyMobileDevice3Exception):
+    """
+    Raised upon pairing completion using the `remotepairingdeviced` service (RemoteXPC).
+
+    remotepairingdeviced closes connection after pairing, so client must re-establish it after pairing is
+    completed.
+    """
     pass


### PR DESCRIPTION
The remote endpoint (`remotepairingdeviced`) triggers a close on the connection FD upon a successful pairing, so raise an appropriate exception we can catch and re-establish the connection for a second time to start a tunnel.

Close #1306

<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
