### PR TITLE
cli_common: Remove redundant extra `--verbose` option

### DIFF
--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -181,9 +181,6 @@ class BaseCommand(click.Command):
 class BaseServiceProviderCommand(BaseCommand):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.params[:0] = [
-            click.Option(('verbosity', '-v', '--verbose'), count=True, callback=set_verbosity, expose_value=False),
-        ]
         self.service_provider = None
         self.callback = choose_service_provider(self.callback)
 


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
