### PR TITLE
cli: Fix typo for `notification` subcommand

### DIFF
--- a/pymobiledevice3/cli/notification.py
+++ b/pymobiledevice3/cli/notification.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 cli = InjectingTyper(
-    name="notifications",
+    name="notification",
     help="Post or observe Darwin notifications via notification_proxy.",
     no_args_is_help=True,
 )


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
