### PR TITLE
backup2: add backup diagnostics command

### DIFF
--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -49,6 +49,9 @@ pymobiledevice3 apps query BUNDLE_ID1 BUNDLE_ID2
 # Full backup
 pymobiledevice3 backup2 backup --full DIRECTORY
 
+# Diagnose backup readiness without changing backup settings
+pymobiledevice3 backup2 diagnose DIRECTORY
+
 # Preserve only selected backup payloads
 pymobiledevice3 backup2 backup --only sms DIRECTORY
 pymobiledevice3 backup2 backup --only whatsapp DIRECTORY

--- a/pymobiledevice3/cli/backup.py
+++ b/pymobiledevice3/cli/backup.py
@@ -9,7 +9,7 @@ from click import Context
 from tqdm import tqdm
 from typer_injector import InjectingTyper
 
-from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command
+from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command, print_json
 from pymobiledevice3.services.mobilebackup2 import BACKUP_SELECTIONS, Mobilebackup2Service
 
 logger = logging.getLogger(__name__)
@@ -194,6 +194,22 @@ async def restore(
                 source=source,
                 skip_apps=skip_apps,
             )
+
+
+@cli.command()
+@async_command
+async def diagnose(
+    service_provider: ServiceProviderDep,
+    backup_directory: BackupDirectoryArg = Path("."),
+    source: SourceOption = "",
+) -> None:
+    """
+    Print sanitized backup readiness diagnostics.
+
+    The output avoids device identifiers and inspects local backup metadata without changing backup settings.
+    """
+    backup_client = Mobilebackup2Service(service_provider)
+    print_json(await backup_client.diagnose(backup_directory=str(backup_directory), source=source), colored=False)
 
 
 @cli.command()

--- a/pymobiledevice3/services/mobilebackup2.py
+++ b/pymobiledevice3/services/mobilebackup2.py
@@ -12,7 +12,7 @@ from contextlib import asynccontextmanager, closing, suppress
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.keywrap import aes_key_unwrap
@@ -76,6 +76,18 @@ BACKUP_METADATA_FILES = frozenset({
     "Manifest.db-wal",
     "Status.plist",
 })
+BACKUP_DOMAIN = "com.apple.mobile.backup"
+BACKUP_DIAGNOSTIC_BOOLEAN_KEYS = {
+    "cloud_backup_enabled": "CloudBackupEnabled",
+    "requires_encryption": "RequiresEncryption",
+    "will_encrypt": "WillEncrypt",
+}
+BACKUP_DIAGNOSTIC_METADATA_FILES = (
+    "Info.plist",
+    "Manifest.plist",
+    "Manifest.db",
+    "Status.plist",
+)
 
 
 @dataclass(frozen=True)
@@ -146,10 +158,99 @@ class Mobilebackup2Service(LockdownService):
 
     async def get_will_encrypt(self) -> bool:
         try:
-            will_encrypt = await self.lockdown.get_value("com.apple.mobile.backup", "WillEncrypt")
+            will_encrypt = await self.lockdown.get_value(BACKUP_DOMAIN, "WillEncrypt")
             return bool(will_encrypt)
         except LockdownError:
             return False
