### PR TITLE
Hotfix/test filter

### DIFF
--- a/pymobiledevice3/services/dvt/testmanaged/xctest_types.py
+++ b/pymobiledevice3/services/dvt/testmanaged/xctest_types.py
@@ -28,6 +28,33 @@ from typing import Any, ClassVar, Optional
 from bpylist2 import archiver
 
 # ---------------------------------------------------------------------------
+# NSKeyedArchive class-hierarchy helper
+# ---------------------------------------------------------------------------
+# bpylist2's Archive.uid_for_archiver only emits ['ClassName'] in '$classes',
+# omitting the full inheritance chain required by NSSecureCoding.  Rather than
+# patching bpylist2 globally, each XCTest type that requires a correct chain
+# calls _patch_class_hierarchy from its encode_archive — mirroring the
+# buildClassDict("ClassName", …, "NSObject") calls in go-ios.
+
+
+def _patch_class_hierarchy(
+    archive_obj: archiver.ArchivingObject,
+    class_name: str,
+    hierarchy: list[str],
+) -> None:
+    """Overwrite the '$classes' list for *class_name* in the live archive.
+
+    bpylist2 creates the class dict in ``uid_for_archiver`` before calling
+    ``encode_archive``, so by the time we get here the entry already exists in
+    ``Archive.objects`` and we can update it in-place.
+    """
+    a = archive_obj._archiver  # type: ignore[attr-defined]
+    uid = a.class_map.get(class_name)
+    if uid is not None:
+        a.objects[uid.data]["$classes"] = hierarchy
+
+
+# ---------------------------------------------------------------------------
 # NSMutableArray — encodes as NSMutableArray (subclass of NSArray)
 # ---------------------------------------------------------------------------
 
@@ -48,6 +75,7 @@ class NSMutableArray:
         # must write NS.objects as a raw list of UIDs directly into the dict.
         a = archive_obj._archiver  # type: ignore[attr-defined]
         archive_obj._archive_obj["NS.objects"] = [a.archive(item) for item in self.items]  # type: ignore[attr-defined]
+        _patch_class_hierarchy(archive_obj, "NSMutableArray", ["NSMutableArray", "NSArray", "NSObject"])
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> NSMutableArray:
@@ -205,6 +233,7 @@ class XCTTestIdentifier:
     def encode_archive(self, archive_obj: archiver.ArchivingObject) -> None:
         archive_obj.encode("c", list(self.components))
         archive_obj.encode("o", self.options)
+        _patch_class_hierarchy(archive_obj, "XCTTestIdentifier", ["XCTTestIdentifier", "NSObject"])
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> XCTTestIdentifier:
@@ -239,6 +268,7 @@ class XCTTestIdentifierSet:
         # Must be NSMutableArray — XCTTestIdentifierSet.identifiers is typed as
         # NSMutableArray<XCTTestIdentifier *> in XCTest's private headers.
         archive_obj.encode("identifiers", NSMutableArray(self.identifiers))
+        _patch_class_hierarchy(archive_obj, "XCTTestIdentifierSet", ["XCTTestIdentifierSet", "NSObject"])
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> XCTTestIdentifierSet:

--- a/pymobiledevice3/services/dvt/testmanaged/xctest_types.py
+++ b/pymobiledevice3/services/dvt/testmanaged/xctest_types.py
@@ -27,6 +27,37 @@ from typing import Any, ClassVar, Optional
 
 from bpylist2 import archiver
 
