### PR TITLE
xcuitest: Fix early registeration of XCTest services

### DIFF
--- a/pymobiledevice3/services/dvt/testmanaged/xcuitest.py
+++ b/pymobiledevice3/services/dvt/testmanaged/xcuitest.py
@@ -60,6 +60,11 @@ class _TestManagerProvider(DtxServiceProvider):
     SERVICE_NAME = "com.apple.testmanagerd.lockdown.secure"
     RSD_SERVICE_NAME = "com.apple.dt.testmanagerd.remote"
     OLD_SERVICE_NAME = "com.apple.testmanagerd.lockdown"
+    REGISTER_SERVICES = (
+        XCTestManager_IDEInterface,
+        XCTestManager_DaemonConnectionInterface,
+        XCTestDriverInterface,
+    )
 
 
 class ProxyIdeToDaemonService(DtxProxyService[XCTestManager_IDEInterface, XCTestManager_DaemonConnectionInterface]):


### PR DESCRIPTION
## Summary

Adds `REGISTER_SERVICES` to `_TestManagerProvider` so that `XCTestManager_IDEInterface`, `XCTestManager_DaemonConnectionInterface`, and `XCTestDriverInterface` are registered during `DtxServiceProvider.connect()`, before the DTX handshake completes.

**Problem:** When running `xcuitest` through a RemotePairing (RSD) tunnel — e.g. via a VPN like Tailscale over a non-local network — the device sends DTX messages (notably `_XCT_testRunnerReadyWithCapabilities:`) immediately after the handshake, before `DtxProxyService.connect()` registers the service classes. Messages fall through to `DTXDynamicService` (which doesn't implement the callback), terminating the connection:
```
DTXDynamicService: dispatch for '_XCT_testRunnerReadyWithCapabilities:' is not implemented
```

This does not affect lockdown (USB) tunnels due to lower latency, but is reliably reproducible over higher-latency RSD tunnels.

## Testing

```bash
# Before fix — fails with DTX error:
python3 -m pymobiledevice3 developer dvt xcuitest --rsd <rsd_addr> <rsd_port> com.example.WDA.xctrunner

# After fix — works:
python3 -m pymobiledevice3 developer dvt xcuitest --rsd <rsd_addr> <rsd_port> com.example.WDA.xctrunner
# [IDE] testRunnerReadyWithCapabilities: {...}
# [IDE] didBeginExecutingTestPlan
# [IDE] testCaseDidStart: UITestingUITests/testRunner
```

Tested on:
- iPhone 14 Pro, iOS 26.4.1
- RemotePairing tunnel via Tailscale VPN (non-local network)
- Lockdown tunnel via USB (regression check — still works)

## AI Assistance

Claude Code (Anthropic) assisted with root cause analysis of the DTX timing issue — tracing message routing through `DTXConnection._on_channel_request` → `_instantiate_dtxproxy` → `_services_cls` lookup to identify the missing early registration. The fix itself and all testing were done manually.