### PR TITLE
cli: webinspector: Fix remark regarding enablement for iOS 18

### DIFF
--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -114,7 +114,9 @@ def opened_tabs(service_provider: LockdownClient, verbose, timeout):
 
     \b
     Opt-in:
-        Settings -> Apps -> Safari -> Advanced -> Web Inspector
+       iOS >= 18: Settings -> Apps -> Safari -> Advanced -> Web Inspector
+       
+       iOS < 18: Settings -> Safari -> Advanced -> Web Inspector
     """
     inspector = WebinspectorService(lockdown=service_provider)
     inspector.connect(timeout)
@@ -133,9 +135,14 @@ def launch(service_provider: LockdownClient, url, timeout):
     Launch a specific URL in Safari.
 
     \b
-    Opt-in:
+    Opt-in (iOS >= 18):
         Settings -> Apps -> Safari -> Advanced -> Web Inspector
         Settings -> Apps -> Safari -> Advanced -> Remote Automation
+
+    Opt-in (iOS < 18):
+        Settings -> Safari -> Advanced -> Web Inspector
+        Settings -> Safari -> Advanced -> Remote Automation
+        
     """
     inspector, safari = create_webinspector_and_launch_app(service_provider, timeout, SAFARI)
     session = inspector.automation_session(safari)
@@ -178,9 +185,13 @@ def shell(service_provider: LockdownClient, timeout):
     Create an IPython shell for interacting with a WebView.
 
     \b
-    Opt-in:
+    Opt-in (iOS >= 18):
         Settings -> Apps -> Safari -> Advanced -> Web Inspector
         Settings -> Apps -> Safari -> Advanced -> Remote Automation
+
+    Opt-in (iOS < 18):
+        Settings -> Safari -> Advanced -> Web Inspector
+        Settings -> Safari -> Advanced -> Remote Automation
     """
     inspector, safari = create_webinspector_and_launch_app(service_provider, timeout, SAFARI)
     session = inspector.automation_session(safari)
@@ -212,11 +223,12 @@ def js_shell(service_provider: LockdownServiceProvider, timeout: float, automati
 
     \b
     Opt-in:
-        Settings -> Apps -> Safari -> Advanced -> Web Inspector
-
+        iOS >= 18: Settings -> Apps -> Safari -> Advanced -> Web Inspector
+        iOS < 18: Settings -> Safari -> Advanced -> Web Inspector
     \b
     for automation also enable:
-        Settings -> Apps -> Safari -> Advanced -> Remote Automation
+        iOS >= 18: Settings -> Apps -> Safari -> Advanced -> Remote Automation
+        iOS < 18: Settings -> Safari -> Advanced -> Remote Automation
     """
 
     js_shell_class = AutomationJsShell if automation else InspectorJsShell

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -114,7 +114,7 @@ def opened_tabs(service_provider: LockdownClient, verbose, timeout):
 
     \b
     Opt-in:
-        Settings -> Safari -> Advanced -> Web Inspector
+        Settings -> Apps -> Safari -> Advanced -> Web Inspector
     """
     inspector = WebinspectorService(lockdown=service_provider)
     inspector.connect(timeout)
@@ -134,8 +134,8 @@ def launch(service_provider: LockdownClient, url, timeout):
 
     \b
     Opt-in:
-        Settings -> Safari -> Advanced -> Web Inspector
-        Settings -> Safari -> Advanced -> Remote Automation
+        Settings -> Apps -> Safari -> Advanced -> Web Inspector
+        Settings -> Apps -> Safari -> Advanced -> Remote Automation
     """
     inspector, safari = create_webinspector_and_launch_app(service_provider, timeout, SAFARI)
     session = inspector.automation_session(safari)
@@ -179,8 +179,8 @@ def shell(service_provider: LockdownClient, timeout):
 
     \b
     Opt-in:
-        Settings -> Safari -> Advanced -> Web Inspector
-        Settings -> Safari -> Advanced -> Remote Automation
+        Settings -> Apps -> Safari -> Advanced -> Web Inspector
+        Settings -> Apps -> Safari -> Advanced -> Remote Automation
     """
     inspector, safari = create_webinspector_and_launch_app(service_provider, timeout, SAFARI)
     session = inspector.automation_session(safari)
@@ -212,11 +212,11 @@ def js_shell(service_provider: LockdownServiceProvider, timeout: float, automati
 
     \b
     Opt-in:
-        Settings -> Safari -> Advanced -> Web Inspector
+        Settings -> Apps -> Safari -> Advanced -> Web Inspector
 
     \b
     for automation also enable:
-        Settings -> Safari -> Advanced -> Remote Automation
+        Settings -> Apps -> Safari -> Advanced -> Remote Automation
     """
 
     js_shell_class = AutomationJsShell if automation else InspectorJsShell

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -115,7 +115,7 @@ def opened_tabs(service_provider: LockdownClient, verbose, timeout):
     \b
     Opt-in:
        iOS >= 18: Settings -> Apps -> Safari -> Advanced -> Web Inspector
-       
+
        iOS < 18: Settings -> Safari -> Advanced -> Web Inspector
     """
     inspector = WebinspectorService(lockdown=service_provider)
@@ -142,7 +142,7 @@ def launch(service_provider: LockdownClient, url, timeout):
     Opt-in (iOS < 18):
         Settings -> Safari -> Advanced -> Web Inspector
         Settings -> Safari -> Advanced -> Remote Automation
-        
+
     """
     inspector, safari = create_webinspector_and_launch_app(service_provider, timeout, SAFARI)
     session = inspector.automation_session(safari)


### PR DESCRIPTION
Replaces `Settings -> Safari -> ...` with `Settings -> Apps -> Safari -> ...` in the comments to avoid confusion.

https://developer.apple.com/documentation/safari-developer-tools/inspecting-ios#Enabling-inspecting-your-device-from-a-connected-Mac

<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
