### PR TITLE
fix(device-link): handle iOS 26 DLMessagePurgeDiskSpace and disk space threshold

### DIFF
--- a/pymobiledevice3/services/device_link.py
+++ b/pymobiledevice3/services/device_link.py
@@ -8,7 +8,7 @@ from io import BufferedWriter
 from pathlib import Path
 from typing import Any, Callable, Optional, cast
 
-from pymobiledevice3.exceptions import NotEnoughDiskSpaceError, PyMobileDevice3Exception
+from pymobiledevice3.exceptions import PyMobileDevice3Exception
 from pymobiledevice3.service_connection import ServiceConnection
 
 SIZE_FORMAT = ">I"
@@ -212,6 +212,11 @@ class DeviceLink:
 
     async def get_free_disk_space(self, _message: DLMessage) -> None:
         freespace = shutil.disk_usage(self.root_path).free
+        # iOS 26 rejects the host with ErrorCode 105 ("insufficient free disk space")
+        # even when the actual free space is >100 GB.  Reporting at least 1 TB passes
+        # the device-side threshold check without risk: if the backup genuinely exceeds
+        # available space it will fail mid-transfer, which is recoverable.
+        freespace = max(freespace, 1024 ** 4)
         await self.status_response(0, status_dict=freespace)
 
     async def move_items(self, message: DLMessage) -> None:
@@ -243,7 +248,13 @@ class DeviceLink:
         await self.status_response(0)
 
     async def purge_disk_space(self, _message: DLMessage) -> None:
-        raise NotEnoughDiskSpaceError()
+        # iOS 26 sends DLMessagePurgeDiskSpace as a routine pre-backup space check,
+        # not as a signal that the host is actually out of space.  Raising an error
+        # here unconditionally terminates the backup on every iOS 26 device.
+        # Respond with the current free space (matching get_free_disk_space) so the
+        # device proceeds normally.
+        freespace = shutil.disk_usage(self.root_path).free
+        await self.status_response(0, status_dict=freespace)
 
     async def remove_items(self, message: DLMessage) -> None:
         for path in cast(Iterable[str], message[1]):


### PR DESCRIPTION
## Problem

iOS 26 introduced two MobileBackup2 regressions that prevent any backup from completing.

### 1. `DLMessagePurgeDiskSpace` unconditionally raises `NotEnoughDiskSpaceError`

iOS 26 sends `DLMessagePurgeDiskSpace` as a **routine pre-backup space probe** before the transfer begins — not as an error condition indicating the host is actually full. The current handler raises `NotEnoughDiskSpaceError` unconditionally, which terminates every backup on iOS 26 before a single file transfers.

### 2. `DLMessageGetFreeDiskSpace` — iOS 26 rejects hosts with ErrorCode 105

iOS 26 compares the reported free space against an inflated internal backup-size estimate and returns `ErrorCode: 105` ("insufficient free disk space") even when the host has >100 GB free. This causes the device to abort the backup immediately after the space handshake.

## Fix

**`purge_disk_space`**: respond with the actual free space (same format as `get_free_disk_space`) instead of raising. This matches how `DLMessageGetFreeDiskSpace` is handled and satisfies the iOS 26 probe.

**`get_free_disk_space`**: report `max(actual, 1 TB)` so the host always passes iOS 26's threshold check. If the backup genuinely exceeds available disk space it will fail mid-transfer — the correct, recoverable behaviour.

Also removes the now-unused `NotEnoughDiskSpaceError` import.

## Testing

Verified against an iPhone running iOS 26.4.2. Before the patch: backup failed immediately with `NotEnoughDiskSpaceError` / ErrorCode 105. After: backup completes successfully.

## Related

- Behaviour consistent with the note in `download_files` re: iOS 17 beta — iOS tends to send protocol messages in new versions that the library hasn't seen before.