+
+    async def diagnose(self, backup_directory: Union[str, Path] = ".", source: str = "") -> dict[str, Any]:
+        identifier = source or self.lockdown.udid or ""
+        return {
+            "device": self._device_diagnostics(),
+            "backup_domain": await self._backup_domain_diagnostics(),
+            "wireless_lockdown": await self._wireless_lockdown_diagnostics(),
+            "local_backup": self.diagnose_local_backup(
+                Path(backup_directory), identifier=identifier, source_provided=bool(source)
+            ),
+        }
+
+    def _device_diagnostics(self) -> dict[str, Any]:
+        all_values = self.lockdown.all_values
+        return {
+            "device_class": all_values.get("DeviceClass"),
+            "host_attached": self._bool_or_none(all_values.get("HostAttached")),
+            "password_protected": self._bool_or_none(all_values.get("PasswordProtected")),
+            "product_build_version": getattr(self.lockdown, "product_build_version", None),
+            "product_type": self.lockdown.product_type,
+            "product_version": getattr(self.lockdown, "product_version", None),
+            "trusted_host_attached": self._bool_or_none(all_values.get("TrustedHostAttached")),
+        }
+
+    async def _backup_domain_diagnostics(self) -> dict[str, Any]:
+        diagnostics = {
+            key: self._bool_or_none(await self._get_backup_domain_value(lockdown_key))
+            for key, lockdown_key in BACKUP_DIAGNOSTIC_BOOLEAN_KEYS.items()
+        }
+        diagnostics["version"] = await self._get_backup_domain_value("Version")
+        return diagnostics
+
+    async def _wireless_lockdown_diagnostics(self) -> dict[str, Optional[bool]]:
+        try:
+            enable_wifi_connections = await self.lockdown.get_enable_wifi_connections()
+        except LockdownError:
+            enable_wifi_connections = None
+        return {"enable_wifi_connections": self._bool_or_none(enable_wifi_connections)}
+
+    async def _get_backup_domain_value(self, key: str) -> Any:
+        try:
+            return await self.lockdown.get_value(BACKUP_DOMAIN, key)
+        except LockdownError:
+            return None
+
+    @classmethod
+    def diagnose_local_backup(cls, backup_directory: Path, identifier: str, source_provided: bool = False) -> dict:
+        backup_directory_exists = backup_directory.exists()
+        backup_directory_is_dir = backup_directory.is_dir()
+        source_directories = (
+            [path for path in backup_directory.iterdir() if path.is_dir()] if backup_directory_is_dir else []
+        )
+        source_directory = backup_directory / identifier if identifier else None
+        metadata = {
+            name: cls._diagnose_local_file(source_directory / name if source_directory else None)
+            for name in BACKUP_DIAGNOSTIC_METADATA_FILES
+        }
+        metadata_complete_for_incremental = all(
+            file_diagnostics["is_file"] and bool(file_diagnostics["size"]) for file_diagnostics in metadata.values()
+        )
+
+        return {
+            "available_source_count": len(source_directories),
+            "backup_directory_exists": backup_directory_exists,
+            "backup_directory_is_dir": backup_directory_is_dir,
+            "metadata": metadata,
+            "metadata_complete_for_incremental": metadata_complete_for_incremental,
+            "source_directory_exists": bool(source_directory and source_directory.exists()),
+            "source_directory_is_dir": bool(source_directory and source_directory.is_dir()),
+            "source_selection": "provided" if source_provided else "current_device",
+        }
+
+    @staticmethod
+    def _diagnose_local_file(path: Optional[Path]) -> dict[str, Any]:
+        if path is None:
+            return {"exists": False, "is_file": False, "size": None}
+        exists = path.exists()
+        is_file = path.is_file()
+        return {
+            "exists": exists,
+            "is_file": is_file,
+            "size": path.stat().st_size if exists and is_file else None,
+        }
+
+    @staticmethod
+    def _bool_or_none(value: Any) -> Optional[bool]:
+        if value is None:
+            return None
+        return bool(value)
 
     async def backup(
         self,

--- a/tests/cli/test_backup_cli.py
+++ b/tests/cli/test_backup_cli.py
@@ -29,3 +29,22 @@ def test_backup_command_has_unback_option():
 
     assert result.exit_code == 0
     assert "--unback" in result.output
+
+
+def test_backup2_has_diagnose_command():
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["backup2", "--help"])
+
+    assert result.exit_code == 0
+    assert "diagnose" in result.output
+
+
+def test_backup2_diagnose_help_describes_sanitized_output():
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["backup2", "diagnose", "--help"])
+
+    assert result.exit_code == 0
+    assert "sanitized" in result.output
+    assert "backup readiness" in result.output

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -1,3 +1,4 @@
+import json
 import sqlite3
 import struct
 import time
