### PR TITLE
irecv: handle legacy devices with missing 'SNON' tag

### DIFF
--- a/pymobiledevice3/irecv.py
+++ b/pymobiledevice3/irecv.py
@@ -256,7 +256,10 @@ class IRecv:
             self.set_interface_altsetting(0, 0)
 
     def _copy_nonce_with_tag(self, tag):
-        return binascii.unhexlify(get_string(self._device, 1).split(f'{tag}:')[1].split(' ')[0])
+        if tag in get_string(self._device, 1):
+            return binascii.unhexlify(get_string(self._device, 1).split(f'{tag}:')[1].split(' ')[0])
+        else:
+            return None
 
     def _find(self, ecid=None, timeout=0xffffffff, is_recovery=None):
         start = time.time()


### PR DESCRIPTION
Handle legacy devices without 'SNON' value:

I tried to communicate with different devices in recovery mode. 
For an iPhone 4s i got an error when trying "pymobiledevice3 recovery shell":

```
return binascii.unhexlify(get_string(self._device, 1).split(f'{tag}:')[1].split(' ')[0])
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

Checking further I found out, this device does not return a value for 'SNON' for "get_string(self._device, 1)":

```
NONC:816837E452E97A730971D3D884628BF0459F7678
NONC:816837E452E97A730971D3D884628BF0459F7678
```

So I added a check for the presence of the tag and let it return None if the tag is not in the string.

Now the shell opens and the device responds to the input.

<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
