### PR TITLE
tunneld: Fix usbmux-udid check when `None`

### DIFF
--- a/pymobiledevice3/tunneld/server.py
+++ b/pymobiledevice3/tunneld/server.py
@@ -77,7 +77,8 @@ class TunneldCore:
             # Linux implementations of `usbmuxd` may report an incorrect value of UDID, dismissing the `-` character.
             # For such cases, we also check for a UDID without it.
             # See: <https://github.com/doronz88/pymobiledevice3/issues/1388#issuecomment-2782249770>
-            if ((task.udid == udid) or (task.udid.replace('-', '') == udid)) and (task.tunnel is not None):
+            task_udid = task.udid or ''
+            if ((task_udid == udid) or (task_udid.replace('-', '') == udid)) and (task.tunnel is not None):
                 return True
 
         return False


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
