### PR TITLE
cli: Fix handling of `--full` option for `backup` subcommand

### DIFF
--- a/pymobiledevice3/cli/backup.py
+++ b/pymobiledevice3/cli/backup.py
@@ -58,7 +58,7 @@ def backup(
         typer.Option(
             help="Whether to do a full backup. If full is True, any previous backup attempts will be discarded.",
         ),
-    ],
+    ] = False,
 ) -> None:
     """
     Backup device.


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
