### PR TITLE
tunneld: Fix `/start-tunnel` request to only return valid tunnels

### DIFF
--- a/pymobiledevice3/tunneld/server.py
+++ b/pymobiledevice3/tunneld/server.py
@@ -399,7 +399,8 @@ class TunneldRunner:
         @self._app.get('/start-tunnel')
         async def start_tunnel(
                 udid: str, ip: Optional[str] = None, connection_type: Optional[str] = None) -> fastapi.Response:
-            udid_tunnels = [t.tunnel for t in self._tunneld_core.tunnel_tasks.values() if t.udid == udid]
+            udid_tunnels = [t.tunnel for t in self._tunneld_core.tunnel_tasks.values() if
+                            t.udid == udid and t.tunnel is not None]
             if len(udid_tunnels) > 0:
                 data = {
                     'interface': udid_tunnels[0].interface,


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
