### PR TITLE
file_relay: add request CLI and compatibility checks

### DIFF
--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -40,6 +40,12 @@ pymobiledevice3 crash pull /path/to/crashes
 # Open AFC shell (media directory)
 pymobiledevice3 afc shell
 
+# Request a compressed CPIO archive from the legacy file_relay service
+# iOS 8.0 and newer normally restrict or remove this service; use
+# --allow-unsupported only when intentionally testing an unsupported device.
+pymobiledevice3 file-relay list-sources
+pymobiledevice3 file-relay request --source CrashReporter --source WiFi file_relay.cpio.gz
+
 # List installed apps
 pymobiledevice3 apps list
 

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -107,6 +107,7 @@ CLI_GROUPS = {
     "crash": "crash",
     "developer": "developer",
     "diagnostics": "diagnostics",
+    "file-relay": "file_relay",
     "lockdown": "lockdown",
     "mounter": "mounter",
     "notification": "notification",

--- a/pymobiledevice3/cli/file_relay.py
+++ b/pymobiledevice3/cli/file_relay.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+from typer_injector import InjectingTyper
+
+from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command
+from pymobiledevice3.services.file_relay import (
+    DEFAULT_SOURCE,
+    KNOWN_SOURCES,
+    FileRelayService,
+    file_relay_unsupported_message,
+    is_file_relay_likely_supported,
+)
+
+cli = InjectingTyper(
+    name="file-relay",
+    help="Request compressed CPIO archives from the legacy file_relay service.",
+    no_args_is_help=True,
+)
+
+OutputPathArg = Annotated[
+    Path,
+    typer.Argument(
+        dir_okay=False,
+        help="Local output archive path.",
+    ),
+]
+SourceOption = Annotated[
+    Optional[list[str]],
+    typer.Option(
+        "--source",
+        "-s",
+        help=f"File relay source to request. Repeat to request multiple sources. Defaults to {DEFAULT_SOURCE}.",
+    ),
+]
+
+
+@cli.command("list-sources")
+def file_relay_list_sources() -> None:
+    """List source names commonly accepted by the legacy file_relay service."""
+    for source in KNOWN_SOURCES:
+        print(source)
+
+
+@cli.command("request")
+@async_command
+async def file_relay_request(
+    service_provider: ServiceProviderDep,
+    out: OutputPathArg,
+    sources: SourceOption = None,
+    timeout: Annotated[
+        Optional[float],
+        typer.Option(
+            "--timeout",
+            help="Seconds to wait for the device to acknowledge the source request.",
+        ),
+    ] = 60.0,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            "-f",
+            help="Overwrite the output archive if it already exists.",
+        ),
+    ] = False,
+    allow_unsupported: Annotated[
+        bool,
+        typer.Option(
+            "--allow-unsupported",
+            help="Try the request even when the device iOS version is unlikely to support file_relay.",
+        ),
+    ] = False,
+) -> None:
+    """Request selected file_relay sources and save the returned compressed CPIO archive."""
+    if out.exists() and not force:
+        raise typer.BadParameter(f"output already exists: {out}", param_hint="OUT")
+
+    if not allow_unsupported and not is_file_relay_likely_supported(service_provider.product_version):
+        typer.echo(file_relay_unsupported_message(service_provider.product_version), err=True)
+        raise typer.Exit(2)
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    async with FileRelayService(service_provider) as service:
+        archive_stream = service.iter_sources(sources, timeout=timeout)
+        try:
+            first_chunk = await archive_stream.__anext__()
+        except StopAsyncIteration:
+            first_chunk = b""
+
+        with out.open("wb") as archive:
+            if first_chunk:
+                archive.write(first_chunk)
+            async for chunk in archive_stream:
+                archive.write(chunk)

