### PR TITLE
cli: replace insecure eval() with ast.literal_eval()

### DIFF
--- a/pymobiledevice3/cli/developer/accessibility/settings.py
+++ b/pymobiledevice3/cli/developer/accessibility/settings.py
@@ -1,3 +1,4 @@
+import ast
 import logging
 
 from typer_injector import InjectingTyper
@@ -30,7 +31,7 @@ def accessibility_settings_set(service_provider: ServiceProviderDep, setting: st
     in order to list all available use the "show" command
     """
     service = AccessibilityAudit(service_provider)
-    service.set_setting(setting, eval(value))
+    service.set_setting(setting, ast.literal_eval(value))
     OSUTILS.wait_return()
 
 

--- a/pymobiledevice3/cli/lockdown.py
+++ b/pymobiledevice3/cli/lockdown.py
@@ -1,3 +1,4 @@
+import ast
 import asyncio
 import logging
 import plistlib
@@ -61,8 +62,8 @@ def lockdown_set(
     domain: Optional[str] = None,
     key: Optional[str] = None,
 ) -> None:
-    """set a lockdown value using python's eval()"""
-    print_json(service_provider.set_value(value=eval(value), domain=domain, key=key))
+    """set a lockdown value using python's ast.literal_eval()"""
+    print_json(service_provider.set_value(value=ast.literal_eval(value), domain=domain, key=key))
 
 
 @cli.command("remove")


### PR DESCRIPTION
Noticed some `eval()` calls in the CLI that could be a bit risky with untrusted input. I've switched them over to `ast.literal_eval()`. It's a straightforward security win for `lockdown set` and accessibility settings without changing how they actually work.

- Replaced raw `eval()` with `ast.literal_eval()` in two locations.
- Updated help text for the affected CLI commands.