### PR TITLE
usbmux: Ignore `Paired` messages

### DIFF
--- a/pymobiledevice3/usbmux.py
+++ b/pymobiledevice3/usbmux.py
@@ -325,6 +325,9 @@ class BinaryMuxConnection(MuxConnection):
             self._add_device(MuxDevice(response.data.device_id, response.data.serial_number, "USB"))
         elif response.header.message == usbmuxd_msgtype.REMOVE:
             self._remove_device(response.data.device_id)
+        elif response.header.message == usbmuxd_msgtype.PAIRED:
+            # Pairing state updates don't change the tracked device list.
+            return
         else:
             raise MuxException(f"Invalid packet type received: {response}")
 
@@ -371,6 +374,9 @@ class PlistMuxConnection(BinaryMuxConnection):
             )
         elif response["MessageType"] == "Detached":
             super()._remove_device(response["DeviceID"])
+        elif response["MessageType"] == "Paired":
+            # Pairing notifications can arrive while listening to state updates.
+            return
         else:
             raise MuxException(f"Invalid packet type received: {response}")
 

--- a/tests/test_usbmux.py
+++ b/tests/test_usbmux.py
@@ -1,0 +1,13 @@
+import socket
+
+from pymobiledevice3.usbmux import PlistMuxConnection
+
+
+def test_plist_mux_ignores_paired_message() -> None:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        mux = PlistMuxConnection(sock)
+        mux._process_device_state({"DeviceID": 28, "MessageType": "Paired"})
+        assert mux.devices == []
+    finally:
+        sock.close()


### PR DESCRIPTION
<!---

Thanks for opening a PR on pymobiledevice3!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
