### PR TITLE
syslog: Fix formatting of entries without an image offset

### DIFF
--- a/pymobiledevice3/cli/syslog.py
+++ b/pymobiledevice3/cli/syslog.py
@@ -50,7 +50,7 @@ def format_line(color, pid, syslog_entry, include_label: bool, image_offset: boo
     image_name = posixpath.basename(syslog_entry.image_name)
     message = syslog_entry.message
     process_name = posixpath.basename(filename)
-    image_offset_str = f"+0x{syslog_entry.image_offset:x}" if image_offset else ""
+    image_offset_str = f"+0x{syslog_entry.image_offset:x}" if image_offset and image_name else ""
     label = ""
 
     if (pid != -1) and (syslog_pid != pid):


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
