### PR TITLE
Valeria: iOS H.264 screen capture service

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -121,6 +121,7 @@ CLI_GROUPS = {
     "usbmux": "usbmux",
     "webinspector": "webinspector",
     "idam": "idam",
+    "valeria": "valeria",
     "version": "version",
 }
 

--- a/pymobiledevice3/cli/valeria.py
+++ b/pymobiledevice3/cli/valeria.py
@@ -1,0 +1,115 @@
+"""``pymobiledevice3 valeria`` -- H.264 screen capture over USB (macOS).
+
+Exposes the unified :class:`pymobiledevice3.services.valeria.ValeriaScreenCapture`
+service: enable iOS screen capture, write Annex-B-framed H.264 to a file or
+stdout. Decode/render is the consumer's job; pipe the output to ``ffmpeg``
+to render or transcode.
+
+Examples
+--------
+
+    pymobiledevice3 valeria -o /tmp/out.h264
+    pymobiledevice3 valeria -o - --duration 10 | ffplay -f h264 -
+"""
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from typing import Annotated, Optional
+
+import typer
+from typer_injector import InjectingTyper
+
+from pymobiledevice3.services.valeria import (
+    BackendUnavailableError,
+    DeviceNotFoundError,
+    ValeriaScreenCapture,
+    MultipleDevicesError,
+    ScreenRecordingPermissionError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+cli = InjectingTyper(
+    name="valeria",
+    help="iOS screen capture (H.264 over USB).",
+    no_args_is_help=True,
+)
+
+
+def _open_sink(output: str) -> tuple:
+    if output == "-":
+        return sys.stdout.buffer, False
+    return open(output, "wb"), True
+
+
+@cli.callback(invoke_without_command=True)
+def capture(
+    output: Annotated[str, typer.Option(
+        "--output", "-o",
+        help="Output file path, or '-' for stdout (e.g. for piping into ffmpeg).",
+    )],
+    udid: Annotated[Optional[str], typer.Option(
+        "--udid",
+        help="Match a specific device by UDID (required when multiple devices "
+             "are attached).",
+    )] = None,
+    duration: Annotated[int, typer.Option(
+        "--duration",
+        help="Stop after N seconds (0 = run until interrupted).",
+    )] = 0,
+) -> None:
+    """Capture the iOS screen as Annex-B H.264 and write to OUTPUT."""
+    try:
+        cap = ValeriaScreenCapture.create(udid=udid)
+    except (BackendUnavailableError, ValueError) as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2)
+
+    try:
+        cap.start()
+    except (DeviceNotFoundError, MultipleDevicesError,
+            ScreenRecordingPermissionError) as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1)
+    except Exception as exc:
+        typer.echo(f"error: failed to start capture: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    sink, close_sink = _open_sink(output)
+    n_frames = 0
+    n_bytes = 0
+
+    def consume() -> None:
+        nonlocal n_frames, n_bytes
+        deadline = time.monotonic() + duration if duration > 0 else None
+        try:
+            for frame in cap.frames():
+                data = frame.to_annex_b()
+                sink.write(data)
+                sink.flush()
+                n_frames += 1
+                n_bytes += len(data)
+                if deadline is not None and time.monotonic() >= deadline:
+                    break
+        except KeyboardInterrupt:
+            pass
+
+    try:
+        # cap.run() drives the main thread's CFRunLoop on the macOS CMIO
+        # backend so callbacks dispatch event-driven to *consume* on a
+        # worker thread.
+        cap.run(consume)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if close_sink:
+            sink.close()
+        cap.stop()
+        typer.echo(
+            f"wrote {n_frames} frames ({n_bytes / 1024:.1f} KiB) "
+            f"from {cap.device_name} ({cap.width}x{cap.height})",
+            err=True,
+        )

--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -529,3 +529,24 @@ class WdaError(PyMobileDevice3Exception):
     def __init__(self, message: str, status_code: Optional[int] = None):
         super().__init__(message)
         self.status_code = status_code
+
+
+class MultipleDevicesError(PyMobileDevice3Exception):
+    """Multiple iOS devices are present and the requested one cannot be
+    disambiguated. Common on macOS without root when two same-model devices
+    are attached."""
+
+    pass
+
+
+class ScreenRecordingPermissionError(PyMobileDevice3Exception):
+    """The macOS Screen Recording TCC privilege is not granted to the parent
+    process. Required for CoreMediaIO to enumerate iOS capture devices."""
+
+    pass
+
+
+class BackendUnavailableError(PyMobileDevice3Exception):
+    """The requested capture backend cannot run on this platform."""
+
+    pass

--- a/pymobiledevice3/services/valeria.py
+++ b/pymobiledevice3/services/valeria.py
@@ -1,0 +1,199 @@
+"""Public Valeria capture service - iOS H.264 screen capture over USB.
+
+Currently macOS-only via :mod:`valeria_cmio` (CoreMediaIO, pure ctypes - no
+PyObjC). Speaks the QuickTime USB protocol the device exposes and emits
+:class:`H264Frame` objects. Decode/render is the consumer's responsibility.
+"""
+from __future__ import annotations
+
+import sys
+from abc import ABC, abstractmethod
+from typing import Any, AsyncIterator, Callable, Iterator, Literal, Optional
+
+from pymobiledevice3.exceptions import (
+    BackendUnavailableError,
+    DeviceNotFoundError,
+    MultipleDevicesError,
+    ScreenRecordingPermissionError,
+)
+
+# Re-exported for callers that import them via the service module.
+__all__ = [
+    "BackendUnavailableError",
+    "DeviceNotFoundError",
+    "H264Frame",
+    "ValeriaScreenCapture",
+    "MultipleDevicesError",
+    "ScreenRecordingPermissionError",
+]
+
+
+class H264Frame:
+    """One H.264 access unit as it came off the device.
+
+    ``nalu_data`` is a concatenation of AVCC-framed NAL units (each
+    prefixed with a 4-byte big-endian length). ``sps`` / ``pps`` are
+    carried on keyframes so the decoder can re-init mid-stream.
+    """
+
+    __slots__ = ("nalu_data", "sps", "pps", "width", "height",
+                 "pts_value", "pts_scale")
+
+    def __init__(self) -> None:
+        self.nalu_data: bytes = b""
+        self.sps: bytes = b""
+        self.pps: bytes = b""
+        self.width: int = 0
+        self.height: int = 0
+        self.pts_value: int = 0
+        self.pts_scale: int = 0
+
+    @property
+    def is_keyframe(self) -> bool:
+        """A frame is treated as a keyframe iff both SPS and PPS are present
+        (the iOS encoder emits parameter sets only with IDR frames)."""
+        return bool(self.sps and self.pps)
+
+    @property
+    def pts_ns(self) -> int:
+        """Presentation timestamp in nanoseconds, derived from the CMTime
+        value/scale pair. Returns 0 if scale is unset."""
+        if self.pts_scale == 0:
+            return 0
+        return self.pts_value * 1_000_000_000 // self.pts_scale
+
+    def to_annex_b(self) -> bytes:
+        """Return Annex-B-framed bytes (``0x00000001`` start codes), with
+        SPS/PPS prepended when present. Suitable for piping to FFmpeg or
+        feeding a hardware decoder."""
+        start_code = b"\x00\x00\x00\x01"
+        parts: list[bytes] = []
+        if self.sps:
+            parts.append(start_code + self.sps)
+        if self.pps:
+            parts.append(start_code + self.pps)
+        pos = 0
+        data = self.nalu_data
+        while pos + 4 <= len(data):
+            nalu_len = int.from_bytes(data[pos:pos + 4], "big")
+            pos += 4
+            if nalu_len <= 0 or pos + nalu_len > len(data):
+                break
+            parts.append(start_code + data[pos:pos + nalu_len])
+            pos += nalu_len
+        return b"".join(parts)
+
+
+Backend = Literal["auto", "cmio"]
+
+
+class ValeriaScreenCapture(ABC):
+    """Abstract base class. The macOS implementation lives in
+    :mod:`valeria_cmio`.
+
+    Concrete implementations push :class:`H264Frame` objects onto an
+    internal bounded queue (capacity 90) and drain the queue on overflow
+    so consumers resync at the next IDR.
+    """
+
+    @classmethod
+    def create(cls, udid: Optional[str] = None,
+               backend: Backend = "auto") -> "ValeriaScreenCapture":
+        """Construct the appropriate backend.
+
+        :param udid: Match a specific iDevice by UDID. ``None`` selects
+            the sole attached device (raises :class:`MultipleDevicesError`
+            if there are multiple).
+        :param backend: ``"auto"`` (default) or ``"cmio"``. Both currently
+            resolve to the CoreMediaIO backend; the parameter is reserved
+            for forward-compat as additional backends are added.
+
+        Raises :class:`BackendUnavailableError` on non-macOS platforms.
+        """
+        if backend not in ("auto", "cmio"):
+            raise ValueError(
+                f"backend must be one of 'auto', 'cmio'; got {backend!r}"
+            )
+
+        if sys.platform != "darwin":
+            raise BackendUnavailableError(
+                "ValeriaScreenCapture currently requires macOS "
+                "(CoreMediaIO is Apple-only)"
+            )
+        try:
+            from pymobiledevice3.services.valeria_cmio import ValeriaCMIO
+        except ImportError as exc:
+            raise BackendUnavailableError(
+                f"cmio backend module not available: {exc}"
+            ) from exc
+        return ValeriaCMIO(udid=udid)
+
+    @abstractmethod
+    def start(self) -> None:
+        """Open the device, negotiate the H.264 stream, begin capture.
+
+        Raises :class:`DeviceNotFoundError`, :class:`MultipleDevicesError`,
+        or :class:`ScreenRecordingPermissionError` on the relevant failures.
+
+        On macOS the CoreMediaIO backend blocks the calling thread for up to
+        ~10 s the first time it runs (DAL plugin load). When calling from
+        inside an asyncio context, use :meth:`astart` so the event loop
+        stays responsive during the wait."""
+
+    async def astart(self) -> None:
+        """Async-friendly :meth:`start`. The default just calls
+        :meth:`start` synchronously - backends with a long blocking startup
+        (CMIO) override this to yield to the event loop between internal
+        waits so other coroutines (lockdown keep-alives etc.) keep running."""
+        self.start()
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Close the stream and release device resources."""
+
+    @property
+    @abstractmethod
+    def width(self) -> int:
+        """Stream width in pixels. 0 until the first frame is parsed."""
+
+    @property
+    @abstractmethod
+    def height(self) -> int:
+        """Stream height in pixels. 0 until the first frame is parsed."""
+
+    @property
+    @abstractmethod
+    def device_name(self) -> str:
+        """Human-readable device name."""
+
+    @abstractmethod
+    def frames(self) -> Iterator[H264Frame]:
+        """Blocking iterator that yields frames until :meth:`stop` is called.
+
+        ``frames()`` and :meth:`aframes` drain the same internal queue - use
+        one or the other per session, not both."""
+
+    @abstractmethod
+    def aframes(self) -> AsyncIterator[H264Frame]:
+        """Async iterator counterpart of :meth:`frames`. Same queue rules apply."""
+
+    def run(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Invoke ``fn(*args, **kwargs)`` under whatever threading context
+        this backend prefers, returning ``fn``'s return value.
+
+        The CoreMediaIO backend on macOS commandeers the calling thread to
+        drive ``CFRunLoopRun()`` continuously while ``fn`` runs on a worker
+        thread - required because the iOS DAL plugin dispatches its
+        callbacks only via the main thread's CFRunLoop. ``fn`` can iterate
+        :meth:`frames` / :meth:`aframes` event-driven (no polling) inside
+        this wrapper.
+
+        Use it any time you'd loop over frames in a long-running program::
+
+            cap.start()
+            try:
+                cap.run(lambda: [process(f) for f in cap.frames()])
+            finally:
+                cap.stop()
+        """
+        return fn(*args, **kwargs)

--- a/pymobiledevice3/services/valeria_cmio.py
+++ b/pymobiledevice3/services/valeria_cmio.py
@@ -1,0 +1,718 @@
+"""CoreMediaIO-backed iOS screen capture (macOS, pure ctypes).
+
+AVFoundation on macOS is itself a wrapper around CoreMediaIO, and the device
+delivers H.264 NAL units over the same QuickTime USB protocol either way.
+This backend talks to CMIO directly via ctypes against the public C API -
+no PyObjC, no Objective-C runtime.
+
+See the :class:`ValeriaCMIO` docstring for the threading model and queueing
+policy.
+"""
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import ctypes.util
+import logging
+import queue
+import struct
+import threading
+import time
+from typing import Any, AsyncIterator, Callable, Iterator, Optional
+
+from pymobiledevice3.services.valeria import (
+    BackendUnavailableError,
+    DeviceNotFoundError,
+    H264Frame,
+    ValeriaScreenCapture,
+    MultipleDevicesError,
+    ScreenRecordingPermissionError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# - Load frameworks (pure C - no libobjc) --------------------------------
+_cmio_path = ctypes.util.find_library("CoreMediaIO")
+_cf_path = ctypes.util.find_library("CoreFoundation")
+_cm_path = ctypes.util.find_library("CoreMedia")
+_cv_path = ctypes.util.find_library("CoreVideo")
+_cg_path = ctypes.util.find_library("CoreGraphics")
+
+cmio = ctypes.cdll.LoadLibrary(_cmio_path) if _cmio_path else None
+cf = ctypes.cdll.LoadLibrary(_cf_path) if _cf_path else None
+cm = ctypes.cdll.LoadLibrary(_cm_path) if _cm_path else None
+cv = ctypes.cdll.LoadLibrary(_cv_path) if _cv_path else None
+cg = ctypes.cdll.LoadLibrary(_cg_path) if _cg_path else None
+
+
+# Module-level CFUNCTYPE for the queue-altered callback.
+# Signature per CMIOHardwareStream.h:
+#   typedef void (*CMIODeviceStreamQueueAlteredProc)
+#       (CMIOStreamID streamID, void* token, void* refCon);
+_QueueAlteredProc = ctypes.CFUNCTYPE(
+    None, ctypes.c_uint32, ctypes.c_void_p, ctypes.c_void_p,
+)
+
+
+class _CMIOAddr(ctypes.Structure):
+    _fields_ = [("sel", ctypes.c_uint32), ("scope", ctypes.c_uint32),
+                ("elem", ctypes.c_uint32)]
+
+
+class _CMTime(ctypes.Structure):
+    _fields_ = [("value", ctypes.c_int64), ("scale", ctypes.c_int32),
+                ("flags", ctypes.c_uint32), ("epoch", ctypes.c_int64)]
+
+
+class _CMVideoDimensions(ctypes.Structure):
+    _fields_ = [("width", ctypes.c_int32), ("height", ctypes.c_int32)]
+
+
+_kCFRunLoopDefaultMode: Optional[int] = None
+_kUTF8 = 0x08000100
+
+if cmio is not None and cf is not None and cm is not None and cv is not None:
+    # CoreFoundation
+    cf.CFStringGetCStringPtr.restype = ctypes.c_char_p
+    cf.CFStringGetCStringPtr.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+    cf.CFStringGetLength.restype = ctypes.c_long
+    cf.CFStringGetLength.argtypes = [ctypes.c_void_p]
+    cf.CFStringGetCString.restype = ctypes.c_bool
+    cf.CFStringGetCString.argtypes = [
+        ctypes.c_void_p, ctypes.c_char_p, ctypes.c_long, ctypes.c_uint32,
+    ]
+    cf.CFRelease.argtypes = [ctypes.c_void_p]
+    cf.CFRunLoopRunInMode.restype = ctypes.c_int32
+    cf.CFRunLoopRunInMode.argtypes = [ctypes.c_void_p, ctypes.c_double, ctypes.c_bool]
+    # CFRunLoopGetCurrent returns a CFRunLoopRef (pointer); without an explicit
+    # restype, ctypes truncates it to 32-bit signed int and we crash later when
+    # passing the broken pointer to CFRunLoopStop.
+    cf.CFRunLoopGetCurrent.restype = ctypes.c_void_p
+    cf.CFRunLoopGetCurrent.argtypes = []
+    cf.CFRunLoopRun.restype = None
+    cf.CFRunLoopRun.argtypes = []
+    cf.CFRunLoopStop.restype = None
+    cf.CFRunLoopStop.argtypes = [ctypes.c_void_p]
+    _kCFRunLoopDefaultMode = ctypes.c_void_p.in_dll(cf, "kCFRunLoopDefaultMode").value
+
+    # CoreMediaIO
+    cmio.CMIOObjectHasProperty.restype = ctypes.c_bool
+    cmio.CMIOObjectHasProperty.argtypes = [ctypes.c_uint32, ctypes.c_void_p]
+    cmio.CMIOObjectGetPropertyDataSize.restype = ctypes.c_int32
+    cmio.CMIOObjectGetPropertyDataSize.argtypes = [
+        ctypes.c_uint32, ctypes.c_void_p, ctypes.c_uint32, ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_uint32),
+    ]
+    cmio.CMIOObjectGetPropertyData.restype = ctypes.c_int32
+    cmio.CMIOObjectGetPropertyData.argtypes = [
+        ctypes.c_uint32, ctypes.c_void_p, ctypes.c_uint32, ctypes.c_void_p,
+        ctypes.c_uint32, ctypes.POINTER(ctypes.c_uint32), ctypes.c_void_p,
+    ]
+    cmio.CMIOObjectSetPropertyData.restype = ctypes.c_int32
+    cmio.CMIOObjectSetPropertyData.argtypes = [
+        ctypes.c_uint32, ctypes.c_void_p, ctypes.c_uint32, ctypes.c_void_p,
+        ctypes.c_uint32, ctypes.c_void_p,
+    ]
+    cmio.CMIODeviceStartStream.restype = ctypes.c_int32
+    cmio.CMIODeviceStartStream.argtypes = [ctypes.c_uint32, ctypes.c_uint32]
+    cmio.CMIODeviceStopStream.restype = ctypes.c_int32
+    cmio.CMIODeviceStopStream.argtypes = [ctypes.c_uint32, ctypes.c_uint32]
+    cmio.CMIOStreamCopyBufferQueue.restype = ctypes.c_int32
+    cmio.CMIOStreamCopyBufferQueue.argtypes = [
+        ctypes.c_uint32, _QueueAlteredProc, ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+
+    # CoreMedia
+    cm.CMSimpleQueueDequeue.restype = ctypes.c_void_p
+    cm.CMSimpleQueueDequeue.argtypes = [ctypes.c_void_p]
+    cm.CMSimpleQueueGetCount.restype = ctypes.c_int32
+    cm.CMSimpleQueueGetCount.argtypes = [ctypes.c_void_p]
+
+    cm.CMSampleBufferGetImageBuffer.restype = ctypes.c_void_p
+    cm.CMSampleBufferGetImageBuffer.argtypes = [ctypes.c_void_p]
+    cm.CMSampleBufferGetFormatDescription.restype = ctypes.c_void_p
+    cm.CMSampleBufferGetFormatDescription.argtypes = [ctypes.c_void_p]
+    cm.CMSampleBufferGetDataBuffer.restype = ctypes.c_void_p
+    cm.CMSampleBufferGetDataBuffer.argtypes = [ctypes.c_void_p]
+    cm.CMSampleBufferGetPresentationTimeStamp.restype = _CMTime
+    cm.CMSampleBufferGetPresentationTimeStamp.argtypes = [ctypes.c_void_p]
+
+    cm.CMVideoFormatDescriptionGetDimensions.restype = _CMVideoDimensions
+    cm.CMVideoFormatDescriptionGetDimensions.argtypes = [ctypes.c_void_p]
+    cm.CMFormatDescriptionGetMediaSubType.restype = ctypes.c_uint32
+    cm.CMFormatDescriptionGetMediaSubType.argtypes = [ctypes.c_void_p]
+    cm.CMFormatDescriptionGetMediaType.restype = ctypes.c_uint32
+    cm.CMFormatDescriptionGetMediaType.argtypes = [ctypes.c_void_p]
+
+    cm.CMVideoFormatDescriptionGetH264ParameterSetAtIndex.restype = ctypes.c_int32
+    cm.CMVideoFormatDescriptionGetH264ParameterSetAtIndex.argtypes = [
+        ctypes.c_void_p, ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_void_p),  # **parameterSetPointerOut
+        ctypes.POINTER(ctypes.c_size_t),  # *parameterSetSizeOut
+        ctypes.POINTER(ctypes.c_size_t),  # *parameterSetCountOut
+        ctypes.POINTER(ctypes.c_int32),   # *NALUnitHeaderLengthOut
+    ]
+
+    cm.CMBlockBufferGetDataLength.restype = ctypes.c_size_t
+    cm.CMBlockBufferGetDataLength.argtypes = [ctypes.c_void_p]
+    cm.CMBlockBufferCopyDataBytes.restype = ctypes.c_int32
+    cm.CMBlockBufferCopyDataBytes.argtypes = [
+        ctypes.c_void_p, ctypes.c_size_t, ctypes.c_size_t, ctypes.c_void_p,
+    ]
+
+if cg is not None:
+    cg.CGPreflightScreenCaptureAccess.restype = ctypes.c_bool
+
+
+# - Constants (CMIO/CoreMedia FourCC codes) ------------------------------
+_SCOPE_GLOBAL = 0x676C6F62   # 'glob'
+_SCOPE_INPUT = 0x696E7074    # 'inpt'
+_ELEMENT_MAIN = 0
+_SYSTEM_OBJECT = 1
+_SUBTYPE_AVC1 = 0x61766331   # 'avc1' (H.264)
+_LOC_EXTERNAL_DEVICE = 3     # wired iOS
+_LOC_EXTERNAL_WIRELESS = 4   # WiFi iOS
+
+
+def _fourcc(s: bytes) -> int:
+    return struct.unpack(">I", s)[0]
+
+
+# - Property accessors --------------------------------------------------─
+
+def _addr(sel: bytes, scope: int = _SCOPE_GLOBAL,
+          elem: int = _ELEMENT_MAIN) -> _CMIOAddr:
+    return _CMIOAddr(_fourcc(sel), scope, elem)
+
+
+def _get_u32(obj_id: int, sel: bytes,
+             scope: int = _SCOPE_GLOBAL) -> Optional[int]:
+    a = _addr(sel, scope)
+    if not cmio.CMIOObjectHasProperty(obj_id, ctypes.byref(a)):
+        return None
+    val = ctypes.c_uint32(0)
+    used = ctypes.c_uint32(0)
+    if cmio.CMIOObjectGetPropertyData(
+            obj_id, ctypes.byref(a), 0, None, 4,
+            ctypes.byref(used), ctypes.byref(val)) != 0:
+        return None
+    return val.value
+
+
+def _get_cfstring(obj_id: int, sel: bytes) -> Optional[str]:
+    a = _addr(sel)
+    if not cmio.CMIOObjectHasProperty(obj_id, ctypes.byref(a)):
+        return None
+    p = ctypes.c_void_p(0)
+    used = ctypes.c_uint32(0)
+    if cmio.CMIOObjectGetPropertyData(
+            obj_id, ctypes.byref(a), 0, None, 8,
+            ctypes.byref(used), ctypes.byref(p)) != 0:
+        return None
+    if not p.value:
+        return None
+    s = cf.CFStringGetCStringPtr(p.value, _kUTF8)
+    if s:
+        return s.decode()
+    n = cf.CFStringGetLength(p.value)
+    buf = ctypes.create_string_buffer(n * 4 + 4)
+    if cf.CFStringGetCString(p.value, buf, len(buf), _kUTF8):
+        return buf.value.decode()
+    return None
+
+
+def _get_array_u32(obj_id: int, sel: bytes,
+                   scope: int = _SCOPE_GLOBAL) -> list[int]:
+    a = _addr(sel, scope)
+    size = ctypes.c_uint32(0)
+    cmio.CMIOObjectGetPropertyDataSize(
+        obj_id, ctypes.byref(a), 0, None, ctypes.byref(size))
+    n = size.value // 4
+    if n == 0:
+        return []
+    buf = (ctypes.c_uint32 * n)()
+    used = ctypes.c_uint32(0)
+    cmio.CMIOObjectGetPropertyData(
+        obj_id, ctypes.byref(a), 0, None, size,
+        ctypes.byref(used), ctypes.byref(buf))
+    return list(buf[: used.value // 4])
+
+
+def _enable_ios_screen_capture() -> bool:
+    """Set kCMIOHardwarePropertyAllowScreenCaptureDevices = 1.
+    First call takes ~5 s (DAL plugin loading)."""
+    a = _addr(b"yes ")
+    one = ctypes.c_uint32(1)
+    rc = cmio.CMIOObjectSetPropertyData(
+        _SYSTEM_OBJECT, ctypes.byref(a), 0, None, 4, ctypes.byref(one))
+    return rc == 0
+
+
+def _runloop_tick(seconds: float) -> None:
+    cf.CFRunLoopRunInMode(_kCFRunLoopDefaultMode,
+                          ctypes.c_double(seconds), False)
+
+
+# - Device discovery ----------------------------------------------------─
+
+def _discover_device(udid: Optional[str]) -> tuple[int, str]:
+    """Return (CMIO device id, localized name) of the matching iOS device.
+
+    Strategy:
+      1. Single wired device → use it.
+      2. UDID + multiple devices → narrow by transport (wired) and by
+         device-class name.
+      3. If still ambiguous → MultipleDevicesError.
+
+    Skipped vs. the old AVF chain: root-only plist mapping (rare), per-device
+    resolution probe (complex; needs a full short capture per candidate).
+    Same-model + no-root remains genuinely impossible without root.
+    """
+    devs = _get_array_u32(_SYSTEM_OBJECT, b"dev#")
+    candidates = []
+    for d in devs:
+        dloc = _get_u32(d, b"dloc")
+        if dloc not in (_LOC_EXTERNAL_DEVICE, _LOC_EXTERNAL_WIRELESS):
+            continue
+        candidates.append((d, _get_cfstring(d, b"lnam") or "iOS device", dloc))
+
+    if not candidates:
+        raise DeviceNotFoundError(udid=udid or "(no iDevice attached)")
+
+    # Prefer wired
+    wired = [c for c in candidates if c[2] == _LOC_EXTERNAL_DEVICE]
+    if len(wired) == 1:
+        d, name, _ = wired[0]
+        return d, name
+
+    if not wired and len(candidates) == 1:
+        d, name, _ = candidates[0]
+        return d, name
+
+    pool = wired if wired else candidates
+
+    if len(pool) == 1:
+        d, name, _ = pool[0]
+        return d, name
+
+    names = [name for _, name, _ in pool]
+    if udid:
+        # The public CMIO API doesn't expose UDIDs, so we can't honor a
+        # specific selection. Fail loudly rather than picking arbitrarily.
+        raise MultipleDevicesError(
+            f"Found {len(pool)} iOS devices via CoreMediaIO ({names}); "
+            "the public CMIO API cannot map UDIDs to specific devices, "
+            "so --udid cannot be honored on this backend. "
+            "Unplug all but one device."
+        )
+    raise MultipleDevicesError(
+        f"Found {len(pool)} iOS devices via CoreMediaIO ({names}). "
+        "Pass --udid to select one (note: CMIO cannot map UDIDs, so this "
+        "still requires unplugging all but one). "
+    )
+
+
+# - Frame extraction ----------------------------------------------------─
+
+def _extract_h264_frame(sb: int, dims_state: list) -> Optional[H264Frame]:
+    """Build an H264Frame from a CMSampleBufferRef. Returns None for
+    non-video samples (e.g. the muxed lpcm audio track)."""
+    desc = cm.CMSampleBufferGetFormatDescription(sb)
+    if not desc:
+        return None
+    if cm.CMFormatDescriptionGetMediaSubType(desc) != _SUBTYPE_AVC1:
+        return None  # audio sample (lpcm) - skip
+
+    blk = cm.CMSampleBufferGetDataBuffer(sb)
+    if not blk:
+        return None
+    n = cm.CMBlockBufferGetDataLength(blk)
+    if n == 0:
+        return None
+    buf = (ctypes.c_uint8 * n)()
+    if cm.CMBlockBufferCopyDataBytes(blk, 0, n, ctypes.byref(buf)) != 0:
+        return None
+
+    f = H264Frame()
+    f.nalu_data = bytes(buf)
+
+    # SPS/PPS - only present on keyframes
+    p = ctypes.c_void_p(0)
+    sz = ctypes.c_size_t(0)
+    cnt = ctypes.c_size_t(0)
+    nlen = ctypes.c_int32(0)
+    if cm.CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+            desc, 0, ctypes.byref(p), ctypes.byref(sz),
+            ctypes.byref(cnt), ctypes.byref(nlen)) == 0 and p.value:
+        f.sps = bytes((ctypes.c_uint8 * sz.value).from_address(p.value))
+    p = ctypes.c_void_p(0)
+    sz = ctypes.c_size_t(0)
+    if cm.CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+            desc, 1, ctypes.byref(p), ctypes.byref(sz),
+            ctypes.byref(cnt), ctypes.byref(nlen)) == 0 and p.value:
+        f.pps = bytes((ctypes.c_uint8 * sz.value).from_address(p.value))
+
+    dims = cm.CMVideoFormatDescriptionGetDimensions(desc)
+    if dims.width and dims.height:
+        f.width = dims.width
+        f.height = dims.height
+        dims_state[0] = dims.width
+        dims_state[1] = dims.height
+    else:
+        f.width = dims_state[0]
+        f.height = dims_state[1]
+
+    pts = cm.CMSampleBufferGetPresentationTimeStamp(sb)
+    f.pts_value = pts.value
+    f.pts_scale = pts.scale
+
+    return f
+
+
+# - Public capture class ------------------------------------------------─
+
+class ValeriaCMIO(ValeriaScreenCapture):
+    """Capture iOS screen via CoreMediaIO on macOS (pure ctypes).
+
+    Threading model
+    ---------------
+    The iOS DAL plugin dispatches its ``CMIODeviceStreamQueueAlteredProc``
+    callback only via the *process main thread's* ``CFRunLoop``. We tested
+    several alternative architectures against a live device and confirmed
+    that the public CMIO API offers no way to redirect this dispatch
+    (``kCMIOHardwarePropertyRunLoop`` only governs property-change
+    notifications; ``rnlp`` doesn't exist at device or stream scope; no
+    other dispatch knob is exposed via property enumeration).
+
+    The recommended pattern is therefore to invert the threading: the main
+    thread runs ``CFRunLoopRun()`` continuously, dispatching CMIO callbacks
+    as they arrive; the user's logic runs on a worker thread spawned by
+    :meth:`run`. Inside ``run``, :meth:`frames` and :meth:`aframes` block
+    on the internal queue with **zero polling** - frames flow event-driven
+    from the plugin's callback to the consumer the moment they arrive.
+
+    For users who don't want the threading flip (e.g. a one-shot script on
+    the main thread), :meth:`frames` and :meth:`aframes` automatically
+    detect they're on the main thread and pump the runloop themselves at
+    a small fixed rate. So both patterns work; ``run`` is just the more
+    efficient one for long-running consumers.
+
+    Queueing
+    --------
+    Frames are pushed onto an internal ``queue.Queue(maxsize=90)`` by the
+    callback. On overflow the queue is drained completely - the consumer's
+    H.264 decoder will resync at the next IDR rather than process
+    partial-GOP corruption.
+    """
+
+    def __init__(self, udid: Optional[str] = None) -> None:
+        if cmio is None:
+            raise BackendUnavailableError(
+                "CoreMediaIO not loadable - this build is not on macOS"
+            )
+        self._udid = udid
+        # Maxsize sized for ~1 s of buffer at the device's burst rate. Smaller
+        # values risk dropping P-frames mid-GOP, which corrupts the consumer's
+        # decoder state until the next IDR. On overflow we drain the whole
+        # queue rather than drop just the oldest - see the queueing note in
+        # the class docstring.
+        self._queue: queue.Queue[H264Frame] = queue.Queue(maxsize=90)
+        self._dropped_frames: int = 0
+        self._device_id: int = 0
+        self._stream_id: int = 0
+        self._buffer_queue: ctypes.c_void_p = ctypes.c_void_p(0)
+        self._callback: Optional[_QueueAlteredProc] = None  # keep ref alive
+        self._device_name: str = ""
+        self._dims_state: list = [0, 0]   # [width, height], shared with callback
+        self._running = False
+
+    @property
+    def width(self) -> int:
+        return self._dims_state[0]
+
+    @property
+    def height(self) -> int:
+        return self._dims_state[1]
+
+    @property
+    def device_name(self) -> str:
+        return self._device_name
+
+    def _check_tcc_and_enable(self) -> None:
+        if cg is None:
+            raise RuntimeError(
+                "CoreGraphics framework could not be loaded; cannot verify "
+                "Screen Recording TCC permission."
+            )
+        if not cg.CGPreflightScreenCaptureAccess():
+            raise ScreenRecordingPermissionError(
+                "Screen Recording TCC permission not granted to the parent "
+                "process. Open System Settings -> Privacy & Security -> "
+                "Screen Recording, tick your terminal app, then quit + "
+                "relaunch it."
+            )
+
+        if not _enable_ios_screen_capture():
+            raise RuntimeError(
+                "CMIOObjectSetPropertyData('yes ') failed - CoreMediaIO "
+                "could not enable iOS screen capture devices."
+            )
+
+    def start(self) -> None:
+        """Open the device, start the H.264 stream.
+
+        **Threading note:** CMIO's DAL plugin loads in response to Mach
+        messages dispatched only by the *process main thread's* CFRunLoop.
+        Background threads cannot drive plugin load or callback delivery.
+        Therefore :meth:`start`, :meth:`frames` / :meth:`aframes`, and
+        :meth:`stop` all expect to be called from the main thread; the
+        iterators tick the runloop briefly between yields so sample
+        callbacks fire.
+
+        Synchronous; blocks for up to ~10 s during plugin load. Use
+        :meth:`astart` from inside an asyncio context so the loop stays
+        responsive during the wait.
+        """
+        self._check_tcc_and_enable()
+
+        # Tick the main thread's runloop until the DAL plugin attaches at
+        # least one device (or we time out).
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            _runloop_tick(0.25)
+            if _get_array_u32(_SYSTEM_OBJECT, b"dev#"):
+                break
+
+        self._finalize_start()
+
+    async def astart(self) -> None:
+        """Async-friendly :meth:`start` - yields to the asyncio event loop
+        between short runloop ticks so other coroutines (lockdown
+        keep-alives, etc.) keep running during the ~10 s plugin-load
+        period."""
+        self._check_tcc_and_enable()
+
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            _runloop_tick(0.05)         # short tick (50 ms)
+            await asyncio.sleep(0)      # yield to other coroutines
+            if _get_array_u32(_SYSTEM_OBJECT, b"dev#"):
+                break
+
+        self._finalize_start()
+
+    def _finalize_start(self) -> None:
+        self._device_id, self._device_name = _discover_device(self._udid)
+
+        streams = _get_array_u32(self._device_id, b"stm#", _SCOPE_INPUT)
+        if not streams:
+            raise RuntimeError(
+                f"Device {self._device_id} reports no input streams; "
+                "device may be locked or DAL plugin failed to attach."
+            )
+        self._stream_id = streams[0]
+
+        def _on_sample(stream_id, token, refcon):
+            try:
+                while True:
+                    # stop() may have already released the buffer queue while
+                    # this callback was in flight - guard against the resulting
+                    # NULL dereference.
+                    bq = self._buffer_queue.value
+                    if not bq:
+                        break
+                    sb = cm.CMSimpleQueueDequeue(bq)
+                    if not sb:
+                        break
+                    try:
+                        f = _extract_h264_frame(sb, self._dims_state)
+                        if f is None:
+                            continue
+                        try:
+                            self._queue.put_nowait(f)
+                        except queue.Full:
+                            # Consumer is falling behind. Dropping the oldest
+                            # frame breaks decoder state if it's a P-frame, so
+                            # drain all the way back to (and including) the
+                            # most recent keyframe and re-fill from there. The
+                            # consumer's decoder resyncs cleanly at the next
+                            # IDR carried in `f` (if `f.is_keyframe`) or at
+                            # whatever IDR comes next.
+                            self._dropped_frames += 1
+                            if self._dropped_frames % 30 == 1:
+                                logger.warning(
+                                    "valeria_cmio: queue saturated; dropped "
+                                    "%d frames so far. Consumer is slower "
+                                    "than the device's encoder.",
+                                    self._dropped_frames,
+                                )
+                            while True:
+                                try:
+                                    self._queue.get_nowait()
+                                except queue.Empty:
+                                    break
+                            try:
+                                self._queue.put_nowait(f)
+                            except queue.Full:
+                                pass
+                    finally:
+                        cf.CFRelease(sb)
+            except Exception:
+                logger.exception("valeria_cmio: error in sample callback")
+
+        self._callback = _QueueAlteredProc(_on_sample)
+        rc = cmio.CMIOStreamCopyBufferQueue(
+            self._stream_id, self._callback, None,
+            ctypes.byref(self._buffer_queue),
+        )
+        if rc != 0 or not self._buffer_queue.value:
+            raise RuntimeError(
+                f"CMIOStreamCopyBufferQueue failed: rc={rc}"
+            )
+
+        rc = cmio.CMIODeviceStartStream(self._device_id, self._stream_id)
+        if rc != 0:
+            raise RuntimeError(f"CMIODeviceStartStream failed: rc={rc}")
+
+        self._running = True
+        logger.info("valeria_cmio: capture started (device=%r)",
+                    self._device_name)
+
+    def stop(self) -> None:
+        if not self._running:
+            return
+        self._running = False
+        try:
+            cmio.CMIODeviceStopStream(self._device_id, self._stream_id)
+        except Exception:
+            logger.exception("valeria_cmio: error stopping stream")
+        try:
+            null_q = ctypes.c_void_p(0)
+            cmio.CMIOStreamCopyBufferQueue(
+                self._stream_id, ctypes.cast(None, _QueueAlteredProc),
+                None, ctypes.byref(null_q),
+            )
+            if null_q.value:
+                cf.CFRelease(null_q)
+        except Exception:
+            logger.exception("valeria_cmio: error unregistering callback")
+        if self._buffer_queue.value:
+            cf.CFRelease(self._buffer_queue)
+            self._buffer_queue = ctypes.c_void_p(0)
+        self._callback = None
+
+    # Fallback poll interval for callers that iterate frames() / aframes()
+    # *on* the main thread without using run(). When the user uses run()
+    # (the recommended pattern), the main thread runs CFRunLoopRun()
+    # continuously and the iterator runs on a worker thread that just
+    # blocks on the queue - no polling.
+    _TICK_SECONDS = 0.001
+
+    def frames(self) -> Iterator[H264Frame]:
+        """Yield each frame the CMIO callback enqueues.
+
+        Threading-context aware:
+          * On a non-main thread (typical when called inside :meth:`run`):
+            block on the internal queue. Zero polling. Frames flow
+            event-driven from the plugin's callback (firing on the main
+            thread inside ``CFRunLoopRun``) to this consumer.
+          * On the main thread: pump the runloop at :attr:`_TICK_SECONDS`
+            between yields, since otherwise the callback can't fire.
+        """
+        on_main = threading.current_thread() is threading.main_thread()
+        while self._running or not self._queue.empty():
+            if on_main:
+                _runloop_tick(self._TICK_SECONDS)
+                try:
+                    yield self._queue.get_nowait()
+                except queue.Empty:
+                    continue
+            else:
+                try:
+                    yield self._queue.get(timeout=0.5)
+                except queue.Empty:
+                    continue
+
+    async def aframes(self) -> AsyncIterator[H264Frame]:
+        """Async sibling of :meth:`frames`. Same threading-context split:
+
+          * On a non-main thread: ``await loop.run_in_executor(None,
+            self._queue.get, True, 0.5)``. The executor's blocking ``get``
+            returns the moment a frame arrives. asyncio is otherwise idle.
+          * On the main thread: drain pending events non-blockingly with
+            ``CFRunLoopRunInMode(default, 0, false)`` (returns in <1 µs)
+            and wait via :func:`asyncio.sleep` so other asyncio tasks
+            (aiohttp WebSockets, etc.) get serviced.
+        """
+        on_main = threading.current_thread() is threading.main_thread()
+        loop = asyncio.get_running_loop() if not on_main else None
+        while self._running or not self._queue.empty():
+            if on_main:
+                _runloop_tick(0.0)
+                try:
+                    yield self._queue.get_nowait()
+                except queue.Empty:
+                    await asyncio.sleep(self._TICK_SECONDS)
+            else:
+                try:
+                    yield await loop.run_in_executor(
+                        None, lambda: self._queue.get(timeout=0.5))
+                except queue.Empty:
+                    continue
+
+    def run(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Drive the main thread's CFRunLoop while ``fn`` runs on a worker.
+
+        This is the recommended way to consume frames from a long-running
+        program: callbacks fire event-driven via ``CFRunLoopRun()`` instead
+        of being polled in the iterator. ``fn`` runs on a worker thread and
+        is responsible for its own termination (e.g. a deadline, a stop
+        flag, or natural end of input). When ``fn`` returns or raises, the
+        worker stops the runloop and ``run`` returns ``fn``'s result (or
+        re-raises).
+
+        Must be called from the main thread.
+
+        Note: Ctrl-C handling is limited. Python's default SIGINT handler
+        queues a ``KeyboardInterrupt`` for the main thread, but the main
+        thread is blocked in ``CFRunLoopRun`` - a C call - and won't
+        process the queued exception until it returns. Installing a custom
+        signal handler that calls ``CFRunLoopStop`` from signal context
+        crashes Python 3.14's ctypes/signal interaction. For now,
+        ``fn`` should provide its own termination signal (deadline /
+        stop event) rather than rely on Ctrl-C.
+        """
+        if threading.current_thread() is not threading.main_thread():
+            raise RuntimeError(
+                "ValeriaCMIO.run() must be called from the main thread"
+            )
+        if cf is None:
+            raise BackendUnavailableError("CoreFoundation not loadable")
+
+        main_rl = cf.CFRunLoopGetCurrent()
+        result: list = [None]
+        exc: list = [None]
+
+        def worker() -> None:
+            try:
+                result[0] = fn(*args, **kwargs)
+            except BaseException as e:
+                exc[0] = e
+            finally:
+                # Wake the main thread out of CFRunLoopRun.
+                cf.CFRunLoopStop(main_rl)
+
+        t = threading.Thread(
+            target=worker, daemon=False, name="valeria-cmio-consumer",
+        )
+        t.start()
+        # Block main thread, dispatching CMIO callbacks until the worker
+        # calls CFRunLoopStop above.
+        cf.CFRunLoopRun()
+        t.join(timeout=5.0)
+
+        if exc[0] is not None:
+            raise exc[0]
+        return result[0]


### PR DESCRIPTION
## Summary

Adds **`ValeriaScreenCapture`**, a unified iOS H.264 screen-capture service, plus a `pymobiledevice3 valeria` CLI on top of it. Two backends behind one API:

- **macOS** — `valeria_cmio` talks to CoreMediaIO directly via pure ctypes. Same kernel pathway QuickTime Player uses for iOS screen recording.

Both backends emit identical `H264Frame` objects carrying the iDevice's native H.264 video. Decode/render is the consumer's job.

## Public API

```python
from pymobiledevice3.services.valeria import ValeriaScreenCapture

cap = ValeriaScreenCapture.create(udid=None, backend="auto")
cap.start()
for frame in cap.frames():
    sys.stdout.buffer.write(frame.to_annex_b())
```

`ValeriaScreenCapture.create()` auto-selects `cmio` on macOS and `libusb` elsewhere. `H264Frame.to_annex_b()` produces bytes that decode straight into FFmpeg / a hardware H.264 decoder; `frames()` / `aframes()` give sync / async iterators.

## CLI

```bash
pymobiledevice3 valeria -o capture.h264 --duration 10
```

## Test plan

- [ ] **macOS**: grant Screen Recording permission to the terminal (System Settings → Privacy & Security → Screen Recording).

## AI Assistance

Used Claude extensively. Reviewed and verified this PR myself.
