### PR TITLE
cli: syslog: Fix handling of `--image-offset`

### DIFF
--- a/pymobiledevice3/cli/syslog.py
+++ b/pymobiledevice3/cli/syslog.py
@@ -258,6 +258,7 @@ def cli_syslog_live(
             include_label,
             regex or [],
             insensitive_regex or [],
+            image_offset,
         )
 
 


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
