### PR TITLE
dvt: Add memory limit waiver for pid

### DIFF
--- a/pymobiledevice3/cli/developer.py
+++ b/pymobiledevice3/cli/developer.py
@@ -126,6 +126,12 @@ def proclist(service_provider: LockdownClient):
 
         print_json(processes)
 
+@dvt.command('memlimitoff', cls=Command)
+@click.argument('pid', type=click.INT)
+def memlimitoff(service_provider: LockdownServiceProvider, pid: int) -> None:
+    """ Disable process memory limit """
+    with DvtSecureSocketProxyService(lockdown=service_provider) as dvt:
+        ProcessControl(dvt).disable_memory_limit_for_pid(pid)
 
 @dvt.command('applist', cls=Command)
 def applist(service_provider: LockdownServiceProvider) -> None:

--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -15,6 +15,7 @@ __all__ = [
     'AccessDeniedError', 'RSDRequiredError', 'SysdiagnoseTimeoutError', 'GetProhibitedError',
     'FeatureNotSupportedError', 'OSNotSupportedError', 'DeprecationError', 'NotEnoughDiskSpaceError',
     'CloudConfigurationAlreadyPresentError', 'QuicProtocolNotSupportedError', 'RemotePairingCompletedError',
+    'DisableMemoryLimitError',
 ]
 
 from typing import Optional
@@ -404,4 +405,9 @@ class RemotePairingCompletedError(PyMobileDevice3Exception):
     remotepairingdeviced closes connection after pairing, so client must re-establish it after pairing is
     completed.
     """
+    pass
+
+
+class DisableMemoryLimitError(PyMobileDevice3Exception):
+    """ Disabling memory limit fails. """
     pass

--- a/pymobiledevice3/services/dvt/instruments/process_control.py
+++ b/pymobiledevice3/services/dvt/instruments/process_control.py
@@ -2,6 +2,7 @@ import dataclasses
 import typing
 from typing import Optional
 
+from pymobiledevice3.exceptions import DisableMemoryLimitError
 from pymobiledevice3.osu.os_utils import get_os_utils
 from pymobiledevice3.services.dvt.dvt_secure_socket_proxy import DvtSecureSocketProxyService
 from pymobiledevice3.services.remote_server import MessageAux
@@ -39,6 +40,15 @@ class ProcessControl:
         """
         self._channel.sendSignal_toPid_(MessageAux().append_obj(sig).append_obj(pid), expects_reply=True)
         return self._channel.receive_plist()
+
+    def disable_memory_limit_for_pid(self, pid: int) -> None:
+        """
+        Waive memory limit for a given pid
+        :param pid: process id.
+        """
+        self._channel.requestDisableMemoryLimitsForPid_(MessageAux().append_int(pid), expects_reply=True)
+        if not self._channel.receive_plist():
+            raise DisableMemoryLimitError()
 
     def kill(self, pid: int):
         """

--- a/tests/services/instruments/test_dvt_secure_socket_proxy.py
+++ b/tests/services/instruments/test_dvt_secure_socket_proxy.py
@@ -49,6 +49,13 @@ def test_applist(dvt):
     assert safari['Type'] == 'PluginKit'
 
 
+def test_memlimitoff(dvt):
+    """
+    Test disabling memory limit.
+    """
+    ProcessControl(dvt).disable_memory_limit_for_pid(get_process_data(dvt, 'SpringBoard')['pid'])
+
+
 def test_kill(dvt):
     """
     Test killing a process.


### PR DESCRIPTION
iOS provides strict limits regarding memory usage (especially for extensions). 

There is a method `- (NSNumber *)requestDisableMemoryLimitsForPid:(int)arg1;` of header file `DTProcessControlServiceAuthorizedMethods.h` which sounded promising to utilize

By sending a message call to invoke that method, the iOS responds with either 0 (false) or 1 (true) if memory limit disabling request was declined or satisfied respectively

Full command to test:
```
pymobiledevice3 developer dvt memlimitoff <PID> --rsd <IPV6-ADDRESS> <RSD-PORT>
```
Expected command output:
```
true
```
OR
```
false
```