--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -28,6 +28,7 @@ __all__ = [
     "ExtractingStackshotError",
     "FatalPairingError",
     "FeatureNotSupportedError",
+    "FileRelayError",
     "GetProhibitedError",
     "IRecvError",
     "IRecvNoDeviceConnectedError",
@@ -110,6 +111,12 @@ class PasswordRequiredError(PairingError):
 
 class BackupFilterPasswordRequiredError(PyMobileDevice3Exception):
     pass
+
+
+class FileRelayError(PyMobileDevice3Exception):
+    def __init__(self, message: str, response: Optional[dict] = None) -> None:
+        super().__init__(message)
+        self.response = response
 
 
 class StartServiceError(PyMobileDevice3Exception):

--- a/pymobiledevice3/services/file_relay.py
+++ b/pymobiledevice3/services/file_relay.py
@@ -1,55 +1,137 @@
-from pymobiledevice3.lockdown import LockdownClient
+import asyncio
+from collections.abc import AsyncGenerator, Iterable
+from typing import Optional
+
+from packaging.version import InvalidVersion, Version
+
+from pymobiledevice3.exceptions import ConnectionTerminatedError, FileRelayError
+from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.services.lockdown_service import LockdownService
 
-SRCFILES = """Baseband
-CrashReporter
-MobileAsset
-VARFS
-HFSMeta
-Lockdown
-MobileBackup
-MobileDelete
-MobileInstallation
-MobileNotes
-Network
-UserDatabases
-WiFi
-WirelessAutomation
-NANDDebugInfo
-SystemConfiguration
-Ubiquity
-tmp
-WirelessAutomation"""
+DEFAULT_CHUNK_SIZE = 1024 * 1024
+DEFAULT_SOURCE = "UserDatabases"
+FILE_RELAY_RESTRICTED_VERSION = Version("8.0")
+SERVICE_NAME = "com.apple.mobile.file_relay"
+
+KNOWN_SOURCES = (
+    "Accounts",
+    "AddressBook",
+    "AppleSupport",
+    "Baseband",
+    "CoreLocation",
+    "CrashReporter",
+    "HFSMeta",
+    "Keyboard",
+    "Lockdown",
+    "MobileAsset",
+    "MobileBackup",
+    "MobileCal",
+    "MobileDelete",
+    "MobileInstallation",
+    "MobileNotes",
+    "NANDDebugInfo",
+    "Network",
+    "Photos",
+    "SystemConfiguration",
+    "Ubiquity",
+    "UserDatabases",
+    "VARFS",
+    "VPN",
+    "Voicemail",
+    "WiFi",
+    "WirelessAutomation",
+    "tmp",
+)
+
+
+def is_file_relay_likely_supported(product_version: str) -> bool:
+    try:
+        return Version(product_version) < FILE_RELAY_RESTRICTED_VERSION
+    except InvalidVersion:
+        return True
+
+
+def file_relay_unsupported_message(product_version: str) -> str:
+    return (
+        "file_relay is a legacy service. "
+        f"The device reports iOS {product_version}; on iOS {FILE_RELAY_RESTRICTED_VERSION} and newer, "
+        "Apple restricts or removes com.apple.mobile.file_relay, so this command is unlikely to be useful. "
+        "Use --allow-unsupported to try anyway."
+    )
 
 
 class FileRelayService(LockdownService):
-    SERVICE_NAME = "com.apple.mobile.file_relay"
+    SERVICE_NAME = SERVICE_NAME
 
-    def __init__(self, lockdown: LockdownClient):
+    def __init__(self, lockdown: LockdownServiceProvider) -> None:
         super().__init__(lockdown, self.SERVICE_NAME)
-        self.packet_num = 0
 
-    async def stop_session(self):
-        self.logger.info("Disconecting...")
-        await self.service.close()
+    async def stop_session(self) -> None:
+        self.logger.info("Disconnecting...")
+        await self.close()
 
-    async def request_sources(self, sources=None):
-        if sources is None:
-            sources = ["UserDatabases"]
+    async def request_sources(
+        self,
+        sources: Optional[Iterable[str]] = None,
+        *,
+        timeout: Optional[float] = None,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+    ) -> bytes:
+        archive = bytearray()
+        async for chunk in self.iter_sources(sources, timeout=timeout, chunk_size=chunk_size):
+            archive.extend(chunk)
+        return bytes(archive)
+
+    async def iter_sources(
+        self,
+        sources: Optional[Iterable[str]] = None,
+        *,
+        timeout: Optional[float] = None,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+    ) -> AsyncGenerator[bytes, None]:
+        normalized_sources = self._normalize_sources(sources)
+        await self._request_sources(normalized_sources, timeout=timeout)
+
+        chunk = await self._read_next_archive_chunk(chunk_size)
+        while chunk:
+            yield chunk
+            chunk = await self._read_next_archive_chunk(chunk_size)
+
+    async def _read_next_archive_chunk(self, chunk_size: int) -> bytes:
+        try:
+            return await self.service.recv_any(chunk_size)
+        except ConnectionTerminatedError:
+            return b""
+
+    async def _request_sources(self, sources: list[str], *, timeout: Optional[float] = None) -> None:
         await self.service.send_plist({"Sources": sources})
-        while 1:
-            res = await self.service.recv_plist()
-            if res:
-                s = res.get("Status")
-                if s == "Acknowledged":
-                    z = b""
-                    while True:
-                        x = await self.service.recv_any()
-                        if not x:
-                            break
-                        z += x
-                    return z
-                else:
-                    print(res.get("Error"))
-                    break
-        return None
+
+        response = await self._receive_response(timeout=timeout)
+        if not isinstance(response, dict):
+            raise FileRelayError(f"file relay returned an unexpected response: {response!r}")
+
+        error = response.get("Error")
+        if error:
+            raise FileRelayError(f"file relay request failed: {error}", response=response)
+
+        status = response.get("Status")
+        if status != "Acknowledged":
+            raise FileRelayError(f"file relay request was not acknowledged: {response!r}", response=response)
+
+    async def _receive_response(self, *, timeout: Optional[float] = None) -> dict:
+        if timeout is None:
+            return await self.service.recv_plist()
+        try:
+            return await asyncio.wait_for(self.service.recv_plist(), timeout=timeout)
+        except asyncio.TimeoutError as e:
+            raise FileRelayError("timed out waiting for file relay acknowledgement") from e
+
+    @staticmethod
+    def _normalize_sources(sources: Optional[Iterable[str]]) -> list[str]:
+        if sources is None:
+            return [DEFAULT_SOURCE]
+
+        normalized_sources = [source for source in sources if source]
+        if not normalized_sources:
+            raise ValueError("at least one file relay source is required")
+        return normalized_sources

--- a/tests/cli/test_file_relay_cli.py
+++ b/tests/cli/test_file_relay_cli.py
@@ -1,0 +1,26 @@
+from typer.testing import CliRunner
+
+from pymobiledevice3 import __main__
+
+
+def test_file_relay_list_sources() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["file-relay", "list-sources"])
+
+    assert result.exit_code == 0
+    assert "CrashReporter" in result.output
+    assert "UserDatabases" in result.output
+    assert "WiFi" in result.output
+
+
+def test_file_relay_request_help() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["file-relay", "request", "--help"])
+
+    assert result.exit_code == 0
+    assert "--source" in result.output
+    assert "--timeout" in result.output
+    assert "--force" in result.output
+    assert "--allow-unsupported" in result.output