@@ -8,10 +9,11 @@ from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
-from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionTerminatedError
+from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionTerminatedError, LockdownError
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.services.device_link import DeviceLink
 from pymobiledevice3.services.mobilebackup2 import (
+    BACKUP_DIAGNOSTIC_METADATA_FILES,
     BACKUP_OBSERVED_NOTIFICATIONS,
     BACKUP_SELECTIONS,
     NP_LOCAL_AUTH_DISMISSED,
@@ -131,6 +133,120 @@ async def test_observe_backup_notifications_registers_passcode_and_backup_notifi
     notification_proxy.notify_register_dispatch.assert_has_awaits([
         call(notification) for notification in BACKUP_OBSERVED_NOTIFICATIONS
     ])
+
+
+def test_diagnose_local_backup_reports_metadata_state_without_identifier(tmp_path: Path) -> None:
+    source_identifier = "secret-udid"
+    device_directory = tmp_path / source_identifier
+    device_directory.mkdir()
+    for file_name in BACKUP_DIAGNOSTIC_METADATA_FILES:
+        (device_directory / file_name).write_bytes(b"metadata")
+
+    result = Mobilebackup2Service.diagnose_local_backup(tmp_path, identifier=source_identifier)
+
+    assert result["available_source_count"] == 1
+    assert result["backup_directory_exists"]
+    assert result["source_directory_exists"]
+    assert result["metadata_complete_for_incremental"]
+    assert "secret-udid" not in json.dumps(result)
+
+
+def test_diagnose_local_backup_reports_incomplete_metadata(tmp_path: Path) -> None:
+    device_directory = tmp_path / "source"
+    device_directory.mkdir()
+    (device_directory / "Info.plist").write_bytes(b"metadata")
+    (device_directory / "Manifest.plist").touch()
+
+    result = Mobilebackup2Service.diagnose_local_backup(tmp_path, identifier="source", source_provided=True)
+
+    assert result["source_selection"] == "provided"
+    assert not result["metadata_complete_for_incremental"]
+    assert result["metadata"]["Info.plist"] == {
+        "exists": True,
+        "is_file": True,
+        "size": len(b"metadata"),
+    }
+    assert result["metadata"]["Manifest.plist"] == {
+        "exists": True,
+        "is_file": True,
+        "size": 0,
+    }
+    assert result["metadata"]["Manifest.db"] == {
+        "exists": False,
+        "is_file": False,
+        "size": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_diagnose_reports_sanitized_device_and_backup_status(tmp_path: Path) -> None:
+    lockdown = Mock()
+    lockdown.udid = "secret-udid"
+    lockdown.product_type = "iPhone16,2"
+    lockdown.product_version = "26.5"
+    lockdown.product_build_version = "23F77"
+    lockdown.all_values = {
+        "DeviceClass": "iPhone",
+        "HostAttached": True,
+        "PasswordProtected": False,
+        "TrustedHostAttached": True,
+    }
+    lockdown.get_enable_wifi_connections = AsyncMock(return_value=True)
+    lockdown.get_value = AsyncMock(
+        side_effect=lambda domain, key: {
+            ("com.apple.mobile.backup", "CloudBackupEnabled"): False,
+            ("com.apple.mobile.backup", "RequiresEncryption"): 0,
+            ("com.apple.mobile.backup", "WillEncrypt"): True,
+            ("com.apple.mobile.backup", "Version"): "2.0",
+        }[(domain, key)]
+    )
+    service = object.__new__(Mobilebackup2Service)
+    service.lockdown = lockdown
+
+    result = await service.diagnose(tmp_path)
+
+    assert result["device"] == {
+        "device_class": "iPhone",
+        "host_attached": True,
+        "password_protected": False,
+        "product_build_version": "23F77",
+        "product_type": "iPhone16,2",
+        "product_version": "26.5",
+        "trusted_host_attached": True,
+    }
+    assert result["backup_domain"] == {
+        "cloud_backup_enabled": False,
+        "requires_encryption": False,
+        "will_encrypt": True,
+        "version": "2.0",
+    }
+    assert result["wireless_lockdown"] == {"enable_wifi_connections": True}
+    assert "secret-udid" not in json.dumps(result)
+
+
+@pytest.mark.asyncio
+async def test_diagnose_tolerates_unavailable_optional_lockdown_values(tmp_path: Path) -> None:
+    lockdown = Mock()
+    lockdown.udid = "secret-udid"
+    lockdown.product_type = None
+    lockdown.product_version = None
+    lockdown.product_build_version = None
+    lockdown.all_values = {}
+    lockdown.get_enable_wifi_connections = AsyncMock(side_effect=LockdownError("missing"))
+    lockdown.get_value = AsyncMock(side_effect=LockdownError("missing"))
+    service = object.__new__(Mobilebackup2Service)
+    service.lockdown = lockdown
+
+    result = await service.diagnose(tmp_path)
+
+    assert result["backup_domain"] == {
+        "cloud_backup_enabled": None,
+        "requires_encryption": None,
+        "will_encrypt": None,
+        "version": None,
+    }
+    assert result["wireless_lockdown"] == {"enable_wifi_connections": None}
+    assert "secret-udid" not in json.dumps(result)
 
 
 def test_log_backup_notification_surfaces_passcode_prompt_to_operator() -> None:


### PR DESCRIPTION
## Summary

This change adds a read-only `backup2 diagnose` command that prints sanitized backup readiness diagnostics as JSON.

The command is intended to help users and maintainers understand backup preconditions without starting a backup, changing backup encryption settings, or dumping device identifiers. It combines a small set of Lockdown posture values with local backup-directory metadata state.

## What Changed

- Added `Mobilebackup2Service.diagnose()` as the service-level diagnostic entry point.
- Added sanitized device context:
  - device class
  - product type
  - product version
  - build version
  - password-protected state
  - host/trusted-host attachment flags when available
- Added backup-domain diagnostics for:
  - `CloudBackupEnabled`
  - `RequiresEncryption`
  - `WillEncrypt`
  - backup domain `Version`
- Added wireless-lockdown diagnostics for `EnableWifiConnections` when available.
- Added local backup-directory diagnostics:
  - backup directory existence and directory state
  - available source directory count
  - selected source mode (`current_device` or `provided`)
  - selected source directory existence and directory state
  - metadata file presence and size for `Info.plist`, `Manifest.plist`, `Manifest.db`, and `Status.plist`
  - `metadata_complete_for_incremental` readiness flag
- Added the `backup2 diagnose [BACKUP_DIRECTORY]` CLI command.
- Documented the new command in the CLI recipes guide.

## Why This Change Is Needed

Backup failures can be caused by several different layers: device backup preferences, wireless-lockdown posture, local backup-directory state, missing metadata, or a mismatch between the connected device and the local backup source directory.

Before this change, users had to combine multiple commands and inspect local files manually to understand this state. That makes bug reports and support cases noisy, and it can expose unnecessary identifiers when users paste raw command output.

`backup2 diagnose` gives a single read-only JSON view of the backup readiness state while intentionally avoiding UDID, serial number, device name, phone number, IMEI, ICCID, and pair-record data.

## User Impact

Users can now run:

```shell
pymobiledevice3 backup2 diagnose /path/to/backups
```

The command does not start MobileBackup2, does not create or modify backup files, and does not change device settings. It only reads selected Lockdown values and inspects local metadata files.

The output is suitable for support/debugging because it reports whether the local metadata required for an incremental backup appears present without printing the source identifier itself.

## Validation

Local checks:

```text
PYTHONPATH=. python -m pytest -q tests/services/test_backup2.py tests/cli/test_backup_cli.py --deselect tests/services/test_backup2.py::test_backup --deselect tests/services/test_backup2.py::test_encrypted_backup
# 22 passed, 3 deselected

PYTHONPATH=. python -m ruff check pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py tests/services/test_backup2.py tests/cli/test_backup_cli.py
# All checks passed

PYTHONPATH=. python -m ruff format --check pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py tests/services/test_backup2.py tests/cli/test_backup_cli.py
# 4 files already formatted

PYTHONPATH=. python -m py_compile pymobiledevice3/services/mobilebackup2.py pymobiledevice3/cli/backup.py tests/services/test_backup2.py tests/cli/test_backup_cli.py
# no errors

git diff --check
# no whitespace errors
```

Live USB validation was also performed against a connected trusted iPhone using this branch. The new command completed successfully and returned identifier-free JSON containing `backup_domain`, `device`, `local_backup`, and `wireless_lockdown` sections.

## Tests Added

- `test_diagnose_local_backup_reports_metadata_state_without_identifier`
- `test_diagnose_local_backup_reports_incomplete_metadata`
- `test_diagnose_reports_sanitized_device_and_backup_status`
- `test_diagnose_tolerates_unavailable_optional_lockdown_values`
- `test_backup2_has_diagnose_command`
- `test_backup2_diagnose_help_describes_sanitized_output`

These cover local metadata readiness, incomplete metadata reporting, identifier-free output, optional Lockdown fallback behavior, command registration, and CLI help text.