### PR TITLE
cli: Fix uncaught StopIteration with --tunnel option

### DIFF
--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -141,10 +141,8 @@ async def _tunneld(udid: Optional[str] = None) -> Optional[RemoteServiceDiscover
         raise NoDeviceConnectedError()
 
     if udid != "":
-        try:
-            # Connect to the specified device
-            service_provider = next(rsd for rsd in rsds if rsd.udid == udid)
-        except IndexError:
+        service_provider = next((rsd for rsd in rsds if rsd.udid == udid), None)
+        if service_provider is None:
             raise DeviceNotFoundError(udid) from None
     else:
         service_provider = rsds[0] if len(rsds) == 1 else prompt_device_list(rsds)


### PR DESCRIPTION
When using the `--tunnel` CLI option with a UDID, if the device is not found `StopIteration` is raised by `next`.
When the relevant line was updated to use `next(...)` instead of `[...][0]`, the caught exception was not updated from `IndexError` to `StopIteration`.

(Interestingly, due to coroutines being implemented on top of generators, `StopIteration` is wrapped in a `RuntimeError` by `asyncio`.)

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
