### PR TITLE
Add screen-mirror browser viewer (optional [screen-mirror] extra)

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -121,6 +121,7 @@ CLI_GROUPS = {
     "usbmux": "usbmux",
     "webinspector": "webinspector",
     "idam": "idam",
+    "screen-mirror": "screen_mirror",
     "version": "version",
 }
 

--- a/pymobiledevice3/cli/screen_mirror.py
+++ b/pymobiledevice3/cli/screen_mirror.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+from typer_injector import InjectingTyper
+
+from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command
+
+cli = InjectingTyper(
+    name="screen-mirror",
+    help="Mirror the device screen to a browser (30-60 fps over USB on macOS, ~4 fps fallback).",
+)
+
+
+@cli.command("screen-mirror")
+@async_command
+async def screen_mirror(
+    service_provider: ServiceProviderDep,
+    host: Annotated[str, typer.Option(help="Bind address (use 0.0.0.0 to expose on the LAN).")] = "127.0.0.1",
+    port: Annotated[int, typer.Option(help="HTTP port for the browser viewer.")] = 8080,
+    fps: Annotated[float, typer.Option(help="Frame-rate cap (AVFoundation delivers up to 60 fps).")] = 60.0,
+    jpeg_quality: Annotated[int, typer.Option(help="JPEG quality 1-100 (higher = sharper, more bandwidth).")] = 60,
+) -> None:
+    """
+    Mirror the device screen to a browser.
+
+    On macOS over USB, uses the same CoreMediaIO/QuickTime capture mechanism
+    as QuickTime Player — 30-60 fps.  The first run will prompt for Camera
+    permission (granted to your terminal app).
+
+    Over WiFi or on non-macOS, falls back to the accessibility daemon (~4 fps).
+
+    \b
+    Prerequisites
+    * Device paired and trusted
+    * pip install aiohttp
+    * pip install pyobjc-framework-AVFoundation pyobjc-framework-CoreMediaIO
+      pyobjc-framework-Quartz      (macOS 60 fps capture, optional)
+    """
+    from pymobiledevice3.services.screen_mirror import ScreenMirrorService
+
+    async with ScreenMirrorService(
+        service_provider,
+        host=host,
+        port=port,
+        fps_cap=fps,
+        jpeg_quality=jpeg_quality,
+    ) as svc:
+        await svc.serve()

