### PR TITLE
house_arrent: add `--documents` to afc and fix windows compat

### DIFF
--- a/pymobiledevice3/cli/apps.py
+++ b/pymobiledevice3/cli/apps.py
@@ -87,18 +87,39 @@ def afc(
 
 
 @cli.command("pull")
-def pull(service_provider: ServiceProviderDep, bundle_id: str, remote_file: Path, local_file: Path) -> None:
+def pull(
+    service_provider: ServiceProviderDep,
+    bundle_id: str,
+    remote_file: str,
+    local_file: Path,
+    documents: Annotated[bool, typer.Option()] = False,
+) -> None:
     """Pull a file from an app container to a local path."""
-    HouseArrestService(lockdown=service_provider, bundle_id=bundle_id).pull(str(remote_file), str(local_file))
+    HouseArrestService(lockdown=service_provider, bundle_id=bundle_id, documents_only=documents).pull(
+        remote_file, str(local_file)
+    )
 
 
 @cli.command("push")
-def push(service_provider: ServiceProviderDep, bundle_id: str, local_file: Path, remote_file: Path) -> None:
+def push(
+    service_provider: ServiceProviderDep,
+    bundle_id: str,
+    local_file: Path,
+    remote_file: str,
+    documents: Annotated[bool, typer.Option()] = False,
+) -> None:
     """Push a local file into an app container."""
-    HouseArrestService(lockdown=service_provider, bundle_id=bundle_id).push(str(local_file), str(remote_file))
+    HouseArrestService(lockdown=service_provider, bundle_id=bundle_id, documents_only=documents).push(
+        str(local_file), remote_file
+    )
 
 
 @cli.command("rm")
-def rm(service_provider: ServiceProviderDep, bundle_id: str, remote_file: Path) -> None:
+def rm(
+    service_provider: ServiceProviderDep,
+    bundle_id: str,
+    remote_file: str,
+    documents: Annotated[bool, typer.Option()] = False,
+) -> None:
     """Delete a file from an app container."""
-    HouseArrestService(lockdown=service_provider, bundle_id=bundle_id).rm(str(remote_file))
+    HouseArrestService(lockdown=service_provider, bundle_id=bundle_id, documents_only=documents).rm(remote_file)


### PR DESCRIPTION
### Description
This PR addresses two issues with the app file management commands:

1. **Add --documents option** - Modern iOS versions no longer accept `VendContainer` access, only `VendDocuments`. This PR adds a `--documents` flag to the `pull`, `push`, and `rm` commands to allow using `documents_only=True` when initializing the `HouseArrestService`.

2. **Fix Windows path handling** - When using `Path` type for the `remote_file` argument on Windows, paths like `/Documents/filename` were being automatically converted to `\\Documents\\filename`, breaking the expected POSIX-style paths expected by the device. Changing the type to `str` preserves the original path format.

### Changes
- Modified `pull`, `push`, and `rm` commands to accept a `--documents` flag
- Changed `remote_file` parameter type from `Path` to `str` for all three commands
- Updated the `HouseArrestService` calls to pass the `documents_only` parameter

<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
