### PR TITLE
typing: Fix typing for `LockdownService`

### DIFF
--- a/pymobiledevice3/services/lockdown_service.py
+++ b/pymobiledevice3/services/lockdown_service.py
@@ -1,4 +1,7 @@
 import logging
+from typing import Optional
+
+from typing_extensions import Self
 
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.service_connection import ServiceConnection
@@ -9,10 +12,10 @@ class LockdownService:
         self,
         lockdown: LockdownServiceProvider,
         service_name: str,
-        is_developer_service=False,
-        service: ServiceConnection = None,
+        is_developer_service: bool = False,
+        service: Optional[ServiceConnection] = None,
         include_escrow_bag: bool = False,
-    ):
+    ) -> None:
         """
         :param lockdown: server provider
         :param service_name: wrapped service name - will attempt
@@ -26,15 +29,15 @@ class LockdownService:
             )
             service = start_service(service_name, include_escrow_bag=include_escrow_bag)
 
-        self.service_name = service_name
-        self.lockdown = lockdown
-        self.service = service
-        self.logger = logging.getLogger(self.__module__)
+        self.service_name: str = service_name
+        self.lockdown: LockdownServiceProvider = lockdown
+        self.service: ServiceConnection = service
+        self.logger: logging.Logger = logging.getLogger(self.__module__)
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    async def __aenter__(self) -> "LockdownService":
+    async def __aenter__(self) -> Self:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
Fix type annotations for the `LockdownService` class, specifically `__aenter__`.

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