+# ---------------------------------------------------------------------------
+# NSMutableArray — encodes as NSMutableArray (subclass of NSArray)
+# ---------------------------------------------------------------------------
+
+
+class NSMutableArray:
+    """Python wrapper that forces NSMutableArray encoding in NSKeyedArchive.
+
+    bpylist2 encodes Python ``list`` as NSArray.  The ``XCTTestIdentifierSet``
+    ``identifiers`` property is typed as ``NSMutableArray<XCTTestIdentifier *>``
+    in XCTest's private headers; sending NSArray causes a silent type-mismatch.
+    """
+
+    def __init__(self, items: list) -> None:
+        self.items = list(items)
+
+    def encode_archive(self, archive_obj: archiver.ArchivingObject) -> None:
+        # bpylist2's encode() would wrap the list in another NSArray UID; we
+        # must write NS.objects as a raw list of UIDs directly into the dict.
+        a = archive_obj._archiver  # type: ignore[attr-defined]
+        archive_obj._archive_obj["NS.objects"] = [a.archive(item) for item in self.items]  # type: ignore[attr-defined]
+
+    @staticmethod
+    def decode_archive(archive_obj: archiver.ArchivedObject) -> NSMutableArray:
+        raw = archive_obj.decode("NS.objects") or []
+        return NSMutableArray(list(raw))
+
+
+archiver.ARCHIVE_CLASS_MAP[NSMutableArray] = "NSMutableArray"  # type: ignore[index]
+archiver.update_class_map({"NSMutableArray": NSMutableArray})
+
 
 class XCTCapabilities:
     """Proxy for XCTest's ``XCTCapabilities`` dictionary wrapper."""
@@ -77,7 +108,9 @@ class XCTestConfiguration:
         "testsDrivenByIDE": False,
         "testsMustRunOnMainThread": True,
         "testsToRun": None,
+        "testIdentifiersToRun": None,
         "testsToSkip": None,
+        "testIdentifiersToSkip": None,
         "treatMissingBaselinesAsFailures": False,
         "userAttachmentLifetime": 0,
         "preferredScreenCaptureFormat": 2,
