### PR TITLE
tests: optimised tests execution

### DIFF
--- a/pymobiledevice3/services/dtfetchsymbols.py
+++ b/pymobiledevice3/services/dtfetchsymbols.py
@@ -22,16 +22,17 @@ class DtFetchSymbols:
         await service.close()
         return files
 
-    async def get_file(self, fileno: int, stream: typing.IO):
+    async def get_file(self, fileno: int, stream: typing.IO, max_bytes: typing.Optional[int] = None):
         service = await self._start_command(self.CMD_GET_FILE)
         await service.sendall(struct.pack(">I", fileno))
 
         size = struct.unpack(">Q", await service.recvall(8))[0]
         self.logger.debug(f"file size: {size}")
 
+        limit = size if max_bytes is None else min(size, max_bytes)
         received = 0
-        while received < size:
-            chunk_size = min(size - received, self.MAX_CHUNK)
+        while received < limit:
+            chunk_size = min(limit - received, self.MAX_CHUNK)
             buf = await service.recvall(chunk_size)
             stream.write(buf)
             received += len(buf)

--- a/tests/services/instruments/test_fetch_symbols.py
+++ b/tests/services/instruments/test_fetch_symbols.py
@@ -15,7 +15,7 @@ async def test_fetch_symbols_list(service_provider: LockdownServiceProvider) -> 
     Test listing of device symbol files
     """
     if Version(service_provider.product_version) < Version("17.0"):
-        DtFetchSymbols(service_provider).list_files()
+        assert len(await DtFetchSymbols(service_provider).list_files()) > 0
     else:
         if not isinstance(service_provider, RemoteServiceDiscoveryService):
             pytest.skip("requires RemoteServiceDiscoveryService")
@@ -27,15 +27,27 @@ async def test_fetch_symbols_list(service_provider: LockdownServiceProvider) -> 
 @pytest.mark.asyncio
 async def test_fetch_symbols_download(service_provider: LockdownServiceProvider, tmp_path: Path) -> None:
     """
-    Test download of device symbol files
+    Test that the download mechanism can transfer data from the device.
+    Only probes a small amount to verify the transfer protocol works without
+    downloading entire symbol files (which can be several GB).
     """
+    _PROBE_BYTES = 64 * 1024  # 64 KB is enough to confirm data flows
+
     if Version(service_provider.product_version) < Version("17.0"):
         tmp_file = Path(tmp_path) / "tmp"
         with tmp_file.open("wb") as file:
-            DtFetchSymbols(service_provider).get_file(0, file)
+            await DtFetchSymbols(service_provider).get_file(0, file, max_bytes=_PROBE_BYTES)
+        assert tmp_file.stat().st_size > 0
     else:
         if not isinstance(service_provider, RemoteServiceDiscoveryService):
             pytest.skip("requires RemoteServiceDiscoveryService")
 
         async with RemoteFetchSymbolsService(service_provider) as fetch_symbols:
-            await fetch_symbols.download(tmp_path)
+            files = await fetch_symbols.get_dsc_file_list()
+            assert len(files) > 0
+            # Receive just the first chunk of the first file to confirm data transfer works.
+            received = 0
+            async for chunk in fetch_symbols.service.iter_file_chunks(files[0].file_size, file_idx=0):
+                received += len(chunk)
+                break
+            assert received > 0

--- a/tests/services/test_crash_reports.py
+++ b/tests/services/test_crash_reports.py
@@ -1,6 +1,5 @@
 import glob
 import shutil
-import time
 from contextlib import suppress
 
 import pytest
@@ -81,7 +80,7 @@ async def test_pull(crash_manager, temp_directory) -> None:
 
 @pytest.mark.parametrize(
     ("end_time", "return_value"),
-    ((-1, True), (0, True), (time.monotonic() + 1000, False), (None, False)),
+    ((-1, True), (0, True), (float("inf"), False), (None, False)),
 )
 def test_check_timeout(crash_manager: CrashReportsManager, end_time: int, return_value: bool) -> None:
     assert crash_manager._check_timeout(end_time) is return_value


### PR DESCRIPTION
trasfer only a bunch of data and mark the test as complete instead of dwonloading potentially huge quantities of data.

When the devie had Safari opened, it's symbols file its huge. I've added some options to specify the amount of data to download, allowing the test to stress only the interesting part.

Also, I've changed the parameter for the crash report test, it was using tiemstamps and that made each test discovery and run unique, as the parameter was changing its value.
In turn, that caused problems with running the tests from VSCode, as it tries to explicitly specify the tests to run toi the runner, but the parameter changed its value and was no longer valid.

<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
