### PR TITLE
services: Add BTLogger

### DIFF
--- a/docs/api/services.md
+++ b/docs/api/services.md
@@ -27,3 +27,5 @@ from `LockdownService`.
 ::: pymobiledevice3.services.crash_reports.CrashReportsManager
 
 ::: pymobiledevice3.services.mobile_image_mounter.MobileImageMounterService
+
+::: pymobiledevice3.services.bt_packet_logger.BtPacketLoggerService

--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -32,6 +32,12 @@ pymobiledevice3 syslog live -m SpringBoard
 # Exclude syslog lines
 pymobiledevice3 syslog live -v unwanted_log
 
+# Capture Bluetooth HCI traffic in PacketLogger format
+pymobiledevice3 btlogger trace.pklg
+
+# Capture Bluetooth HCI traffic as pcapng for Wireshark
+pymobiledevice3 btlogger -f pcapng trace.pcapng
+
 # Restart device
 pymobiledevice3 diagnostics restart
 

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -108,6 +108,7 @@ CLI_GROUPS = {
     "amfi": "amfi",
     "apps": "apps",
     "backup2": "backup",
+    "btlogger": "btlogger",
     "bonjour": "bonjour",
     "companion": "companion_proxy",
     "crash": "crash",

--- a/pymobiledevice3/cli/btlogger.py
+++ b/pymobiledevice3/cli/btlogger.py
@@ -1,0 +1,59 @@
+import sys
+from collections.abc import AsyncIterable
+from enum import Enum
+from pathlib import Path
+from typing import Annotated, BinaryIO
+
+import typer
+from typer_injector import InjectingTyper
+
+from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command
+from pymobiledevice3.services.bt_packet_logger import BtPacketLoggerService
+
+cli = InjectingTyper(
+    name="btlogger",
+    help="Capture Bluetooth HCI traffic via com.apple.bluetooth.BTPacketLogger.",
+    no_args_is_help=True,
+)
+
+
+class BtLoggerFormat(str, Enum):
+    PACKETLOGGER = "packetlogger"
+    PCAPNG = "pcapng"
+
+
+async def _write(
+    service: BtPacketLoggerService,
+    format_: BtLoggerFormat,
+    out: BinaryIO,
+    packet_generator: AsyncIterable[bytes],
+) -> None:
+    if format_ is BtLoggerFormat.PACKETLOGGER:
+        await service.write_to_packetlogger(out, packet_generator)
+    else:
+        await service.write_to_pcapng(out, packet_generator)
+
+
+@cli.command()
+@async_command
+async def capture(
+    service_provider: ServiceProviderDep,
+    out: Path,
+    format_: Annotated[
+        BtLoggerFormat,
+        typer.Option(
+            "--format",
+            "-f",
+            help="Output format: Apple's PacketLogger format (.pklg) or pcapng for Wireshark.",
+        ),
+    ] = BtLoggerFormat.PACKETLOGGER,
+) -> None:
+    """Capture Bluetooth HCI traffic to a file. Use '-' to stream to stdout."""
+    async with BtPacketLoggerService(service_provider) as service:
+        packet_generator = service.watch()
+        if str(out) == "-":
+            await _write(service, format_, sys.stdout.buffer, packet_generator)
+            return
+
+        with out.open("wb") as out_file:
+            await _write(service, format_, out_file, packet_generator)

--- a/pymobiledevice3/services/bt_packet_logger.py
+++ b/pymobiledevice3/services/bt_packet_logger.py
@@ -1,0 +1,145 @@
+import logging
+from collections.abc import AsyncGenerator, AsyncIterable
+from dataclasses import dataclass
+from enum import IntEnum
+from struct import pack, unpack
+from typing import BinaryIO, Optional
+
+import pcapng.blocks as blocks
+from pcapng import FileWriter
+
+from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+from pymobiledevice3.services.lockdown_service import LockdownService
+
+PACKETLOGGER_RECORD_HEADER_SIZE = 13
+SERVICE_PACKET_SIZE_HEADER = 2
+PCAPNG_LINKTYPE_BLUETOOTH_HCI_H4_WITH_PHDR = 201
+logger = logging.getLogger(__name__)
+
+
+class PacketLoggerPacketType(IntEnum):
+    HCI_COMMAND = 0x00
+    HCI_EVENT = 0x01
+    SENT_ACL_DATA = 0x02
+    RECV_ACL_DATA = 0x03
+    SENT_SCO_DATA = 0x08
+    RECV_SCO_DATA = 0x09
+
+
+# Maps a PacketLogger record type to its HCI H4 type byte and direction (0 = sent, 1 = received).
+HCI_H4_TYPE_BY_PACKET_TYPE: dict[int, tuple[int, int]] = {
+    PacketLoggerPacketType.HCI_COMMAND: (0x01, 0),
+    PacketLoggerPacketType.SENT_ACL_DATA: (0x02, 0),
+    PacketLoggerPacketType.RECV_ACL_DATA: (0x02, 1),
+    PacketLoggerPacketType.SENT_SCO_DATA: (0x03, 0),
+    PacketLoggerPacketType.RECV_SCO_DATA: (0x03, 1),
+    PacketLoggerPacketType.HCI_EVENT: (0x04, 1),
+}
+
+
+@dataclass(frozen=True)
+class PacketLoggerRecord:
+    length: int
+    seconds: int
+    microseconds: int
+    packet_type: int
+    payload: bytes
+
+
+def parse_packetlogger_record(data: bytes) -> PacketLoggerRecord:
+    if len(data) < PACKETLOGGER_RECORD_HEADER_SIZE:
+        raise ValueError(f"packet logger record too short: {len(data)} bytes")
+
+    length = unpack(">I", data[:4])[0]
+    seconds = unpack(">I", data[4:8])[0]
+    microseconds = unpack(">I", data[8:12])[0]
+    payload = data[PACKETLOGGER_RECORD_HEADER_SIZE:]
+    return PacketLoggerRecord(
+        length=length,
+        seconds=seconds,
+        microseconds=microseconds,
+        packet_type=data[12],
+        payload=payload,
+    )
+
+
+def packetlogger_record_to_hci_h4_phdr(record: PacketLoggerRecord) -> Optional[bytes]:
+    """Build a DLT_BLUETOOTH_HCI_H4_WITH_PHDR (link-type 201) frame from a PacketLogger record.
+
+    The frame is a 4-byte big-endian direction pseudo-header (0 = sent, 1 = received), followed by
+    the HCI H4 type byte and the HCI payload. Returns None for record types that don't map to HCI.
+    """
+    mapping = HCI_H4_TYPE_BY_PACKET_TYPE.get(record.packet_type)
+    if mapping is None:
+        logger.debug("skipping unsupported PacketLogger record type: 0x%02x", record.packet_type)
+        return None
+    hci_h4_type, direction_in = mapping
+    return pack(">I", direction_in) + bytes([hci_h4_type]) + record.payload
+
+
+async def write_packetlogger_stream(out: BinaryIO, packet_generator: AsyncIterable[bytes]) -> None:
+    async for packet in packet_generator:
+        out.write(packet)
+        out.flush()
+
+
+async def write_pcapng_stream(
+    out: BinaryIO, packet_generator: AsyncIterable[bytes], product_version: str = "", tz_offset_seconds: int = 0
+) -> None:
+    # The BTPacketLogger service reports record timestamps as device-local wall-clock time, whereas the pcapng
+    # EnhancedPacket timestamp (with the default if_tsresol of 1e-6) is interpreted as UTC. Subtract the device's
+    # UTC offset so Wireshark doesn't apply the timezone shift a second time when rendering the display time.
+    shb = blocks.SectionHeader(
+        options={
+            "shb_hardware": "artificial",
+            "shb_os": "iOS",
+            "shb_userappl": "pymobiledevice3",
+        }
+    )
+    shb.new_member(
+        blocks.InterfaceDescription,
+        link_type=PCAPNG_LINKTYPE_BLUETOOTH_HCI_H4_WITH_PHDR,
+        options={"if_description": "Bluetooth HCI", "if_os": f"iOS {product_version}"},
+    )
+    writer = FileWriter(out, shb)
+
+    async for packet in packet_generator:
+        try:
+            record = parse_packetlogger_record(packet)
+        except ValueError as e:
+            logger.debug("skipping malformed PacketLogger record (%s): %r", e, packet[:32])
+            continue
+        frame = packetlogger_record_to_hci_h4_phdr(record)
+        if frame is None:
+            continue
+
+        timestamp_microseconds = int((record.seconds - tz_offset_seconds) * 1_000_000 + record.microseconds)
+        enhanced_packet = shb.new_member(blocks.EnhancedPacket)
+        enhanced_packet.packet_data = frame
+        enhanced_packet.timestamp_high = (timestamp_microseconds >> 32) & 0xFFFFFFFF
+        enhanced_packet.timestamp_low = timestamp_microseconds & 0xFFFFFFFF
+        writer.write_block(enhanced_packet)
+        out.flush()
+
+
+class BtPacketLoggerService(LockdownService):
+    SERVICE_NAME = "com.apple.bluetooth.BTPacketLogger"
+
+    def __init__(self, lockdown: LockdownServiceProvider) -> None:
+        super().__init__(lockdown, self.SERVICE_NAME)
+
+    async def watch(self, packets_count: int = -1) -> AsyncGenerator[bytes, None]:
+        packet_index = 0
+        while packet_index != packets_count:
+            packet_length = unpack("<H", await self.service.recvall(SERVICE_PACKET_SIZE_HEADER))[0]
+            if packet_length == 0:
+                continue
+            yield await self.service.recvall(packet_length)
+            packet_index += 1
+
+    async def write_to_packetlogger(self, out: BinaryIO, packet_generator: AsyncIterable[bytes]) -> None:
+        await write_packetlogger_stream(out, packet_generator)
+
+    async def write_to_pcapng(self, out: BinaryIO, packet_generator: AsyncIterable[bytes]) -> None:
+        tz_offset_seconds = self.lockdown.all_values.get("TimeZoneOffsetFromUTC") or 0
+        await write_pcapng_stream(out, packet_generator, self.lockdown.product_version, tz_offset_seconds)

--- a/tests/services/test_bt_packet_logger.py
+++ b/tests/services/test_bt_packet_logger.py
@@ -1,0 +1,190 @@
+from io import BytesIO
+
+import pytest
+from pcapng import FileScanner
+from pcapng.blocks import EnhancedPacket, InterfaceDescription, SectionHeader
+
+from pymobiledevice3.services.bt_packet_logger import (
+    PCAPNG_LINKTYPE_BLUETOOTH_HCI_H4_WITH_PHDR,
+    PacketLoggerPacketType,
+    packetlogger_record_to_hci_h4_phdr,
+    parse_packetlogger_record,
+    write_packetlogger_stream,
+    write_pcapng_stream,
+)
+
+
+def _create_packetlogger_record(
+    packet_type: int,
+    payload: bytes,
+    *,
+    seconds: int = 0x01020304,
+    microseconds: int = 0x05060708,
+) -> bytes:
+    payload_length = 9 + len(payload)
+    return (
+        payload_length.to_bytes(4, "big")
+        + seconds.to_bytes(4, "big")
+        + microseconds.to_bytes(4, "big")
+        + bytes([packet_type])
+        + payload
+    )
+
+
+def test_parse_packetlogger_record() -> None:
+    payload = b"\x01\x02\x03\x04"
+    raw_record = _create_packetlogger_record(PacketLoggerPacketType.HCI_EVENT, payload)
+
+    record = parse_packetlogger_record(raw_record)
+
+    assert record.length == 9 + len(payload)
+    assert record.seconds == 0x01020304
+    assert record.microseconds == 0x05060708
+    assert record.packet_type == PacketLoggerPacketType.HCI_EVENT
+    assert record.payload == payload
+
+
+def test_parse_packetlogger_record_rejects_short_input() -> None:
+    with pytest.raises(ValueError, match="too short"):
+        parse_packetlogger_record(b"\x00" * 12)
+
+
+@pytest.mark.parametrize(
+    ("packet_type", "expected_direction", "expected_h4_type"),
+    [
+        (PacketLoggerPacketType.HCI_COMMAND, 0, 0x01),
+        (PacketLoggerPacketType.SENT_ACL_DATA, 0, 0x02),
+        (PacketLoggerPacketType.RECV_ACL_DATA, 1, 0x02),
+        (PacketLoggerPacketType.SENT_SCO_DATA, 0, 0x03),
+        (PacketLoggerPacketType.RECV_SCO_DATA, 1, 0x03),
+        (PacketLoggerPacketType.HCI_EVENT, 1, 0x04),
+    ],
+)
+def test_packetlogger_record_to_hci_h4_phdr(packet_type, expected_direction, expected_h4_type) -> None:
+    payload = b"\xaa\xbb\xcc"
+    record = parse_packetlogger_record(_create_packetlogger_record(packet_type, payload))
+
+    frame = packetlogger_record_to_hci_h4_phdr(record)
+
+    assert frame is not None
+    assert int.from_bytes(frame[0:4], "big") == expected_direction
+    assert frame[4] == expected_h4_type
+    assert frame[5:] == payload
+
+
+def test_packetlogger_record_to_hci_h4_phdr_skips_unknown_type() -> None:
+    record = parse_packetlogger_record(_create_packetlogger_record(0xFC, b"\x00\x01"))
+
+    assert packetlogger_record_to_hci_h4_phdr(record) is None
+
+
+@pytest.mark.asyncio
+async def test_write_packetlogger_stream() -> None:
+    records = [
+        _create_packetlogger_record(PacketLoggerPacketType.HCI_COMMAND, b"\x01"),
+        _create_packetlogger_record(PacketLoggerPacketType.HCI_EVENT, b"\x02\x03"),
+    ]
+    out = BytesIO()
+
+    async def generate():
+        for record in records:
+            yield record
+
+    await write_packetlogger_stream(out, generate())
+
+    assert out.getvalue() == b"".join(records)
+
+
+@pytest.mark.asyncio
+async def test_write_pcapng_stream() -> None:
+    seconds = 0x01020304
+    microseconds = 0x00050607
+    payload = b"\x11\x22"
+    record = _create_packetlogger_record(
+        PacketLoggerPacketType.RECV_ACL_DATA, payload, seconds=seconds, microseconds=microseconds
+    )
+    out = BytesIO()
+
+    async def generate():
+        yield record
+
+    await write_pcapng_stream(out, generate(), product_version="17.0")
+
+    out.seek(0)
+    parsed = list(FileScanner(out))
+    assert isinstance(parsed[0], SectionHeader)
+    interface = next(block for block in parsed if isinstance(block, InterfaceDescription))
+    assert interface.link_type == PCAPNG_LINKTYPE_BLUETOOTH_HCI_H4_WITH_PHDR
+
+    packets = [block for block in parsed if isinstance(block, EnhancedPacket)]
+    assert len(packets) == 1
+    # recv ACL -> direction 1, H4 type 0x02
+    assert packets[0].packet_data == b"\x00\x00\x00\x01\x02" + payload
+    expected_us = seconds * 1_000_000 + microseconds
+    actual_us = (packets[0].timestamp_high << 32) | packets[0].timestamp_low
+    assert actual_us == expected_us
+
+
+@pytest.mark.asyncio
+async def test_write_pcapng_stream_converts_local_time_to_utc() -> None:
+    seconds = 0x01020304
+    microseconds = 0x00050607
+    tz_offset_seconds = 2 * 3600  # device in UTC+2
+    record = _create_packetlogger_record(
+        PacketLoggerPacketType.HCI_EVENT, b"\x11\x22", seconds=seconds, microseconds=microseconds
+    )
+    out = BytesIO()
+
+    async def generate():
+        yield record
+
+    await write_pcapng_stream(out, generate(), tz_offset_seconds=tz_offset_seconds)
+
+    out.seek(0)
+    packets = [block for block in FileScanner(out) if isinstance(block, EnhancedPacket)]
+    assert len(packets) == 1
+    expected_us = (seconds - tz_offset_seconds) * 1_000_000 + microseconds
+    actual_us = (packets[0].timestamp_high << 32) | packets[0].timestamp_low
+    assert actual_us == expected_us
+
+
+@pytest.mark.asyncio
+async def test_write_pcapng_stream_accepts_float_tz_offset() -> None:
+    # Lockdown reports TimeZoneOffsetFromUTC as a float, which previously made the microsecond
+    # timestamp a float and broke the >> 32 bit-shift used for timestamp_high.
+    seconds = 0x01020304
+    microseconds = 0x00050607
+    tz_offset_seconds = 2 * 3600.0  # float, as returned by a real device
+    record = _create_packetlogger_record(
+        PacketLoggerPacketType.HCI_EVENT, b"\x11\x22", seconds=seconds, microseconds=microseconds
+    )
+    out = BytesIO()
+
+    async def generate():
+        yield record
+
+    await write_pcapng_stream(out, generate(), tz_offset_seconds=tz_offset_seconds)
+
+    out.seek(0)
+    packets = [block for block in FileScanner(out) if isinstance(block, EnhancedPacket)]
+    assert len(packets) == 1
+    expected_us = int((seconds - tz_offset_seconds) * 1_000_000 + microseconds)
+    actual_us = (packets[0].timestamp_high << 32) | packets[0].timestamp_low
+    assert actual_us == expected_us
+
+
+@pytest.mark.asyncio
+async def test_write_pcapng_stream_skips_malformed_and_unknown() -> None:
+    out = BytesIO()
+
+    async def generate():
+        yield b"\x00\x01\x02"  # too short to parse
+        yield _create_packetlogger_record(0xFC, b"\x00\x01")  # unknown type
+        yield _create_packetlogger_record(PacketLoggerPacketType.HCI_EVENT, b"\x04\x05")
+
+    await write_pcapng_stream(out, generate())
+
+    out.seek(0)
+    packets = [block for block in FileScanner(out) if isinstance(block, EnhancedPacket)]
+    assert len(packets) == 1
+    assert packets[0].packet_data == b"\x00\x00\x00\x01\x04\x04\x05"


### PR DESCRIPTION
## Summary

Closes #1669.

Adds a `btlogger` CLI and `BtPacketLoggerService` that captures Bluetooth **HCI** traffic from a device via `com.apple.bluetooth.BTPacketLogger` (the same service libimobiledevice's `idevicebtlogger` uses). This operates on the HCI layer, not general IP PCAPs.

Two output formats:
- **`packetlogger`** (default) — the raw Apple PacketLogger record stream (`.pklg`), openable in Apple's PacketLogger.app.
- **`pcapng`** (`-f pcapng`) — written with `python-pcapng`, reusing the same writer path as the `pcapd` service from #1003: a `SectionHeader` + `InterfaceDescription(link_type=201, BLUETOOTH_HCI_H4_WITH_PHDR)` + one `EnhancedPacket` per HCI record. Opens directly in Wireshark.

Usage:
```shell
# raw PacketLogger format
pymobiledevice3 btlogger trace.pklg

# pcapng for Wireshark
pymobiledevice3 btlogger -f pcapng trace.pcapng

# stream to stdout
pymobiledevice3 btlogger -f pcapng -
```

The wire format was implemented against libimobiledevice's `idevicebtlogger`: 2-byte big-endian framing, the 13-byte record header (length / BE seconds / BE microseconds / type), and the packet-type → HCI H4 type + direction mapping. Each record becomes a link-type-201 frame (4-byte BE direction pseudo-header + H4 type byte + payload) wrapped in a pcapng `EnhancedPacket`.

Addresses the points raised in #1669:
- **Wireshark-usable** — yes, link-type 201.
- **Use `python-pcapng` like #1003** — done; the pcapng writer mirrors `PcapdService.write_to_pcap`.
- **Per-process attribution** — not applicable: the BTPacketLogger HCI stream carries no process identity (unlike `pcapd`'s per-packet `pid`/`comm`), so there's nothing to attach.

## Testing

- `pytest tests/services/test_bt_packet_logger.py` — 12 passed: record parsing, type→H4/direction mapping (all packet types), unknown/malformed-record skipping, the packetlogger stream writer, and a pcapng round-trip (re-parsed with `pcapng.FileScanner`, asserting link-type 201, packet bytes, and reconstructed timestamps).
- `ruff check` / `ruff format --check` clean.
- **Not yet validated against a real device** — I don't have a Bluetooth-capable device on hand. @jvdsn offered to verify against their hardware; on-device confirmation is the remaining step before merge.

## AI Assistance

The initial skeleton was AI-generated. Since then: removed a stray committed `foo.pcap` artifact, reviewed the protocol/conversion logic line-by-line against libimobiledevice's `idevicebtlogger.c` / `bt_packet_logger.c`, and rewrote the pcap output to emit pcapng via `python-pcapng` (matching the `pcapd`/#1003 pattern) with round-trip tests. On-device behavior remains to be verified.