### PR TITLE
Userspace TUN for RSD

### DIFF
--- a/pymobiledevice3/cli/lockdown.py
+++ b/pymobiledevice3/cli/lockdown.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import platform
 import plistlib
 from pathlib import Path
 from typing import Optional
@@ -164,12 +165,15 @@ def lockdown_wifi_connections(service_provider: LockdownClient, state):
 @lockdown_group.command('start-tunnel', cls=Command)
 @click.option('--script-mode', is_flag=True,
               help='Show only HOST and port number to allow easy parsing from external shell scripts')
-@sudo_required
+@click.option('--userspace-tun-host', help='Specify a host to listen on to enable userspace TUN')
 def cli_start_tunnel(
-        service_provider: LockdownServiceProvider, script_mode: bool) -> None:
+        service_provider: LockdownServiceProvider, script_mode: bool, userspace_tun_host: Optional[str] = None) -> None:
     """ start tunnel """
+    if userspace_tun_host is None or platform.system() == 'Darwin':
+        sudo_required(lambda: None)()
     service = CoreDeviceTunnelProxy(service_provider)
-    asyncio.run(tunnel_task(service, script_mode=script_mode, secrets=None, protocol=TunnelProtocol.TCP), debug=True)
+    asyncio.run(tunnel_task(service, script_mode=script_mode, secrets=None,
+                protocol=TunnelProtocol.TCP, userspace_tun_host=userspace_tun_host), debug=True)
 
 
 @lockdown_group.command('assistive-touch', cls=Command)

--- a/pymobiledevice3/remote/module_imports.py
+++ b/pymobiledevice3/remote/module_imports.py
@@ -4,9 +4,9 @@ from typing import Callable, Optional
 logger = logging.getLogger(__name__)
 
 try:
-    from pymobiledevice3.remote.tunnel_service import RemotePairingQuicTunnel, start_tunnel
+    from pymobiledevice3.remote.tunnel_service import _RemotePairingQuicTunnelMixin, start_tunnel
 
-    MAX_IDLE_TIMEOUT = RemotePairingQuicTunnel.MAX_IDLE_TIMEOUT
+    MAX_IDLE_TIMEOUT = _RemotePairingQuicTunnelMixin.MAX_IDLE_TIMEOUT
 except ImportError:
     start_tunnel: Optional[Callable] = None
     MAX_IDLE_TIMEOUT = None

--- a/pymobiledevice3/remote/remote_service_discovery.py
+++ b/pymobiledevice3/remote/remote_service_discovery.py
@@ -28,10 +28,16 @@ RSD_PORT = 58783
 
 
 class RemoteServiceDiscoveryService(LockdownServiceProvider):
-    def __init__(self, address: tuple[str, int], name: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        address: tuple[str, int],
+        userspace_tun_address: "tuple[str, int] | None" = None,
+        name: Optional[str] = None
+    ) -> None:
         super().__init__()
         self.name = name
-        self.service = RemoteXPCConnection(address)
+        self.service = RemoteXPCConnection(address, userspace_tun_address)
+        self.userspace_tun_address = userspace_tun_address
         self.peer_info: Optional[dict] = None
         self.lockdown: Optional[LockdownClient] = None
         self.all_values: Optional[dict] = None
@@ -75,7 +81,11 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         return self.lockdown.get_value(domain, key)
 
     def start_lockdown_service_without_checkin(self, name: str) -> ServiceConnection:
-        return ServiceConnection.create_using_tcp(self.service.address[0], self.get_service_port(name))
+        return ServiceConnection.create_using_tcp(
+            self.service.address[0],
+            self.get_service_port(name),
+            userspace_tun_address=self.userspace_tun_address
+        )
 
     def start_lockdown_service(self, name: str, include_escrow_bag: bool = False) -> ServiceConnection:
         service = self.start_lockdown_service_without_checkin(name)
@@ -112,7 +122,10 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
             raise
 
     def start_remote_service(self, name: str) -> RemoteXPCConnection:
-        service = RemoteXPCConnection((self.service.address[0], self.get_service_port(name)))
+        service = RemoteXPCConnection(
+            (self.service.address[0], self.get_service_port(name)),
+            self.userspace_tun_address
+        )
         return service
 
     def start_service(self, name: str) -> Union[RemoteXPCConnection, ServiceConnection]:

--- a/pymobiledevice3/remote/remotexpc.py
+++ b/pymobiledevice3/remote/remotexpc.py
@@ -1,4 +1,5 @@
 import asyncio
+import socket
 import sys
 from asyncio import IncompleteReadError
 from typing import AsyncIterable, Optional
@@ -37,9 +38,10 @@ resp = await client.send_receive_request({"Command": "DoSomething"})
 
 
 class RemoteXPCConnection:
-    def __init__(self, address: tuple[str, int]):
+    def __init__(self, address: tuple[str, int], userspace_tun_address: "tuple[str, int] | None" = None):
         self._previous_frame_data = b''
         self.address = address
+        self.userspace_tun_address = userspace_tun_address
         self.next_message_id: dict[int, int] = {ROOT_CHANNEL: 0, REPLY_CHANNEL: 0}
         self.peer_info = None
         self._reader: Optional[asyncio.StreamReader] = None
@@ -53,7 +55,15 @@ class RemoteXPCConnection:
         await self.close()
 
     async def connect(self) -> None:
-        self._reader, self._writer = await asyncio.open_connection(self.address[0], self.address[1])
+        if self.userspace_tun_address:
+            self._reader, self._writer = await asyncio.open_connection(*self.userspace_tun_address)
+            self._writer.write(
+                socket.inet_pton(socket.AF_INET6, self.address[0])
+                + self.address[1].to_bytes(4, "little")
+            )
+            await self._writer.drain()
+        else:
+            self._reader, self._writer = await asyncio.open_connection(self.address[0], self.address[1])
         try:
             await self._do_handshake()
         except Exception:  # noqa: E722

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ sslpsk-pmd3>=1.0.3;python_version<'3.13'
 python-pcapng>=2.1.1
 plumbum
 pyimg4>=0.8.8
+swtcp6_pmd3 @ git+https://github.com/strobecat/swtcp6-pmd3@f59719e


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

This PR wants to add a userspace TUN to connect to RSD service.  

I've tested that `pymobiledevice3 developer dvt ls / --userspace-wrapper ... --rsd ...` with  `pymobiledevice3 lockdown start-tunnel --userspace-host 0.0.0.0` works on iPadOS 18.5 and Python 3.10.12. Tunneld current not ported  

Source of `swtcp6_pmd3` is here: [strobecat/swtcp6-pmd3](https://github.com/strobecat/swtcp6-pmd3) (I assume Apple only use ipv6 for RSD)
the packages serve as a virtual NIC and TCP FSMs, process (everytime `.poll()` got called) raw IPv6 bytes from device, update TCP FSM, and send raw bytes to the device.
Closes #1260 

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
