### PR TITLE
cli: Fix click options parse for tunneld

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,4 +39,5 @@ python-pcapng>=2.1.1
 plumbum
 pyimg4>=0.8.8
 typer>=0.20.0
+click>=8.2.0
 typer-injector>=0.2.0


### PR DESCRIPTION
Typer on python 3.13.4 complains about TunnelProtocol lacking the `casefold` attribute.
Making the enum an explicit `str` enum fix it.

Tsted with iOS 26.1

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