@@ -124,14 +157,31 @@ archiver.update_class_map({
 
 @dataclass
 class XCTTestIdentifier:
-    """Decoded proxy for ``XCTTestIdentifier``.
+    """Proxy for ``XCTTestIdentifier``.
 
     ``components`` is the ordered list of name parts, e.g.
     ``["DemoAppUITests", "testFail"]``.  Use :attr:`test_class` /
     :attr:`test_method` as shortcuts.
+
+    ``options`` follows XCTest's convention:
+    - ``2`` — leaf (class + method)
+    - ``3`` — class-level (class only, matches all methods)
     """
 
     components: list[str] = field(default_factory=list)
+    options: int = 2
+
+    @classmethod
+    def from_string(cls, test_spec: str) -> XCTTestIdentifier:
+        """Parse ``'ClassName/methodName'`` or ``'ClassName'`` into an identifier.
+
+        The ``options`` value follows the XCTest convention used by Xcode 15 /
+        go-ios: ``3`` for a class-level selector (no method), ``2`` for a
+        leaf (class + method).
+        """
+        parts = [p for p in test_spec.split("/") if p]
+        options = 3 if len(parts) == 1 else 2
+        return cls(components=parts, options=options)
 
     @property
     def test_class(self) -> str:
@@ -144,11 +194,57 @@ class XCTTestIdentifier:
     def __str__(self) -> str:
         return "/".join(self.components)
 
+    def __hash__(self) -> int:
+        return hash((tuple(self.components), self.options))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, XCTTestIdentifier):
+            return NotImplemented
+        return self.components == other.components and self.options == other.options
+
+    def encode_archive(self, archive_obj: archiver.ArchivingObject) -> None:
+        archive_obj.encode("c", list(self.components))
+        archive_obj.encode("o", self.options)
+
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> XCTTestIdentifier:
         raw = archive_obj.decode("c")
         components = list(raw) if raw else []
-        return XCTTestIdentifier(components=components)
+        options = archive_obj.decode("o") or 2
+        return XCTTestIdentifier(components=components, options=int(options))
+
+
+@dataclass
+class XCTTestIdentifierSet:
+    """Proxy for ``XCTTestIdentifierSet`` — the iOS 17+ filter type.
+
+    On iOS 17+, ``XCTestConfiguration`` recognises ``testIdentifiersToRun``
+    and ``testIdentifiersToSkip`` keys whose values are ``XCTTestIdentifierSet``
+    objects.  The legacy ``testsToRun``/``testsToSkip`` NSSet<NSString> keys
+    are ignored by modern runners.
+
+    ``identifiers`` is encoded as ``NSMutableArray<XCTTestIdentifier *>``
+    (``identifiers`` key) — matching the private-framework wire format used by
+    Xcode 15 and go-ios.
+    """
+
+    identifiers: list[XCTTestIdentifier] = field(default_factory=list)
+
+    @classmethod
+    def from_strings(cls, test_specs: list[str]) -> XCTTestIdentifierSet:
+        """Build a set from human-readable ``'ClassName/method'`` strings."""
+        return cls(identifiers=[XCTTestIdentifier.from_string(s) for s in test_specs])
+
+    def encode_archive(self, archive_obj: archiver.ArchivingObject) -> None:
+        # Must be NSMutableArray — XCTTestIdentifierSet.identifiers is typed as
+        # NSMutableArray<XCTTestIdentifier *> in XCTest's private headers.
+        archive_obj.encode("identifiers", NSMutableArray(self.identifiers))
+
+    @staticmethod
+    def decode_archive(archive_obj: archiver.ArchivedObject) -> XCTTestIdentifierSet:
+        raw = archive_obj.decode("identifiers")
+        identifiers = list(raw.items) if isinstance(raw, NSMutableArray) else (list(raw) if raw else [])
+        return XCTTestIdentifierSet(identifiers=identifiers)
 
 
 @dataclass
@@ -305,6 +401,7 @@ class XCTestCaseRunConfiguration:
 
 archiver.update_class_map({
     "XCTTestIdentifier": XCTTestIdentifier,
+    "XCTTestIdentifierSet": XCTTestIdentifierSet,
     "XCTSourceCodeLocation": XCTSourceCodeLocation,
     "XCTSourceCodeContext": XCTSourceCodeContext,
     "XCTIssue": XCTIssue,
@@ -313,3 +410,8 @@ archiver.update_class_map({
     "XCTAttachment": XCTAttachment,
     "XCTestCaseRunConfiguration": XCTestCaseRunConfiguration,
 })
+
+# Register XCTTestIdentifier and XCTTestIdentifierSet in the encoding map so
+# bpylist2 can archive them (used when building XCTestConfiguration).
+archiver.ARCHIVE_CLASS_MAP[XCTTestIdentifier] = "XCTTestIdentifier"  # type: ignore[index]
+archiver.ARCHIVE_CLASS_MAP[XCTTestIdentifierSet] = "XCTTestIdentifierSet"  # type: ignore[index]

--- a/pymobiledevice3/services/dvt/testmanaged/xcuitest.py
+++ b/pymobiledevice3/services/dvt/testmanaged/xcuitest.py
@@ -38,6 +38,7 @@ from pymobiledevice3.services.dvt.testmanaged.dtx_services import (  # noqa: F40
 )
 from pymobiledevice3.services.dvt.testmanaged.xctest_types import (
     XCTestConfiguration,
+    XCTTestIdentifierSet,
 )
 from pymobiledevice3.services.installation_proxy import InstallationProxyService
 
@@ -297,11 +298,28 @@ class TestConfig:
                 "targetApplicationBundleID must be set if target_app_info is provided"
             )
 
+        # Build test-filter fields.  iOS 17+ runners use testIdentifiersToRun /
+        # testIdentifiersToSkip (XCTTestIdentifierSet with XCTTestIdentifier
+        # objects).  The legacy testsToRun / testsToSkip NSSet<NSString> fields
+        # are also populated for compatibility with older runners.
+        def _to_filter_pair(
+            specs: Optional[list],
+        ) -> tuple[Optional[set], Optional[XCTTestIdentifierSet]]:
+            if not specs:
+                return None, None
+            strings = [str(s) for s in specs]
+            return set(strings), XCTTestIdentifierSet.from_strings(strings)
+
+        tests_to_run_set, tests_to_run_ids = _to_filter_pair(self.tests_to_run)
+        tests_to_skip_set, tests_to_skip_ids = _to_filter_pair(self.tests_to_skip)
+
         return XCTestConfiguration({
             "testBundleURL": NSURL(None, f"file://{self.runner_app_info['Path']}/PlugIns/{config_name}.xctest"),
             "sessionIdentifier": session_identifier,
-            "testsToRun": self.tests_to_run or set(),
-            "testsToSkip": self.tests_to_skip or set(),
+            "testsToRun": tests_to_run_set,
+            "testIdentifiersToRun": tests_to_run_ids,
+            "testsToSkip": tests_to_skip_set,
+            "testIdentifiersToSkip": tests_to_skip_ids,
             "testsMustRunOnMainThread": True,
             "reportResultsToIDE": True,
             "reportActivities": True,

--- a/tests/services/test_xcuitest_filter.py
+++ b/tests/services/test_xcuitest_filter.py
@@ -1,0 +1,318 @@
+"""Reproduction test for GitHub issue #1678 — TestConfig.tests_to_run filter silently ignored.
+
+https://github.com/doronz88/pymobiledevice3/issues/1678
+
+Summary
+-------
+When ``TestConfig(tests_to_run=...)`` is used on iOS 17+, the filter is silently ignored and
+the full test suite runs instead of just the requested subset.  The issue is that
+``XCTestConfiguration`` serialises ``testsToRun`` as plain ``NSString`` objects (via Python
+``set``/``str``), but iOS 17+ XCTest matches filters against ``XCTTestIdentifier`` objects.
+``XCTTestIdentifier`` has a ``decode_archive`` but no ``encode_archive``, so the outgoing
+payload never contains proper ``XCTTestIdentifier`` archive nodes.
+
+Test structure
+--------------
+1. ``test_baseline_no_filter``  - run the full bundle, collect every test that fires.
+   This establishes the baseline set of test names for the bundle.
+
+2. ``test_filter_with_plain_strings``  - pass ``tests_to_run`` as a list of plain
+   ``str`` identifiers.  Assert that the runner reports "Selected tests" (not "All tests")
+   as the top-level suite, and that *only* the requested test(s) ran.
+
+3. ``test_filter_with_xct_identifiers``  - same as above, but wraps the identifier in an
+   ``XCTTestIdentifier`` instance, confirming that objects are also handled correctly.
+
+Configuration
+-------------
+Tests are parametrized via ``tests/services/xcuitest.json`` (not tracked by git).
+Copy ``xcuitest.json.example`` and fill in your own values.  The config entries used
+by these tests must include:
+
+.. code-block:: json
+
+    {
+        "id":              "my_app",
+        "runner_bundle_id": "com.example.MyApp.xctrunner",
+        "target_bundle_id": "com.example.MyApp",
+        "filter_test":      "MyAppUITests/testSomething",
+        "all_tests":        ["MyAppUITests/testSomething", "MyAppUITests/testOther"],
+        "runner_env":       {},
+        "timeout":          60.0
+    }
+
+Usage
+-----
+    # iOS 17+ via tunneld:
+    pytest tests/services/test_xcuitest_filter_repro.py -s --tunnel '' -v
+
+    # iOS 14-16 via USB:
+    pytest tests/services/test_xcuitest_filter_repro.py -s -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+import pytest
+import pytest_asyncio
+
+from pymobiledevice3.services.dvt.testmanaged.xctest_types import (
+    XCTestConfiguration,
+    XCTTestIdentifier,
+)
+from pymobiledevice3.services.dvt.testmanaged.xcuitest import (
+    TestConfig,
+    XCTestCaseResult,
+    XCUITestListener,
+    XCUITestService,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default timeout for each run (seconds); overridden per-config via xcuitest.json.
+RUN_TIMEOUT = 120.0
+
+
+# ---------------------------------------------------------------------------
+# Listener
+# ---------------------------------------------------------------------------
+
+
+class _RecordingListener(XCUITestListener):
+    """Captures test lifecycle events so tests can assert on them."""
+
+    def __init__(self) -> None:
+        self.suite_starts: list[str] = []
+        self.suite_finishes: list[str] = []
+        self.test_cases_started: list[str] = []
+        self.test_cases_finished: list[str] = []
+        self.log_messages: list[str] = []
+        self.ready_event = asyncio.Event()
+        # Tracks the outermost top-level suite name reported by the runner.
+        # "All tests"      → filter NOT applied
+        # "Selected tests" → filter WAS applied (iOS 17+ XCTest)
+        self.top_level_suite: Optional[str] = None
+
+    async def did_begin_executing_test_plan(self) -> None:
+        logger.info("[listener] did_begin_executing_test_plan")
+
+    async def did_finish_executing_test_plan(self) -> None:
+        logger.info("[listener] did_finish_executing_test_plan")
+
+    async def test_bundle_ready(self) -> None:
+        self.ready_event.set()
+
+    async def test_bundle_ready_with_capabilities(self, capabilities) -> Optional[XCTestConfiguration]:
+        self.ready_event.set()
+        return None
+
+    async def test_bundle_ready_with_protocol_version(self, protocol_version, minimum_version) -> None:
+        self.ready_event.set()
+
+    async def test_suite_did_start(self, suite: str, started_at: str) -> None:
+        logger.info("[listener] suite_start: %r", suite)
+        self.suite_starts.append(suite)
+        # NOTE: dtx_services.py filters out "All tests" (and the empty-string
+        # root suite) before calling this method, so "All tests" never arrives
+        # here.  "Selected tests" is NOT filtered, so it arrives when a
+        # testsToRun filter was honoured by the runner.
+        if self.top_level_suite is None and suite == "Selected tests":
+            self.top_level_suite = suite
+
+    async def test_suite_did_finish(
+        self,
+        suite,
+        finished_at,
+        run_count,
+        failures,
+        unexpected,
+        test_duration,
+        total_duration,
+        skipped,
+        expected_failures,
+        uncaught_exceptions,
+    ) -> None:
+        logger.info("[listener] suite_finish: %r  run_count=%s", suite, run_count)
+        self.suite_finishes.append(suite)
+
+    async def test_case_did_start(self, test_class: str, method: str) -> None:
+        identifier = f"{test_class}/{method}"
+        logger.info("[listener] case_start: %s", identifier)
+        self.test_cases_started.append(identifier)
+
+    async def test_case_did_finish(self, result: XCTestCaseResult) -> None:
+        identifier = f"{result.test_class}/{result.method}"
+        logger.info("[listener] case_finish: %s  status=%s", identifier, result.status)
+        self.test_cases_finished.append(identifier)
+
+    async def test_case_did_fail(self, test_class, method, message, file, line) -> None:
+        logger.warning("[listener] case_fail: %s/%s  msg=%r", test_class, method, message)
+
+    async def log_message(self, message: str) -> None:
+        self.log_messages.append(message)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def xcuitest_svc(service_provider) -> XCUITestService:
+    """Create an XCUITestService, skipping if DVT is unavailable."""
+    from pymobiledevice3.exceptions import InvalidServiceError
+    from pymobiledevice3.services.dvt.instruments.dvt_provider import DvtProvider
+
+    try:
+        async with DvtProvider(service_provider):
+            pass
+    except InvalidServiceError:
+        pytest.skip("DVT provider not accessible — is a developer image mounted?")
+    return XCUITestService(service_provider)
+
+
+async def _run_with_listener(
+    svc: XCUITestService,
+    cfg: TestConfig,
+    *,
+    timeout: float = RUN_TIMEOUT,
+) -> _RecordingListener:
+    """Run the test suite and return the populated listener."""
+    listener = _RecordingListener()
+    await svc.run(cfg, timeout=timeout, listener=listener)
+    return listener
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_baseline_no_filter(xcuitest_svc: XCUITestService, xcuitest_cfg: dict[str, Any]) -> None:
+    """Baseline: run the full bundle without any filter.
+
+    Asserts:
+    - The plan finishes without timeout.
+    - At least one test case was executed.
+    - The top-level suite is not "Selected tests" (no filter applied).
+    - All expected tests ran (if ``all_tests`` is provided in the config).
+    """
+    timeout = xcuitest_cfg.get("timeout", RUN_TIMEOUT)
+    cfg = await TestConfig.create_for(
+        xcuitest_svc.lockdown,
+        runner_bundle_id=xcuitest_cfg["runner_bundle_id"],
+        target_bundle_id=xcuitest_cfg["target_bundle_id"],
+    )
+    assert cfg.tests_to_run is None
+
+    listener = await _run_with_listener(xcuitest_svc, cfg, timeout=timeout)
+
+    print("\n=== Baseline run (no filter) ===")
+    print(f"  Top-level suite  : {listener.top_level_suite!r}")
+    print(f"  Suite starts     : {listener.suite_starts}")
+    print(f"  Tests started    : {listener.test_cases_started}")
+    print(f"  Tests finished   : {listener.test_cases_finished}")
+
+    assert listener.test_cases_started, "No test cases started — bundle may be empty or runner failed"
+
+    assert listener.top_level_suite is None, (
+        f"Without a filter, 'Selected tests' should NOT appear; got {listener.top_level_suite!r}"
+    )
+
+    all_tests = xcuitest_cfg.get("all_tests")
+    if all_tests:
+        ran = set(listener.test_cases_started)
+        expected = set(all_tests)
+        assert ran == expected, (
+            f"Expected all bundle tests to run without a filter.\n"
+            f"  Missing: {expected - ran}\n"
+            f"  Extra:   {ran - expected}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_filter_with_plain_strings(xcuitest_svc: XCUITestService, xcuitest_cfg: dict[str, Any]) -> None:
+    """Verify filter via tests_to_run=[str] works after the fix for issue #1678.
+
+    Previously this silently ran the full bundle because:
+    - testsToRun was serialised as NSSet<NSString> (ignored by iOS 17+ runners)
+    - testIdentifiersToRun was absent from XCTestConfiguration
+
+    After the fix, both testsToRun (legacy) and testIdentifiersToRun
+    (XCTTestIdentifierSet with XCTTestIdentifier objects) are populated.
+    """
+    filter_test = xcuitest_cfg.get("filter_test")
+    if not filter_test:
+        pytest.skip("'filter_test' not set in xcuitest config")
+
+    timeout = xcuitest_cfg.get("timeout", RUN_TIMEOUT)
+    cfg = await TestConfig.create_for(
+        xcuitest_svc.lockdown,
+        runner_bundle_id=xcuitest_cfg["runner_bundle_id"],
+        target_bundle_id=xcuitest_cfg["target_bundle_id"],
+    )
+    cfg.tests_to_run = [filter_test]
+
+    listener = await _run_with_listener(xcuitest_svc, cfg, timeout=timeout)
+
+    print("\n=== Filter run (plain strings) ===")
+    print(f"  Requested filter : {filter_test!r}")
+    print(f"  Top-level suite  : {listener.top_level_suite!r}")
+    print(f"  Tests started    : {listener.test_cases_started}")
+    print(f"  Tests finished   : {listener.test_cases_finished}")
+
+    assert listener.top_level_suite == "Selected tests", (
+        f"Filter was NOT applied: top-level suite is {listener.top_level_suite!r} "
+        f"instead of 'Selected tests'. This reproduces issue #1678 — "
+        f"tests_to_run={cfg.tests_to_run!r} was silently ignored."
+    )
+    assert listener.test_cases_started == [filter_test], (
+        f"Only {filter_test!r} should have run, but runner executed: {listener.test_cases_started}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_filter_with_xct_identifiers(xcuitest_svc: XCUITestService, xcuitest_cfg: dict[str, Any]) -> None:
+    """Verify that passing XCTTestIdentifier objects in tests_to_run also works.
+
+    This confirms that:
+    - XCTTestIdentifier.encode_archive is implemented
+    - XCTTestIdentifier is hashable
+    - When XCTTestIdentifier objects are passed, they are converted to
+      strings via str() and then to XCTTestIdentifierSet — filter applies.
+    """
+    filter_test = xcuitest_cfg.get("filter_test")
+    if not filter_test:
+        pytest.skip("'filter_test' not set in xcuitest config")
+
+    components = filter_test.split("/")
+    identifier = XCTTestIdentifier(components=components)
+
+    assert hasattr(identifier, "encode_archive"), "XCTTestIdentifier is missing encode_archive"
+    assert callable(identifier.__hash__), "XCTTestIdentifier is not hashable"
+
+    timeout = xcuitest_cfg.get("timeout", RUN_TIMEOUT)
+    cfg = await TestConfig.create_for(
+        xcuitest_svc.lockdown,
+        runner_bundle_id=xcuitest_cfg["runner_bundle_id"],
+        target_bundle_id=xcuitest_cfg["target_bundle_id"],
+    )
+    cfg.tests_to_run = [identifier]
+
+    listener = await _run_with_listener(xcuitest_svc, cfg, timeout=timeout)
+
+    print("\n=== Filter run (XCTTestIdentifier) ===")
+    print(f"  Requested filter : {identifier!r}")
+    print(f"  Top-level suite  : {listener.top_level_suite!r}")
+    print(f"  Tests started    : {listener.test_cases_started}")
+
+    assert listener.top_level_suite == "Selected tests", (
+        f"Filter still NOT applied with XCTTestIdentifier objects: top-level suite is {listener.top_level_suite!r}."
+    )
+    assert listener.test_cases_started == [filter_test], (
+        f"Only {filter_test!r} should have run, but got: {listener.test_cases_started}"
+    )

--- a/tests/services/test_xcuitest_filter.py
+++ b/tests/services/test_xcuitest_filter.py
@@ -64,7 +64,9 @@ from pymobiledevice3.services.dvt.testmanaged.xctest_types import (
     XCTTestIdentifier,
 )
 from pymobiledevice3.services.dvt.testmanaged.xcuitest import (
-    TestConfig,
+    TestConfig as _TestConfig,
+)
+from pymobiledevice3.services.dvt.testmanaged.xcuitest import (
     XCTestCaseResult,
     XCUITestListener,
     XCUITestService,
@@ -176,7 +178,7 @@ async def xcuitest_svc(service_provider) -> XCUITestService:
 
 async def _run_with_listener(
     svc: XCUITestService,
-    cfg: TestConfig,
+    cfg: _TestConfig,
     *,
     timeout: float = RUN_TIMEOUT,
 ) -> _RecordingListener:
@@ -202,7 +204,7 @@ async def test_baseline_no_filter(xcuitest_svc: XCUITestService, xcuitest_cfg: d
     - All expected tests ran (if ``all_tests`` is provided in the config).
     """
     timeout = xcuitest_cfg.get("timeout", RUN_TIMEOUT)
-    cfg = await TestConfig.create_for(
+    cfg = await _TestConfig.create_for(
         xcuitest_svc.lockdown,
         runner_bundle_id=xcuitest_cfg["runner_bundle_id"],
         target_bundle_id=xcuitest_cfg["target_bundle_id"],
@@ -250,7 +252,7 @@ async def test_filter_with_plain_strings(xcuitest_svc: XCUITestService, xcuitest
         pytest.skip("'filter_test' not set in xcuitest config")
 
     timeout = xcuitest_cfg.get("timeout", RUN_TIMEOUT)
-    cfg = await TestConfig.create_for(
+    cfg = await _TestConfig.create_for(
         xcuitest_svc.lockdown,
         runner_bundle_id=xcuitest_cfg["runner_bundle_id"],
         target_bundle_id=xcuitest_cfg["target_bundle_id"],
@@ -296,7 +298,7 @@ async def test_filter_with_xct_identifiers(xcuitest_svc: XCUITestService, xcuite
     assert callable(identifier.__hash__), "XCTTestIdentifier is not hashable"
 
     timeout = xcuitest_cfg.get("timeout", RUN_TIMEOUT)
-    cfg = await TestConfig.create_for(
+    cfg = await _TestConfig.create_for(
         xcuitest_svc.lockdown,
         runner_bundle_id=xcuitest_cfg["runner_bundle_id"],
         target_bundle_id=xcuitest_cfg["target_bundle_id"],

--- a/tests/services/xcuitest.example.json
+++ b/tests/services/xcuitest.example.json
@@ -4,6 +4,11 @@
     "runner_bundle_id": "com.example.MyApp.xctrunner",
     "target_bundle_id": "com.example.MyApp",
     "runner_env": {},
-    "timeout": 30.0
+    "timeout": 60.0,
+    "filter_test": "MyAppUITests/testSomething",
+    "all_tests": [
+      "MyAppUITests/testSomething",
+      "MyAppUITests/testSomethingElse"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Add support for XCTTestIdentifierSet

## Testing

```
# iOS 16.x via USB:
 pytest tests/services/test_xcuitest_filter.py -s --xcuitest-config /path/to/config.json -v
 
 # iOS 17+ via tunneld:
 pytest tests/services/test_xcuitest_filter.py -s --xcuitest-config /path/to/config.json --tunnel '' -
```

Tested on iOS 16.5 and 26.2 .

## AI Assistance

copilot with Sonnet 4.6 to write the reproduction test and preliminary fix.
Reviewed and correct the fix and tested it in different configurations.

Closes #1678 
