### PR TITLE
lockdown: Fix handling of device disconnection during ctor over usbmux

### DIFF
--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -619,9 +619,9 @@ class UsbmuxLockdownClient(LockdownClient):
                  label: str = DEFAULT_LABEL, system_buid: str = SYSTEM_BUID, pair_record: Optional[dict] = None,
                  pairing_records_cache_folder: Path = None, port: int = SERVICE_PORT,
                  usbmux_address: Optional[str] = None):
+        self.usbmux_address = usbmux_address
         super().__init__(service, host_id, identifier, label, system_buid, pair_record, pairing_records_cache_folder,
                          port)
-        self.usbmux_address = usbmux_address
 
     @property
     def short_info(self) -> dict:


### PR DESCRIPTION
Since every lockdown protocol handler may try to reconnect to the device, we must initialize `self.usbmux_address` before triggering the ctor. This solves the issue when the device disconnects while ctor didn't finish the job.

<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
