### PR TITLE
syslog live: add --format json for NDJSON output

### DIFF
--- a/pymobiledevice3/cli/syslog.py
+++ b/pymobiledevice3/cli/syslog.py
@@ -1,13 +1,16 @@
+import json
 import logging
 import os
 import posixpath
 import re
 from contextlib import nullcontext
+from enum import Enum
 from pathlib import Path
 from typing import Annotated, Optional, TextIO
 
 import typer
 from typer_injector import InjectingTyper
+from typing_extensions import assert_never
 
 from pymobiledevice3.cli.cli_common import (
     ServiceProviderDep,
@@ -28,6 +31,30 @@ cli = InjectingTyper(
 )
 
 
+class SyslogFormat(str, Enum):
+    TEXT = "text"
+    JSON = "json"
+
+
+def format_json_line(syslog_entry: SyslogEntry) -> str:
+    label: Optional[dict[str, str]] = None
+    if syslog_entry.label is not None:
+        label = {"subsystem": syslog_entry.label.subsystem, "category": syslog_entry.label.category}
+    return json.dumps(
+        {
+            "pid": syslog_entry.pid,
+            "timestamp": syslog_entry.timestamp.isoformat(),
+            "level": syslog_entry.level.name,
+            "image_name": syslog_entry.image_name,
+            "image_offset": syslog_entry.image_offset,
+            "filename": syslog_entry.filename,
+            "message": syslog_entry.message,
+            "label": label,
+        },
+        ensure_ascii=False,
+    )
+
+
 @cli.command("live-old")
 @async_command
 async def syslog_live_old(service_provider: ServiceProviderDep) -> None:
@@ -37,9 +64,7 @@ async def syslog_live_old(service_provider: ServiceProviderDep) -> None:
             print(line)
 
 
-def format_line(
-    color: bool, pid: int, syslog_entry: SyslogEntry, include_label: bool, image_offset: bool = False
-) -> Optional[str]:
+def format_line(syslog_entry: SyslogEntry, *, include_label: bool, image_offset: bool, color: bool) -> str:
     log_level_colors = {
         SyslogLogLevel.NOTICE.name: "white",
         SyslogLogLevel.INFO.name: "white",
@@ -58,9 +83,6 @@ def format_line(
     process_name = posixpath.basename(filename)
     image_offset_str = f"+0x{syslog_entry.image_offset:x}" if image_offset and image_name else ""
     label = ""
-
-    if (pid != -1) and (syslog_pid != pid):
-        return None
 
     if syslog_entry.label is not None:
         label = f"[{syslog_entry.label.subsystem}][{syslog_entry.label.category}]"
@@ -154,6 +176,12 @@ def _highlight_regex_filters(styled_line: str, match_regex: list[re.Pattern[str]
     return styled_line
 
 
+def _emit_line(line: str, out: Optional[TextIO]) -> None:
+    print(line, flush=True)
+    if out:
+        print(line, file=out, flush=True)
+
+
 async def syslog_live(
     service_provider: LockdownServiceProvider,
     out: Optional[TextIO],
@@ -168,48 +196,63 @@ async def syslog_live(
     insensitive_regex: list[str],
     image_offset: bool = False,
     start_after: Optional[str] = None,
+    output_format: SyslogFormat = SyslogFormat.TEXT,
 ) -> None:
     match_regex = [re.compile(f".*({r}).*", re.DOTALL) for r in regex]
     match_regex += [re.compile(f".*({r}).*", re.IGNORECASE | re.DOTALL) for r in insensitive_regex]
     started = start_after is None
 
-    if start_after is not None:
+    if start_after is not None and output_format is SyslogFormat.TEXT:
         print(f'Waiting for "{start_after}" ...', flush=True)
 
-    should_color_output = user_requested_colored_output()
+    should_color_output = output_format is SyslogFormat.TEXT and user_requested_colored_output()
 
     async for syslog_entry in OsTraceService(lockdown=service_provider).syslog(pid=pid):
         if process_name and posixpath.basename(syslog_entry.filename) != process_name:
             continue
 
-        line = format_line(False, pid, syslog_entry, include_label, image_offset)
-        styled_line = format_line(should_color_output, pid, syslog_entry, include_label, image_offset)
-
-        if line is None or styled_line is None:
+        if pid != -1 and syslog_entry.pid != pid:
             continue
 
-        if not started:
-            if start_after not in line:
+        if output_format is SyslogFormat.JSON:
+            json_line = format_json_line(syslog_entry)
+            _emit_line(json_line, out)
+
+        elif output_format is SyslogFormat.TEXT:
+            line = format_line(
+                syslog_entry,
+                include_label=include_label,
+                image_offset=image_offset,
+                color=False,
+            )
+
+            if not started:
+                if start_after not in line:
+                    continue
+                started = True
+
+            if _should_skip_line(line, invert_match, invert_match_insensitive):
                 continue
-            started = True
 
-        if _should_skip_line(line, invert_match, invert_match_insensitive):
-            continue
+            if not _should_keep_line(line, match, match_insensitive, match_regex):
+                continue
 
-        if not _should_keep_line(line, match, match_insensitive, match_regex):
-            continue
-
-        if should_color_output:
-            styled_line = _highlight_match_filters(styled_line, match, match_insensitive)
-            styled_line = _highlight_regex_filters(styled_line, match_regex)
-
-        print(styled_line, flush=True)
-
-        if out:
             if should_color_output:
-                print(styled_line, file=out, flush=True)
+                styled_line = format_line(
+                    syslog_entry,
+                    include_label=include_label,
+                    image_offset=image_offset,
+                    color=True,
+                )
+                styled_line = _highlight_match_filters(styled_line, match, match_insensitive)
+                styled_line = _highlight_regex_filters(styled_line, match_regex)
             else:
-                print(line, file=out, flush=True)
+                styled_line = line
+
+            _emit_line(styled_line, out)
+
+        else:
+            assert_never(output_format)
 
 
 @cli.command("live")
@@ -221,7 +264,9 @@ async def cli_syslog_live(
         typer.Option(
             "--out",
             "-o",
-            help="log file",
+            help="Save every log entry to this file. NOTE: stdout is not suppressed — entries are "
+            "printed to both stdout and the file (tee-like). Redirect stdout with '>/dev/null' to keep "
+            "only the file.",
         ),
     ] = None,
     pid: Annotated[
@@ -241,7 +286,8 @@ async def cli_syslog_live(
         typer.Option(
             "--match",
             "-m",
-            help="filter only logs matching this expression (repeatable; all must match - conjunction)",
+            help="filter only logs matching this expression "
+            "(repeatable; all must match - conjunction). Text mode only.",
         ),
     ] = None,
     invert_match: Annotated[
@@ -249,7 +295,8 @@ async def cli_syslog_live(
         typer.Option(
             "--invert-match",
             "-v",
-            help="filter only logs not matching this expression (repeatable; any match excludes - disjunction)",
+            help="filter only logs not matching this expression "
+            "(repeatable; any match excludes - disjunction). Text mode only.",
         ),
     ] = None,
     match_insensitive: Annotated[
@@ -258,7 +305,7 @@ async def cli_syslog_live(
             "--match-insensitive",
             "-mi",
             help="filter only logs matching this expression, case-insensitively "
-            "(repeatable; all must match - conjunction)",
+            "(repeatable; all must match - conjunction). Text mode only.",
         ),
     ] = None,
     invert_match_insensitive: Annotated[
@@ -267,14 +314,14 @@ async def cli_syslog_live(
             "--invert-match-insensitive",
             "-vi",
             help="filter only logs not matching this expression, case-insensitively "
-            "(repeatable; any match excludes - disjunction)",
+            "(repeatable; any match excludes - disjunction). Text mode only.",
         ),
     ] = None,
     include_label: Annotated[
         bool,
         typer.Option(
             "--label",
-            help="should include label",
+            help="should include label (text mode only; JSON always emits the label field).",
         ),
     ] = False,
     regex: Annotated[
@@ -282,7 +329,8 @@ async def cli_syslog_live(
         typer.Option(
             "--regex",
             "-e",
-            help="filter only lines matching given regex (repeatable; any match includes - disjunction)",
+            help="filter only lines matching given regex "
+            "(repeatable; any match includes - disjunction). Text mode only.",
         ),
     ] = None,
     insensitive_regex: Annotated[
@@ -291,7 +339,7 @@ async def cli_syslog_live(
             "--insensitive-regex",
             "-ei",
             help="filter only lines matching given regex, case-insensitively "
-            "(repeatable; any match includes - disjunction)",
+            "(repeatable; any match includes - disjunction). Text mode only.",
         ),
     ] = None,
     image_offset: Annotated[
@@ -299,16 +347,25 @@ async def cli_syslog_live(
         typer.Option(
             "--image-offset",
             "-io",
-            help="Include image offset in log line",
+            help="Include image offset in log line (text mode only; JSON always emits image_offset).",
         ),
     ] = False,
     start_after: Annotated[
         Optional[str],
         typer.Option(
             "--start-after",
-            help="Start printing only after this string is seen",
+            help="Start printing only after this string is seen. Text mode only.",
         ),
     ] = None,
+    output_format: Annotated[
+        SyslogFormat,
+        typer.Option(
+            "--format",
+            help="Output format. 'json' emits one JSON per line (NDJSON); only --pid and --process-name "
+            "apply, other filters are ignored.",
+            case_sensitive=False,
+        ),
+    ] = SyslogFormat.TEXT,
 ) -> None:
     """view live syslog lines"""
 
@@ -327,6 +384,7 @@ async def cli_syslog_live(
             insensitive_regex or [],
             image_offset,
             start_after,
+            output_format,
         )
 
 

--- a/tests/cli/test_syslog.py
+++ b/tests/cli/test_syslog.py
@@ -1,3 +1,4 @@
+import json
 import re
 from datetime import datetime
 from io import StringIO
@@ -5,7 +6,9 @@ from io import StringIO
 import pytest
 
 from pymobiledevice3.cli import syslog as syslog_module
-from pymobiledevice3.services.os_trace import SyslogEntry, SyslogLogLevel
+from pymobiledevice3.services.os_trace import SyslogEntry, SyslogLabel, SyslogLogLevel
+
+pytestmark = [pytest.mark.cli]
 
 _FAKE_SERVICE_PROVIDER = object()
 
@@ -239,3 +242,161 @@ async def test_syslog_live_regex_filters_and_writes_plain_output_to_out(monkeypa
     assert printed_lines[0].endswith("daemon ready")
     assert printed_lines[1].endswith("worker ready")
     assert out_lines == printed_lines
+
+
+def test_format_json_line_with_label():
+    entry = SyslogEntry(
+        pid=42,
+        timestamp=datetime(2026, 4, 18, 10, 15, 32, 123456),
+        level=SyslogLogLevel.ERROR,
+        image_name="/p/App",
+        image_offset=16,
+        filename="/p/App",
+        message="hello",
+        label=SyslogLabel(subsystem="com.foo.bar", category="cat"),
+    )
+    obj = json.loads(syslog_module.format_json_line(entry))
+    assert obj == {
+        "pid": 42,
+        "timestamp": "2026-04-18T10:15:32.123456",
+        "level": "ERROR",
+        "image_name": "/p/App",
+        "image_offset": 16,
+        "filename": "/p/App",
+        "message": "hello",
+        "label": {"subsystem": "com.foo.bar", "category": "cat"},
+    }
+
+
+def test_format_json_line_handles_null_label():
+    entry = _create_syslog_entry("plain")  # no label
+    obj = json.loads(syslog_module.format_json_line(entry))
+    assert obj["label"] is None
+    assert obj["message"] == "plain"
+
+
+def test_format_json_line_preserves_unicode():
+    entry = _create_syslog_entry("hello 🚀 мир")
+    raw = syslog_module.format_json_line(entry)
+    assert "🚀" in raw  # ensure_ascii=False keeps raw unicode
+    assert json.loads(raw)["message"] == "hello 🚀 мир"
+
+
+@pytest.mark.asyncio
+async def test_syslog_live_json_emits_valid_ndjson(monkeypatch, capsys):
+    printed_lines, _ = await _run_syslog_live(
+        monkeypatch,
+        capsys,
+        _create_syslog_entries(["hello", "world"]),
+        output_format=syslog_module.SyslogFormat.JSON,
+    )
+    assert len(printed_lines) == 2
+    parsed = [json.loads(line) for line in printed_lines]
+    assert [p["message"] for p in parsed] == ["hello", "world"]
+    assert all(p["level"] == "INFO" for p in parsed)
+    assert all(p["pid"] == 123 for p in parsed)
+
+
+@pytest.mark.asyncio
+async def test_syslog_live_json_ignores_text_filters(monkeypatch, capsys):
+    # Every text-mode filter flag must be ignored in JSON mode.
+    printed_lines, _ = await _run_syslog_live(
+        monkeypatch,
+        capsys,
+        _create_syslog_entries(["keep this", "skip this"]),
+        output_format=syslog_module.SyslogFormat.JSON,
+        match=["keep"],
+        invert_match=["skip"],
+        match_insensitive=["KEEP"],
+        invert_match_insensitive=["SKIP"],
+        regex=["keep"],
+        insensitive_regex=["KEEP"],
+        start_after="never-appears",
+        include_label=True,
+        image_offset=True,
+    )
+    # All entries emitted; none are filtered out.
+    assert len(printed_lines) == 2
+    messages = [json.loads(line)["message"] for line in printed_lines]
+    assert messages == ["keep this", "skip this"]
+
+
+@pytest.mark.asyncio
+async def test_syslog_live_json_applies_process_name_filter(monkeypatch, capsys):
+    entries = [
+        _create_syslog_entry("from test-process"),
+        SyslogEntry(
+            pid=456,
+            timestamp=datetime(2024, 1, 1, 0, 0, 1),
+            level=SyslogLogLevel.INFO,
+            image_name="/usr/libexec/other",
+            image_offset=0,
+            filename="/usr/libexec/other",
+            message="from other",
+        ),
+    ]
+    printed_lines, _ = await _run_syslog_live(
+        monkeypatch,
+        capsys,
+        entries,
+        output_format=syslog_module.SyslogFormat.JSON,
+        process_name="test-process",
+    )
+    assert len(printed_lines) == 1
+    assert json.loads(printed_lines[0])["message"] == "from test-process"
+
+
+@pytest.mark.asyncio
+async def test_syslog_live_json_applies_pid_filter(monkeypatch, capsys):
+    entries = [
+        _create_syslog_entry("pid 123"),  # default pid is 123
+        SyslogEntry(
+            pid=999,
+            timestamp=datetime(2024, 1, 1, 0, 0, 1),
+            level=SyslogLogLevel.INFO,
+            image_name="/usr/libexec/test-process",
+            image_offset=0,
+            filename="/usr/libexec/test-process",
+            message="pid 999",
+        ),
+    ]
+    printed_lines, _ = await _run_syslog_live(
+        monkeypatch,
+        capsys,
+        entries,
+        output_format=syslog_module.SyslogFormat.JSON,
+        pid=999,
+    )
+    assert len(printed_lines) == 1
+    assert json.loads(printed_lines[0])["pid"] == 999
+
+
+@pytest.mark.asyncio
+async def test_syslog_live_json_tees_to_out(monkeypatch, capsys):
+    out = StringIO()
+    printed_lines, out_value = await _run_syslog_live(
+        monkeypatch,
+        capsys,
+        _create_syslog_entries(["one", "two"]),
+        output_format=syslog_module.SyslogFormat.JSON,
+        out=out,
+    )
+    out_lines = out_value.strip().splitlines()
+    assert out_lines == printed_lines  # same NDJSON to both stdout and file
+    assert [json.loads(line)["message"] for line in out_lines] == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_syslog_live_json_suppresses_start_after_banner(monkeypatch, capsys):
+    # In text mode, `--start-after` prints a "Waiting for..." banner to stdout.
+    # That would corrupt NDJSON; JSON mode must suppress it.
+    printed_lines, _ = await _run_syslog_live(
+        monkeypatch,
+        capsys,
+        _create_syslog_entries(["one"]),
+        output_format=syslog_module.SyslogFormat.JSON,
+        start_after="anything",
+    )
+    assert len(printed_lines) == 1
+    # The single line must parse as valid JSON — no banner contamination.
+    assert json.loads(printed_lines[0])["message"] == "one"


### PR DESCRIPTION
Adds `--format json` to `syslog live` for consumers that parse logs programmatically rather than regex-matching the text format. Emits one JSON object per line (NDJSON) with fields mapping 1:1 to SyslogEntry. Only --pid and --process-name apply in JSON mode; text-based filters are text-mode only and documented as such in each flag's help text. Also adds `pytest.mark.cli` to tests/cli/test_syslog.py so it's picked up by CI's `pytest -m cli`.