--- a/pymobiledevice3/services/SCREEN_MIRROR_ARCHITECTURE.md
+++ b/pymobiledevice3/services/SCREEN_MIRROR_ARCHITECTURE.md
@@ -1,0 +1,212 @@
+# Screen Mirror — Architecture & Upgrade Path
+
+## Current Implementation (MJPEG, 60 fps)
+
+```
+iOS device ──[H.264 over USB]──▶ iOSScreenCapture.plugin (DAL)
+    ──[DECODES to BGRA]──▶ AVCaptureVideoDataOutput
+    ──[CIContext GPU JPEG encode]──▶ WebSocket
+    ──▶ browser <img> tag
+```
+
+### Capture backends (priority order)
+
+1. **AVFoundation / CoreMediaIO** (macOS + USB only, 30-60 fps)
+   - Same mechanism as QuickTime Player
+   - `CMIOObjectSetPropertyData` enables iOS screen capture devices per-process
+   - `NSRunLoop` must be spun for CoreMediaIO DAL plugin loading (Mach port notifications)
+   - Camera TCC permission is attributed to the parent terminal app
+   - `CIContext.JPEGRepresentationOfImage:colorSpace:options:` for GPU-accelerated JPEG
+   - Device throttles frame rate when screen is static (~25 fps) and delivers full rate during motion (~60 fps)
+
+2. **Accessibility daemon** (~4 fps, USB or WiFi)
+   - `deviceCaptureScreenshot` on `com.apple.accessibility.axAuditDaemon.remoteserver`
+   - Lockdown-only, works without Developer Mode
+
+### Key discoveries
+
+- **NSRunLoop is required** for CoreMediaIO plugin loading. Without it, the CMIO property
+  call succeeds but no devices appear. The `iOSScreenCapture.plugin` DAL plugin loads via
+  Mach port notifications delivered through the run loop.
+
+- **Camera TCC is required for frame delivery, not device discovery.** Without Camera
+  permission, AVFoundation finds the device but delivers zero frames.
+
+- **`dispatch_queue_create` on macOS 26+**: libdispatch.dylib is in the dyld shared cache
+  and cannot be loaded by path. Use `ctypes.CDLL(None)` to access symbols from the default
+  process symbol space.
+
+- **Valeria protocol activation is automatic.** The `iOSScreenCaptureAssistant` daemon
+  handles the USB vendor control transfer (`0x40, 0x52`) when the DAL plugin loads. No
+  manual activation needed.
+
+## Multi-device selection & the AVFoundation UDID gap
+
+When multiple iOS devices are connected over USB, `--udid` selects which device to mirror.
+The accessibility capture backend handles this natively — the lockdown service provider is
+already connected to the correct device.  AVFoundation, however, has a fundamental limitation.
+
+### The problem
+
+Apple's `iOSScreenCapture.plugin` DAL plugin exposes each iOS device as an
+`AVCaptureDevice` with a randomly generated UUID (`uniqueID`).  **There is no public or
+private API to map this UUID back to the iOS device's UDID.**
+
+| What we know on each side | AVFoundation | USB / usbmux |
+|---|---|---|
+| Device identifier | Random UUID v4 | UDID (40-char hex) |
+| Connection ID | CMIO object ID (e.g. 37) | usbmux device ID (e.g. 63) |
+| Name | `localizedName()` = "iPad" | USB product name = "iPad" |
+
+The two ID spaces are completely separate — no shared key exists to join them.
+
+### What was tried
+
+| Approach | Result |
+|---|---|
+| CMIO device properties (brute-forced all printable 4-char selectors) | Only standard props (`uid`, `muid`, `tran`, `dloc`, …); no UDID |
+| CMIO HAL enumeration API on macOS 26 | Returns error `0x776F743F` ('wot?') — broken |
+| `AVCaptureDALDevice` private ivars via ObjC runtime | `_creatorID` = plugin bundle ID, nothing device-specific |
+| IOKit registry search for the AVFoundation UUID | UUID not present anywhere in `ioreg` |
+| `AMDeviceGetConnectionID()` vs AVFoundation `connectionID` | Different ID spaces (63 ≠ 37) |
+| `AMDeviceCopyDeviceLocation()` (USB locationID) | Available from USB side (0x02110000) but CMIO `dloc` is just an enum (3 = external) |
+| UUID derivation (hash of UDID?) | UUID v4 — randomly generated, not deterministic |
+| `iOSScreenCaptureAssistant` system logs | Device identifiers redacted as `<private>` |
+| `com.apple.cmio.guid.substitute` preference | Looked up by assistant but not set; lives only in daemon process memory |
+| `CMIOObjectShow()` debug dump | Only class/name/channels — no UDID |
+| DAL plugin binary (`iOSScreenCapture`) | Calls `AMDeviceCopyDeviceIdentifier()` internally but never exposes it through CMIO properties |
+
+### Current behavior
+
+| Scenario | Backend | FPS |
+|---|---|---|
+| Single device | AVFoundation | 30-60 |
+| Multiple devices, different models (iPad + iPhone) | AVFoundation (matched by USB product name) | 30-60 |
+| Multiple identical devices (2× iPad) + `--udid` | Accessibility (lockdown targets correct device) | ~4 |
+| Multiple devices, no `--udid` | AVFoundation (first device, with warning) | 30-60 |
+
+### Future improvement
+
+If Apple adds a CMIO property exposing the UDID or USB locationID, or if the Valeria USB
+protocol can be reverse-engineered to identify devices before AVFoundation claims them, the
+AVFoundation backend could support `--udid` for same-model multi-device setups.
+
+---
+
+## Upgrade Path: VideoToolbox H.264 Streaming
+
+The current MJPEG approach re-encodes every frame as an independent JPEG. This works well
+at 60 fps but is suboptimal in two ways:
+
+1. **No temporal compression** — each frame is a full image. A typical 1200x1600 JPEG at
+   quality 0.6 is ~80-120 KB. At 60 fps that's ~5-7 MB/s through the WebSocket. H.264
+   with temporal compression would be ~0.5-1 MB/s at equal or better visual quality.
+
+2. **Double encode/decode** — the iOS device sends H.264 over USB, the DAL plugin decodes
+   to raw pixels, we re-encode as JPEG, the browser decodes the JPEG. With H.264 output
+   the browser could use its native hardware decoder.
+
+### Architecture for H.264 path
+
+```
+iOS device ──[H.264 over USB]──▶ iOSScreenCapture.plugin (DAL)
+    ──[DECODES to BGRA]──▶ AVCaptureVideoDataOutput
+    ──[VTCompressionSession hardware H.264]──▶ NAL units
+    ──[fMP4 muxer]──▶ WebSocket
+    ──▶ browser Media Source Extensions (MSE)
+```
+
+### Implementation steps
+
+#### 1. VTCompressionSession (Python/ctypes or PyObjC)
+
+```
+VideoToolbox.VTCompressionSessionCreate(
+    allocator=None,
+    width=1200, height=1600,
+    codecType=kCMVideoCodecType_H264,  # 0x61766331 ('avc1')
+    encoderSpecification=None,  # let system pick (hardware on Apple Silicon)
+    imageBufferAttributes=None,
+    compressedDataAllocator=None,
+    outputCallback=callback_func,
+    refcon=None,
+)
+```
+
+Key properties to set:
+- `kVTCompressionPropertyKey_RealTime: True` — prioritize latency over quality
+- `kVTCompressionPropertyKey_ProfileLevel: kVTProfileLevel_H264_Main_AutoLevel`
+- `kVTCompressionPropertyKey_AverageBitRate: 4_000_000` (4 Mbps, tunable)
+- `kVTCompressionPropertyKey_MaxKeyFrameInterval: 60` (keyframe every ~1 sec)
+- `kVTCompressionPropertyKey_AllowFrameReordering: False` — no B-frames, lower latency
+
+In the AVCaptureVideoDataOutput delegate, instead of JPEG encoding:
+```python
+VTCompressionSessionEncodeFrame(session, pixelBuffer, timestamp, duration, None, None, None)
+```
+
+The output callback receives CMSampleBuffers containing H.264 NAL units.
+
+#### 2. Fragmented MP4 (fMP4) muxing
+
+Browsers' Media Source Extensions require fMP4 (ISO BMFF) format, not raw H.264.
+Each segment needs:
+- `ftyp` box (once, at init)
+- `moov` box with `mvhd`, `trak`, `mdia`, `minf`, `stbl`, `avcC` (once, at init)
+- `moof` + `mdat` boxes per segment (each containing 1-N frames)
+
+Libraries that could help:
+- Manual construction with `struct.pack` (~200 lines for minimal fMP4)
+- `mp4box` / `bento4` CLI tools for reference
+- Python `construct` library for declarative binary format
+
+#### 3. Browser Media Source Extensions (MSE)
+
+```javascript
+const ms = new MediaSource();
+video.src = URL.createObjectURL(ms);
+ms.addEventListener('sourceopen', () => {
+    const sb = ms.addSourceBuffer('video/mp4; codecs="avc1.4D0029"');
+    ws.onmessage = e => {
+        sb.appendBuffer(e.data);
+    };
+});
+```
+
+Replace the `<img>` tag with a `<video>` tag. Each WebSocket message is an fMP4 segment
+that gets appended to the SourceBuffer.
+
+#### 4. Latency considerations
+
+- VTCompressionSession with `RealTime=True` and no B-frames adds ~1 frame of latency
+- fMP4 segments of 1-3 frames keep latency low (~30-50 ms)
+- MSE in browsers adds ~1 frame of buffering
+- Total expected latency: ~50-100 ms (vs ~16 ms for current MJPEG)
+
+The latency tradeoff is worth it for bandwidth savings on remote/LAN viewing. For local
+use the current MJPEG path at 60 fps is already excellent.
+
+### Alternative: Intercept H.264 before decoding
+
+The most efficient path would skip the decode/re-encode entirely:
+
+```
+iOS device ──[H.264 over USB]──▶ intercept at USB/Valeria level ──▶ browser
+```
+
+This would require reverse-engineering the Valeria USB protocol to extract the raw H.264
+stream before the DAL plugin decodes it. The protocol uses USB bulk transfers on the
+SubClass 0x2A interface. Activation is via vendor control transfer `ctrl_transfer(0x40,
+0x52, 0x00, 0x02)`. The stream format is undocumented but likely CMSampleBuffer-wrapped
+H.264 NALUs. This approach would give zero re-encoding overhead but requires significant
+reverse engineering effort.
+
+### QuickTime's "High" vs "Maximum"
+
+For reference, QuickTime Player's recording quality settings control the VTCompressionSession
+parameters:
+- **Maximum**: Higher bitrate, less compression, larger files (~100 Mbps for 1080p)
+- **High**: Lower bitrate, more compression, smaller files (~30 Mbps for 1080p)
+
+Both use hardware H.264 encoding via VideoToolbox. The visual difference is primarily
+visible in high-motion scenes with fine detail.

