### PR TITLE
xcuitest: fix DYLD env vars passed to test runner on iOS 17+

### DIFF
--- a/pymobiledevice3/services/dvt/testmanaged/xcuitest.py
+++ b/pymobiledevice3/services/dvt/testmanaged/xcuitest.py
@@ -345,11 +345,12 @@ def _generate_launch_args(
     }
 
     if product_major_version >= 11:
-        app_env["DYLD_INSERT_LIBRARIES"] = "/Developer/usr/lib/libMainThreadChecker.dylib"
         app_env["OS_ACTIVITY_DT_MODE"] = "YES"
+        if product_major_version < 17:
+            app_env["DYLD_INSERT_LIBRARIES"] = "/Developer/usr/lib/libMainThreadChecker.dylib"
     if product_major_version >= 17:
-        app_env["DYLD_FRAMEWORK_PATH"] = f"${app_env['DYLD_FRAMEWORK_PATH']}/System/Developer/Library/Frameworks:"
-        app_env["DYLD_LIBRARY_PATH"] = f"${app_env['DYLD_LIBRARY_PATH']}:/System/Developer/usr/lib"
+        app_env["DYLD_FRAMEWORK_PATH"] = f"{app_env['DYLD_FRAMEWORK_PATH']}/System/Developer/Library/Frameworks:"
+        app_env["DYLD_LIBRARY_PATH"] = f"{app_env['DYLD_LIBRARY_PATH']}:/System/Developer/usr/lib"
         app_env["XCTestConfigurationFilePath"] = ""  # sent as return value of _XCT_testRunnerReadyWithCapabilities
         app_env["XCTestManagerVariant"] = "DDI"
 


### PR DESCRIPTION
## Summary

Two demonstrably wrong env-var values that `_generate_launch_args` passes to the XCUITest test runner. Mostly cosmetic on iOS 17-18 (dyld tolerated them), more severe on iOS 26.4.2 where one of them can cascade into `XCTAutomationSupport.framework` failing to resolve and the runner aborting in `+[XCTRunnerDaemonSession sharedSession]` with `SIGABRT`.

## Bug 1: literal dollar sign in f-string (not shell expansion)

Current code (line 351):

```python
app_env["DYLD_FRAMEWORK_PATH"] = f"${app_env['DYLD_FRAMEWORK_PATH']}/System/Developer/Library/Frameworks:"
```

Python `f"..."` substitutes with `{x}`, not `${x}`. The leading `$` is a literal character. iOS launchd does not shell-expand env vars, so the resulting `DYLD_FRAMEWORK_PATH` (and likewise `DYLD_LIBRARY_PATH`) starts with a stray `$`, e.g.:

```
$/private/var/containers/Bundle/Application/.../Frameworks:/System/Developer/Library/Frameworks:
```

dyld tolerates this on older iOS (skipping the malformed first entry), but on iOS 26 the bad prefix can cascade into `XCTAutomationSupport.framework` failing to resolve and the test runner aborting.

## Bug 2: DYLD_INSERT_LIBRARIES points at a path emptied on iOS 17+

Current code (line 348):

```python
app_env["DYLD_INSERT_LIBRARIES"] = "/Developer/usr/lib/libMainThreadChecker.dylib"
```

Apple moved the developer libs from `/Developer/usr/lib/` to `/System/Developer/usr/lib/` on iOS 17+, and `libMainThreadChecker.dylib` is no longer shipped to devices at all. Inserting a non-existent dylib is at best a no-op + dyld warning. This PR gates the insert on `product_major_version < 17`.

## Reproduction (before this PR)

- Device: iPhone 17 Pro Max, iOS 26.4.2 (build 23E261)
- pymd3: 9.12.1 (latest on PyPI)
- WDA bundle: `appium/WebDriverAgent` master, sideloaded via Flexstore
- Command: `pymobiledevice3 developer dvt xcuitest com.facebook.WebDriverAgentRunner.xctrunner`
- Result: `WebDriverAgentRunner-Runner-*.ips` crash log with `+[XCTRunnerDaemonSession sharedSession] +316 -> NSAssertion -> abort()` exactly ~1.2s after launch.

Independently observed by @JulesGosnell on iPhone 14 / iOS 26.4.2 — see #1666 comment 2.

## After this PR

DTX session progresses cleanly through:

- `_IDE_initiateControlSessionWithCapabilities_` (returns rich caps from device)
- `_IDE_initiateSessionWithIdentifier_capabilities_` (returns caps)
- `launchSuspendedProcessWithDevicePath:bundleIdentifier:...` (real PID returned)
- `_IDE_authorizeTestSessionWithProcessID_` (returns True)

## What this PR does NOT claim to fix

This PR does **not** unblock real test runs on iOS 26.4.2 by itself. It fixes two long-standing, demonstrably wrong env-var values that were masked by dyld's tolerance on older iOS. The remaining iOS-26-only failure (the reverse `XCTestDriverInterface` proxy channel never opens after `authorize_test`) looks like a separate iOS 26 testmanagerd change; that one is tracked in #1666 and is outside the scope of this PR.

## Related

- Closes part of #1666 (the DYLD env var portion)
- Does not close #1666 itself (reverse channel remains broken)

## Test plan

- [x] Verified the diff is byte-identical to the runtime-patched version that gets us 7/8 launch steps green on iOS 26.4.2
- [x] Existing behavior preserved on iOS < 17 (DYLD_INSERT_LIBRARIES still set)
- [ ] CI green
