### PR TITLE
bonjour: Fix TXT key access in remote pairing CLI

### DIFF
--- a/pymobiledevice3/cli/bonjour.py
+++ b/pymobiledevice3/cli/bonjour.py
@@ -65,7 +65,7 @@ async def cli_remotepairing_manual_pairing_task(timeout: float) -> None:
             output.append({
                 "hostname": address.full_ip,
                 "port": answer.port,
-                "name": answer.properties[b"name"].decode(),
+                "name": answer.properties["name"],
             })
     print_json(output)
 

--- a/pymobiledevice3/cli/remote.py
+++ b/pymobiledevice3/cli/remote.py
@@ -293,7 +293,7 @@ async def start_remote_pair_task(device_name: Optional[str]) -> None:
 
     devices: list[RemotePairingManualPairingDevice] = []
     for answer in await browse_remotepairing_manual_pairing():
-        current_device_name = answer.properties[b"name"].decode()
+        current_device_name = answer.properties["name"]
 
         if device_name is not None and current_device_name != device_name:
             continue
@@ -304,7 +304,7 @@ async def start_remote_pair_task(device_name: Optional[str]) -> None:
                     ip=address.full_ip,
                     port=answer.port,
                     device_name=current_device_name,
-                    identifier=answer.properties[b"identifier"].decode(),
+                    identifier=answer.properties["identifier"],
                 )
             )
 


### PR DESCRIPTION
## Why

Remotepairing manual-pairing service properties are parsed as string keys, but these CLI paths read them using bytes keys. This causes KeyError during device browse and pair flows.

## Approach

Use string-key lookups directly in the two affected CLI code paths to match the existing ServiceInstance properties shape. Keep the change minimal and avoid unrelated refactors.

## How it works

- Update pymobiledevice3/cli/bonjour.py to read answer.properties["name"].
- Update pymobiledevice3/cli/remote.py to read answer.properties["name"] and answer.properties["identifier"].
- Preserve existing control flow and output structure.

## Links

- N/A