### PR TITLE
Hotfix/concurrent

### DIFF
--- a/pymobiledevice3/restore/fdr.py
+++ b/pymobiledevice3/restore/fdr.py
@@ -117,7 +117,7 @@ class FDRClient:
     async def _proxy_service_to_host(self, host_socket: socket.socket) -> None:
         loop = asyncio.get_running_loop()
         while True:
-            buf = await asyncio.to_thread(self.service.recv_sync, CHUNK_SIZE)
+            buf = await self.service.recv_any(CHUNK_SIZE)
             if not buf:
                 return
             await loop.sock_sendall(host_socket, buf)
@@ -131,7 +131,7 @@ class FDRClient:
             await self.service.sendall(buf)
 
     async def handle_proxy_cmd(self) -> None:
-        buf = await asyncio.to_thread(self.service.recv_sync, CHUNK_SIZE)
+        buf = await self.service.recv_any(CHUNK_SIZE)
         logger.debug(f"got proxy command with {len(buf)} bytes")
 
         # acknowledge request and payload

--- a/pymobiledevice3/restore/restore.py
+++ b/pymobiledevice3/restore/restore.py
@@ -1282,7 +1282,7 @@ class Restore(BaseRestore):
 
         with open(filename, "wb") as f:
             while True:
-                buf = client.recv_sync()
+                buf = await client.recv_any()
                 if not buf:
                     break
                 f.write(buf)

--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -107,6 +107,14 @@ class ServiceConnection:
         self.max_ssl_proto = ssl.TLSVersion.TLSv1_3
         self.socket.setblocking(False)
 