--- a/tests/services/test_file_relay.py
+++ b/tests/services/test_file_relay.py
@@ -1,0 +1,117 @@
+import asyncio
+from typing import Optional
+
+import pytest
+
+from pymobiledevice3.exceptions import FileRelayError
+from pymobiledevice3.services.file_relay import (
+    DEFAULT_SOURCE,
+    FileRelayService,
+    file_relay_unsupported_message,
+    is_file_relay_likely_supported,
+)
+
+
+class _FakeFileRelayConnection:
+    def __init__(self, response: dict, chunks: Optional[list[bytes]] = None) -> None:
+        self.response = response
+        self.chunks = list(chunks or [])
+        self.sent_plists = []
+
+    async def send_plist(self, request: dict) -> None:
+        self.sent_plists.append(request)
+
+    async def recv_plist(self) -> dict:
+        return self.response
+
+    async def recv_any(self, _chunk_size: int) -> bytes:
+        if not self.chunks:
+            return b""
+        return self.chunks.pop(0)
+
+
+def _file_relay_service(connection: _FakeFileRelayConnection) -> FileRelayService:
+    service = FileRelayService(object())
+    service._service = connection
+    return service
+
+
+@pytest.mark.parametrize(
+    ("product_version", "expected"),
+    [
+        ("7.1.2", True),
+        ("8.0", False),
+        ("17.5", False),
+        ("invalid", True),
+    ],
+)
+def test_is_file_relay_likely_supported(product_version: str, expected: bool) -> None:
+    assert is_file_relay_likely_supported(product_version) is expected
+
+
+def test_file_relay_unsupported_message_points_to_override() -> None:
+    message = file_relay_unsupported_message("17.5")
+
+    assert "legacy service" in message
+    assert "iOS 17.5" in message
+    assert "--allow-unsupported" in message
+
+
+@pytest.mark.asyncio
+async def test_request_sources_uses_default_source() -> None:
+    connection = _FakeFileRelayConnection({"Status": "Acknowledged"}, [b"archive", b""])
+    service = _file_relay_service(connection)
+
+    archive = await service.request_sources()
+
+    assert archive == b"archive"
+    assert connection.sent_plists == [{"Sources": [DEFAULT_SOURCE]}]
+
+
+@pytest.mark.asyncio
+async def test_iter_sources_streams_requested_sources() -> None:
+    connection = _FakeFileRelayConnection({"Status": "Acknowledged"}, [b"part-1", b"part-2", b""])
+    service = _file_relay_service(connection)
+
+    chunks = [chunk async for chunk in service.iter_sources(["CrashReporter", "WiFi"], chunk_size=7)]
+
+    assert chunks == [b"part-1", b"part-2"]
+    assert connection.sent_plists == [{"Sources": ["CrashReporter", "WiFi"]}]
+
+
+@pytest.mark.asyncio
+async def test_iter_sources_raises_file_relay_error() -> None:
+    response = {"Error": "InvalidSource"}
+    connection = _FakeFileRelayConnection(response)
+    service = _file_relay_service(connection)
+
+    with pytest.raises(FileRelayError, match="InvalidSource") as exc:
+        _ = [chunk async for chunk in service.iter_sources(["Invalid"])]
+
+    assert exc.value.response == response
+
+
+@pytest.mark.asyncio
+async def test_iter_sources_raises_when_request_is_not_acknowledged() -> None:
+    response = {"Status": "Unexpected"}
+    connection = _FakeFileRelayConnection(response)
+    service = _file_relay_service(connection)
+
+    with pytest.raises(FileRelayError, match="not acknowledged") as exc:
+        _ = [chunk async for chunk in service.iter_sources(["CrashReporter"])]
+
+    assert exc.value.response == response
+
+
+@pytest.mark.asyncio
+async def test_iter_sources_raises_when_acknowledgement_times_out() -> None:
+    class SlowConnection(_FakeFileRelayConnection):
+        async def recv_plist(self) -> dict:
+            await asyncio.Future()
+            return {}
+
+    connection = SlowConnection({"Status": "Acknowledged"})
+    service = _file_relay_service(connection)
+
+    with pytest.raises(FileRelayError, match="timed out"):
+        _ = [chunk async for chunk in service.iter_sources(["CrashReporter"], timeout=0.01)]


