### PR TITLE
webinspector: Fix `WebinspectorService.close` failing if connect failed

### DIFF
--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -156,10 +156,13 @@ class WebinspectorService:
         self._recv_task = asyncio.create_task(self._receiving_task())
 
     async def close(self):
-        self._recv_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await self._recv_task
-        await self.service.close()
+        if self._recv_task is not None:
+            self._recv_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._recv_task
+
+        if self.service is not None:
+            await self.service.close()
 
     async def _recv_message(self):
         while True:


### PR DESCRIPTION
If `WebinapectorService.connect` fails after setting `service` but before setting `_recv_task`, `close` will fail and the service will be left open.

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