--- a/pymobiledevice3/services/avfoundation_capture.py
+++ b/pymobiledevice3/services/avfoundation_capture.py
@@ -1,0 +1,416 @@
+"""
+AVFoundation-based iOS screen capture (macOS only).
+
+Uses CoreMediaIO to expose the iOS device's screen as an AVCaptureDevice —
+the same mechanism QuickTime Player uses.  Delivers decoded video frames at
+30-60 fps over the existing USB connection.
+
+Requirements (all optional — the module degrades gracefully):
+    pip install pyobjc-framework-AVFoundation pyobjc-framework-CoreMediaIO pyobjc-framework-Quartz
+
+If PyObjC is not installed the public entry point ``AVFoundationCapture.start()``
+returns *False* and the caller should fall back to another capture method.
+
+Camera TCC
+----------
+macOS requires Camera permission to access iOS capture devices via CoreMediaIO.
+On first use, ``requestAccessForMediaType:`` triggers a system dialog asking
+the user to grant Camera access to the parent terminal app (Terminal.app,
+iTerm2, etc.).  Once granted, all processes launched from that terminal inherit
+the permission automatically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import ctypes.util
+import logging
+import platform
+import queue
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# PyObjC imports — optional, macOS only
+# ---------------------------------------------------------------------------
+
+_PYOBJC = False
+try:
+    if platform.system() == "Darwin":
+        import objc as _objc  # noqa: F401
+        import AVFoundation as _AVF  # noqa: F401
+        import CoreMedia as _CM  # noqa: F401
+        import Quartz as _Q  # noqa: F401
+        from Foundation import NSObject as _NSObject, NSRunLoop as _NSRunLoop, NSDate as _NSDate  # noqa: F401
+        _PYOBJC = True
+except ImportError:
+    pass
+
+# ---------------------------------------------------------------------------
+# CoreMediaIO property call (pure ctypes — no PyObjC needed)
+# ---------------------------------------------------------------------------
+
+
+def _enable_ios_screen_capture() -> bool:
+    """Set kCMIOHardwarePropertyAllowScreenCaptureDevices = 1.
+
+    Without this call iOS devices are invisible to AVFoundation.
+    This is a **per-process** setting.
+    """
+    path = ctypes.util.find_library("CoreMediaIO")
+    if not path:
+        return False
+    try:
+        cmio = ctypes.cdll.LoadLibrary(path)
+    except OSError:
+        return False
+
+    class _Addr(ctypes.Structure):
+        _fields_ = [
+            ("mSelector", ctypes.c_uint32),
+            ("mScope", ctypes.c_uint32),
+            ("mElement", ctypes.c_uint32),
+        ]
+
+    addr = _Addr(
+        0x79657320,  # 'yes ' — kCMIOHardwarePropertyAllowScreenCaptureDevices
+        0x676C6F62,  # 'glob' — kCMIOObjectPropertyScopeGlobal
+        0,           # kCMIOObjectPropertyElementMain
+    )
+    allow = ctypes.c_uint32(1)
+    rc = cmio.CMIOObjectSetPropertyData(
+        ctypes.c_uint32(1),           # kCMIOObjectSystemObject
+        ctypes.byref(addr),
+        ctypes.c_uint32(0), None,     # qualifier
+        ctypes.c_uint32(4),           # dataSize
+        ctypes.byref(allow),
+    )
+    if rc != 0:
+        logger.debug("CMIOObjectSetPropertyData returned %d", rc)
+    return rc == 0
+
+
+def _run_loop_tick(seconds: float = 1.0) -> None:
+    """Spin the NSRunLoop so CoreMediaIO can process Mach messages
+    (DAL plugin loading, device detection, etc.)."""
+    _NSRunLoop.currentRunLoop().runUntilDate_(
+        _NSDate.dateWithTimeIntervalSinceNow_(seconds)
+    )
+
+
+def _get_usb_product_name(udid: str) -> Optional[str]:
+    """Look up the USB product name for an iOS device by its UDID.
+
+    The USB serial number of iOS devices matches the UDID exposed by usbmux.
+    Returns the USB product string (e.g. "iPad", "iPhone") or *None*.
+    """
+    try:
+        import usb.core
+        for dev in usb.core.find(find_all=True, idVendor=0x05AC):  # Apple
+            try:
+                if dev.serial_number == udid:
+                    return dev.product
+            except Exception:
+                continue
+    except ImportError:
+        pass
+    return None
+
+
+def _discover_ios_device(udid: Optional[str] = None, timeout: float = 5.0):
+    """Enable CMIO, spin the run loop, and return an iOS AVCaptureDevice.
+
+    If *udid* is given, looks up the USB product name for that UDID and
+    matches it against AVFoundation's ``localizedName()``.  When only one
+    iOS capture device is found, returns it directly regardless of name.
+
+    Returns ``None`` if no device is found or if multiple same-name devices
+    are present and cannot be disambiguated (the caller should fall back to
+    accessibility-based capture which supports UDID selection natively).
+    """
+    if not _enable_ios_screen_capture():
+        return None
+
+    # Resolve UDID → USB product name (e.g. "iPad") for matching
+    target_name = _get_usb_product_name(udid) if udid else None
+    if udid and target_name:
+        logger.debug("AVFoundation: UDID %s…%s → USB product '%s'",
+                      udid[:8], udid[-4:], target_name)
+
+    import time
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        _run_loop_tick(1.0)
+        discovery = _AVF.AVCaptureDeviceDiscoverySession \
+            .discoverySessionWithDeviceTypes_mediaType_position_(
+                [_AVF.AVCaptureDeviceTypeExternal],
+                _AVF.AVMediaTypeMuxed,
+                _AVF.AVCaptureDevicePositionUnspecified,
+            )
+        devices = list(discovery.devices() or [])
+        if not devices:
+            continue
+        if len(devices) == 1:
+            return devices[0]
+        # Multiple devices — try to match by USB product name
+        if target_name:
+            matches = [d for d in devices
+                       if str(d.localizedName() or "") == target_name]
+            if len(matches) == 1:
+                return matches[0]
+            if len(matches) > 1:
+                # Multiple devices with same name — AVFoundation cannot
+                # disambiguate (no UDID exposed through CMIO).  Return
+                # None so the caller falls back to accessibility capture
+                # which targets the correct device via the service provider.
+                logger.info(
+                    "AVFoundation: %d devices named '%s' — cannot match "
+                    "by UDID.  Falling back to accessibility capture.",
+                    len(matches), target_name)
+                return None
+        # No UDID given — use first device
+        if not udid:
+            names = [str(d.localizedName()) for d in devices]
+            logger.warning("AVFoundation: multiple devices %s — pass "
+                           "--udid to select a specific device.", names)
+            return devices[0]
+        # UDID given but no product name resolved — can't match
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Camera TCC helper
+# ---------------------------------------------------------------------------
+
+
+def _request_camera_access() -> bool:
+    """Request Camera TCC access, blocking until the user responds.
+
+    On macOS, Camera permission is attributed to the **parent terminal**
+    (Terminal.app, iTerm2, etc.).  When ``requestAccessForMediaType:`` is
+    called for the first time, macOS shows a system dialog asking the user
+    to grant Camera access to the terminal app.  Once granted, all future
+    processes launched from that terminal inherit the permission.
+    """
+    if not _PYOBJC:
+        return False
+
+    status = _AVF.AVCaptureDevice.authorizationStatusForMediaType_(
+        _AVF.AVMediaTypeVideo
+    )
+    if status == 3:  # already authorized
+        return True
+    if status == 2:  # denied — user must re-enable in System Settings
+        return False
+
+    # status 0 (notDetermined) — trigger the system prompt
+    import threading
+    event = threading.Event()
+    granted_box: list[bool] = [False]
+
+    def handler(granted: bool) -> None:
+        granted_box[0] = granted
+        event.set()
+
+    logger.info("Requesting Camera permission (grant access to your terminal app)…")
+    _AVF.AVCaptureDevice.requestAccessForMediaType_completionHandler_(
+        _AVF.AVMediaTypeVideo, handler
+    )
+    event.wait(timeout=120)  # wait up to 2 minutes for user to respond
+    return granted_box[0]
+
+
+# ---------------------------------------------------------------------------
+# Dispatch queue helper
+# ---------------------------------------------------------------------------
+
+
+def _create_dispatch_queue():
+    """Create a serial GCD queue for AVFoundation frame callbacks."""
+    # On macOS 26+ libdispatch.dylib is in the dyld shared cache and cannot be
+    # loaded by path.  The symbols are already in every process, so we load from
+    # the default symbol space with ``ctypes.CDLL(None)``.
+    try:
+        lib = ctypes.CDLL(None)
+        lib.dispatch_queue_create.restype = ctypes.c_void_p
+        lib.dispatch_queue_create.argtypes = [ctypes.c_char_p, ctypes.c_void_p]
+        ptr = lib.dispatch_queue_create(b"com.pymobiledevice3.avfcapture", None)
+        if not ptr:
+            return None
+        # dispatch_queue_t is an ObjC object since macOS 10.8
+        return _objc.objc_object(c_void_p=ptr)
+    except Exception as exc:
+        logger.debug("dispatch_queue_create failed: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# ObjC sample-buffer delegate
+# ---------------------------------------------------------------------------
+
+if _PYOBJC:
+    class _FrameDelegate(_NSObject):
+        """AVCaptureVideoDataOutputSampleBufferDelegate that converts frames to JPEG.
+
+        Uses a persistent CIContext for GPU-accelerated JPEG encoding, bypassing
+        the slower NSBitmapImageRep intermediate path.
+        """
+
+        def initWithQueue_quality_(self, frame_queue: queue.Queue, jpeg_quality: float):
+            self = _objc.super(_FrameDelegate, self).init()
+            if self is not None:
+                self._q = frame_queue
+                self._ci_ctx = _Q.CIContext.context()
+                self._colorspace = _Q.CGColorSpaceCreateDeviceRGB()
+                self._jpeg_opts = {
+                    _Q.kCGImageDestinationLossyCompressionQuality: jpeg_quality,
+                }
+            return self
+
+        def captureOutput_didOutputSampleBuffer_fromConnection_(
+            self, output, sample_buffer, connection
+        ):
+            try:
+                pixel_buf = _CM.CMSampleBufferGetImageBuffer(sample_buffer)
+                if pixel_buf is None:
+                    return
+                ci = _Q.CIImage.imageWithCVPixelBuffer_(pixel_buf)
+                if ci is None:
+                    return
+                data = self._ci_ctx.JPEGRepresentationOfImage_colorSpace_options_(
+                    ci, self._colorspace, self._jpeg_opts,
+                )
+                if data is None:
+                    return
+                jpeg = bytes(data)
+                # Drop stale frame if queue is full
+                try:
+                    self._q.get_nowait()
+                except queue.Empty:
+                    pass
+                self._q.put_nowait(jpeg)
+            except Exception:
+                pass  # hot path — never log per-frame
+
+
+# ---------------------------------------------------------------------------
+# Public capture class
+# ---------------------------------------------------------------------------
+
+
+class AVFoundationCapture:
+    """Capture iOS screen via AVFoundation / CoreMediaIO.
+
+    Usage::
+
+        cap = AVFoundationCapture()
+        if cap.start():
+            while True:
+                jpeg = await cap.get_frame()
+                ...
+            cap.stop()
+    """
+
+    def __init__(self, jpeg_quality: float = 0.6, udid: Optional[str] = None) -> None:
+        self._jpeg_quality = jpeg_quality
+        self._udid = udid
+        self._queue: queue.Queue[bytes] = queue.Queue(maxsize=2)
+        self._session: object = None
+        self._delegate: object = None  # prevent GC
+        self._running = False
+        self.width: int = 0
+        self.height: int = 0
+        self.device_name: str = ""
+
+    def start(self) -> bool:
+        """Find an iOS device over USB and start capturing. Returns *True* on success."""
+        if not _PYOBJC:
+            logger.debug("PyObjC not available — AVFoundation capture disabled")
+            return False
+
+        # ---- Camera TCC ----
+        if not _request_camera_access():
+            logger.info("AVFoundation: Camera permission not granted. "
+                        "Enable Camera access for your terminal app in "
+                        "System Settings → Privacy & Security → Camera.")
+            return False
+
+        # ---- discover iOS device (spins the run loop for plugin loading) ----
+        device = _discover_ios_device(udid=self._udid, timeout=8.0)
+        if device is None:
+            logger.info("AVFoundation: no iOS device found "
+                        "(is it connected via USB and trusted?)")
+            return False
+
+        self.device_name = str(device.localizedName() or "iOS device")
+        logger.info("AVFoundation: found '%s'", self.device_name)
+
+        # ---- resolution ----
+        try:
+            desc = device.activeFormat().formatDescription()
+            dims = _CM.CMVideoFormatDescriptionGetDimensions(desc)
+            self.width = dims.width
+            self.height = dims.height
+            logger.info("AVFoundation: %dx%d", self.width, self.height)
+        except Exception:
+            pass
+
+        # ---- session ----
+        session = _AVF.AVCaptureSession.alloc().init()
+
+        result = _AVF.AVCaptureDeviceInput.deviceInputWithDevice_error_(device, None)
+        inp = result[0] if isinstance(result, tuple) else result
+        if inp is None or not session.canAddInput_(inp):
+            logger.error("AVFoundation: cannot create device input "
+                         "(Camera permission may be required)")
+            return False
+        session.addInput_(inp)
+
+        out = _AVF.AVCaptureVideoDataOutput.alloc().init()
+        out.setAlwaysDiscardsLateVideoFrames_(True)
+        out.setVideoSettings_({
+            str(_Q.kCVPixelBufferPixelFormatTypeKey):
+                int(_Q.kCVPixelFormatType_32BGRA),
+        })
+
+        delegate = _FrameDelegate.alloc().initWithQueue_quality_(
+            self._queue, self._jpeg_quality
+        )
+
+        dq = _create_dispatch_queue()
+        if dq is None:
+            logger.error("AVFoundation: cannot create dispatch queue")
+            return False
+        out.setSampleBufferDelegate_queue_(delegate, dq)
+
+        if not session.canAddOutput_(out):
+            logger.error("AVFoundation: cannot add video output")
+            return False
+        session.addOutput_(out)
+
+        session.startRunning()
+        self._session = session
+        self._delegate = delegate
+        self._running = True
+        logger.info("AVFoundation: capture started")
+        return True
+
+    def stop(self) -> None:
+        """Stop the capture session."""
+        if self._session is not None and self._running:
+            self._session.stopRunning()
+            self._running = False
+            logger.info("AVFoundation: capture stopped")
+
+    async def get_frame(self, timeout: float = 0.5) -> Optional[bytes]:
+        """Await the next JPEG frame. Returns ``None`` on timeout."""
+        loop = asyncio.get_event_loop()
+        try:
+            return await loop.run_in_executor(
+                None, lambda: self._queue.get(timeout=timeout),
+            )
+        except queue.Empty:
+            return None

--- a/pymobiledevice3/services/screen_mirror.py
+++ b/pymobiledevice3/services/screen_mirror.py
@@ -1,0 +1,401 @@
+"""
+pymobiledevice3/services/screen_mirror.py
+
+Browser-based screen mirror for iOS devices.
+
+Capture backends (tried in priority order)
+------------------------------------------
+1. **AVFoundation** (macOS + USB only, 30-60 fps)
+   Same CoreMediaIO/QuickTime mechanism as QuickTime Player.
+   Requires ``pip install pyobjc-framework-AVFoundation pyobjc-framework-CoreMediaIO
+   pyobjc-framework-Quartz``.
+
+2. **Accessibility daemon** (~4 fps, USB or WiFi)
+   ``deviceCaptureScreenshot`` via the accessibility audit daemon.
+   Works without Developer Mode.
+
+Requirements
+------------
+- Device paired and trusted
+- ``pip install aiohttp``          web server
+- ``pip install pillow``           PNG→JPEG re-encoding (optional)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import time
+from typing import Optional
+
+from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+from pymobiledevice3.services.accessibilityaudit import AccessibilityAudit
+
+logger = logging.getLogger(__name__)
+
+_JPEG_QUALITY = 60
+
+
+def _compress_frame(png_bytes: bytes, quality: int = _JPEG_QUALITY) -> bytes:
+    try:
+        from PIL import Image
+        img = Image.open(io.BytesIO(png_bytes))
+        buf = io.BytesIO()
+        img.convert("RGB").save(buf, format="JPEG", quality=quality, optimize=False)
+        jpeg = buf.getvalue()
+        return jpeg if len(jpeg) < len(png_bytes) else png_bytes
+    except ImportError:
+        return png_bytes
+
+
+class ScreenMirrorService:
+    """
+    Captures iOS screen frames and serves them to a browser via WebSocket.
+
+    Usage::
+
+        async with ScreenMirrorService(lockdown) as svc:
+            await svc.serve()   # blocks; open http://localhost:8080
+    """
+
+    def __init__(
+        self,
+        lockdown: LockdownServiceProvider,
+        host: str = "127.0.0.1",
+        port: int = 8080,
+        fps_cap: float = 60.0,
+        jpeg_quality: int = _JPEG_QUALITY,
+    ) -> None:
+        self._lockdown = lockdown
+        self._host = host
+        self._port = port
+        self._min_interval = 1.0 / fps_cap
+        self._jpeg_quality = jpeg_quality
+
+        self._client_queues: set[asyncio.Queue] = set()
+        self._latest_frame: Optional[bytes] = None
+        self._display_width: int = 0
+        self._display_height: int = 0
+
+    async def __aenter__(self) -> "ScreenMirrorService":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    async def serve(self) -> None:
+        """Start capturing and serving. Blocks until Ctrl-C."""
+        try:
+            from aiohttp import web  # noqa: F401
+        except ImportError:
+            raise RuntimeError("aiohttp is required: pip install aiohttp")
+
+        capture_task = asyncio.create_task(self._capture_loop(), name="capture")
+        server_task = asyncio.create_task(self._run_server(), name="server")
+
+        try:
+            await asyncio.gather(capture_task, server_task)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+        finally:
+            capture_task.cancel()
+            server_task.cancel()
+            await asyncio.gather(capture_task, server_task, return_exceptions=True)
+
+    # ------------------------------------------------------------------
+    # Capture loop
+    # ------------------------------------------------------------------
+
+    def _push_frame(self, png: bytes) -> None:
+        """Compress and broadcast a raw PNG frame to all WebSocket clients."""
+        if not self._display_width:
+            # Extract native dimensions from PNG IHDR (bytes 16–23) and halve
+            # for logical points (all current iOS devices are 2× or 3× Retina;
+            # halving is exact for 2× and gives a close-enough aspect for 3×).
+            try:
+                import struct as _struct
+                w, h = _struct.unpack(">II", png[16:24])
+                self._display_width = w // 2
+                self._display_height = h // 2
+                logger.info("Display (from PNG IHDR): %dx%d native → %dx%d logical",
+                            w, h, self._display_width, self._display_height)
+            except Exception:
+                pass
+
+        frame = _compress_frame(png, self._jpeg_quality)
+        self._latest_frame = frame
+        for q in list(self._client_queues):
+            if q.full():
+                try:
+                    q.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            q.put_nowait(frame)
+
+    def _broadcast_frame(self, jpeg: bytes) -> None:
+        """Send a pre-compressed JPEG frame to all WebSocket clients."""
+        self._latest_frame = jpeg
+        for q in list(self._client_queues):
+            if q.full():
+                try:
+                    q.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            q.put_nowait(jpeg)
+
+    async def _capture_loop(self) -> None:
+        """Try capture methods in priority order: AVFoundation → accessibility."""
+        if await self._capture_loop_avfoundation():
+            return
+        await self._capture_loop_accessibility()
+
+    async def _capture_loop_avfoundation(self) -> bool:
+        """
+        Highest priority: AVFoundation via CoreMediaIO (macOS only, 30-60 fps).
+        Uses the same mechanism as QuickTime — iOS device appears as a capture device
+        over USB.  Requires: ``pip install pyobjc-framework-AVFoundation
+        pyobjc-framework-CoreMediaIO pyobjc-framework-Quartz``
+        """
+        try:
+            from pymobiledevice3.services.avfoundation_capture import AVFoundationCapture
+        except ImportError:
+            return False
+
+        udid = getattr(self._lockdown, 'identifier', None)
+        cap = AVFoundationCapture(jpeg_quality=self._jpeg_quality / 100.0, udid=udid)
+        if not cap.start():
+            return False
+
+        if cap.width and cap.height:
+            self._display_width = cap.width // 2
+            self._display_height = cap.height // 2
+            logger.info("AVFoundation: %dx%d native → %dx%d logical",
+                        cap.width, cap.height, self._display_width, self._display_height)
+
+        logger.info("Screenshot: AVFoundation (high-fps)")
+        try:
+            while True:
+                jpeg = await cap.get_frame(timeout=1.0)
+                if jpeg:
+                    # Extract dimensions from JPEG SOF0 marker on first frame
+                    if not self._display_width and len(jpeg) > 16:
+                        try:
+                            from PIL import Image
+                            img = Image.open(io.BytesIO(jpeg))
+                            w, h = img.size
+                            self._display_width = w // 2
+                            self._display_height = h // 2
+                            logger.info("AVFoundation: %dx%d → %dx%d logical",
+                                        w, h, self._display_width, self._display_height)
+                        except Exception:
+                            pass
+                    self._broadcast_frame(jpeg)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning("AVFoundation capture error: %s — falling back", exc)
+            return False
+        finally:
+            cap.stop()
+        return True
+
+    async def _capture_loop_accessibility(self) -> None:
+        """Fallback path: ``deviceCaptureScreenshot`` via accessibility daemon (~4 fps)."""
+        async with AccessibilityAudit(self._lockdown) as audit:
+            logger.info("Screenshot: accessibility daemon (fallback)")
+            while True:
+                t0 = time.monotonic()
+                try:
+                    result = await audit._invoke("deviceCaptureScreenshot")
+                    png = result.get("imageData", b"") if isinstance(result, dict) else b""
+                    if not png:
+                        await asyncio.sleep(0.1)
+                        continue
+
+                    if not self._display_width and isinstance(result, dict):
+                        try:
+                            parts = result.get("displayBounds", "").strip("{}").split(",")
+                            self._display_width = int(float(parts[2]))
+                            self._display_height = int(float(parts[3]))
+                            logger.info("Display (from bounds): %dx%d",
+                                        self._display_width, self._display_height)
+                        except Exception:
+                            pass
+
+                    self._push_frame(png)
+
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.warning("Accessibility capture error: %s", exc)
+                    await asyncio.sleep(0.5)
+                    continue
+
+                elapsed = time.monotonic() - t0
+                sleep = self._min_interval - elapsed
+                if sleep > 0:
+                    await asyncio.sleep(sleep)
+
+    # ------------------------------------------------------------------
+    # Web server
+    # ------------------------------------------------------------------
+
+    async def _run_server(self) -> None:
+        from aiohttp import web
+
+        app = web.Application()
+        app.router.add_get("/", self._handle_index)
+        app.router.add_get("/ws", self._handle_ws)
+
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, self._host, self._port)
+        await site.start()
+
+        # When bound to 0.0.0.0, show the real LAN IP so the user can click it.
+        display_host = self._host
+        if display_host in ("0.0.0.0", ""):
+            import socket as _socket
+            try:
+                with _socket.socket(_socket.AF_INET, _socket.SOCK_DGRAM) as s:
+                    s.connect(("8.8.8.8", 80))
+                    display_host = s.getsockname()[0]
+            except Exception:
+                display_host = "localhost"
+
+        url = f"http://{display_host}:{self._port}"
+        link = f"\033]8;;{url}\033\\{url}\033]8;;\033\\"
+        print()
+        print(f"  Screen mirror ready  →  {link}")
+        print("  Open in any browser  ·  Ctrl-C to stop")
+        print()
+
+        try:
+            await asyncio.Event().wait()
+        finally:
+            await runner.cleanup()
+
+    async def _handle_index(self, _request: object) -> object:
+        from aiohttp import web
+
+        for _ in range(40):
+            if self._display_width:
+                break
+            await asyncio.sleep(0.1)
+
+        w = self._display_width or 810
+        h = self._display_height or 1080
+        html = _HTML_TEMPLATE.replace("__W__", str(w)).replace("__H__", str(h))
+        return web.Response(text=html, content_type="text/html")
+
+    async def _handle_ws(self, request: object) -> object:
+        from aiohttp import web
+
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)  # type: ignore[arg-type]
+
+        q: asyncio.Queue[bytes] = asyncio.Queue(maxsize=2)
+        self._client_queues.add(q)
+        logger.debug("Browser connected (%d clients)", len(self._client_queues))
+
+        try:
+            if self._latest_frame:
+                await ws.send_bytes(self._latest_frame)
+
+            while not ws.closed:
+                try:
+                    frame = await asyncio.wait_for(q.get(), timeout=5.0)
+                    await ws.send_bytes(frame)
+                except asyncio.TimeoutError:
+                    continue
+                except Exception:
+                    break
+        finally:
+            self._client_queues.discard(q)
+            logger.debug("Browser disconnected (%d clients)", len(self._client_queues))
+
+        return ws
+
+# ---------------------------------------------------------------------------
+# Browser UI
+# ---------------------------------------------------------------------------
+
+_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>pymobiledevice3 · screen mirror</title>
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  background: #111; display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  min-height: 100dvh; font-family: ui-monospace, "Cascadia Code", "SF Mono", monospace;
+  color: #888; gap: 8px; padding: 10px;
+}
+#wrap {
+  position: relative; border: 1.5px solid #2a2a2a; border-radius: 14px;
+  overflow: hidden; box-shadow: 0 8px 48px rgba(0,0,0,.9);
+}
+#screen { display: block; }
+#bar { display: flex; gap: 16px; font-size: 11px; letter-spacing: .05em; align-items: center; }
+.dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: #333; margin-right: 5px; }
+.ok .dot { background: #3f3; } .err .dot { background: #f33; } .warn .dot { background: #fa0; }
+</style>
+</head>
+<body>
+<div id="wrap"><img id="screen" alt=""></div>
+<div id="bar">
+  <span id="sws" class="warn"><span class="dot"></span>stream</span>
+  <span id="sfps">– fps</span>
+</div>
+<script>
+(function () {
+  'use strict';
+  const W = __W__, H = __H__;
+  const screenEl = document.getElementById('screen');
+  const sws      = document.getElementById('sws');
+  const sfps     = document.getElementById('sfps');
+
+  function fit() {
+    const maxH = window.innerHeight * 0.94;
+    const maxW = window.innerWidth * 0.98;
+    const s = Math.min(maxH / H, maxW / W);
+    screenEl.style.width  = Math.round(W * s) + 'px';
+    screenEl.style.height = Math.round(H * s) + 'px';
+  }
+  fit(); window.addEventListener('resize', fit);
+
+  let prevUrl = null, frameCount = 0, lastFpsTime = performance.now();
+  function connect() {
+    const ws = new WebSocket('ws://' + location.host + '/ws');
+    ws.binaryType = 'blob';
+    ws.onopen  = () => { sws.className = 'ok'; };
+    ws.onclose = () => { sws.className = 'err'; setTimeout(connect, 2000); };
+    ws.onerror = () => { sws.className = 'err'; };
+    ws.onmessage = e => {
+      const url = URL.createObjectURL(e.data);
+      screenEl.src = url;
+      if (prevUrl) URL.revokeObjectURL(prevUrl);
+      prevUrl = url;
+      frameCount++;
+      const now = performance.now();
+      if (now - lastFpsTime >= 1000) {
+        sfps.textContent = frameCount + ' fps';
+        frameCount = 0; lastFpsTime = now;
+      }
+    };
+  }
+  connect();
+})();
+</script>
+</body>
+</html>
+"""


### PR DESCRIPTION
Stacks on top of #1671 — the IOSScreenCapture API. **Please review #1671 first**; this PR is a no-op without it.

Adds `pymobiledevice3 screen-mirror`: a small aiohttp web server that forwards the iPad's H.264 stream straight to the browser over WebSocket. The browser decodes with hardware via WebCodecs — no server-side decode or re-encode, ~3 MB/s pass-through, 60 fps on every modern browser.

Gated behind a `[screen-mirror]` extra so the default `pip install pymobiledevice3` doesn't pull aiohttp:

```bash
pip install "pymobiledevice3[screen-mirror]"
pymobiledevice3 screen-mirror      # then open http://127.0.0.1:8080
```

Browser needs WebCodecs (Chrome/Edge 94+, Safari 16.4+, Firefox 130+).

## What's in here

- `pymobiledevice3/services/screen_mirror.py` — capture loop + WebSocket fan-out
- `pymobiledevice3/cli/screen_mirror.py` — CLI flags (`--port`, `--host`, `--backend`, `--redact` for safe-to-share log output)
- HTML/JS player using WebCodecs `VideoDecoder` rendered to a `<canvas>`
- `[screen-mirror]` opt-in dependency on `aiohttp` in `pyproject.toml`

Consumes the `IOSScreenCapture` API from #1671. No platform branching in the consumer code; both backends are interchangeable.

## Note

Built on top of `feature/valeria-screen-capture` (PR #1671), so this PR's diff only shows the new screen-mirror commit when reviewed against the API PR. Targeted at `master` here so it can land cleanly once #1671 is in.