### PR TITLE
crash: fix sysdiagnose notification timeout handling

### DIFF
--- a/pymobiledevice3/services/crash_reports.py
+++ b/pymobiledevice3/services/crash_reports.py
@@ -256,7 +256,7 @@ class CrashReportsManager:
             callback(time.monotonic() - start_time)
 
         self.logger.info("sysdiagnose tarball creation has been started")
-        await self._wait_for_sysdiagnose_to_finish(timeout)
+        await self._wait_for_sysdiagnose_to_finish(end_time)
 
         if callback is not None:
             callback(time.monotonic() - start_time)
@@ -267,7 +267,13 @@ class CrashReportsManager:
             callback(time.monotonic() - start_time)
 
     async def _wait_for_sysdiagnose_to_finish(self, end_time: Optional[float] = None) -> None:
-        async with NotificationProxyService(self.lockdown, timeout=end_time) as service:
+        notification_timeout = None
+        if end_time is not None:
+            notification_timeout = end_time - time.monotonic()
+            if notification_timeout <= 0:
+                raise SysdiagnoseTimeoutError("Timeout waiting for sysdiagnose completion")
+
+        async with NotificationProxyService(self.lockdown, timeout=notification_timeout) as service:
             stop_notification = "com.apple.sysdiagnose.sysdiagnoseStopped"
             await service.notify_register_dispatch(stop_notification)
             try:

--- a/pymobiledevice3/services/notification_proxy.py
+++ b/pymobiledevice3/services/notification_proxy.py
@@ -1,3 +1,4 @@
+import asyncio
 import socket
 from collections.abc import AsyncGenerator
 from typing import Optional, Union
@@ -28,8 +29,7 @@ class NotificationProxyService(LockdownService):
         else:
             super().__init__(lockdown, secure_service_name)
 
-        if timeout is not None:
-            self.service.socket.settimeout(timeout)
+        self._timeout = timeout
 
     async def notify_post(self, name: str) -> None:
         """Send notification to the device's notification_proxy."""
@@ -43,6 +43,9 @@ class NotificationProxyService(LockdownService):
     async def receive_notification(self) -> AsyncGenerator[dict, None]:
         while True:
             try:
-                yield await self.service.recv_plist()
-            except socket.timeout as e:
+                if self._timeout is None:
+                    yield await self.service.recv_plist()
+                else:
+                    yield await asyncio.wait_for(self.service.recv_plist(), timeout=self._timeout)
+            except (asyncio.TimeoutError, socket.timeout) as e:
                 raise NotificationTimeoutError from e

--- a/tests/services/test_crash_reports.py
+++ b/tests/services/test_crash_reports.py
@@ -9,8 +9,9 @@ from typing import Optional
 import pytest
 import pytest_asyncio
 
-from pymobiledevice3.exceptions import AfcFileNotFoundError
+from pymobiledevice3.exceptions import AfcFileNotFoundError, SysdiagnoseTimeoutError
 from pymobiledevice3.lockdown import LockdownClient
+from pymobiledevice3.services import crash_reports as crash_reports_module
 from pymobiledevice3.services.crash_reports import CrashReportsManager
 
 BASENAME = "__pymobiledevice3_tests"
@@ -158,6 +159,80 @@ async def test_parse_invalid_raises(crash_manager: CrashReportsManager, remote_t
 )
 def test_check_timeout(crash_manager: CrashReportsManager, end_time: int, return_value: bool) -> None:
     assert crash_manager._check_timeout(end_time) is return_value
