### PR TITLE
cli: tunneld: Double check the UDID parameter with/without a dash (#1462)

### DIFF
--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -288,7 +288,7 @@ class RSDCommand(BaseServiceProviderCommand):
         if udid != '':
             try:
                 # Connect to the specified device
-                self.service_provider = [rsd for rsd in rsds if rsd.udid == udid][0]
+                self.service_provider = [rsd for rsd in rsds if rsd.udid == udid or rsd.udid.replace('-', '') == udid][0]
             except IndexError:
                 raise DeviceNotFoundError(udid)
         else:


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**


As you can see from the command results, the Identifier is inconsistent with the UniqueDeviceID, When executing device-related commands, it shows that the udid cannot be found, and PR fixed this problem
```shell
pymobiledevice3 usbmux list
[
    {
        "BuildVersion": "22D72",
        "ConnectionType": "USB",
        "DeviceClass": "iPhone",
        "DeviceName": "iPhoneXR",
        "Identifier": "0000802000060D691AD8003A",
        "ProductType": "iPhone11,8",
        "ProductVersion": "18.3.1",
        "UniqueDeviceID": "00008020-00060D691AD8003A"
    }
]
```

```shell
pymobiledevice3 developer dvt ls --udid 00008020-00060D691AD8003A
or
pymobiledevice3 developer dvt ls --udid 0000802000060D691AD8003A

Not found 0000802000060D691AD8003A
```