### PR TITLE
backup2: add backup encryption status command

### DIFF
--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -49,6 +49,9 @@ pymobiledevice3 apps query BUNDLE_ID1 BUNDLE_ID2
 # Full backup
 pymobiledevice3 backup2 backup --full DIRECTORY
 
+# Show local backup encryption status
+pymobiledevice3 backup2 encryption-status
+
 # Preserve only selected backup payloads
 pymobiledevice3 backup2 backup --only sms DIRECTORY
 pymobiledevice3 backup2 backup --only whatsapp DIRECTORY

--- a/pymobiledevice3/cli/backup.py
+++ b/pymobiledevice3/cli/backup.py
@@ -9,7 +9,7 @@ from click import Context
 from tqdm import tqdm
 from typer_injector import InjectingTyper
 
-from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command
+from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command, print_json
 from pymobiledevice3.services.mobilebackup2 import BACKUP_SELECTIONS, Mobilebackup2Service
 
 logger = logging.getLogger(__name__)
@@ -284,6 +284,18 @@ async def encryption(
             await backup_client.change_password(str(backup_directory), new=password)
         else:
             await backup_client.change_password(str(backup_directory), old=password)
+
+
+@cli.command("encryption-status")
+@async_command
+async def encryption_status(service_provider: ServiceProviderDep) -> None:
+    """
+    Show backup encryption status.
+
+    Outputs will_encrypt for whether future local backups are encrypted and requires_encryption for device policy.
+    """
+    async with Mobilebackup2Service(service_provider) as backup_client:
+        print_json(await backup_client.get_encryption_status(), colored=False)
 
 
 @cli.command()

--- a/pymobiledevice3/services/mobilebackup2.py
+++ b/pymobiledevice3/services/mobilebackup2.py
@@ -76,6 +76,9 @@ BACKUP_METADATA_FILES = frozenset({
     "Manifest.db-wal",
     "Status.plist",
 })
+BACKUP_DOMAIN = "com.apple.mobile.backup"
+BACKUP_WILL_ENCRYPT_KEY = "WillEncrypt"
+BACKUP_REQUIRES_ENCRYPTION_KEY = "RequiresEncryption"
 
 
 @dataclass(frozen=True)
@@ -145,9 +148,20 @@ class Mobilebackup2Service(LockdownService):
             super().__init__(lockdown, self.RSD_SERVICE_NAME, include_escrow_bag=True)
 
     async def get_will_encrypt(self) -> bool:
+        return await self._get_backup_domain_bool(BACKUP_WILL_ENCRYPT_KEY)
+
+    async def get_requires_encryption(self) -> bool:
+        return await self._get_backup_domain_bool(BACKUP_REQUIRES_ENCRYPTION_KEY)
+
+    async def get_encryption_status(self) -> dict[str, bool]:
+        return {
+            "will_encrypt": await self.get_will_encrypt(),
+            "requires_encryption": await self.get_requires_encryption(),
+        }
+
+    async def _get_backup_domain_bool(self, key: str) -> bool:
         try:
-            will_encrypt = await self.lockdown.get_value("com.apple.mobile.backup", "WillEncrypt")
-            return bool(will_encrypt)
+            return bool(await self.lockdown.get_value(BACKUP_DOMAIN, key))
         except LockdownError:
             return False
 

--- a/tests/cli/test_backup_cli.py
+++ b/tests/cli/test_backup_cli.py
@@ -29,3 +29,22 @@ def test_backup_command_has_unback_option():
 
     assert result.exit_code == 0
     assert "--unback" in result.output
+
+
+def test_backup2_has_encryption_status_command():
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["backup2", "--help"])
+
+    assert result.exit_code == 0
+    assert "encryption-status" in result.output
+
+
+def test_backup2_encryption_status_help_describes_output():
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["backup2", "encryption-status", "--help"])
+
+    assert result.exit_code == 0
+    assert "will_encrypt" in result.output
+    assert "requires_encryption" in result.output

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -8,12 +8,15 @@ from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
-from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionTerminatedError
+from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionTerminatedError, LockdownError
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.services.device_link import DeviceLink
 from pymobiledevice3.services.mobilebackup2 import (
+    BACKUP_DOMAIN,
     BACKUP_OBSERVED_NOTIFICATIONS,
+    BACKUP_REQUIRES_ENCRYPTION_KEY,
     BACKUP_SELECTIONS,
+    BACKUP_WILL_ENCRYPT_KEY,
     NP_LOCAL_AUTH_DISMISSED,
     NP_LOCAL_AUTH_PRESENTED,
     NP_SYNC_CANCEL_REQUEST,
@@ -131,6 +134,38 @@ async def test_observe_backup_notifications_registers_passcode_and_backup_notifi
     notification_proxy.notify_register_dispatch.assert_has_awaits([
         call(notification) for notification in BACKUP_OBSERVED_NOTIFICATIONS
     ])
+
+
+@pytest.mark.asyncio
+async def test_get_encryption_status_reads_backup_domain_flags() -> None:
+    lockdown = Mock()
+    lockdown.get_value = AsyncMock(
+        side_effect=lambda domain, key: {
+            (BACKUP_DOMAIN, BACKUP_WILL_ENCRYPT_KEY): True,
+            (BACKUP_DOMAIN, BACKUP_REQUIRES_ENCRYPTION_KEY): False,
+        }[(domain, key)]
+    )
+    service = object.__new__(Mobilebackup2Service)
+    service.lockdown = lockdown
+
+    assert await service.get_encryption_status() == {
+        "will_encrypt": True,
+        "requires_encryption": False,
+    }
+    lockdown.get_value.assert_has_awaits([
+        call(BACKUP_DOMAIN, BACKUP_WILL_ENCRYPT_KEY),
+        call(BACKUP_DOMAIN, BACKUP_REQUIRES_ENCRYPTION_KEY),
+    ])
+
+
+@pytest.mark.asyncio
+async def test_get_backup_domain_bool_returns_false_on_lockdown_error() -> None:
+    lockdown = Mock()
+    lockdown.get_value = AsyncMock(side_effect=LockdownError("missing"))
+    service = object.__new__(Mobilebackup2Service)
+    service.lockdown = lockdown
+
+    assert not await service.get_requires_encryption()
 
 
 def test_log_backup_notification_surfaces_passcode_prompt_to_operator() -> None:


### PR DESCRIPTION
## Summary

This change adds a read-only `backup2 encryption-status` command that reports the current local backup encryption state exposed by Lockdown in the `com.apple.mobile.backup` domain.

The existing `backup2 encryption on|off PASSWORD` command is intentionally left unchanged. This PR adds a separate status command so operators can check backup encryption state without changing device settings or providing a password.

## What Changed

- Added explicit constants for the backup Lockdown domain and encryption status keys:
  - `com.apple.mobile.backup`
  - `WillEncrypt`
  - `RequiresEncryption`
- Added `_get_backup_domain_bool()` so backup-domain boolean reads share the same `LockdownError` fallback behavior.
- Updated `get_will_encrypt()` to use the shared helper while preserving its existing return behavior.
- Added `get_requires_encryption()` to expose the device policy flag.
- Added `get_encryption_status()` to return both status values in one service-level API.
- Added the `backup2 encryption-status` CLI command with stable JSON output:

```json
{
    "requires_encryption": false,
    "will_encrypt": false
}
```

- Documented the new command in the CLI recipes guide.

## Why This Change Is Needed

`WillEncrypt` is already used internally to decide whether backup filtering requires a password, but there was no non-mutating CLI path to inspect that state directly.

A read-only status command is useful before backup, filtering, restore, or password-handling workflows because it tells the operator whether future local backups are configured to be encrypted and whether the device reports an encryption requirement. Keeping this logic in `Mobilebackup2Service` also avoids duplicating Lockdown key reads directly in CLI code.

The command is separate from `backup2 encryption` to preserve the existing `encryption on|off PASSWORD` interface and avoid changing the behavior of the mutating encryption command.

## User Impact

Users can now run:

```shell
pymobiledevice3 backup2 encryption-status
```

The command does not modify backup settings. It only prints:

- `will_encrypt`: whether future local backups are configured to be encrypted
- `requires_encryption`: whether the device reports a policy requiring encrypted backups

## Validation

Local checks:

```text
PYTHONPATH=. python -m pytest -q tests/services/test_backup2.py tests/cli/test_backup_cli.py --deselect tests/services/test_backup2.py::test_backup --deselect tests/services/test_backup2.py::test_encrypted_backup
# 20 passed, 3 deselected

PYTHONPATH=. python -m ruff check pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py tests/services/test_backup2.py tests/cli/test_backup_cli.py
# All checks passed

PYTHONPATH=. python -m ruff format --check pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py tests/services/test_backup2.py tests/cli/test_backup_cli.py
# 4 files already formatted

PYTHONPATH=. python -m py_compile pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py tests/services/test_backup2.py tests/cli/test_backup_cli.py
# no errors

git diff --check
# no whitespace errors
```

Live USB validation was also performed against a connected trusted iPhone using this branch. The new command completed successfully and returned:

```json
{
    "requires_encryption": false,
    "will_encrypt": false
}
```

## Tests Added

- `test_get_encryption_status_reads_backup_domain_flags`
- `test_get_backup_domain_bool_returns_false_on_lockdown_error`
- `test_backup2_has_encryption_status_command`
- `test_backup2_encryption_status_help_describes_output`

These cover the service-level Lockdown key reads, the existing `LockdownError` fallback behavior, command registration, and the CLI help text describing the JSON fields.