+
+
+async def test_get_new_sysdiagnose_uses_absolute_timeout_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = CrashReportsManager(object())
+    calls = {}
+
+    async def fake_get_new_sysdiagnose_filename(end_time: Optional[float] = None) -> str:
+        calls["filename_end_time"] = end_time
+        return "DiagnosticLogs/sysdiagnose/sysdiagnose.tar.gz"
+
+    async def fake_wait_for_sysdiagnose_to_finish(end_time: Optional[float] = None) -> None:
+        calls["wait_end_time"] = end_time
+
+    async def fake_pull(out: str, entry: str, erase: bool = True) -> None:
+        calls["pull"] = (out, entry, erase)
+
+    monkeypatch.setattr(crash_reports_module.time, "monotonic", lambda: 100.0)
+    manager._get_new_sysdiagnose_filename = fake_get_new_sysdiagnose_filename
+    manager._wait_for_sysdiagnose_to_finish = fake_wait_for_sysdiagnose_to_finish
+    manager.pull = fake_pull
+
+    await manager.get_new_sysdiagnose("/tmp/out", timeout=30, erase=False)
+
+    assert calls == {
+        "filename_end_time": 130.0,
+        "wait_end_time": 130.0,
+        "pull": ("/tmp/out", "DiagnosticLogs/sysdiagnose/sysdiagnose.tar.gz", False),
+    }
+
+
+async def test_wait_for_sysdiagnose_uses_remaining_notification_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = CrashReportsManager(object())
+    calls = {}
+
+    class FakeNotificationProxyService:
+        def __init__(self, lockdown, timeout: Optional[float] = None) -> None:
+            calls["lockdown"] = lockdown
+            calls["timeout"] = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
+        async def notify_register_dispatch(self, name: str) -> None:
+            calls["registered"] = name
+
+        async def receive_notification(self):
+            yield {"Name": "com.apple.other"}
+            yield {"Name": "com.apple.sysdiagnose.sysdiagnoseStopped"}
+
+    async def fake_sleep(delay: float) -> None:
+        calls["sleep"] = delay
+
+    monkeypatch.setattr(crash_reports_module.time, "monotonic", lambda: 125.0)
+    monkeypatch.setattr(crash_reports_module, "NotificationProxyService", FakeNotificationProxyService)
+    monkeypatch.setattr(crash_reports_module.asyncio, "sleep", fake_sleep)
+
+    await manager._wait_for_sysdiagnose_to_finish(130.0)
+
+    assert calls["lockdown"] is manager.lockdown
+    assert calls["timeout"] == 5.0
+    assert calls["registered"] == "com.apple.sysdiagnose.sysdiagnoseStopped"
+    assert calls["sleep"] == crash_reports_module.IOS17_SYSDIAGNOSE_DELAY
+
+
+async def test_wait_for_sysdiagnose_raises_when_deadline_expired(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = CrashReportsManager(object())
+
+    monkeypatch.setattr(crash_reports_module.time, "monotonic", lambda: 125.0)
+
+    with pytest.raises(SysdiagnoseTimeoutError, match="Timeout waiting for sysdiagnose completion"):
+        await manager._wait_for_sysdiagnose_to_finish(120.0)
 
 
 async def test_parse_latest(crash_manager: CrashReportsManager, remote_temp_directory: str) -> None:

--- a/tests/services/test_notification_proxy.py
+++ b/tests/services/test_notification_proxy.py
@@ -1,0 +1,49 @@
+import asyncio
+
+import pytest
+
+from pymobiledevice3.exceptions import NotificationTimeoutError
+from pymobiledevice3.services.notification_proxy import NotificationProxyService
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def recv_plist(self) -> dict:
+        await asyncio.Future()
+
+
+class _FakeLockdown:
+    def __init__(self) -> None:
+        self.connection = _FakeConnection()
+        self.started_services = []
+
+    async def start_lockdown_service(self, service_name: str, include_escrow_bag: bool = False):
+        self.started_services.append((service_name, include_escrow_bag))
+        return self.connection
+
+
+@pytest.mark.asyncio
+async def test_notification_proxy_timeout_does_not_touch_lazy_connection() -> None:
+    lockdown = _FakeLockdown()
+    service = NotificationProxyService(lockdown, timeout=7)
+
+    assert lockdown.started_services == []
+
+    await service.connect()
+
+    assert lockdown.started_services == [(NotificationProxyService.SERVICE_NAME, False)]
+
+
+@pytest.mark.asyncio
+async def test_receive_notification_raises_notification_timeout() -> None:
+    service = NotificationProxyService(_FakeLockdown(), timeout=0.01)
+    await service.connect()
+
+    with pytest.raises(NotificationTimeoutError):
+        async for _ in service.receive_notification():
+            pass


### PR DESCRIPTION
## Summary

This change fixes timeout handling for notification-proxy consumers and corrects the `crash sysdiagnose` timeout flow.

When `NotificationProxyService` was constructed with a timeout, it attempted to set the timeout through `self.service.socket` during `__init__`. At that point the service connection may still be lazy, so `self.service.socket` can resolve to the lazy proxy method instead of an established socket object. In that case, commands such as `crash sysdiagnose --timeout ...` can fail after the device has already started creating the sysdiagnose archive.

This PR keeps notification-proxy construction lazy-safe and makes the timeout apply to the async receive operation itself.

## What Changed

- Stopped touching `self.service.socket` in `NotificationProxyService.__init__`.
- Stored the optional notification timeout on the service instance.
- Wrapped `service.recv_plist()` in `asyncio.wait_for()` when a timeout is configured.
- Converted both `asyncio.TimeoutError` and `socket.timeout` into `NotificationTimeoutError`.
- Updated `CrashReportsManager.get_new_sysdiagnose()` to pass the absolute timeout deadline to `_wait_for_sysdiagnose_to_finish()`.
- Converted the absolute deadline into the remaining notification timeout immediately before waiting for `com.apple.sysdiagnose.sysdiagnoseStopped`.
- Added an explicit `SysdiagnoseTimeoutError` if the deadline has already expired before notification wait begins.

## Why

`NotificationProxyService` should not force a connection during construction. Most callers rely on the existing lazy connection behavior, and timeout configuration should not change that lifecycle.

For `crash sysdiagnose`, the timeout is documented as the maximum time to wait for sysdiagnose completion. The same deadline should cover both phases:

- detecting the newly created in-progress sysdiagnose archive
- waiting for the sysdiagnose completion notification

This keeps the timeout bounded across the full operation instead of restarting or misapplying it after archive detection.

## User Impact

`crash sysdiagnose --timeout ...` no longer crashes after the device starts sysdiagnose creation because of lazy service connection handling.

If the device does not emit the completion notification within the remaining timeout, the command now fails through the expected sysdiagnose timeout path instead of exposing an internal attribute error.

## Validation

Local checks:

```text
.venv/bin/python -m pytest -q tests/services/test_notification_proxy.py tests/services/test_crash_reports.py::test_get_new_sysdiagnose_uses_absolute_timeout_deadline tests/services/test_crash_reports.py::test_wait_for_sysdiagnose_uses_remaining_notification_timeout tests/services/test_crash_reports.py::test_wait_for_sysdiagnose_raises_when_deadline_expired
# 5 passed

.venv/bin/python -m py_compile pymobiledevice3/services/notification_proxy.py pymobiledevice3/services/crash_reports.py tests/services/test_notification_proxy.py tests/services/test_crash_reports.py
# no errors

git diff --check
# no whitespace errors
```

Live USB validation was also performed against a connected iPhone. The patched command detected sysdiagnose archive creation, registered for `com.apple.sysdiagnose.sysdiagnoseStopped`, waited for completion, pulled the sysdiagnose archive successfully, and exited with code 0.

## Tests Added

- `test_notification_proxy_timeout_does_not_touch_lazy_connection`
- `test_receive_notification_raises_notification_timeout`
- `test_get_new_sysdiagnose_uses_absolute_timeout_deadline`
- `test_wait_for_sysdiagnose_uses_remaining_notification_timeout`
- `test_wait_for_sysdiagnose_raises_when_deadline_expired`

These cover lazy-safe notification-proxy construction, timeout-to-`NotificationTimeoutError` conversion, and correct sysdiagnose deadline propagation.
