### PR TITLE
irecv: Update `serial_number` property to return string

### DIFF
--- a/pymobiledevice3/irecv.py
+++ b/pymobiledevice3/irecv.py
@@ -83,7 +83,7 @@ class IRecv:
 
     @property
     def serial_number(self) -> int:
-        return int(self._device_info["SRNM"], 16)
+        return self._device_info["SRNM"]
 
     @property
     def iboot_version(self) -> str:


### PR DESCRIPTION
Change serial_number property to return a string instead of an integer.

<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
