### PR TITLE
Fix filtered payload bug in service_connection.py

### DIFF
--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -60,12 +60,12 @@ def parse_plist(payload: bytes) -> dict:
     :param payload: The plist-formatted byte string to parse.
     :return: The parsed dictionary.
     :raises PyMobileDevice3Exception: If the payload is invalid.
-    :retries with a filtered payload if plistlib compains about "not well-formed (invalid token)"
+    :retries with a filtered payload of only valid XML characters if plistlib compains about "not well-formed (invalid token)"
     """
     try:
         return plistlib.loads(payload)
     except xml.parsers.expat.ExpatError:
-        payload = bytes([b for b in payload if b not in (0x00, 0x10)])
+        payload = bytes([b for b in payload if b >= 0x20 or b in (0x09, 0x0a, 0x0d)])
         try:
             return plistlib.loads(payload)
         except plistlib.InvalidFileException:


### PR DESCRIPTION
Hello,

To make this library work with my iPhone, I found that 0x13 also needed to be filtered out so I fixed the bug by filtering the payload down to only valid XML characters. I used https://www.w3.org/TR/xml/#charsets as a guide to which characters should be filtered out.

Thanks,
Hady