### PR TITLE
webinspector: remove required `verbose` param to fix `opened-tabs` command

### DIFF
--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -107,7 +107,7 @@ def create_webinspector_and_launch_app(lockdown: LockdownClient, timeout: float,
 @webinspector.command(cls=Command)
 @click.option('-t', '--timeout', default=3, show_default=True, type=float)
 @catch_errors
-def opened_tabs(service_provider: LockdownClient, verbose, timeout):
+def opened_tabs(service_provider: LockdownClient, timeout):
     """
     Show all currently opened tabs.
 


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**

## Description

Currently, the command - `pymobiledevice3 webinspector opened-tabs --rsd ...` returns an error:

```
TypeError: opened_tabs() missing 1 required positional argument: 'verbose'
```

In the `opened_tabs()` function, there is a `verbose` param which is unused and not required.

Tested the fix, both commands with or without the `--verbose` flag works now.

Output:

```
sudo pymobiledevice3 webinspector opened-tabs --rsd ... -v
2025-09-02 17:53:39 admin-MacBook-Pro pymobiledevice3.services.webinspector[22163] DEBUG Listing app with id PID:2193
2025-09-02 17:53:39 admin-MacBook-Pro pymobiledevice3.services.webinspector[22163] DEBUG Listing app with id PID:2184
<Safari(2184) TYPE:WIRTypeWebPage URL:https://www.google.com/?client=safari>
<Safari(2184) TYPE:WIRTypeWebPage URL:https://www.selenium.dev/>
```