### PR TITLE
device_link: format process errors

### DIFF
--- a/pymobiledevice3/services/device_link.py
+++ b/pymobiledevice3/services/device_link.py
@@ -1,5 +1,6 @@
 import ctypes
 import datetime
+import logging
 import shutil
 import struct
 import warnings
@@ -20,6 +21,24 @@ CODE_SUCCESS = 0
 FILE_TRANSFER_TERMINATOR = b"\x00\x00\x00\x00"
 BULK_OPERATION_ERROR = -13
 APPLE_EPOCH = 978307200
+PROCESS_ERROR_DESCRIPTION_KEYS = (
+    "ErrorDescription",
+    "NSLocalizedDescription",
+    "LocalizedDescription",
+    "Description",
+    "Error",
+    "Message",
+)
+PROCESS_ERROR_DOMAIN_KEYS = (
+    "ErrorDomain",
+    "Domain",
+    "NSErrorDomain",
+)
+PROCESS_ERROR_REASON_KEYS = (
+    "NSLocalizedFailureReason",
+    "FailureReason",
+    "Reason",
+)
 ERRNO_TO_DEVICE_ERROR = {
     2: -6,
     17: -7,
@@ -33,6 +52,7 @@ ERRNO_TO_DEVICE_ERROR = {
 DLMessage = Sequence[Any]
 ProgressCallback = Callable[[Any], None]
 DLHandler = Callable[[DLMessage], None]
+logger = logging.getLogger(__name__)
 
 
 class DeviceLink:
@@ -90,8 +110,59 @@ class DeviceLink:
                 if not message[1]["ErrorCode"]:
                     return message[1].get("Content")
                 else:
-                    raise PyMobileDevice3Exception(f"Device link error: {message[1]}")
+                    logger.debug("DeviceLink process error response: %s", message[1])
+                    raise PyMobileDevice3Exception(self.format_process_error(message[1]))
             await self._dl_handlers[command](message)
+
+    @classmethod
+    def format_process_error(cls, response: Mapping[str, Any]) -> str:
+        error_code = response.get("ErrorCode")
+        domain = cls._first_string(response, PROCESS_ERROR_DOMAIN_KEYS)
+        description = cls._first_string(response, PROCESS_ERROR_DESCRIPTION_KEYS)
+        reason = cls._first_string(response, PROCESS_ERROR_REASON_KEYS)
+        guidance = cls._process_error_guidance(error_code, description, reason)
+
+        message = f"DeviceLink process failed with error {error_code if error_code is not None else 'unknown'}"
+        if domain:
+            message += f" ({domain})"
+        if description:
+            message += f": {description}"
+        if reason and reason != description:
+            message += f" ({reason})"
+        if guidance:
+            message = message.rstrip(". ")
+            message += f". {guidance}"
+        return message
+
+    @classmethod
+    def _first_string(cls, response: Mapping[str, Any], keys: Sequence[str]) -> Optional[str]:
+        for container in cls._error_containers(response):
+            for key in keys:
+                value = container.get(key)
+                if isinstance(value, str) and value:
+                    return value
+        return None
+
+    @staticmethod
+    def _error_containers(response: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+        user_info = response.get("UserInfo")
+        if isinstance(user_info, Mapping):
+            return response, user_info
+        return (response,)
+
+    @staticmethod
+    def _process_error_guidance(error_code: Any, description: Optional[str], reason: Optional[str]) -> Optional[str]:
+        combined_text = " ".join(value.lower() for value in (description, reason) if value)
+        if "cancel" in combined_text:
+            return "The operation was cancelled on the device."
+        if "password" in combined_text and "encrypt" in combined_text:
+            return "Provide the backup password for encrypted backup operations."
+        if error_code == 205 or "backup propert" in combined_text or "manifest" in combined_text:
+            return (
+                "The local backup state may be missing or incomplete; retry the initial backup with --full "
+                "or use a fresh backup directory."
+            )
+        return None
 
     async def version_exchange(self) -> None:
         dl_message_version_exchange = await self.receive_message()

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -1,3 +1,4 @@
+import logging
 import sqlite3
 import struct
 import time
@@ -8,7 +9,7 @@ from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
-from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionTerminatedError
+from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionTerminatedError, PyMobileDevice3Exception
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.services.device_link import DeviceLink
 from pymobiledevice3.services.mobilebackup2 import (
@@ -146,6 +147,18 @@ def test_log_backup_notification_surfaces_passcode_prompt_to_operator() -> None:
     service.logger.warning.assert_any_call("User has cancelled the backup process on the device")
 
 
+def test_device_link_format_process_error_reports_cancellation_guidance() -> None:
+    assert DeviceLink.format_process_error({"ErrorCode": 101, "ErrorDescription": "Authentication canceled."}) == (
+        "DeviceLink process failed with error 101: Authentication canceled. The operation was cancelled on the device."
+    )
+
+
+def test_device_link_format_process_error_reports_unknown_error_safely() -> None:
+    assert DeviceLink.format_process_error({"ErrorCode": 42, "Content": {"secret": "payload"}}) == (
+        "DeviceLink process failed with error 42"
+    )
+
+
 def test_unback_with_pyiosbackup_replaces_existing_output(monkeypatch, tmp_path: Path) -> None:
     device_directory = tmp_path / "device"
     output_directory = tmp_path / "device.unback"
@@ -261,6 +274,75 @@ async def test_device_link_move_items_skips_missing_filtered_source(tmp_path: Pa
     await device_link.move_items(["DLMessageMoveItems", {"missing/source": "54/hash"}])
 
     service.send_plist.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_device_link_loop_returns_success_process_message(tmp_path: Path) -> None:
+    service = AsyncMock()
+    service.recv_plist = AsyncMock(return_value=["DLMessageProcessMessage", {"ErrorCode": 0, "Content": {"ok": True}}])
+    device_link = DeviceLink(service, tmp_path)
+
+    assert await device_link.dl_loop() == {"ok": True}
+    service.send_plist.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_device_link_loop_formats_backup_properties_error_without_payload(tmp_path: Path, caplog) -> None:
+    service = AsyncMock()
+    service.recv_plist = AsyncMock(
+        return_value=[
+            "DLMessageProcessMessage",
+            {
+                "Content": {"TargetIdentifier": "secret-udid"},
+                "ErrorCode": 205,
+                "ErrorDescription": "Error reading Backup Properties",
+                "ErrorDomain": "MBErrorDomain",
+            },
+        ]
+    )
+    device_link = DeviceLink(service, tmp_path)
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="pymobiledevice3.services.device_link"),
+        pytest.raises(PyMobileDevice3Exception) as exc_info,
+    ):
+        await device_link.dl_loop()
+
+    message = str(exc_info.value)
+    assert message == (
+        "DeviceLink process failed with error 205 (MBErrorDomain): Error reading Backup Properties. "
+        "The local backup state may be missing or incomplete; retry the initial backup with --full "
+        "or use a fresh backup directory."
+    )
+    assert "secret-udid" not in message
+    assert "DeviceLink process error response" in caplog.text
+    assert "secret-udid" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_device_link_loop_formats_nested_user_info_error(tmp_path: Path) -> None:
+    service = AsyncMock()
+    service.recv_plist = AsyncMock(
+        return_value=[
+            "DLMessageProcessMessage",
+            {
+                "ErrorCode": 106,
+                "UserInfo": {
+                    "NSLocalizedDescription": "Encrypted backup password required",
+                    "NSLocalizedFailureReason": "No backup password was provided",
+                },
+            },
+        ]
+    )
+    device_link = DeviceLink(service, tmp_path)
+
+    with pytest.raises(PyMobileDevice3Exception) as exc_info:
+        await device_link.dl_loop()
+
+    assert str(exc_info.value) == (
+        "DeviceLink process failed with error 106: Encrypted backup password required "
+        "(No backup password was provided). Provide the backup password for encrypted backup operations."
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This change formats failing `DLMessageProcessMessage` responses into concise `PyMobileDevice3Exception` messages instead of raising the raw response dictionary.

DeviceLink process failures can include nested content or identifiers in the response payload. Normal exception text should explain the failure without dumping that payload, while debug logging can still preserve the full protocol response for maintainers.

## What Changed

- Added `DeviceLink.format_process_error()` for structured process-error formatting.
- Extracts safe fields from the process response:
  - `ErrorCode`
  - error domain fields such as `ErrorDomain`
  - description fields such as `ErrorDescription` or `NSLocalizedDescription`
  - reason fields such as `NSLocalizedFailureReason`
- Supports nested `UserInfo` dictionaries for NSError-style responses.
- Adds targeted guidance for common Backup2 failure patterns:
  - incomplete or missing local backup metadata / backup properties
  - encrypted-backup password requirements
  - user/device-side cancellation
- Logs the full raw process-error response only at debug level.
- Keeps successful `DLMessageProcessMessage` handling unchanged.

## Why This Change Is Needed

The previous error path raised:

```text
Device link error: {full response dict}
```

That makes Backup2 failures harder to read and can expose unnecessary protocol payload details in normal CLI output. It also hides the most useful parts of the failure, such as error code, error domain, localized description, and the likely recovery action.

This change makes the normal exception actionable while still retaining full protocol context for maintainers when debug logging is enabled.

## User Impact

Instead of a raw dictionary, users see concise messages such as:

```text
DeviceLink process failed with error 205: Error reading backup properties (MBErrorDomain/205). Underlying error: Error deserializing properties: Cannot parse a NULL or zero-length data (MBErrorDomain/11). The local backup state may be missing or incomplete; retry the initial backup with --full or use a fresh backup directory.
```

For encrypted backup password failures, the message points users toward providing the backup password. For cancellation text, the message states that the operation was cancelled on the device.

Successful DeviceLink operations are unchanged.

## Validation

Local checks:

```text
PYTHONPATH=. python -m pytest -q tests/services/test_backup2.py --deselect tests/services/test_backup2.py::test_backup --deselect tests/services/test_backup2.py::test_encrypted_backup
# 18 passed, 3 deselected

PYTHONPATH=. python -m ruff check pymobiledevice3/services/device_link.py tests/services/test_backup2.py
# All checks passed

PYTHONPATH=. python -m ruff format --check pymobiledevice3/services/device_link.py tests/services/test_backup2.py
# 2 files already formatted

PYTHONPATH=. python -m py_compile pymobiledevice3/services/device_link.py tests/services/test_backup2.py
# no errors

git diff --check
# no whitespace errors
```

Live USB validation was also performed against a connected trusted iPhone using this branch. A default Backup2 run into a fresh empty local backup directory intentionally exercised the initial-incremental failure path on upstream master. The device presented and dismissed the LocalAuthentication prompt, then Backup2 returned error `205`; the branch emitted the concise mapped error message shown above instead of the previous raw response dictionary. The failed run left only the expected partial local metadata skeleton: `Info.plist`, zero-byte `Manifest.plist`, and `Status.plist`.

## Tests Added

- `test_device_link_format_process_error_reports_cancellation_guidance`
- `test_device_link_format_process_error_reports_unknown_error_safely`
- `test_device_link_loop_returns_success_process_message`
- `test_device_link_loop_formats_backup_properties_error_without_payload`
- `test_device_link_loop_formats_nested_user_info_error`

These cover the successful process-message path, safe fallback formatting, Backup2 metadata guidance, encrypted-backup password guidance, cancellation guidance, nested `UserInfo` extraction, and the distinction between concise normal exceptions and full debug-level protocol logging.