### PR TITLE
backup2: validate completed backup metadata

### DIFF
--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -49,6 +49,9 @@ pymobiledevice3 apps query BUNDLE_ID1 BUNDLE_ID2
 # Full backup
 pymobiledevice3 backup2 backup --full DIRECTORY
 
+# Validate a completed local backup
+pymobiledevice3 backup2 verify DIRECTORY
+
 # Preserve only selected backup payloads
 pymobiledevice3 backup2 backup --only sms DIRECTORY
 pymobiledevice3 backup2 backup --only whatsapp DIRECTORY

--- a/pymobiledevice3/cli/backup.py
+++ b/pymobiledevice3/cli/backup.py
@@ -9,7 +9,8 @@ from click import Context
 from tqdm import tqdm
 from typer_injector import InjectingTyper
 
-from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command
+from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command, print_json
+from pymobiledevice3.exceptions import BackupValidationError
 from pymobiledevice3.services.mobilebackup2 import BACKUP_SELECTIONS, Mobilebackup2Service
 
 logger = logging.getLogger(__name__)
@@ -136,6 +137,20 @@ async def backup(
                 password=password,
                 unback=unback,
             )
+
+
+@cli.command()
+def verify(backup_directory: BackupDirectoryArg, source: SourceOption = "") -> None:
+    """
+    Validate local backup metadata without connecting to a device.
+    """
+    try:
+        source = Mobilebackup2Service.resolve_backup_source(backup_directory, source)
+        result = Mobilebackup2Service.validate_backup(backup_directory, source, include_file_summary=True)
+    except BackupValidationError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+    print_json(result.to_dict(), colored=False)
 
 
 @cli.command()