### PR DESCRIPTION
## Summary

This change makes the existing `FileRelayService` usable from the CLI and tightens its protocol handling around the legacy `com.apple.mobile.file_relay` service.

The service already existed in pymobiledevice3, but it buffered the returned archive in memory, printed device-side errors instead of surfacing them as exceptions, and had no top-level command. This PR adds a `file-relay` CLI group, streams the returned archive to disk, and adds a version preflight so modern iOS users get an actionable message before attempting a service that is normally unavailable or restricted.

The implementation follows the libimobiledevice file_relay flow: send a plist containing `Sources`, require `Status: Acknowledged`, then read the returned compressed CPIO stream from the same service connection.

## What Changed

- Added a top-level `file-relay` CLI group.
- Added `file-relay list-sources` to print known file_relay source names.
- Added `file-relay request OUT` to request one or more sources and write the returned compressed CPIO archive to disk.
- Added repeatable `--source/-s` selection, defaulting to `UserDatabases` for API compatibility with the existing service default.
- Added `--timeout` for the acknowledgement wait.
- Added `--force/-f` to make archive overwrite explicit.
- Added `--allow-unsupported` to intentionally bypass the iOS-version compatibility gate.
- Updated `FileRelayService` to stream archive chunks through `iter_sources()` instead of requiring full in-memory buffering.
- Kept `request_sources()` as a convenience API, now implemented on top of the streaming path.
- Added `FileRelayError` so device-side responses such as `InvalidSource`, `StagingEmpty`, or `PermissionDenied` are surfaced as structured failures.
- Replaced printed service errors with exceptions carrying the original response when available.
- Added a conservative compatibility helper for iOS 8.0 and newer, where libimobiledevice documents the newer file_relay security behavior through `PermissionDenied`.
- Updated CLI recipes with the legacy-service caveat.

