### PR TITLE
restore: Use the new `ApParameters` key whenever in lockdown

### DIFF
--- a/pymobiledevice3/restore/base_restore.py
+++ b/pymobiledevice3/restore/base_restore.py
@@ -78,7 +78,8 @@ class BaseRestore:
         return stitch_component(component_name,
                                 self.build_identity.get_component(component_name, tss=tss, data=data, path=path).data,
                                 tss,
-                                self.build_identity)
+                                self.build_identity,
+                                self.device.ap_parameters)
 
     def populate_tss_request_from_manifest(self, parameters: dict, additional_keys: Optional[list[str]] = None) -> None:
         """ equivalent to idevicerestore:tss_parameters_add_from_manifest """

--- a/pymobiledevice3/restore/device.py
+++ b/pymobiledevice3/restore/device.py
@@ -38,14 +38,29 @@ class Device:
         return self.irecv.is_image4_supported
 
     @cached_property
+    def ap_parameters(self) -> dict:
+        if self.lockdown:
+            try:
+                return self.lockdown.get_value(key='ApParameters')
+            except MissingValueError:
+                pass
+        return {}
+
+    @cached_property
     def ap_nonce(self):
         if self.lockdown:
+            ap_nonce_from_ap_parameters = self.ap_parameters.get('ApNonce')
+            if ap_nonce_from_ap_parameters:
+                return ap_nonce_from_ap_parameters
             return self.lockdown.get_value(key='ApNonce')
         return self.irecv.ap_nonce
 
     @cached_property
     def sep_nonce(self):
         if self.lockdown:
+            sep_nonce_from_ap_parameters = self.ap_parameters.get('SepNonce')
+            if sep_nonce_from_ap_parameters:
+                return sep_nonce_from_ap_parameters
             return self.lockdown.get_value(key='SEPNonce')
         return self.irecv.sep_nonce
 

--- a/pymobiledevice3/restore/img4.py
+++ b/pymobiledevice3/restore/img4.py
@@ -3,8 +3,6 @@ import logging
 from ipsw_parser.build_identity import BuildIdentity
 from pyimg4 import IM4P, IM4R, IMG4, RestoreProperty
 
-from pymobiledevice3.restore.tss import TSSResponse
-
 logger = logging.getLogger(__name__)
 
 COMPONENT_FOURCC = {
@@ -123,7 +121,7 @@ COMPONENT_FOURCC = {
 }
 
 
-def stitch_component(name: str, im4p_data: bytes, tss: TSSResponse, build_identity: BuildIdentity,
+def stitch_component(name: str, im4p_data: bytes, tss: dict, build_identity: BuildIdentity,
                      ap_parameters: dict) -> bytes:
     logger.info(f'Personalizing IMG4 component {name}...')
 

--- a/pymobiledevice3/restore/img4.py
+++ b/pymobiledevice3/restore/img4.py
@@ -123,7 +123,8 @@ COMPONENT_FOURCC = {
 }
 
 
-def stitch_component(name: str, im4p_data: bytes, tss: TSSResponse, build_identity: BuildIdentity) -> bytes:
+def stitch_component(name: str, im4p_data: bytes, tss: TSSResponse, build_identity: BuildIdentity,
+                     ap_parameters: dict) -> bytes:
     logger.info(f'Personalizing IMG4 component {name}...')
 
     im4p = IM4P(data=im4p_data)
@@ -143,12 +144,16 @@ def stitch_component(name: str, im4p_data: bytes, tss: TSSResponse, build_identi
         if info.get('RequiresNonceSlot', False) and name in ('SEP', 'SepStage1', 'LLB'):
             logger.debug(f'{name}: RequiresNonceSlot for {name}')
             if name in ('SEP', 'SepStage1'):
+                snid = ap_parameters.get('SepNonceSlotID', info.get('SepNonceSlotID', 2))
+                logger.debug(f'snid: {snid}')
                 im4r.add_property(
-                    RestoreProperty(fourcc='snid', value=info.get('SepNonceSlotID', 2))
+                    RestoreProperty(fourcc='snid', value=snid)
                 )
             else:
+                anid = ap_parameters.get('ApNonceSlotID', info.get('ApNonceSlotID', 0))
+                logger.debug(f'anid: {anid}')
                 im4r.add_property(
-                    RestoreProperty(fourcc='anid', value=info.get('ApNonceSlotID', 0))
+                    RestoreProperty(fourcc='anid', value=anid)
                 )
 
         for key in tbm_dict.keys():

--- a/pymobiledevice3/restore/recovery.py
+++ b/pymobiledevice3/restore/recovery.py
@@ -454,7 +454,7 @@ class Recovery(BaseRestore):
             # normal mode
             self.logger.info('going into Recovery')
 
-            # in case lockdown has disconnected while waiting for a ticket
+            # In case lockdown has disconnected while waiting for a ticket
             self.device.lockdown = create_using_usbmux(serial=self.device.lockdown.udid, connection_type='USB')
             self.device.lockdown.enter_recovery()
 

--- a/pymobiledevice3/restore/tss.py
+++ b/pymobiledevice3/restore/tss.py
@@ -7,9 +7,9 @@ from uuid import uuid4
 
 import asn1
 import requests
-from ipsw_parser.img4 import COMPONENT_FOURCC
 
 from pymobiledevice3.exceptions import PyMobileDevice3Exception
+from pymobiledevice3.restore.img4 import COMPONENT_FOURCC
 from pymobiledevice3.utils import bytes_to_uint, plist_access_path
 
 TSS_CONTROLLER_ACTION_URL = 'http://gs.apple.com/TSS/controller?action=2'


### PR DESCRIPTION
This key overrides some of the preflight parameters such as the SEP nonce and slot IDs.

<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
