### PR TITLE
backup2: add DeviceLink receive timeout

### DIFF
--- a/pymobiledevice3/cli/backup.py
+++ b/pymobiledevice3/cli/backup.py
@@ -100,6 +100,14 @@ async def backup(
             help="Also unpack the completed backup locally using pyiosbackup. Existing unpacked contents are replaced.",
         ),
     ] = False,
+    device_link_timeout: Annotated[
+        Optional[float],
+        typer.Option(
+            "--device-link-timeout",
+            min=0,
+            help="Optional timeout in seconds for each DeviceLink message during backup. Use 0 to disable.",
+        ),
+    ] = None,
 ) -> None:
     """
     Backup device.
@@ -135,6 +143,7 @@ async def backup(
                 filter_callback=filter_callback,
                 password=password,
                 unback=unback,
+                device_link_timeout=device_link_timeout,
             )
 
 

--- a/pymobiledevice3/services/device_link.py
+++ b/pymobiledevice3/services/device_link.py
@@ -1,3 +1,4 @@
+import asyncio
 import ctypes
 import datetime
 import shutil
@@ -42,11 +43,13 @@ class DeviceLink:
         root_path: Path,
         preserve_file: Optional[Callable[[str, str], bool]] = None,
         post_file_receive: Optional[Callable[[str, str], None]] = None,
+        receive_timeout: Optional[float] = None,
     ) -> None:
         self.service: ServiceConnection = service
         self.root_path: Path = root_path
         self.preserve_file = preserve_file
         self.post_file_receive = post_file_receive
+        self.receive_timeout = receive_timeout if receive_timeout and receive_timeout > 0 else None
         self._dl_handlers: dict[str, DLHandler] = {
             "DLMessageCreateDirectory": self.create_directory,
             "DLMessageUploadFiles": self.upload_files,
@@ -268,7 +271,16 @@ class DeviceLink:
         ])
 
     async def receive_message(self) -> DLMessage:
-        return cast(DLMessage, await self.service.recv_plist())
+        try:
+            if self.receive_timeout is None:
+                message = await self.service.recv_plist()
+            else:
+                message = await asyncio.wait_for(self.service.recv_plist(), timeout=self.receive_timeout)
+        except asyncio.TimeoutError as e:
+            raise PyMobileDevice3Exception(
+                f"Timed out after {self.receive_timeout:g}s waiting for DeviceLink message"
+            ) from e
+        return cast(DLMessage, message)
 
     async def disconnect(self) -> None:
         await self.service.send_plist(["DLMessageDisconnect", "___EmptyParameterString___"])

--- a/pymobiledevice3/services/mobilebackup2.py
+++ b/pymobiledevice3/services/mobilebackup2.py
@@ -159,6 +159,7 @@ class Mobilebackup2Service(LockdownService):
         filter_callback: Optional[BackupFilterCallback] = None,
         password: str = "",
         unback: bool = False,
+        device_link_timeout: Optional[float] = None,
     ) -> None:
         """
         Backup a device.
@@ -168,6 +169,7 @@ class Mobilebackup2Service(LockdownService):
         :param filter_callback: Callback deciding whether to keep a backup file.
         :param password: Password of the backup if it is encrypted.
         :param unback: Also unpack the completed backup locally using pyiosbackup.
