### PR TITLE
device_link: report unsupported commands

### DIFF
--- a/pymobiledevice3/services/device_link.py
+++ b/pymobiledevice3/services/device_link.py
@@ -1,5 +1,6 @@
 import ctypes
 import datetime
+import logging
 import shutil
 import struct
 import warnings
@@ -33,6 +34,7 @@ ERRNO_TO_DEVICE_ERROR = {
 DLMessage = Sequence[Any]
 ProgressCallback = Callable[[Any], None]
 DLHandler = Callable[[DLMessage], None]
+logger = logging.getLogger(__name__)
 
 
 class DeviceLink:
@@ -91,7 +93,12 @@ class DeviceLink:
                     return message[1].get("Content")
                 else:
                     raise PyMobileDevice3Exception(f"Device link error: {message[1]}")
-            await self._dl_handlers[command](message)
+
+            handler = self._dl_handlers.get(command)
+            if handler is None:
+                logger.debug("Unsupported DeviceLink message: %s", message)
+                raise PyMobileDevice3Exception(f"Unsupported DeviceLink command: {command}")
+            await handler(message)
 
     async def version_exchange(self) -> None:
         dl_message_version_exchange = await self.receive_message()

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -1,3 +1,4 @@
+import logging
 import sqlite3
 import struct
 import time
@@ -8,7 +9,7 @@ from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
-from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionTerminatedError
+from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionTerminatedError, PyMobileDevice3Exception
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.services.device_link import DeviceLink
 from pymobiledevice3.services.mobilebackup2 import (
@@ -261,6 +262,54 @@ async def test_device_link_move_items_skips_missing_filtered_source(tmp_path: Pa
     await device_link.move_items(["DLMessageMoveItems", {"missing/source": "54/hash"}])
 
     service.send_plist.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_device_link_loop_dispatches_known_command(tmp_path: Path) -> None:
+    service = AsyncMock()
+    service.recv_plist = AsyncMock(
+        side_effect=[
+            ["DLMessageGetFreeDiskSpace"],
+            ["DLMessageProcessMessage", {"ErrorCode": 0, "Content": "done"}],
+        ]
+    )
+    device_link = DeviceLink(service, tmp_path)
+
+    assert await device_link.dl_loop() == "done"
+    status_response = service.send_plist.await_args_list[0].args[0]
+    assert status_response[0] == "DLMessageStatusResponse"
+    assert status_response[1] == 0
+    assert status_response[2] == "___EmptyParameterString___"
+    assert isinstance(status_response[3], int)
+
+
+@pytest.mark.asyncio
+async def test_device_link_loop_returns_success_process_message(tmp_path: Path) -> None:
+    service = AsyncMock()
+    service.recv_plist = AsyncMock(return_value=["DLMessageProcessMessage", {"ErrorCode": 0, "Content": {"ok": True}}])
+    device_link = DeviceLink(service, tmp_path)
+
+    assert await device_link.dl_loop() == {"ok": True}
+    service.send_plist.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_device_link_loop_reports_unsupported_command_without_payload(tmp_path: Path, caplog) -> None:
+    service = AsyncMock()
+    service.recv_plist = AsyncMock(return_value=["DLMessageFutureCommand", {"secret": "payload"}])
+    device_link = DeviceLink(service, tmp_path)
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="pymobiledevice3.services.device_link"),
+        pytest.raises(PyMobileDevice3Exception) as exc_info,
+    ):
+        await device_link.dl_loop()
+
+    message = str(exc_info.value)
+    assert message == "Unsupported DeviceLink command: DLMessageFutureCommand"
+    assert "payload" not in message
+    assert "Unsupported DeviceLink message" in caplog.text
+    assert "payload" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This change makes `DeviceLink.dl_loop()` report unsupported DeviceLink commands with a clear `PyMobileDevice3Exception` instead of raising a raw `KeyError`.

As iOS evolves, Backup2/DeviceLink may introduce new command names before pymobiledevice3 has a handler for them. A `KeyError` makes that failure look like an internal dictionary bug and hides the protocol-level reason. This PR keeps the behavior explicit: known commands still dispatch normally, while unknown commands fail with the unsupported command name.

## What Changed

- Replaced direct `_dl_handlers[command]` lookup with a guarded `.get()` lookup.
- Raised `PyMobileDevice3Exception` when no handler exists for the received command.
- Kept the user-facing exception concise:

```text
Unsupported DeviceLink command: DLMessageFutureCommand
```

- Added debug-level logging of the full unsupported DeviceLink message:

```python
logger.debug("Unsupported DeviceLink message: %s", message)
```

This keeps normal exceptions clean while still giving maintainers useful protocol context when debug logging is enabled.

## Why

Unsupported DeviceLink commands are protocol compatibility issues, not ordinary Python dictionary failures. Reporting them explicitly makes future iOS Backup2 changes easier to diagnose and gives users an actionable error message.

The full message is only logged at debug level so regular error output does not dump potentially large or sensitive payloads.

## Validation

Local checks:

```text
python -m pytest -q tests/services/test_backup2.py -k 'device_link_loop or move_items or upload_files'
# 6 passed, 13 deselected

python -m ruff check pymobiledevice3/services/device_link.py tests/services/test_backup2.py
# All checks passed

python -m ruff format --check pymobiledevice3/services/device_link.py tests/services/test_backup2.py
# 2 files already formatted

python -m compileall -q pymobiledevice3/services/device_link.py tests/services/test_backup2.py
# no errors

git diff --check
# no whitespace errors
```

## Tests Added

- `test_device_link_loop_dispatches_known_command`
- `test_device_link_loop_returns_success_process_message`
- `test_device_link_loop_reports_unsupported_command_without_payload`

These cover normal handler dispatch, unchanged `DLMessageProcessMessage` success behavior, and the unsupported-command path with clean exception output plus debug-level payload logging.