## Why The Compatibility Check Was Added

`file_relay` is a legacy acquisition service. libimobiledevice still implements it, but its own changelog notes the newer security behavior around iOS 8+ through `PermissionDenied` handling.

Without a compatibility check, users on modern iOS versions can run the command and only see a low-level service connection failure. That is technically accurate, but not very helpful: the problem is usually that the device OS no longer exposes a useful file_relay path, not that the output path or source name is wrong.

The default behavior now checks `service_provider.product_version` before opening the service. For iOS 8.0 and newer it exits early with a clear message explaining that the command is unlikely to be useful and that `--allow-unsupported` can be used for deliberate research or legacy testing.

This keeps the CLI informative by default while still leaving the raw protocol attempt available to users who know they want it.

## User Impact

Users can now run:

```text
pymobiledevice3 file-relay list-sources
pymobiledevice3 file-relay request --source CrashReporter --source WiFi file_relay.cpio.gz
```

On unsupported modern devices, the command exits before creating an output archive and explains why the legacy service is unlikely to work.

When `--allow-unsupported` is provided, the command bypasses the preflight and attempts the service anyway.

## Validation

Local checks:

```text
PYTHONPATH=. python -m pytest -q tests/services/test_file_relay.py tests/cli/test_file_relay_cli.py
# 12 passed

PYTHONPATH=. python -m ruff check pymobiledevice3/services/file_relay.py pymobiledevice3/cli/file_relay.py pymobiledevice3/__main__.py pymobiledevice3/exceptions.py tests/services/test_file_relay.py tests/cli/test_file_relay_cli.py
# All checks passed

PYTHONPATH=. python -m ruff format --check pymobiledevice3/services/file_relay.py pymobiledevice3/cli/file_relay.py pymobiledevice3/__main__.py pymobiledevice3/exceptions.py tests/services/test_file_relay.py tests/cli/test_file_relay_cli.py docs/guides/cli-recipes.md
# 7 files already formatted

PYTHONPATH=. python -m py_compile pymobiledevice3/services/file_relay.py pymobiledevice3/cli/file_relay.py pymobiledevice3/__main__.py pymobiledevice3/exceptions.py tests/services/test_file_relay.py tests/cli/test_file_relay_cli.py
# no errors

git diff --check
# no whitespace errors
```

CLI smoke checks:

```text
PYTHONPATH=. python -m pymobiledevice3 file-relay --help
PYTHONPATH=. python -m pymobiledevice3 file-relay list-sources
PYTHONPATH=. python -m pymobiledevice3 file-relay request --help
```

Live USB validation was also performed against a connected modern iPhone. Without `--allow-unsupported`, the command exited before service startup with the new compatibility message and did not create an output archive. With `--allow-unsupported`, the command bypassed the preflight and reached the expected legacy service-port refusal on the device.

## Tests Added

- `test_file_relay_list_sources`
- `test_file_relay_request_help`
- `test_is_file_relay_likely_supported`
- `test_file_relay_unsupported_message_points_to_override`
- `test_request_sources_uses_default_source`
- `test_iter_sources_streams_requested_sources`
- `test_iter_sources_raises_file_relay_error`
- `test_iter_sources_raises_when_request_is_not_acknowledged`
- `test_iter_sources_raises_when_acknowledgement_times_out`

These cover command registration/help, source listing, compatibility messaging, default source behavior, source request serialization, streaming, device-side error mapping, non-acknowledged responses, and acknowledgement timeout handling.