### PR TITLE
lockdown: Add missing exception type for `retry_create_using_usbmux()`

### DIFF
--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -1689,6 +1689,7 @@ async def retry_create_using_usbmux(retry_timeout: Optional[float] = None, **kwa
             construct.core.StreamError,
             DeviceNotFoundError,
             IncompleteReadError,
+            ConnectionTerminatedError,
         ):
             pass
 


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
