### PR TITLE
backup2: use full mode for initial backups

### DIFF
--- a/pymobiledevice3/cli/backup.py
+++ b/pymobiledevice3/cli/backup.py
@@ -87,7 +87,11 @@ async def backup(
     full: Annotated[
         bool,
         typer.Option(
-            help="Whether to do a full backup. If full is True, any previous backup attempts will be discarded.",
+            help=(
+                "Force a full backup and discard previous local backup state. "
+                "By default, backup is incremental when valid local metadata exists, "
+                "and automatically becomes full for an empty or incomplete backup directory."
+            ),
         ),
     ] = False,
     only: BackupSelectionOption = None,

--- a/pymobiledevice3/services/mobilebackup2.py
+++ b/pymobiledevice3/services/mobilebackup2.py
@@ -76,6 +76,7 @@ BACKUP_METADATA_FILES = frozenset({
     "Manifest.db-wal",
     "Status.plist",
 })
+INCREMENTAL_BACKUP_REQUIRED_FILES = ("Manifest.plist", "Manifest.db", "Status.plist")
 
 
 @dataclass(frozen=True)
@@ -170,10 +171,10 @@ class Mobilebackup2Service(LockdownService):
         :param unback: Also unpack the completed backup locally using pyiosbackup.
         The function shall receive the percentage as a parameter.
         """
-        full = full or filter_callback is not None
         backup_directory = Path(backup_directory)
         device_directory = backup_directory / self.lockdown.udid
         device_directory.mkdir(exist_ok=True, mode=0o755, parents=True)
+        full = self._should_do_full_backup(full, device_directory, filter_callback)
 
         if filter_callback is not None and not password and await self.get_will_encrypt():
             raise BackupFilterPasswordRequiredError(
@@ -229,6 +230,22 @@ class Mobilebackup2Service(LockdownService):
                 notification_task.cancel()
                 with suppress(asyncio.CancelledError):
                     await notification_task
+
+    @classmethod
+    def _should_do_full_backup(
+        cls,
+        full: bool,
+        device_directory: Path,
+        filter_callback: Optional[BackupFilterCallback] = None,
+    ) -> bool:
+        return full or filter_callback is not None or not cls._has_incremental_backup_metadata(device_directory)
+
+    @staticmethod
+    def _has_incremental_backup_metadata(device_directory: Path) -> bool:
+        return all(
+            (device_directory / filename).is_file() and (device_directory / filename).stat().st_size > 0
+            for filename in INCREMENTAL_BACKUP_REQUIRED_FILES
+        )
 
     async def _observe_backup_notifications(self, notification_proxy: NotificationProxyService) -> None:
         for notification in BACKUP_OBSERVED_NOTIFICATIONS:

--- a/tests/cli/test_backup_cli.py
+++ b/tests/cli/test_backup_cli.py
@@ -29,3 +29,17 @@ def test_backup_command_has_unback_option():
 
     assert result.exit_code == 0
     assert "--unback" in result.output
+
+
+def test_backup_full_help_describes_conditional_default():
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["backup2", "backup", "--help"])
+
+    assert result.exit_code == 0
+    normalized_output = " ".join(result.output.split())
+    assert "incremental" in normalized_output
+    assert "valid local metadata exists" in normalized_output
+    assert "full for an" in normalized_output
+    assert "empty or incomplete backup" in normalized_output
+    assert "directory" in normalized_output

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -120,6 +120,33 @@ def test_should_preserve_backup_file_keeps_metadata() -> None:
     assert Mobilebackup2Service.should_preserve_backup_file("Manifest.db", "ignored", None)
 
 
+def test_should_do_full_backup_when_incremental_metadata_is_missing(tmp_path: Path) -> None:
+    assert Mobilebackup2Service._should_do_full_backup(False, tmp_path) is True
+
+
+def test_should_do_incremental_backup_when_metadata_exists(tmp_path: Path) -> None:
+    for filename in ("Manifest.plist", "Manifest.db", "Status.plist"):
+        (tmp_path / filename).write_text("data")
+
+    assert Mobilebackup2Service._should_do_full_backup(False, tmp_path) is False
+
+
+def test_should_do_full_backup_when_incremental_metadata_is_empty(tmp_path: Path) -> None:
+    (tmp_path / "Manifest.plist").write_text("")
+    (tmp_path / "Manifest.db").write_text("data")
+    (tmp_path / "Status.plist").write_text("data")
+
+    assert Mobilebackup2Service._should_do_full_backup(False, tmp_path) is True
+
+
+def test_should_do_full_backup_when_explicit_or_filtered(tmp_path: Path) -> None:
+    for filename in ("Manifest.plist", "Manifest.db", "Status.plist"):
+        (tmp_path / filename).write_text("data")
+
+    assert Mobilebackup2Service._should_do_full_backup(True, tmp_path) is True
+    assert Mobilebackup2Service._should_do_full_backup(False, tmp_path, filter_callback=lambda _file: True) is True
+
+
 @pytest.mark.asyncio
 async def test_observe_backup_notifications_registers_passcode_and_backup_notifications() -> None:
     notification_proxy = Mock()


### PR DESCRIPTION
## Summary

This change fixes the first-backup path for `backup2 backup` when the target backup directory is empty or contains incomplete local backup metadata.

The current CLI default passes `full=False` to `Mobilebackup2Service.backup()`. That is correct for an existing valid backup, but it is not safe for a first backup into an empty directory: the device receives an incremental backup request without usable local backup metadata and can reject the operation with `MBErrorDomain/205` caused by an empty or unreadable backup properties file.

This PR keeps the normal incremental default for existing valid backups, while automatically promoting only initial or incomplete local backup directories to a full backup.

## Default Behavior After This Change

This PR does **not** make every default backup a full backup.

The effective behavior becomes:

- `backup2 backup <empty-dir>`: promoted to full backup automatically.
- `backup2 backup <incomplete-dir>`: promoted to full backup automatically.
- `backup2 backup <existing-valid-backup-dir>`: remains incremental/update.
- `backup2 backup --full <dir>`: always forces a full backup and discards previous local backup state.
- Filtered backups using `--only` or `--only-regex`: still force full backup, preserving the existing behavior.

The CLI option default remains `full=False`. The service only promotes the run to full when the local device backup directory is missing the metadata required for a valid incremental backup.

## What Changed

- Added an explicit incremental-metadata check for the local device backup directory.
- Require `Manifest.plist`, `Manifest.db`, and `Status.plist` to exist and be non-empty before using the incremental path.
- Promote backup mode to full when that metadata is missing or empty.
- Preserve explicit `--full` behavior.
- Preserve filtered-backup behavior, where a filter callback requires full mode.
- Updated `backup2 backup --full` command-line help to document the conditional default behavior.
- Added focused service tests for the mode-selection helper.
- Added a CLI help test so the documented behavior remains visible to users.

## Why

A first backup cannot be incremental because there is no valid local backup state to compare against. In that case the CLI should not ask the device to perform an incremental backup.

The Python service default already allowed first backups to work because `Mobilebackup2Service.backup()` defaults `full=True` when called directly. The CLI, however, overrides that with `full=False` by default. This change makes the effective CLI behavior match the state of the local backup directory instead of blindly treating an empty directory as an incremental backup target.

For existing valid backups, the incremental path remains the default because the required local metadata is already present.

## User Impact

Users can run `backup2 backup <backup-directory>` against a new backup directory and get a working initial backup without discovering that they need to pass `--full` manually.

Users who already have a valid backup directory keep the current efficient incremental/update behavior by default.

The command-line help now explains this distinction directly on the `--full` option.

## Validation

Local checks:

```text
PYTHONPATH=. .venv/bin/python -m pytest -q tests/cli/test_backup_cli.py tests/services/test_backup2.py -k 'backup_full_help or should_do_full_backup or should_do_incremental_backup or observe_backup_notifications or log_backup_notification or move_items or upload_files'
# 10 passed, 14 deselected

PYTHONPATH=. .venv/bin/python -m ruff check pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py tests/services/test_backup2.py tests/cli/test_backup_cli.py
# All checks passed

PYTHONPATH=. .venv/bin/python -m ruff format --check pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py tests/services/test_backup2.py tests/cli/test_backup_cli.py
# 4 files already formatted

PYTHONPATH=. .venv/bin/python -m py_compile pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py tests/services/test_backup2.py tests/cli/test_backup_cli.py
# no errors

git diff --check
# no whitespace errors
```

Live USB validation was also performed against a connected unlocked iPhone:

- Current upstream CLI default into an empty backup directory failed with `MBErrorDomain/205`; the local `Manifest.plist` was zero-length and no `Manifest.db` existed.
- Current upstream CLI `--full` into an empty backup directory completed successfully and produced populated backup metadata.
- Current upstream CLI default into an existing valid backup directory completed as an incremental/update run.
- Current upstream CLI `--full` into an existing valid backup directory completed as a full refresh.
- Patched CLI default into an empty backup directory completed successfully and produced populated backup metadata.
- Patched CLI default into the resulting valid backup directory completed as an incremental/update run.

## Tests Added

- `test_should_do_full_backup_when_incremental_metadata_is_missing`
- `test_should_do_incremental_backup_when_metadata_exists`
- `test_should_do_full_backup_when_incremental_metadata_is_empty`
- `test_should_do_full_backup_when_explicit_or_filtered`
- `test_backup_full_help_describes_conditional_default`

These cover the initial-backup promotion, the preserved incremental default for valid backups, empty metadata handling, explicit/filtered full behavior, and the updated command-line help.