### PR TITLE
posix_util: Fix handling of network interfaces with multiple ips

### DIFF
--- a/pymobiledevice3/osu/posix_util.py
+++ b/pymobiledevice3/osu/posix_util.py
@@ -36,7 +36,9 @@ class Posix(OsUtils):
         return [
             f"{ip.ip[0]}%{adapter.nice_name}"
             for adapter in get_adapters()
-            if not adapter.nice_name.startswith("tun") and (ip := next((i for i in adapter.ips if i.is_IPv6), None))
+            if not adapter.nice_name.startswith("tun")
+            for ip in (next((i for i in adapter.ips if i.is_IPv6), None),)
+            if ip
         ]
 
     def chown_to_non_sudo_if_needed(self, path: Path) -> None:

--- a/pymobiledevice3/osu/posix_util.py
+++ b/pymobiledevice3/osu/posix_util.py
@@ -34,9 +34,9 @@ class Posix(OsUtils):
 
     def get_ipv6_ips(self) -> list[str]:
         return [
-            f"{adapter.ips[0].ip[0]}%{adapter.nice_name}"
+            f"{ip.ip[0]}%{adapter.nice_name}"
             for adapter in get_adapters()
-            if adapter.ips[0].is_IPv6 and not adapter.nice_name.startswith("tun")
+            if not adapter.nice_name.startswith("tun") and (ip := next((i for i in adapter.ips if i.is_IPv6), None))
         ]
 
     def chown_to_non_sudo_if_needed(self, path: Path) -> None:


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

We have a large number of iOS 17+ devices running on our boxes. We were having issues when rebooting devices and the tunnels would not get re-created. Digging through some logs we discovered that the nics that were getting created did not always have the ipv6 ips in the first position of the list of assigned ip addresses.

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