+        :param device_link_timeout: Optional timeout in seconds for each DeviceLink message.
         The function shall receive the percentage as a parameter.
         """
         full = full or filter_callback is not None
@@ -181,7 +183,12 @@ class Mobilebackup2Service(LockdownService):
             )
 
         async with (
-            self.device_link(backup_directory, filter_callback=filter_callback, password=password) as dl,
+            self.device_link(
+                backup_directory,
+                filter_callback=filter_callback,
+                password=password,
+                receive_timeout=device_link_timeout,
+            ) as dl,
             NotificationProxyService(self.lockdown) as notification_proxy,
             AfcService(self.lockdown) as afc,
             self._backup_lock(afc, notification_proxy),
@@ -823,7 +830,11 @@ class Mobilebackup2Service(LockdownService):
 
     @asynccontextmanager
     async def device_link(
-        self, backup_directory, filter_callback: Optional[BackupFilterCallback] = None, password: str = ""
+        self,
+        backup_directory,
+        filter_callback: Optional[BackupFilterCallback] = None,
+        password: str = "",
+        receive_timeout: Optional[float] = None,
     ):
         dl = DeviceLink(
             self.service,
@@ -831,6 +842,7 @@ class Mobilebackup2Service(LockdownService):
             preserve_file=lambda file_name, device_name: self.should_preserve_backup_file(
                 file_name, device_name, filter_callback
             ),
+            receive_timeout=receive_timeout,
         )
         await dl.version_exchange()
         await self.version_exchange(dl)

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -1,3 +1,4 @@
+import asyncio
 import sqlite3
 import struct
 import time
@@ -8,7 +9,7 @@ from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
-from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionTerminatedError
+from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionTerminatedError, PyMobileDevice3Exception
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.services.device_link import DeviceLink
 from pymobiledevice3.services.mobilebackup2 import (
@@ -261,6 +262,38 @@ async def test_device_link_move_items_skips_missing_filtered_source(tmp_path: Pa
     await device_link.move_items(["DLMessageMoveItems", {"missing/source": "54/hash"}])
 
     service.send_plist.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_device_link_receive_message_returns_received_message(tmp_path: Path) -> None:
+    service = AsyncMock()
+    service.recv_plist = AsyncMock(return_value=["DLMessageDeviceReady"])
+    device_link = DeviceLink(service, tmp_path, receive_timeout=1)
+
+    assert await device_link.receive_message() == ["DLMessageDeviceReady"]
+
+
+@pytest.mark.asyncio
+async def test_device_link_zero_receive_timeout_disables_timeout(tmp_path: Path) -> None:
+    service = AsyncMock()
+    service.recv_plist = AsyncMock(return_value=["DLMessageDeviceReady"])
+    device_link = DeviceLink(service, tmp_path, receive_timeout=0)
+
+    assert device_link.receive_timeout is None
+    assert await device_link.receive_message() == ["DLMessageDeviceReady"]
+
+
+@pytest.mark.asyncio
+async def test_device_link_receive_message_times_out(tmp_path: Path) -> None:
+    async def never_return():
+        await asyncio.Event().wait()
+
+    service = AsyncMock()
+    service.recv_plist = AsyncMock(side_effect=never_return)
+    device_link = DeviceLink(service, tmp_path, receive_timeout=0.01)
+
+    with pytest.raises(PyMobileDevice3Exception, match=r"Timed out after 0\.01s waiting for DeviceLink message"):
+        await device_link.receive_message()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This change adds an optional per-message receive timeout for Backup2 DeviceLink sessions.

Backup2 currently waits indefinitely for the next DeviceLink plist message. That is the right default for compatibility, but it gives callers no bounded failure mode when a device stops progressing or when the session is waiting for device-side action. This PR keeps the existing default behavior unchanged and lets callers opt into a clear timeout when they need one.

## What Changed

- Added an optional `receive_timeout` parameter to `DeviceLink`.
- Normalized unset, `None`, and `0` timeout values to the existing no-timeout behavior.
- Wrapped `service.recv_plist()` in `asyncio.wait_for()` only when a positive timeout is configured.
- Converted `asyncio.TimeoutError` into a `PyMobileDevice3Exception` with a clear DeviceLink timeout message.
- Threaded the timeout through `Mobilebackup2Service.backup()`.
- Exposed the option on `backup2 backup`:

```text
pymobiledevice3 backup2 backup --device-link-timeout <seconds> <backup-directory>
```

## Why The Timeout Is Opt-In

The existing behavior is to wait indefinitely for the next DeviceLink message. Some backup sessions legitimately take a long time, so changing the default could introduce regressions for slow devices, large backups, or unusual transports.

For that reason, this PR only applies the timeout when a positive value is explicitly provided:

```python
self.receive_timeout = receive_timeout if receive_timeout and receive_timeout > 0 else None
```

This means:

- omitted option: unchanged behavior
- `--device-link-timeout 0`: unchanged behavior
- positive value: bound each DeviceLink receive operation

The timeout is per DeviceLink message, not a total backup duration limit.

## User Impact

Callers that want the current behavior do not need to change anything.

Automation or interactive backup workflows can now choose a bounded wait:

```text
pymobiledevice3 backup2 backup --device-link-timeout 120 ./backup
```

If the device does not send the next DeviceLink message within the configured deadline, the command fails with a clear error instead of waiting indefinitely:

```text
Timed out after 120s waiting for DeviceLink message
```

## Validation

Local checks:

```text
python -m pytest -q tests/services/test_backup2.py -k 'observe_backup_notifications or log_backup_notification or device_link_receive_message or zero_receive_timeout or move_items or upload_files'
# 8 passed, 11 deselected

python -m ruff check pymobiledevice3/services/device_link.py pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py tests/services/test_backup2.py
# All checks passed

python -m ruff format --check pymobiledevice3/services/device_link.py pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py tests/services/test_backup2.py
# 4 files already formatted

python -m compileall -q pymobiledevice3/services/device_link.py pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py tests/services/test_backup2.py
# no errors

git diff --check origin/master..HEAD
# no whitespace errors
```

Manual Backup2 validation was also performed with `--full --device-link-timeout 120`; the backup completed successfully with the timeout path enabled and produced the expected backup metadata files.

## Tests Added

- `test_device_link_receive_message_returns_received_message`
- `test_device_link_zero_receive_timeout_disables_timeout`
- `test_device_link_receive_message_times_out`

These cover the normal receive path, the explicit zero/no-timeout behavior, and the timeout-to-`PyMobileDevice3Exception` path.