--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -7,6 +7,7 @@ __all__ = [
     "ArbitrationError",
     "ArgumentError",
     "BackupFilterPasswordRequiredError",
+    "BackupValidationError",
     "BadCommandError",
     "BadDevError",
     "CannotStopSessionError",
@@ -109,6 +110,10 @@ class PasswordRequiredError(PairingError):
 
 
 class BackupFilterPasswordRequiredError(PyMobileDevice3Exception):
+    pass
+
+
+class BackupValidationError(PyMobileDevice3Exception):
     pass
 
 

--- a/pymobiledevice3/services/mobilebackup2.py
+++ b/pymobiledevice3/services/mobilebackup2.py
@@ -24,6 +24,7 @@ from pymobiledevice3.exceptions import (
     AfcException,
     AfcFileNotFoundError,
     BackupFilterPasswordRequiredError,
+    BackupValidationError,
     LockdownError,
     PyMobileDevice3Exception,
 )
@@ -76,6 +77,7 @@ BACKUP_METADATA_FILES = frozenset({
     "Manifest.db-wal",
     "Status.plist",
 })
+REQUIRED_BACKUP_METADATA_FILES = ("Info.plist", "Manifest.plist", "Manifest.db", "Status.plist")
 
 
 @dataclass(frozen=True)
@@ -101,6 +103,50 @@ class BackupFile:
     relative_path: Optional[str] = None
     file_name: Optional[str] = None
     device_name: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class BackupValidationResult:
+    identifier: str
+    device_directory: Path
+    required_file_sizes: dict[str, int]
+    is_encrypted: bool
+    manifest_file_count: Optional[int]
+    filesystem_file_count: Optional[int]
+    filesystem_size: Optional[int]
+    info: dict
+    manifest: dict
+    status: dict
+
+    def to_dict(self) -> dict:
+        info_summary = {
+            key: self.info.get(key)
+            for key in ("Build Version", "Product Type", "Product Version", "Target Type", "iTunes Version")
+            if key in self.info
+        }
+        manifest_summary = {
+            key: self.manifest.get(key)
+            for key in ("Date", "IsEncrypted", "ProductVersion", "Version", "WasPasscodeSet")
+            if key in self.manifest
+        }
+        status_summary = {
+            key: self.status.get(key)
+            for key in ("BackupState", "Date", "IsFullBackup", "SnapshotState", "Version")
+            if key in self.status
+        }
+        return {
+            "complete": True,
+            "source": self.identifier,
+            "path": str(self.device_directory),
+            "encrypted": self.is_encrypted,
+            "manifest_file_count": self.manifest_file_count,
+            "filesystem_file_count": self.filesystem_file_count,
+            "filesystem_size": self.filesystem_size,
+            "required_file_sizes": self.required_file_sizes,
+            "info": info_summary,
+            "manifest": manifest_summary,
+            "status": status_summary,
+        }
 
 
 BackupFilterCallback = Callable[[BackupFile], bool]
@@ -223,6 +269,18 @@ class Mobilebackup2Service(LockdownService):
                 await dl.dl_loop(progress_callback)
                 if filter_callback is not None:
                     self.prune_backup_directory(device_directory, filter_callback, password=password)
+                validation_result = self.validate_backup(
+                    backup_directory,
+                    self.lockdown.udid,
+                    include_file_summary=True,
+                )
+                self.logger.info(
+                    "Backup completed: encrypted=%s, manifest files=%s, filesystem files=%s, filesystem size=%s",
+                    validation_result.is_encrypted,
+                    validation_result.manifest_file_count,
+                    validation_result.filesystem_file_count,
+                    validation_result.filesystem_size,
+                )
                 if unback:
                     self.unback_with_pyiosbackup(device_directory, password=password)
             finally:
@@ -278,7 +336,7 @@ class Mobilebackup2Service(LockdownService):
         """
         backup_directory = Path(backup_directory)
         source = source if source else self.lockdown.udid
-        self._assert_backup_exists(backup_directory, source)
+        self.validate_backup(backup_directory, source)
 
         async with (
             self.device_link(backup_directory) as dl,
@@ -331,7 +389,7 @@ class Mobilebackup2Service(LockdownService):
         :return: Information about a backup.
         """
         backup_dir = Path(backup_directory)
-        self._assert_backup_exists(backup_dir, source if source else self.lockdown.udid)
+        self.validate_backup(backup_dir, source if source else self.lockdown.udid)
         async with self.device_link(backup_dir) as dl:
             message = {"MessageName": "Info", "TargetIdentifier": self.lockdown.udid}
             if source:
@@ -349,7 +407,7 @@ class Mobilebackup2Service(LockdownService):
         """
         backup_dir = Path(backup_directory)
         source = source if source else self.lockdown.udid
-        self._assert_backup_exists(backup_dir, source)
+        self.validate_backup(backup_dir, source)
         async with self.device_link(backup_dir) as dl:
             await dl.send_process_message({
                 "MessageName": "List",
@@ -367,7 +425,7 @@ class Mobilebackup2Service(LockdownService):
         :param source: Identifier of device to unpack its backup.
         """
         backup_dir = Path(backup_directory)
-        self._assert_backup_exists(backup_dir, source if source else self.lockdown.udid)
+        self.validate_backup(backup_dir, source if source else self.lockdown.udid)
         async with self.device_link(backup_dir) as dl:
             message = {"MessageName": "Unback", "TargetIdentifier": self.lockdown.udid}
             if source:
@@ -398,7 +456,7 @@ class Mobilebackup2Service(LockdownService):
         :param source: Identifier of device to extract file from its backup.
         """
         backup_dir = Path(backup_directory)
-        self._assert_backup_exists(backup_dir, source if source else self.lockdown.udid)
+        self.validate_backup(backup_dir, source if source else self.lockdown.udid)
         async with self.device_link(backup_dir) as dl:
             message = {
                 "MessageName": "Extract",
@@ -555,10 +613,122 @@ class Mobilebackup2Service(LockdownService):
 
     @staticmethod
     def _assert_backup_exists(backup_directory: Path, identifier: str):
-        device_directory = backup_directory / identifier
-        assert (device_directory / "Info.plist").exists()
-        assert (device_directory / "Manifest.plist").exists()
-        assert (device_directory / "Status.plist").exists()
+        Mobilebackup2Service.validate_backup(backup_directory, identifier)
+
+    @staticmethod
+    def resolve_backup_source(backup_directory: Union[str, Path], identifier: str = "") -> str:
+        backup_directory = Path(backup_directory)
+        if identifier:
+            return identifier
+        if not backup_directory.exists():
+            raise BackupValidationError(f"Backup directory {backup_directory} does not exist")
+        if not backup_directory.is_dir():
+            raise BackupValidationError(f"Backup path {backup_directory} is not a directory")
+
+        candidates = sorted(
+            path.name for path in backup_directory.iterdir() if path.is_dir() and (path / "Info.plist").exists()
+        )
+        if len(candidates) == 1:
+            return candidates[0]
+        if not candidates:
+            raise BackupValidationError(
+                f"No backup source was found under {backup_directory}. "
+                "Expected a device backup directory containing Info.plist."
+            )
+        raise BackupValidationError(
+            f"Multiple backup sources were found under {backup_directory}. Pass --source to select one."
+        )
+
+    @classmethod
+    def validate_backup(
+        cls,
+        backup_directory: Union[str, Path],
+        identifier: str,
+        *,
+        include_file_summary: bool = False,
+    ) -> BackupValidationResult:
+        if not identifier:
+            identifier = cls.resolve_backup_source(backup_directory)
+
+        device_directory = Path(backup_directory) / identifier
+        errors = []
+        required_file_sizes = {}
+        if not device_directory.exists():
+            errors.append("backup directory is missing")
+        elif not device_directory.is_dir():
+            errors.append("backup path is not a directory")
+        else:
+            for name in REQUIRED_BACKUP_METADATA_FILES:
+                path = device_directory / name
+                if not path.exists():
+                    errors.append(f"{name} is missing")
+                    continue
+                if not path.is_file():
+                    errors.append(f"{name} is not a file")
+                    continue
+                size = path.stat().st_size
+                if size == 0:
+                    errors.append(f"{name} is empty")
+                required_file_sizes[name] = size
+
+        if errors:
+            raise BackupValidationError(f"Incomplete backup for source {identifier}: {'; '.join(errors)}")
+
+        info = cls._load_backup_plist(device_directory / "Info.plist")
+        manifest = cls._load_backup_plist(device_directory / "Manifest.plist")
+        status = cls._load_backup_plist(device_directory / "Status.plist")
+        is_encrypted = bool(manifest.get("IsEncrypted", False))
+        manifest_file_count = None if is_encrypted else cls._count_manifest_files(device_directory / "Manifest.db")
+
+        filesystem_file_count = None
+        filesystem_size = None
+        if include_file_summary:
+            filesystem_file_count, filesystem_size = cls._summarize_backup_filesystem(device_directory)
+
+        return BackupValidationResult(
+            identifier=identifier,
+            device_directory=device_directory,
+            required_file_sizes=required_file_sizes,
+            is_encrypted=is_encrypted,
+            manifest_file_count=manifest_file_count,
+            filesystem_file_count=filesystem_file_count,
+            filesystem_size=filesystem_size,
+            info=info,
+            manifest=manifest,
+            status=status,
+        )
+
+    @staticmethod
+    def _load_backup_plist(path: Path) -> dict:
+        try:
+            with path.open("rb") as fd:
+                data = plistlib.load(fd)
+        except (plistlib.InvalidFileException, EOFError, OSError) as exc:
+            raise BackupValidationError(f"{path.name} is not a valid plist") from exc
+        if not isinstance(data, dict):
+            raise BackupValidationError(f"{path.name} is not a plist dictionary")
+        return data
+
+    @staticmethod
+    def _count_manifest_files(manifest_db_path: Path) -> int:
+        uri = f"{manifest_db_path.resolve().as_uri()}?mode=ro"
+        try:
+            with closing(sqlite3.connect(uri, uri=True)) as connection:
+                row = connection.execute("SELECT count(*) FROM Files").fetchone()
+        except sqlite3.DatabaseError as exc:
+            raise BackupValidationError("Manifest.db is not a readable MobileBackup2 SQLite database") from exc
+        return int(row[0])
+
+    @staticmethod
+    def _summarize_backup_filesystem(device_directory: Path) -> tuple[int, int]:
+        file_count = 0
+        total_size = 0
+        for path in device_directory.rglob("*"):
+            if not path.is_file():
+                continue
+            file_count += 1
+            total_size += path.stat().st_size
+        return file_count, total_size
 
     @staticmethod
     def resolve_backup_selection(only: Optional[Sequence[str]]) -> tuple[BackupSelectionRule, ...]:

--- a/tests/cli/test_backup_cli.py
+++ b/tests/cli/test_backup_cli.py
@@ -1,6 +1,28 @@
+import json
+import plistlib
+import sqlite3
+from contextlib import closing
+
 from typer.testing import CliRunner
 
 from pymobiledevice3 import __main__
+
+
+def create_complete_backup(tmp_path):
+    source = "test-source"
+    device_directory = tmp_path / source
+    device_directory.mkdir()
+    (device_directory / "Info.plist").write_bytes(plistlib.dumps({"Product Type": "iPhone1,1"}))
+    (device_directory / "Manifest.plist").write_bytes(plistlib.dumps({"IsEncrypted": False, "Version": "10.0"}))
+    (device_directory / "Status.plist").write_bytes(plistlib.dumps({"SnapshotState": "finished"}))
+    with closing(sqlite3.connect(device_directory / "Manifest.db")) as connection:
+        connection.execute("CREATE TABLE Files (fileID TEXT, domain TEXT, relativePath TEXT)")
+        connection.execute(
+            "INSERT INTO Files (fileID, domain, relativePath) VALUES (?, ?, ?)",
+            ("file-1", "HomeDomain", "Library/SMS/sms.db"),
+        )
+        connection.commit()
+    return source
 
 
 def test_backup_only_regex_invalid_pattern(tmp_path):
@@ -29,3 +51,43 @@ def test_backup_command_has_unback_option():
 
     assert result.exit_code == 0
     assert "--unback" in result.output
+
+
+def test_backup_command_has_verify_subcommand():
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["backup2", "verify", "--help"])
+
+    assert result.exit_code == 0
+    assert "Validate local backup metadata" in result.output
+
+
+def test_backup_verify_outputs_validation_summary(tmp_path):
+    source = create_complete_backup(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["backup2", "verify", "--source", source, str(tmp_path)])
+
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert output["complete"] is True
+    assert output["source"] == source
+    assert output["manifest_file_count"] == 1
+    assert output["required_file_sizes"]["Manifest.db"] > 0
+
+
+def test_backup_verify_reports_incomplete_backup_without_traceback(tmp_path):
+    source = "test-source"
+    device_directory = tmp_path / source
+    device_directory.mkdir()
+    (device_directory / "Info.plist").write_bytes(plistlib.dumps({}))
+    (device_directory / "Manifest.plist").write_bytes(b"")
+    (device_directory / "Status.plist").write_bytes(plistlib.dumps({}))
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["backup2", "verify", "--source", source, str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "Error: Incomplete backup" in result.output
+    assert "Manifest.plist is empty" in result.output
+    assert "Traceback" not in result.output

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -1,3 +1,4 @@
+import plistlib
 import sqlite3
 import struct
 import time
@@ -8,7 +9,7 @@ from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
-from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionTerminatedError
+from pymobiledevice3.exceptions import BackupValidationError, ConnectionFailedError, ConnectionTerminatedError
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.services.device_link import DeviceLink
 from pymobiledevice3.services.mobilebackup2 import (
@@ -22,6 +23,51 @@ from pymobiledevice3.services.mobilebackup2 import (
 )
 
 PASSWORD = "1234"
+BACKUP_SOURCE = "test-source"
+
+
+def create_test_backup(backup_directory: Path, source: str = BACKUP_SOURCE, encrypted: bool = False) -> Path:
+    device_directory = backup_directory / source
+    device_directory.mkdir()
+    (device_directory / "Info.plist").write_bytes(
+        plistlib.dumps({
+            "Build Version": "23A000",
+            "Product Type": "iPhone1,1",
+            "Product Version": "1.0",
+            "Target Type": "Device",
+            "iTunes Version": "10.0.1",
+        })
+    )
+    (device_directory / "Manifest.plist").write_bytes(
+        plistlib.dumps({
+            "Date": "2026-01-01T00:00:00Z",
+            "IsEncrypted": encrypted,
+            "Version": "10.0",
+        })
+    )
+    (device_directory / "Status.plist").write_bytes(
+        plistlib.dumps({
+            "BackupState": "new",
+            "IsFullBackup": True,
+            "SnapshotState": "finished",
+            "Version": "3.3",
+        })
+    )
+    manifest_db = device_directory / "Manifest.db"
+    if encrypted:
+        manifest_db.write_bytes(b"encrypted manifest db")
+    else:
+        with closing(sqlite3.connect(manifest_db)) as connection:
+            connection.execute("CREATE TABLE Files (fileID TEXT, domain TEXT, relativePath TEXT)")
+            connection.executemany(
+                "INSERT INTO Files (fileID, domain, relativePath) VALUES (?, ?, ?)",
+                [
+                    ("file-1", "HomeDomain", "Library/SMS/sms.db"),
+                    ("file-2", "HomeDomain", "Library/Safari/Bookmarks.db"),
+                ],
+            )
+            connection.commit()
+    return device_directory
 
 
 def ignore_connection_errors(f):
@@ -118,6 +164,71 @@ def test_selection_filter_callback_matches_upload_and_manifest_forms() -> None:
 
 def test_should_preserve_backup_file_keeps_metadata() -> None:
     assert Mobilebackup2Service.should_preserve_backup_file("Manifest.db", "ignored", None)
+
+
+def test_resolve_backup_source_uses_single_backup_directory(tmp_path: Path) -> None:
+    create_test_backup(tmp_path)
+
+    assert Mobilebackup2Service.resolve_backup_source(tmp_path) == BACKUP_SOURCE
+
+
+def test_resolve_backup_source_requires_source_for_multiple_backups(tmp_path: Path) -> None:
+    create_test_backup(tmp_path)
+    create_test_backup(tmp_path, source="second-source")
+
+    with pytest.raises(BackupValidationError, match="Pass --source"):
+        Mobilebackup2Service.resolve_backup_source(tmp_path)
+
+
+def test_resolve_backup_source_reports_missing_backup_directory(tmp_path: Path) -> None:
+    with pytest.raises(BackupValidationError, match="does not exist"):
+        Mobilebackup2Service.resolve_backup_source(tmp_path / "missing")
+
+
+def test_validate_backup_accepts_complete_unencrypted_backup(tmp_path: Path) -> None:
+    create_test_backup(tmp_path)
+
+    result = Mobilebackup2Service.validate_backup(tmp_path, BACKUP_SOURCE, include_file_summary=True)
+
+    assert result.identifier == BACKUP_SOURCE
+    assert result.is_encrypted is False
+    assert result.manifest_file_count == 2
+    assert result.filesystem_file_count == 4
+    assert result.filesystem_size
+    assert result.required_file_sizes["Manifest.db"] > 0
+    assert result.to_dict()["complete"] is True
+
+
+def test_validate_backup_accepts_encrypted_manifest_db_without_sqlite_parse(tmp_path: Path) -> None:
+    create_test_backup(tmp_path, encrypted=True)
+
+    result = Mobilebackup2Service.validate_backup(tmp_path, BACKUP_SOURCE)
+
+    assert result.is_encrypted is True
+    assert result.manifest_file_count is None
+
+
+def test_validate_backup_reports_missing_metadata(tmp_path: Path) -> None:
+    (tmp_path / BACKUP_SOURCE).mkdir()
+
+    with pytest.raises(BackupValidationError, match=r"Info\.plist is missing"):
+        Mobilebackup2Service.validate_backup(tmp_path, BACKUP_SOURCE)
+
+
+def test_validate_backup_reports_empty_manifest_plist(tmp_path: Path) -> None:
+    device_directory = create_test_backup(tmp_path)
+    (device_directory / "Manifest.plist").write_bytes(b"")
+
+    with pytest.raises(BackupValidationError, match=r"Manifest\.plist is empty"):
+        Mobilebackup2Service.validate_backup(tmp_path, BACKUP_SOURCE)
+
+
+def test_validate_backup_reports_invalid_manifest_db(tmp_path: Path) -> None:
+    device_directory = create_test_backup(tmp_path)
+    (device_directory / "Manifest.db").write_bytes(b"not sqlite")
+
+    with pytest.raises(BackupValidationError, match=r"Manifest\.db is not a readable"):
+        Mobilebackup2Service.validate_backup(tmp_path, BACKUP_SOURCE)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds explicit validation for completed MobileBackup2 backup metadata and exposes a local `backup2 verify` command for offline checks.

## What Changed

- Added `BackupValidationError` and `BackupValidationResult` for structured backup validation failures and summaries.
- Validates that completed backups contain non-empty `Info.plist`, `Manifest.plist`, `Manifest.db`, and `Status.plist` files.
- Parses the required plist files as dictionaries before a backup is consumed.
- Checks unencrypted `Manifest.db` files by opening them read-only and counting rows from the `Files` table.
- Skips SQLite parsing for encrypted `Manifest.db` files after `Manifest.plist` reports `IsEncrypted`, while still requiring the database file to exist and be non-empty.
- Replaces the previous raw `assert`-based backup existence check with structured validation before `restore`, `info`, `list`, `unback`, and `extract` consume a local backup.
- Runs validation after a backup completes and logs concise completion metadata.
- Adds `pymobiledevice3 backup2 verify DIRECTORY` to validate a local backup without connecting to a device.
- Documents the new command in the CLI recipes guide.

## Why This Change Is Needed

The previous backup preflight only asserted that a small subset of metadata files existed. It did not check `Manifest.db`, did not reject zero-byte placeholder metadata left by interrupted backups, and surfaced incomplete backups as generic assertion failures or later protocol failures.

This change makes incomplete or corrupt backup metadata fail early with deterministic messages. It also gives users a cheap offline command to verify a backup directory before running follow-up commands that depend on complete metadata.

## User Impact

- Completed backups now receive an immediate metadata validation pass.
- Local backup-consuming commands fail earlier and more clearly when metadata is incomplete.
- `backup2 verify` can be used without a connected device.
- Encrypted backups remain supported for metadata validation without requiring the backup password.
- Existing backup creation, restore, extraction, filtering, and encryption behavior is unchanged apart from the added validation.

## Validation

- `python -m pytest -q tests/services/test_backup2.py tests/cli/test_backup_cli.py --deselect tests/services/test_backup2.py::test_backup --deselect tests/services/test_backup2.py::test_encrypted_backup`
- `python -m ruff check pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py pymobiledevice3/exceptions.py tests/services/test_backup2.py tests/cli/test_backup_cli.py`
- `python -m ruff format --check pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py pymobiledevice3/exceptions.py tests/services/test_backup2.py tests/cli/test_backup_cli.py`
- `python -m py_compile pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py pymobiledevice3/exceptions.py`
- `git diff --check`
- Manual CLI smoke: `backup2 verify` returns a JSON summary for a complete local backup.
- Manual CLI smoke: `backup2 verify` exits with a concise `Error: Incomplete backup ...` message and no traceback for an incomplete local backup.
- Live USB full-backup test on a connected device: `backup2 backup --full <backup-dir>` completed successfully and the new post-backup validation ran after transfer completion.
- Live USB verification of the produced backup: `backup2 verify <backup-dir>` returned `complete: true`, `encrypted: false`, `manifest_file_count: 8463`, `filesystem_file_count: 2645`, and non-empty required metadata files.

The two existing live-device pytest tests were not run in this sandbox because they require direct usbmux socket access from pytest. The live CLI backup path above was run with usbmux access enabled.

## Tests Added

- Complete unencrypted backup validation.
- Encrypted backup metadata validation without SQLite parsing.
- Missing metadata detection.
- Empty metadata detection.
- Invalid `Manifest.db` detection.
- Source auto-selection and multiple-source error handling.
- `backup2 verify` CLI help, success JSON output, and no-traceback incomplete-backup failure handling.