+        # Shared Future used by _ensure_started() to avoid duplicate start() calls when
+        # multiple coroutines race to use a not-yet-started connection simultaneously.
+        self._start_future: Optional[asyncio.Future] = None
+
+        # Held across the full send→recv pair in send_recv_plist() so that concurrent
+        # callers (e.g. LockdownClient shared by many tasks) are serialised automatically.
+        self._transaction_lock = asyncio.Lock()
+
     @staticmethod
     async def create_using_tcp(
         hostname: str, port: int, keep_alive: bool = True, create_connection_timeout: int = DEFAULT_TIMEOUT
@@ -170,7 +178,20 @@ class ServiceConnection:
     async def _ensure_started(self) -> None:
         if self.reader is not None and self.writer is not None:
             return
-        await self.start()
+        if self._start_future is not None:
+            return await self._start_future
+        fut = asyncio.get_running_loop().create_future()
+        self._start_future = fut
+        try:
+            await self.start()
+            fut.set_result(None)
+        except BaseException as e:
+            self._start_future = None  # allow retry on next call
+            if isinstance(e, asyncio.CancelledError):
+                fut.cancel()
+            else:
+                fut.set_exception(e)
+            raise
 
     async def aclose(self) -> None:
         """Asynchronously close the connection."""
@@ -192,6 +213,7 @@ class ServiceConnection:
         self.socket = None
         self.writer = None
         self.reader = None
+        self._start_future = None
 
     def recv_sync(self, length: int = 4096) -> bytes:
         """
@@ -224,17 +246,36 @@ class ServiceConnection:
         except ssl.SSLEOFError as e:
             raise ConnectionTerminatedError from e
 
+    async def send_recv_prefixed(self, data: bytes, endianity: str = ">") -> bytes:
+        """
+        Atomically send raw bytes and receive a length-prefixed response, under the
+        transaction lock.
+
+        This is the lowest-level concurrent-safe send→recv primitive. Higher-level
+        methods such as :meth:`send_recv_plist` are built on top of it.
+
+        :param data: Raw bytes to send (already serialised by the caller).
+        :param endianity: The byte order for the length prefix.
+        :return: The raw response bytes (may be empty).
+        """
+        async with self._transaction_lock:
+            await self.sendall(data)
+            return await self.recv_prefixed(endianity=endianity)
+
     async def send_recv_plist(self, data: dict, endianity: str = ">", fmt: Enum = plistlib.FMT_XML) -> Any:
         """
         Asynchronously send a plist to the socket and receive a plist response.
+
+        This method is safe to call concurrently from multiple coroutines on the same
+        connection: a per-connection lock serialises each send→recv pair atomically so
+        that responses are always matched to their request.
 
         :param data: The dictionary to send as a plist.
         :param endianity: The byte order ('>' for big-endian, '<' for little-endian).
         :param fmt: The plist format (e.g., plistlib.FMT_XML).
         :return: The received plist as a dictionary.
         """
-        await self.send_plist(data, endianity=endianity, fmt=fmt)
-        return await self.recv_plist(endianity=endianity)
+        return parse_plist(await self.send_recv_prefixed(build_plist(data, endianity, fmt), endianity))
 
     def recvall_sync(self, size: int) -> bytes:
         """

--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -41,7 +41,7 @@ from xonsh.cli_utils import Annotated, Arg, ArgParserAlias
 from xonsh.main import main as xonsh_main
 from xonsh.tools import print_color
 
-from pymobiledevice3.exceptions import AfcException, AfcFileNotFoundError, ArgumentError
+from pymobiledevice3.exceptions import AfcException, AfcFileNotFoundError, ArgumentError, ConnectionTerminatedError
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.services.lockdown_service import LockdownService
@@ -284,7 +284,10 @@ class AfcService(LockdownService):
     rename, and directory operations.
 
     The service communicates using a custom binary protocol with operation codes for
-    different file system operations.
+    different file system operations. AFC responses echo the ``packet_num`` from the
+    request, enabling full concurrent operation: multiple callers may issue operations
+    simultaneously and a background reader task routes each response to the correct waiter
+    via a per-``packet_num`` Future.
 
     Attributes:
         SERVICE_NAME: Service identifier for lockdown-based connections
@@ -306,6 +309,64 @@ class AfcService(LockdownService):
             service_name = self.SERVICE_NAME if isinstance(lockdown, LockdownClient) else self.RSD_SERVICE_NAME
         super().__init__(lockdown, service_name)
         self.packet_num = 0
+        # Demux state — populated in __aenter__, torn down in __aexit__
+        self._afc_pending: dict[int, asyncio.Future] = {}
+        self._afc_write_lock = asyncio.Lock()
+        self._afc_reader_task: Optional[asyncio.Task] = None
+
+    async def __aenter__(self):
+        await super().__aenter__()
+        self._afc_reader_task = asyncio.create_task(self._afc_reader_loop(), name="afc-reader")
+        return self
+
+    async def aclose(self) -> None:
+        if self._afc_reader_task is not None:
+            self._afc_reader_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._afc_reader_task
+            self._afc_reader_task = None
+        for fut in self._afc_pending.values():
+            if not fut.done():
+                fut.set_exception(ConnectionTerminatedError())
+        self._afc_pending.clear()
+        await super().close()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.aclose()
+
+    async def _afc_reader_loop(self) -> None:
+        """Background task: read AFC response packets and route them to waiting callers."""
+        try:
+            while True:
+                header_bytes = await self.service.recvall(afc_header_t.sizeof())
+                if not header_bytes:
+                    break
+                header = afc_header_t.parse(header_bytes)
+                assert header.entire_length >= afc_header_t.sizeof()
+                length = header.entire_length - afc_header_t.sizeof()
+                data = await self.service.recvall(length) if length else b""
+
+                status = AfcError.SUCCESS
+                if header.operation == AfcOpcode.STATUS:
+                    if length != 8:
+                        self.logger.error("Status length != 8")
+                    status = afc_error_construct.parse(data)
+                elif header.operation != AfcOpcode.DATA:
+                    self.logger.debug("Unexpected AFC opcode %s", header.operation)
+
+                fut = self._afc_pending.pop(header.packet_num, None)
+                if fut is not None and not fut.done():
+                    fut.set_result((status, data))
+                else:
+                    self.logger.warning("AFC: no waiter for packet_num=%d", header.packet_num)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            # Propagate to all pending waiters so they don't hang
+            for fut in self._afc_pending.values():
+                if not fut.done():
+                    fut.set_exception(e)
+            self._afc_pending.clear()
 
     async def pull(
         self,
@@ -740,6 +801,8 @@ class AfcService(LockdownService):
         Read data from an open file handle.
 
         Automatically handles large reads by splitting into multiple operations.
+        Each chunk send+receive is performed atomically via the demux reader so
+        concurrent callers on the same AfcService instance are safe.
 
         :param handle: File handle returned from fopen
         :param sz: Number of bytes to read
@@ -749,10 +812,9 @@ class AfcService(LockdownService):
         data = b""
         while sz > 0:
             to_read = MAXIMUM_READ_SIZE if sz > MAXIMUM_READ_SIZE else sz
-            await self._dispatch_packet(
+            status, chunk = await self._send_and_wait(
                 AfcOpcode.READ, afc_fread_req_t.build(AfcFreadRequest(handle=handle, size=to_read))
             )
-            status, chunk = await self._receive_data()
             if status != AfcError.SUCCESS:
                 raise AfcException("fread error", status)
             sz -= to_read
@@ -764,6 +826,8 @@ class AfcService(LockdownService):
         Write data to an open file handle.
 
         Automatically handles large writes by splitting into multiple operations.
+        Each chunk send+receive is performed atomically via the demux reader so
+        concurrent callers on the same AfcService instance are safe.
 
         :param handle: File handle returned from fopen
         :param data: Bytes to write
@@ -774,17 +838,13 @@ class AfcService(LockdownService):
         chunks_count = len(data) // chunk_size
         for i in range(chunks_count):
             chunk = data[i * chunk_size : (i + 1) * chunk_size]
-            await self._dispatch_packet(AfcOpcode.WRITE, file_handle + chunk, this_length=48)
-
-            status, _response = await self._receive_data()
+            status, _ = await self._send_and_wait(AfcOpcode.WRITE, file_handle + chunk, this_length=48)
             if status != AfcError.SUCCESS:
                 raise AfcException(f"failed to write chunk: {status}", status)
 
         if len(data) % chunk_size:
             chunk = data[chunks_count * chunk_size :]
-            await self._dispatch_packet(AfcOpcode.WRITE, file_handle + chunk, this_length=48)
-
-            status, _response = await self._receive_data()
+            status, _ = await self._send_and_wait(AfcOpcode.WRITE, file_handle + chunk, this_length=48)
             if status != AfcError.SUCCESS:
                 raise AfcException(f"failed to write last chunk: {status}", status)
 
@@ -903,29 +963,36 @@ class AfcService(LockdownService):
             AfcOpcode.FILE_LOCK, afc_lock_t.build(AfcLockRequest(handle=handle, op=operation))
         )
 
-    async def _dispatch_packet(self, operation: AfcOpcode, data: bytes, this_length: int = 0) -> None:
+    async def _dispatch_packet(self, operation: AfcOpcode, data: bytes, this_length: int = 0) -> int:
         """
         Send an AFC protocol packet to the device.
 
         :param operation: AFC operation code
         :param data: Packet payload data
         :param this_length: Override for the packet length field (0 for auto-calculation)
+        :return: The packet_num assigned to this packet (used to match the response)
         """
+        pkt_num = self.packet_num
         entire_length = afc_header_t.sizeof() + len(data)
         header = afc_header_t.build(
             AfcHeader(
                 entire_length=entire_length,
                 this_length=this_length or entire_length,
-                packet_num=self.packet_num,
+                packet_num=pkt_num,
                 operation=operation,
             )
         )
         self.packet_num += 1
         await self.service.sendall(header + data)
+        return pkt_num
 
     async def _receive_data(self):
         """
         Receive an AFC protocol response packet from the device.
+
+        .. deprecated::
+            Internal use only. External callers should use :meth:`_do_operation` or
+            :meth:`_send_and_wait` which use the background demux reader.
 
         :return: Tuple of (status_code, response_data)
         """
@@ -945,17 +1012,55 @@ class AfcService(LockdownService):
                 self.logger.debug("Unexpected AFC opcode %s", header.operation)
         return status, data
 
+    async def _send_and_wait(self, operation: AfcOpcode, data: bytes, this_length: int = 0):
+        """
+        Atomically send one AFC packet and wait for its response via the demux reader.
+
+        The write lock ensures that ``packet_num`` assignment, Future registration, and
+        the actual ``sendall`` are an uninterruptible unit so the background reader always
+        finds a registered Future before the response arrives.
+
+        If the background reader task has not been started yet (e.g. when the service is
+        used without ``async with``), it is started lazily on the first call.
+
+        :param operation: AFC operation code
+        :param data: Packet payload
+        :param this_length: Override for the ``this_length`` header field
+        :return: Tuple of (AfcError, response_bytes)
+        """
+        # Ensure we're connected (lazy connect for non-async-with usage)
+        await self.connect()
+        # Start background reader lazily for callers that don't use async with.
+        # Also restart it if it exited (e.g. connection error): the new task will
+        # fail immediately on the broken socket and propagate the error to the caller
+        # via _afc_pending, giving a clean exception rather than an infinite hang.
+        if self._afc_reader_task is None or self._afc_reader_task.done():
+            self._afc_reader_task = asyncio.create_task(self._afc_reader_loop(), name="afc-reader")
+        loop = asyncio.get_event_loop()
+        async with self._afc_write_lock:
+            fut: asyncio.Future = loop.create_future()
+            # Register *before* sending so the reader never misses the response
+            pkt_num = self.packet_num
+            self._afc_pending[pkt_num] = fut
+            try:
+                await self._dispatch_packet(operation, data, this_length)
+            except BaseException:
+                self._afc_pending.pop(pkt_num, None)
+                raise
+        return await fut
+
     async def _do_operation(self, opcode: AfcOpcode, data: bytes = b"", filename: Optional[str] = None) -> bytes:
         """
         Performs a low-level operation using the specified opcode and additional data.
 
         This method dispatches a packet with the given opcode and data, waits for a
-        response, and processes the result to determine success or failure. If the
-        operation is unsuccessful, an appropriate exception is raised.
+        response via the background demux reader, and processes the result to determine
+        success or failure. Multiple callers may call this concurrently on the same
+        instance; each operation is matched to its response by ``packet_num``.
 
         :param opcode: The operation code specifying the type of operation to perform.
         :param data: The additional data to send along with the operation. Defaults to an empty byte string.
-        :param  filename: The filename associated with the operation, if applicable. Defaults to None.
+        :param filename: The filename associated with the operation, if applicable. Defaults to None.
 
         :returns: bytes: The data received as a response to the operation.
 
@@ -965,8 +1070,7 @@ class AfcService(LockdownService):
             AfcFileNotFoundError: Exception raised when the operation fails due to
                                   an object not being found (e.g., file or directory).
         """
-        await self._dispatch_packet(opcode, data)
-        status, data = await self._receive_data()
+        status, data = await self._send_and_wait(opcode, data)
 
         exception = AfcException
         if status != AfcError.SUCCESS:

--- a/pymobiledevice3/services/crash_reports.py
+++ b/pymobiledevice3/services/crash_reports.py
@@ -64,10 +64,10 @@ class CrashReportsManager:
         raise RuntimeError("Use async context manager: `async with ...`")
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await self.close()
+        await self.aclose()
 
-    async def close(self) -> None:
-        await self.afc.close()
+    async def aclose(self) -> None:
+        await self.afc.aclose()
 
     async def clear(self, path: str = "/") -> None:
         """

--- a/pymobiledevice3/services/device_arbitration.py
+++ b/pymobiledevice3/services/device_arbitration.py
@@ -10,8 +10,7 @@ class DtDeviceArbitration(LockdownService):
         super().__init__(lockdown, self.SERVICE_NAME, is_developer_service=True)
 
     async def _send_recv(self, request: dict) -> dict:
-        await self.service.send_plist(request)
-        return await self.service.recv_plist()
+        return await self.service.send_recv_plist(request)
 
     async def version(self) -> dict:
         return await self._send_recv({"command": "version"})

--- a/pymobiledevice3/services/diagnostics.py
+++ b/pymobiledevice3/services/diagnostics.py
@@ -962,8 +962,7 @@ class DiagnosticsService(LockdownService):
         super().__init__(lockdown, service_name, service=None)
 
     async def _send_recv(self, request: dict) -> dict:
-        await self.service.send_plist(request)
-        return await self.service.recv_plist()
+        return await self.service.send_recv_plist(request)
 
     async def mobilegestalt(self, keys: Optional[list[str]] = None) -> dict:
         if keys is None or len(keys) == 0:

--- a/pymobiledevice3/services/file_relay.py
+++ b/pymobiledevice3/services/file_relay.py
@@ -44,7 +44,7 @@ class FileRelayService(LockdownService):
                 if s == "Acknowledged":
                     z = b""
                     while True:
-                        x = self.service.recv_sync()
+                        x = await self.service.recv_any()
                         if not x:
                             break
                         z += x

--- a/pymobiledevice3/services/house_arrest.py
+++ b/pymobiledevice3/services/house_arrest.py
@@ -34,8 +34,7 @@ class HouseArrestService(AfcService):
         return service
 
     async def send_command(self, bundle_id: str, cmd: str = "VendContainer") -> None:
-        await self.service.send_plist({"Command": cmd, "Identifier": bundle_id})
-        response = await self.service.recv_plist()
+        response = await self.service.send_recv_plist({"Command": cmd, "Identifier": bundle_id})
         error = response.get("Error")
         if error:
             if error == "ApplicationLookupFailed":

--- a/pymobiledevice3/services/idam.py
+++ b/pymobiledevice3/services/idam.py
@@ -14,9 +14,7 @@ class IDAMService(LockdownService):
             super().__init__(lockdown, self.RSD_SERVICE_NAME)
 
     async def configuration_inquiry(self) -> dict:
-        await self.service.send_plist({"Configuration Inquiry": True})
-        return await self.service.recv_plist()
+        return await self.service.send_recv_plist({"Configuration Inquiry": True})
 
     async def set_idam_configuration(self, value: bool) -> None:
-        await self.service.send_plist({"Set IDAM Configuration": value})
-        await self.service.recv_plist()
+        await self.service.send_recv_plist({"Set IDAM Configuration": value})

--- a/pymobiledevice3/services/lockdown_service.py
+++ b/pymobiledevice3/services/lockdown_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from inspect import isawaitable
 from typing import Optional, Union
@@ -52,6 +53,9 @@ class LockdownService:
         self._service: Optional[ServiceConnection] = service
         self._service_proxy = _LazyServiceConnection(self)
         self.logger: logging.Logger = logging.getLogger(self.__module__)
+        # Shared Future: the first connect() call creates it; concurrent callers join it
+        # instead of racing to call start_lockdown_service() multiple times.
+        self._connect_future: Optional[asyncio.Future] = None
 
     @property
     def service(self) -> Union[ServiceConnection, _LazyServiceConnection]:
@@ -76,13 +80,27 @@ class LockdownService:
         if self._service is not None:
             await self._service.close()
             self._service = None
+        self._connect_future = None
 
     async def connect(self) -> None:
         if self._service is not None:
             return
+        if self._connect_future is not None:
+            return await self._connect_future
+        fut = asyncio.get_running_loop().create_future()
+        self._connect_future = fut
         start_service = (
             self.lockdown.start_lockdown_developer_service
             if self._is_developer_service
             else self.lockdown.start_lockdown_service
         )
-        self._service = await start_service(self.service_name, include_escrow_bag=self._include_escrow_bag)
+        try:
+            self._service = await start_service(self.service_name, include_escrow_bag=self._include_escrow_bag)
+            fut.set_result(None)
+        except BaseException as e:
+            self._connect_future = None  # allow retry
+            if isinstance(e, asyncio.CancelledError):
+                fut.cancel()
+            else:
+                fut.set_exception(e)
+            raise

--- a/pymobiledevice3/services/misagent.py
+++ b/pymobiledevice3/services/misagent.py
@@ -29,32 +29,29 @@ class MisagentService(LockdownService):
             super().__init__(lockdown, self.RSD_SERVICE_NAME)
 
     async def install(self, plist: BytesIO) -> dict:
-        await self.service.send_plist({
+        response = await self.service.send_recv_plist({
             "MessageType": "Install",
             "Profile": plist.read(),
             "ProfileType": "Provisioning",
         })
-        response = await self.service.recv_plist()
         if response["Status"]:
             raise PyMobileDevice3Exception(f"invalid status: {response}")
 
         return response
 
     async def remove(self, profile_id: str) -> dict:
-        await self.service.send_plist({
+        response = await self.service.send_recv_plist({
             "MessageType": "Remove",
             "ProfileID": profile_id,
             "ProfileType": "Provisioning",
         })
-        response = await self.service.recv_plist()
         if response["Status"]:
             raise PyMobileDevice3Exception(f"invalid status: {response}")
 
         return response
 
     async def copy_all(self) -> list[ProvisioningProfile]:
-        await self.service.send_plist({"MessageType": "CopyAll", "ProfileType": "Provisioning"})
-        response = await self.service.recv_plist()
+        response = await self.service.send_recv_plist({"MessageType": "CopyAll", "ProfileType": "Provisioning"})
         if response["Status"]:
             raise PyMobileDevice3Exception(f"invalid status: {response}")
 

--- a/pymobiledevice3/services/mobile_config.py
+++ b/pymobiledevice3/services/mobile_config.py
@@ -115,8 +115,7 @@ class MobileConfigService(LockdownService):
         await self._send_recv({"RequestType": "RemoveProfile", "ProfileIdentifier": data})
 
     async def _send_recv(self, request: dict) -> dict:
-        await self.service.send_plist(request)
-        response = await self.service.recv_plist()
+        response = await self.service.send_recv_plist(request)
         if response.get("Status", None) != "Acknowledged":
             error_chain = response.get("ErrorChain")
             if error_chain is not None:

--- a/pymobiledevice3/services/power_assertion.py
+++ b/pymobiledevice3/services/power_assertion.py
@@ -30,6 +30,5 @@ class PowerAssertionService(LockdownService):
         if details is not None:
             msg["AssertionDetailKey"] = details
 
-        await self.service.send_plist(msg)
-        await self.service.recv_plist()
+        await self.service.send_recv_plist(msg)
         yield

--- a/pymobiledevice3/services/preboard.py
+++ b/pymobiledevice3/services/preboard.py
@@ -16,9 +16,7 @@ class PreboardService(LockdownService):
             super().__init__(lockdown, self.RSD_SERVICE_NAME)
 
     async def create_stashbag(self, manifest):
-        await self.service.send_plist({"Command": "CreateStashbag", "Manifest": manifest})
-        return await self.service.recv_plist()
+        return await self.service.send_recv_plist({"Command": "CreateStashbag", "Manifest": manifest})
 
     async def commit(self, manifest):
-        await self.service.send_plist({"Command": "CommitStashbag", "Manifest": manifest})
-        return await self.service.recv_plist()
+        return await self.service.send_recv_plist({"Command": "CommitStashbag", "Manifest": manifest})

--- a/pymobiledevice3/services/springboard.py
+++ b/pymobiledevice3/services/springboard.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+from pymobiledevice3.service_connection import build_plist
 from pymobiledevice3.services.lockdown_service import LockdownService
 
 
@@ -27,39 +28,33 @@ class SpringBoardServicesService(LockdownService):
         cmd = {"command": "getIconState"}
         if format_version:
             cmd["formatVersion"] = format_version
-        await self.service.send_plist(cmd)
-        return await self.service.recv_plist()
+        return await self.service.send_recv_plist(cmd)
 
     async def set_icon_state(self, newstate: Optional[list] = None) -> None:
         if newstate is None:
             newstate = {}
-        await self.service.send_plist({"command": "setIconState", "iconState": newstate})
-        await self.service.recv_prefixed()
+        await self.service.send_recv_prefixed(build_plist({"command": "setIconState", "iconState": newstate}))
 
     async def get_icon_pngdata(self, bundle_id: str) -> bytes:
-        await self.service.send_plist({"command": "getIconPNGData", "bundleId": bundle_id})
-        return (await self.service.recv_plist()).get("pngData")
+        return (await self.service.send_recv_plist({"command": "getIconPNGData", "bundleId": bundle_id})).get("pngData")
 
     async def get_interface_orientation(self) -> InterfaceOrientation:
-        await self.service.send_plist({"command": "getInterfaceOrientation"})
-        res = await self.service.recv_plist()
+        res = await self.service.send_recv_plist({"command": "getInterfaceOrientation"})
         return InterfaceOrientation(res.get("interfaceOrientation"))
 
     async def get_wallpaper_pngdata(self) -> bytes:
-        await self.service.send_plist({"command": "getHomeScreenWallpaperPNGData"})
-        return (await self.service.recv_plist()).get("pngData")
+        return (await self.service.send_recv_plist({"command": "getHomeScreenWallpaperPNGData"})).get("pngData")
 
     async def get_homescreen_icon_metrics(self) -> dict[str, float]:
-        await self.service.send_plist({"command": "getHomeScreenIconMetrics"})
-        return await self.service.recv_plist()
+        return await self.service.send_recv_plist({"command": "getHomeScreenIconMetrics"})
 
     async def get_wallpaper_info(self, wallpaper_name: str) -> dict:
-        await self.service.send_plist({"command": "getWallpaperInfo", "wallpaperName": wallpaper_name})
-        return await self.service.recv_plist()
+        return await self.service.send_recv_plist({"command": "getWallpaperInfo", "wallpaperName": wallpaper_name})
 
     async def reload_icon_state(self) -> None:
         await self.set_icon_state(await self.get_icon_state())
 
     async def get_wallpaper_preview_image(self, wallpaper_name: str) -> bytes:
-        await self.service.send_plist({"command": "getWallpaperPreviewImage", "wallpaperName": wallpaper_name})
-        return (await self.service.recv_plist())["pngData"]
+        return (
+            await self.service.send_recv_plist({"command": "getWallpaperPreviewImage", "wallpaperName": wallpaper_name})
+        )["pngData"]

--- a/tests/cli/developer/dvt/sysmon/test_process_unit.py
+++ b/tests/cli/developer/dvt/sysmon/test_process_unit.py
@@ -344,5 +344,5 @@ async def test_select_process_from_sysmon_raises_when_no_usable_snapshot(monkeyp
 
     monkeypatch.setattr(process_module.Sysmontap, "create", fake_create)
 
-    with pytest.raises(typer.BadParameter, match="failed to collect a process snapshot"):
+    with pytest.raises(typer.BadParameter, match="Failed to collect a process snapshot"):
         await _select_process_from_sysmon(object(), {}, None, ProcessSelectionMode.FIRST)

--- a/tests/services/test_afc.py
+++ b/tests/services/test_afc.py
@@ -1,3 +1,4 @@
+import asyncio
 import pathlib
 from datetime import datetime
 
@@ -361,3 +362,28 @@ async def test_push_pull_bigger_than_max_chunk(afc: AfcService) -> None:
     await afc.set_file_contents("test", contents)
     assert contents == await afc.get_file_contents("test")
     await afc.rm("test")
+
+
+async def test_concurrent_operations(lockdown: LockdownClient) -> None:
+    """
+    Verify that a single AfcService instance handles multiple concurrent operations
+    correctly via the packet_num demultiplexer.
+
+    Before the background reader + packet_num demux was implemented this test failed with:
+        RuntimeError: readexactly() called while another coroutine is already waiting
+    """
+    async with AfcService(lockdown) as afc:
+        # 10 concurrent get_device_info calls — all must return non-empty dicts
+        results = await asyncio.gather(*[afc.get_device_info() for _ in range(10)])
+        assert all(isinstance(r, dict) and len(r) > 0 for r in results), (
+            f"Expected all concurrent get_device_info calls to return non-empty dicts, got {results}"
+        )
+
+        # 5 concurrent listdir("/") — all must return the same non-empty listing
+        listings = await asyncio.gather(*[afc.listdir("/") for _ in range(5)])
+        assert all(isinstance(r, list) and len(r) > 0 for r in listings), (
+            f"Expected all concurrent listdir calls to return non-empty lists, got {listings}"
+        )
+        assert all(sorted(r) == sorted(listings[0]) for r in listings), (
+            f"Expected all concurrent listdir results to be identical, got {listings}"
+        )

--- a/tests/services/test_apps.py
+++ b/tests/services/test_apps.py
@@ -49,9 +49,9 @@ async def test_parallel_installations_cleanup(lockdown: LockdownClient, monkeypa
         return wrapped_send_plist
 
     async with (
-        await create_using_usbmux(serial=lockdown.identifier) as lockdown,
-        InstallationProxyService(lockdown=lockdown) as first,
-        InstallationProxyService(lockdown=lockdown) as second,
+        await create_using_usbmux(serial=lockdown.identifier) as inner_lockdown,
+        InstallationProxyService(lockdown=inner_lockdown) as first,
+        InstallationProxyService(lockdown=inner_lockdown) as second,
     ):
         monkeypatch.setattr(first.service, "send_plist", wrap_send_plist(first.service, captured_plists))
         monkeypatch.setattr(second.service, "send_plist", wrap_send_plist(second.service, captured_plists))

--- a/tests/services/test_apps.py
+++ b/tests/services/test_apps.py
@@ -49,10 +49,9 @@ async def test_parallel_installations_cleanup(lockdown: LockdownClient, monkeypa
         return wrapped_send_plist
 
     async with (
-        await create_using_usbmux(serial=lockdown.identifier) as first_lockdown,
-        await create_using_usbmux(serial=lockdown.identifier) as second_lockdown,
-        InstallationProxyService(lockdown=first_lockdown) as first,
-        InstallationProxyService(lockdown=second_lockdown) as second,
+        await create_using_usbmux(serial=lockdown.identifier) as lockdown,
+        InstallationProxyService(lockdown=lockdown) as first,
+        InstallationProxyService(lockdown=lockdown) as second,
     ):
         monkeypatch.setattr(first.service, "send_plist", wrap_send_plist(first.service, captured_plists))
         monkeypatch.setattr(second.service, "send_plist", wrap_send_plist(second.service, captured_plists))
@@ -63,7 +62,15 @@ async def test_parallel_installations_cleanup(lockdown: LockdownClient, monkeypa
             return_exceptions=True,
         )
 
-    assert all(isinstance(result, AppInstallError) for result in results)
+    # https://github.com/doronz88/pymobiledevice3/issues/1595
+    # will fails with:
+    # >       assert all(isinstance(result, AppInstallError) for result in results), f"Expected both installations to fail with AppInstallError, got {results}"
+    # E       AssertionError: Expected both installations to fail with AppInstallError, got [AppInstallError('APIInternalError: Error Domain=IXErrorDomain Code=13 "Failed to get bundle ID from /private/var/tmp/com.apple.appinstall.temp/temp.oX9BMG/Extracted/Payload/Test.app" UserInfo={NSLocalizedDescription=Failed to get bundle ID from /private/var/tmp/com.apple.appinstall.temp/temp.oX9BMG/Extracted/Payload/Test.app, FunctionName=+[IXPlaceholder _placeholderForBundle:client:withParent:installType:metadata:placeholderType:mayBeDeltaPackage:isFromSerializedPlaceholder:location:error:], SourceFileLine=752, NSLocalizedFailureReason=Missing bundle ID.}'), RuntimeError('readexactly() called while another coroutine is already waiting for incoming data')]
+    # E       assert False
+    # E        +  where False = all(<generator object test_parallel_installations_cleanup.<locals>.<genexpr> at 0x1121d7760>)
+    assert all(isinstance(result, AppInstallError) for result in results), (
+        f"Expected both installations to fail with AppInstallError, got {results}"
+    )
     assert len(captured_plists) == 2, f"Expected 2 captured plists, got {len(captured_plists)}"
 
     package_paths = [payload["PackagePath"] for payload in captured_plists]

--- a/tests/services/test_house_arrest.py
+++ b/tests/services/test_house_arrest.py
@@ -11,9 +11,10 @@ from pymobiledevice3.services.installation_proxy import InstallationProxyService
 async def user_bundle_id(lockdown: LockdownClient) -> str:
     async with InstallationProxyService(lockdown=lockdown) as installation_proxy:
         user_apps = await installation_proxy.get_apps(application_type="User")
-    if not user_apps:
-        pytest.skip("No user apps installed to exercise house arrest")
-    return next(iter(user_apps))
+    file_sharing_apps = [bundle_id for bundle_id, app_info in user_apps.items() if app_info.get("UIFileSharingEnabled")]
+    if not file_sharing_apps:
+        pytest.skip("No user apps with UIFileSharingEnabled installed to exercise house arrest")
+    return file_sharing_apps[0]
 
 
 @pytest.mark.asyncio
@@ -26,7 +27,6 @@ async def test_missing_bundle_id(lockdown: LockdownClient) -> None:
 @pytest.mark.asyncio
 async def test_vend_container_lists_app_root(lockdown: LockdownClient, user_bundle_id: str) -> None:
     async with await HouseArrestService.create(
-        lockdown=lockdown, bundle_id=user_bundle_id, documents_only=False
+        lockdown=lockdown, bundle_id=user_bundle_id, documents_only=True
     ) as service:
-        entries = set(await service.listdir("/"))
-    assert "Documents" in entries
+        await service.listdir("/Documents")


### PR DESCRIPTION
Allow certain services to be used concurrently:
  - LockdownClient: spawn different services concurrently
  - AFC: transfer files concurrently
  - *Service: most services are stateless and are now usable concurrently

Services that are stateful and/or receive unsolicitated events:
  - InstallationProxy
  - NotificationProxy
  - os_trace
  - heartbeat
  - file_relay
  - device_link
  - companion
  - mobile_image_mounter

These services change their behaviour according to the service state ( or stream data after a certain call ), therefore cannot be safely used concurrently.

Fixes #1595 

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
