### PR TITLE
accessibilityaudit: Fix enumeration

### DIFF
--- a/pymobiledevice3/services/accessibilityaudit.py
+++ b/pymobiledevice3/services/accessibilityaudit.py
@@ -432,6 +432,7 @@ class AccessibilityAudit(RemoteServer):
                 continue
 
             # each such event should contain exactly one element that became in focus
+            current_item = event.data[0]
             current_identifier = current_item.platform_identifier
 
             if current_identifier in visited_identifiers:

--- a/pymobiledevice3/services/accessibilityaudit.py
+++ b/pymobiledevice3/services/accessibilityaudit.py
@@ -440,5 +440,4 @@ class AccessibilityAudit(RemoteServer):
 
             yield current_item
             visited_identifiers.add(current_identifier)
-            
             self.move_focus_next()

--- a/pymobiledevice3/services/accessibilityaudit.py
+++ b/pymobiledevice3/services/accessibilityaudit.py
@@ -424,7 +424,7 @@ class AccessibilityAudit(RemoteServer):
         # every focus change is expected publish a "hostInspectorCurrentElementChanged:"
         self.move_focus_next()
 
-        first_item = None
+        visited_identifiers = set()
 
         for event in iterator:
             if event.name != 'hostInspectorCurrentElementChanged:':
@@ -432,12 +432,12 @@ class AccessibilityAudit(RemoteServer):
                 continue
 
             # each such event should contain exactly one element that became in focus
-            current_item = event.data[0]
+            current_identifier = current_item.platform_identifier
 
-            if first_item is None:
-                first_item = current_item
-            elif first_item.caption == current_item.caption:
-                break  # Break if we encounter the first item again (loop)
+            if current_identifier in visited_identifiers:
+                break  # Exit if we've seen this element before (loop detected)
 
             yield current_item
+            visited_identifiers.add(current_identifier)
+            
             self.move_focus_next()


### PR DESCRIPTION
In the updated approach, we replace the use of `caption` with `platform_identifier` to ensure that the focus is handled correctly. The reason for this change is that the caption could repeat in the focus order, leading to an early exit from the flow, which could cause issues.

Additionally, we've switched to using a set-based check instead of evaluating only the first element. This helps avoid potential infinite loops, an issue that was previously observed in the App Store.


## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
