### PR TITLE
backup2: surface LocalAuthentication prompts during backup

### DIFF
--- a/pymobiledevice3/services/mobilebackup2.py
+++ b/pymobiledevice3/services/mobilebackup2.py
@@ -54,6 +54,20 @@ NP_SYNC_WILL_START = "com.apple.itunes-mobdev.syncWillStart"
 NP_SYNC_DID_START = "com.apple.itunes-mobdev.syncDidStart"
 NP_SYNC_LOCK_REQUEST = "com.apple.itunes-mobdev.syncLockRequest"
 NP_SYNC_DID_FINISH = "com.apple.itunes-mobdev.syncDidFinish"
+NP_SYNC_CANCEL_REQUEST = "com.apple.itunes-client.syncCancelRequest"
+NP_SYNC_SUSPEND_REQUEST = "com.apple.itunes-client.syncSuspendRequest"
+NP_SYNC_RESUME_REQUEST = "com.apple.itunes-client.syncResumeRequest"
+NP_BACKUP_DOMAIN_CHANGED = "com.apple.mobile.backup.domain_changed"
+NP_LOCAL_AUTH_PRESENTED = "com.apple.LocalAuthentication.ui.presented"
+NP_LOCAL_AUTH_DISMISSED = "com.apple.LocalAuthentication.ui.dismissed"
+BACKUP_OBSERVED_NOTIFICATIONS = (
+    NP_SYNC_CANCEL_REQUEST,
+    NP_SYNC_SUSPEND_REQUEST,
+    NP_SYNC_RESUME_REQUEST,
+    NP_BACKUP_DOMAIN_CHANGED,
+    NP_LOCAL_AUTH_PRESENTED,
+    NP_LOCAL_AUTH_DISMISSED,
+)
 BACKUP_METADATA_FILES = frozenset({
     "Info.plist",
     "Manifest.plist",
@@ -172,42 +186,68 @@ class Mobilebackup2Service(LockdownService):
             AfcService(self.lockdown) as afc,
             self._backup_lock(afc, notification_proxy),
         ):
+            await self._observe_backup_notifications(notification_proxy)
+            notification_task = asyncio.create_task(self._log_backup_notifications(notification_proxy))
             # Initialize Info.plist
-            info_plist = await self.init_mobile_backup_factory_info(afc)
-            with open(device_directory / "Info.plist", "wb") as fd:
-                plistlib.dump(info_plist, fd)
+            try:
+                info_plist = await self.init_mobile_backup_factory_info(afc)
+                with open(device_directory / "Info.plist", "wb") as fd:
+                    plistlib.dump(info_plist, fd)
 
-            # Initialize Status.plist file if doesn't exist.
-            status_path = device_directory / "Status.plist"
-            current_date = datetime.now()
-            current_date = current_date.replace(tzinfo=None)
-            if full or not status_path.exists():
-                with open(device_directory / "Status.plist", "wb") as fd:
-                    plistlib.dump(
-                        {
-                            "BackupState": "new",
-                            "Date": current_date,
-                            "IsFullBackup": full,
-                            "Version": "3.3",
-                            "SnapshotState": "finished",
-                            "UUID": str(uuid.uuid4()).upper(),
-                        },
-                        fd,
-                        fmt=plistlib.FMT_BINARY,
-                    )
+                # Initialize Status.plist file if doesn't exist.
+                status_path = device_directory / "Status.plist"
+                current_date = datetime.now()
+                current_date = current_date.replace(tzinfo=None)
+                if full or not status_path.exists():
+                    with open(device_directory / "Status.plist", "wb") as fd:
+                        plistlib.dump(
+                            {
+                                "BackupState": "new",
+                                "Date": current_date,
+                                "IsFullBackup": full,
+                                "Version": "3.3",
+                                "SnapshotState": "finished",
+                                "UUID": str(uuid.uuid4()).upper(),
+                            },
+                            fd,
+                            fmt=plistlib.FMT_BINARY,
+                        )
 
-            # Create Manifest.plist if doesn't exist.
-            manifest_path = device_directory / "Manifest.plist"
-            if full:
-                manifest_path.unlink(missing_ok=True)
-            (device_directory / "Manifest.plist").touch()
+                # Create Manifest.plist if doesn't exist.
+                manifest_path = device_directory / "Manifest.plist"
+                if full:
+                    manifest_path.unlink(missing_ok=True)
+                (device_directory / "Manifest.plist").touch()
 
-            await dl.send_process_message({"MessageName": "Backup", "TargetIdentifier": self.lockdown.udid})
-            await dl.dl_loop(progress_callback)
-            if filter_callback is not None:
-                self.prune_backup_directory(device_directory, filter_callback, password=password)
-            if unback:
-                self.unback_with_pyiosbackup(device_directory, password=password)
+                await dl.send_process_message({"MessageName": "Backup", "TargetIdentifier": self.lockdown.udid})
+                await dl.dl_loop(progress_callback)
+                if filter_callback is not None:
+                    self.prune_backup_directory(device_directory, filter_callback, password=password)
+                if unback:
+                    self.unback_with_pyiosbackup(device_directory, password=password)
+            finally:
+                notification_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await notification_task
+
+    async def _observe_backup_notifications(self, notification_proxy: NotificationProxyService) -> None:
+        for notification in BACKUP_OBSERVED_NOTIFICATIONS:
+            await notification_proxy.notify_register_dispatch(notification)
+
+    async def _log_backup_notifications(self, notification_proxy: NotificationProxyService) -> None:
+        async for event in notification_proxy.receive_notification():
+            self._log_backup_notification(event)
+
+    def _log_backup_notification(self, event: dict) -> None:
+        name = event.get("Name")
+        if name == NP_LOCAL_AUTH_PRESENTED:
+            self.logger.warning("Please enter the device passcode to continue the backup")
+        elif name == NP_LOCAL_AUTH_DISMISSED:
+            self.logger.info("Device passcode prompt dismissed")
+        elif name == NP_SYNC_CANCEL_REQUEST:
+            self.logger.warning("User has cancelled the backup process on the device")
+        else:
+            self.logger.debug("Received backup notification: %s", event)
 
     async def restore(
         self,

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -4,14 +4,22 @@ import time
 from contextlib import closing
 from pathlib import Path
 from ssl import SSLEOFError
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
 from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionTerminatedError
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.services.device_link import DeviceLink
-from pymobiledevice3.services.mobilebackup2 import BACKUP_SELECTIONS, BackupFile, Mobilebackup2Service
+from pymobiledevice3.services.mobilebackup2 import (
+    BACKUP_OBSERVED_NOTIFICATIONS,
+    BACKUP_SELECTIONS,
+    NP_LOCAL_AUTH_DISMISSED,
+    NP_LOCAL_AUTH_PRESENTED,
+    NP_SYNC_CANCEL_REQUEST,
+    BackupFile,
+    Mobilebackup2Service,
+)
 
 PASSWORD = "1234"
 
@@ -110,6 +118,32 @@ def test_selection_filter_callback_matches_upload_and_manifest_forms() -> None:
 
 def test_should_preserve_backup_file_keeps_metadata() -> None:
     assert Mobilebackup2Service.should_preserve_backup_file("Manifest.db", "ignored", None)
+
+
+@pytest.mark.asyncio
+async def test_observe_backup_notifications_registers_passcode_and_backup_notifications() -> None:
+    notification_proxy = Mock()
+    notification_proxy.notify_register_dispatch = AsyncMock()
+
+    service = object.__new__(Mobilebackup2Service)
+    await service._observe_backup_notifications(notification_proxy)
+
+    notification_proxy.notify_register_dispatch.assert_has_awaits([
+        call(notification) for notification in BACKUP_OBSERVED_NOTIFICATIONS
+    ])
+
+
+def test_log_backup_notification_surfaces_passcode_prompt_to_operator() -> None:
+    service = object.__new__(Mobilebackup2Service)
+    service.logger = Mock()
+
+    service._log_backup_notification({"Name": NP_LOCAL_AUTH_PRESENTED})
+    service._log_backup_notification({"Name": NP_LOCAL_AUTH_DISMISSED})
+    service._log_backup_notification({"Name": NP_SYNC_CANCEL_REQUEST})
+
+    service.logger.warning.assert_any_call("Please enter the device passcode to continue the backup")
+    service.logger.info.assert_called_once_with("Device passcode prompt dismissed")
+    service.logger.warning.assert_any_call("User has cancelled the backup process on the device")
 
 
 def test_unback_with_pyiosbackup_replaces_existing_output(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

This change makes `Mobilebackup2Service.backup()` observe Backup2-related notification-proxy events while a backup is running, and surfaces the iOS LocalAuthentication/passcode gate to the operator instead of leaving the backup apparently stalled with no actionable message.

On recent iOS versions, the device may present a LocalAuthentication/passcode prompt before Backup2 proceeds. The underlying backup can still be valid and unencrypted, but the host-side tool waits until the user authorizes on the device. Without observing these notifications, the CLI provides no clear indication that the operator must unlock/approve the prompt on the iPhone.

## What Changed

- Added explicit notification names for Backup2/operator-relevant events:
  - `com.apple.itunes-client.syncCancelRequest`
  - `com.apple.itunes-client.syncSuspendRequest`
  - `com.apple.itunes-client.syncResumeRequest`
  - `com.apple.mobile.backup.domain_changed`
  - `com.apple.LocalAuthentication.ui.presented`
  - `com.apple.LocalAuthentication.ui.dismissed`
- Added `BACKUP_OBSERVED_NOTIFICATIONS` so the set of backup-time notifications is defined in one place.
- Added `_observe_backup_notifications()` to register those notification names with `NotificationProxyService` before the backup request is sent.
- Added `_log_backup_notifications()` to consume notification-proxy events in the background while Backup2 is running.
- Added `_log_backup_notification()` to translate the important device-side events into operator-facing logs:
  - warns when the passcode / LocalAuthentication prompt is presented
  - confirms when the prompt is dismissed
  - warns when the user cancels the backup process on the device
  - leaves other backup notifications at debug level

## Why The `try/finally` Was Added

The backup body now starts a background task that listens for notification-proxy events for the lifetime of the backup:

```python
notification_task = asyncio.create_task(self._log_backup_notifications(notification_proxy))
```

The existing backup flow is wrapped in `try/finally` so that this listener is always cancelled and awaited when the backup exits, regardless of whether the backup succeeds, fails, is cancelled by the user, or raises during setup/transfer.

Without this cleanup, the async notification listener could outlive the backup operation and keep waiting on notification-proxy events after the Backup2 command has already ended. The `finally` block makes the task lifetime match the backup lifetime:

```python
finally:
    notification_task.cancel()
    with suppress(asyncio.CancelledError):
        await notification_task
```

This keeps the implementation bounded and avoids leaking a background task while preserving the existing backup behavior.

## User Impact

When iOS presents the passcode / LocalAuthentication prompt, the CLI now tells the operator what is happening:

```text
Please enter the device passcode to continue the backup
Device passcode prompt dismissed
```

This is especially useful for forensic or acquisition workflows where the device is connected and trusted, but the host appears to hang until the user approves the device-side prompt.

## Validation

Local checks:

```text
python -m pytest -q tests/services/test_backup2.py -k 'observe_backup_notifications or log_backup_notification'
# 2 passed, 14 deselected

python -m ruff check pymobiledevice3/services/mobilebackup2.py tests/services/test_backup2.py
# All checks passed

python -m ruff format --check pymobiledevice3/services/mobilebackup2.py tests/services/test_backup2.py
# 2 files already formatted

git diff --check
# no whitespace errors
```

Live USB validation was also performed against an iPhone running iOS 26.5 using this branch. The run observed `com.apple.LocalAuthentication.ui.presented`, logged the passcode prompt, observed `com.apple.LocalAuthentication.ui.dismissed`, and completed the Backup2 flow successfully with a populated `Manifest.db`, `Manifest.plist`, `Info.plist`, and `Status.plist`.

## Tests Added

- `test_observe_backup_notifications_registers_passcode_and_backup_notifications`
- `test_log_backup_notification_surfaces_passcode_prompt_to_operator`

These cover both the notification registration set and the operator-facing log behavior for the LocalAuthentication prompt, prompt dismissal, and on-device cancellation event.
