### PR TITLE
afc: fix the docstring for afc `makedirs`

### DIFF
--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -574,6 +574,7 @@ class AfcService(LockdownService):
         Create a directory on the device.
 
         Note: This behaves like os.makedirs and will create parent directories as needed.
+        It is idempotent and will not raise an error if the directory already exists.
 
         :param filename: Path of the directory to create
         :return: Response data from the operation

--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -573,7 +573,7 @@ class AfcService(LockdownService):
         """
         Create a directory on the device.
 
-        Note: Unlike os.makedirs, this does not create parent directories automatically.
+        Note: This behaves like os.makedirs and will create parent directories as needed.
 
         :param filename: Path of the directory to create
         :return: Response data from the operation


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

The `makedirs` method **does** creates parent directories even if they don't exist. 
We have tests in https://github.com/doronz88/pymobiledevice3/blob/fac18022a216f1f520f2de069c0a755888abb334/tests/services/test_afc.py#L332-L348 which confirms this behaviour.

Let me know if there's a different reason for that note.

Also, when we call the `makedirs` command twice with same path, it does not raises an error, should we also document this idempotency?

Doing:
```python
afc.makedirs("test_a/test_b/test_c/test_d")
afc.makedirs("test_a/test_b/test_c/test_d")
```
does not raises error

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
