### PR TITLE
requirements: replace `remotezip` with `remotezip2`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ nest_asyncio>=1.5.5
 Pillow
 inquirer3>=0.6.0
 ipsw_parser>=1.3.4
-remotezip
+remotezip2
 zeroconf>=0.132.2
 ifaddr
 hyperframe


### PR DESCRIPTION
pymobiledevice3 requires both remotezip and ipsw-parser. ipsw-parser requires remotezip2 (your fork)
I guess it's better to use a fixed version


## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
