### PR TITLE
cli_remote: Fix for `remote tunneld` on Python 3.12 and lower

### DIFF
--- a/pymobiledevice3/cli/remote.py
+++ b/pymobiledevice3/cli/remote.py
@@ -83,14 +83,14 @@ def cli_tunneld(
     port: Annotated[int, typer.Option(help="Port to bind the tunneld server to.")] = TUNNELD_DEFAULT_ADDRESS[1],
     daemonize: Annotated[bool, typer.Option("--daemonize", "-d", help="Run tunneld in the background.")] = False,
     protocol: Annotated[
-        TunnelProtocol,
+        str,
         typer.Option(
             "--protocol",
             "-p",
             case_sensitive=False,
             help="Transport protocol for tunneld (default: TCP on Python >=3.13, otherwise QUIC).",
         ),
-    ] = TunnelProtocol.DEFAULT,
+    ] = TunnelProtocol.DEFAULT.value,
     usb: Annotated[bool, typer.Option(help="Enable USB monitoring")] = True,
     wifi: Annotated[bool, typer.Option(help="Enable WiFi monitoring")] = True,
     usbmux: Annotated[bool, typer.Option(help="Enable usbmux monitoring")] = True,


### PR DESCRIPTION
On Python 3.11 and 3.12 (macOS 12) I was not able to use `pymobiledevice3 remote tunneld`.
This led to the error:

`'TunnelProtocol' object has no attribute 'casefold'`

Changing:

```python3
    protocol: Annotated[
        TunnelProtocol,
        typer.Option(
            "--protocol",
            "-p",
            case_sensitive=False,
            help="Transport protocol for tunneld (default: TCP on Python >=3.13, otherwise QUIC).",
        ),
    ] = TunnelProtocol.DEFAULT,
```
to:
```python3
    protocol: Annotated[
        str,
        typer.Option(
            "--protocol",
            "-p",
            case_sensitive=False,
            help="Transport protocol for tunneld (default: TCP on Python >=3.13, otherwise QUIC).",
        ),
    ] = TunnelProtocol.DEFAULT.value,
```
in cli/remote.py fixed this issue for me.

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
