### PR TITLE
maintenance: Fix python3.9 support

### DIFF
--- a/pymobiledevice3/remote/common.py
+++ b/pymobiledevice3/remote/common.py
@@ -2,12 +2,12 @@ import sys
 from enum import Enum
 
 
-class ConnectionType(Enum):
+class ConnectionType(str, Enum):
     USB = "usb"
     WIFI = "wifi"
 
 
-class TunnelProtocol(Enum):
+class TunnelProtocol(str, Enum):
     TCP = "tcp"
     QUIC = "quic"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,5 @@ python-pcapng>=2.1.1
 plumbum
 pyimg4>=0.8.8
 typer>=0.20.0
-click>=8.2.0
 typer-injector>=0.2.0
 defusedxml


### PR DESCRIPTION
Click isn't a direct dependency any longer and thus was removed. Additionally, we required to make enums for choices also extend `str` so they work on older versions.

Close #1630

<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
