### PR TITLE
tcp_forwarder: default to localhost binding and add --host option

### DIFF
--- a/pymobiledevice3/cli/developer/debugserver.py
+++ b/pymobiledevice3/cli/developer/debugserver.py
@@ -51,7 +51,14 @@ def debugserver_applist(service_provider: ServiceProviderDep) -> None:
 
 
 @cli.command("start-server")
-def debugserver_start_server(service_provider: ServiceProviderDep, local_port: Optional[int] = None) -> None:
+def debugserver_start_server(
+    service_provider: ServiceProviderDep,
+    local_port: Optional[int] = None,
+    host: Annotated[
+        str,
+        typer.Option(help="Address to bind the local port to."),
+    ] = "127.0.0.1",
+) -> None:
     """
     Start debugserver and print the LLDB connect string.
 
@@ -66,10 +73,10 @@ def debugserver_start_server(service_provider: ServiceProviderDep, local_port: O
         service_name = "com.apple.internal.dt.remote.debugproxy"
 
     if local_port is not None:
-        print(DEBUGSERVER_CONNECTION_STEPS.format(host="127.0.0.1", port=local_port))
+        print(DEBUGSERVER_CONNECTION_STEPS.format(host=host, port=local_port))
         print("Started port forwarding. Press Ctrl-C to close this shell when done")
         sys.stdout.flush()
-        LockdownTcpForwarder(service_provider, local_port, service_name).start()
+        LockdownTcpForwarder(service_provider, local_port, service_name).start(address=host)
     elif Version(service_provider.product_version) >= Version("17.0"):
         if not isinstance(service_provider, RemoteServiceDiscoveryService):
             raise RSDRequiredError(service_provider.identifier)

--- a/pymobiledevice3/cli/usbmux.py
+++ b/pymobiledevice3/cli/usbmux.py
@@ -43,6 +43,10 @@ def usbmux_forward(
         Optional[str],
         typer.Option(help="Device serial/UDID to forward traffic to."),
     ] = None,
+    host: Annotated[
+        str,
+        typer.Option(help="Address to bind the local port to."),
+    ] = "127.0.0.1",
     daemonize: Annotated[
         bool,
         typer.Option("--daemonize", "-d", help="Run the forwarder in the background."),
@@ -58,10 +62,12 @@ def usbmux_forward(
             raise NotImplementedError("daemonizing is only supported on unix platforms") from e
 
         with tempfile.NamedTemporaryFile("wt") as pid_file:
-            daemon = Daemonize(app=f"forwarder {src_port}->{dst_port}", pid=pid_file.name, action=forwarder.start)
+            daemon = Daemonize(
+                app=f"forwarder {src_port}->{dst_port}", pid=pid_file.name, action=lambda: forwarder.start(address=host)
+            )
             daemon.start()
     else:
-        forwarder.start()
+        forwarder.start(address=host)
 
 
 @cli.command("list")

--- a/pymobiledevice3/tcp_forwarder.py
+++ b/pymobiledevice3/tcp_forwarder.py
@@ -38,7 +38,7 @@ class TcpForwarderBase:
         # socket to its remote socket and vice versa
         self.connections = {}
 
-    def start(self, address="0.0.0.0"):
+    def start(self, address="127.0.0.1"):
         """forward each connection from given local machine port to remote device port"""
         # create local tcp server socket
         self.server_socket = socket.socket()


### PR DESCRIPTION
Moved the default socket binding to `127.0.0.1` for the TCP forwarder. Binding to all interfaces by default felt like a bit too much exposure for local tunneling. I've added a `--host` option as well, so anyone who actually needs to listen on `0.0.0.0` can still do it explicitly.

- Changed `0.0.0.0` to `127.0.0.1` in `tcp_forwarder.py`.
- Exposed the new `--host` flag in `usbmux forward` and `debugserver start-server`.