### PR TITLE
installation_proxy: implement developer package installation

### DIFF
--- a/pymobiledevice3/cli/apps.py
+++ b/pymobiledevice3/cli/apps.py
@@ -45,10 +45,11 @@ def uninstall(service_provider: LockdownClient, bundle_id):
 
 
 @apps.command('install', cls=Command)
+@click.option('--developer', is_flag=True, help='Install developer package')
 @click.argument('package', type=click.Path(exists=True))
-def install(service_provider: LockdownServiceProvider, package: str) -> None:
+def install(service_provider: LockdownServiceProvider, package: str, developer: bool) -> None:
     """ install given .ipa/.app/.ipcc """
-    InstallationProxyService(lockdown=service_provider).install_from_local(package)
+    InstallationProxyService(lockdown=service_provider).install_from_local(package, developer=developer)
 
 
 @apps.command('afc', cls=Command)

--- a/pymobiledevice3/services/installation_proxy.py
+++ b/pymobiledevice3/services/installation_proxy.py
@@ -150,7 +150,7 @@ class InstallationProxyService(LockdownService):
 
     @str_to_path('package_path')
     def install_from_local(self, package_path: Path, cmd: str = 'Install', options: Optional[dict] = None,
-                           handler: Callable = None, *args) -> None:
+                           handler: Callable = None, developer: bool = False, *args) -> None:
         """ upload given ipa/ipcc onto device and install it """
         ipcc_mode = package_path.suffix == '.ipcc'
 
@@ -166,6 +166,9 @@ class InstallationProxyService(LockdownService):
             else:
                 # treat as ipa
                 ipa_contents = package_path.read_bytes()
+
+        if developer:
+            options['PackageType'] = 'Developer'
 
         with AfcService(self.lockdown) as afc:
             if not ipcc_mode:


### PR DESCRIPTION
This enables sideloading of apps with the `Developer` PackageType via the new `--developer` knob for `apps install`.
App bundles and IPA files signed with a 7-day developer certificate must use this PackageType to install correctly. Tested on my iOS 15 device.

(Fun fact: `ideviceinstaller` uses this PackageType for all app bundles.)

The CLI implementation is complete, but `InstallationProxyService::install` and `InstallationProxyService::upgrade` do not explicitly add this parameter. I’m not sure whether it should be added there, or if `install_from_local` should remain unchanged and the `options` object be constructed directly at the cli layer?


## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
