### PR TITLE
profile: add audit summary command

### DIFF
--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -46,6 +46,9 @@ pymobiledevice3 apps list
 # Query specific app bundle IDs
 pymobiledevice3 apps query BUNDLE_ID1 BUNDLE_ID2
 
+# Summarize installed configuration-profile payloads
+pymobiledevice3 profile audit
+
 # Full backup
 pymobiledevice3 backup2 backup --full DIRECTORY
 

--- a/pymobiledevice3/cli/profile.py
+++ b/pymobiledevice3/cli/profile.py
@@ -29,6 +29,13 @@ async def profile_list(service_provider: ServiceProviderDep) -> None:
     print_json(await MobileConfigService(lockdown=service_provider).get_profile_list())
 
 
+@cli.command("audit")
+@async_command
+async def profile_audit(service_provider: ServiceProviderDep) -> None:
+    """Summarize installed profile payloads and audit-relevant flags"""
+    print_json(await MobileConfigService(lockdown=service_provider).get_profile_audit())
+
+
 @cli.command("install")
 @async_command
 async def profile_install(

--- a/pymobiledevice3/services/mobile_config.py
+++ b/pymobiledevice3/services/mobile_config.py
@@ -1,5 +1,6 @@
 import contextlib
 import plistlib
+from collections import Counter
 from enum import Enum
 from pathlib import Path
 from typing import Any, Optional
@@ -18,6 +19,55 @@ from pymobiledevice3.services.lockdown_service import LockdownService
 ERROR_CLOUD_CONFIGURATION_ALREADY_PRESENT = 14002
 GLOBAL_HTTP_PROXY_UUID = "86a52338-52f7-4c09-b005-52baf3dc4882"
 GLOBAL_RESTRICTIONS_UUID = "e22a0a66-08a8-43f5-9bbc-5279af35bb2b"
+CERTIFICATE_PAYLOAD_TYPES = {
+    "com.apple.security.acme",
+    "com.apple.security.certificatepreference",
+    "com.apple.security.identitypreference",
+    "com.apple.security.pem",
+    "com.apple.security.pkcs1",
+    "com.apple.security.pkcs12",
+    "com.apple.security.root",
+    "com.apple.security.scep",
+}
+ROOT_CERTIFICATE_PAYLOAD_TYPES = {"com.apple.security.root"}
+NON_ROOT_CERTIFICATE_PAYLOAD_TYPES = CERTIFICATE_PAYLOAD_TYPES - ROOT_CERTIFICATE_PAYLOAD_TYPES
+VPN_PAYLOAD_TYPES = {
+    "com.apple.vpn.managed",
+    "com.apple.vpn.managed.applayer",
+}
+AUDIT_PAYLOAD_RULES = (
+    ("mdm", "high", "has_mdm", {"com.apple.mdm"}),
+    ("global_http_proxy", "high", "has_global_http_proxy", {"com.apple.proxy.http.global"}),
+    ("vpn", "medium", "has_vpn", VPN_PAYLOAD_TYPES),
+    ("root_certificate", "medium", "has_root_certificates", ROOT_CERTIFICATE_PAYLOAD_TYPES),
+    ("certificate", "medium", "has_certificates", NON_ROOT_CERTIFICATE_PAYLOAD_TYPES),
+    ("web_content_filter", "medium", "has_web_content_filter", {"com.apple.webcontent-filter"}),
+    ("dns_settings", "medium", "has_dns_settings", {"com.apple.dnsProxy.managed", "com.apple.dnsSettings.managed"}),
+    ("wifi", "low", "has_wifi", {"com.apple.wifi.managed"}),
+    ("restrictions", "low", "has_restrictions", {"com.apple.applicationaccess"}),
+)
+AUDIT_FLAG_NAMES = (
+    *(rule[2] for rule in AUDIT_PAYLOAD_RULES),
+    "has_removal_disallowed_profiles",
+)
+PROFILE_SUMMARY_KEYS = {
+    "IsEncrypted": "is_encrypted",
+    "PayloadDisplayName": "display_name",
+    "PayloadExpirationDate": "expiration_date",
+    "PayloadIdentifier": "identifier",
+    "PayloadOrganization": "organization",
+    "PayloadRemovalDate": "removal_date",
+    "PayloadRemovalDisallowed": "removal_disallowed",
+    "PayloadUUID": "uuid",
+    "PayloadVersion": "version",
+}
+PAYLOAD_SUMMARY_KEYS = {
+    "PayloadDisplayName": "display_name",
+    "PayloadIdentifier": "identifier",
+    "PayloadType": "type",
+    "PayloadUUID": "uuid",
+    "PayloadVersion": "version",
+}
 
 
 class Purpose(Enum):
@@ -90,6 +140,106 @@ class MobileConfigService(LockdownService):
 
     async def get_profile_list(self) -> dict:
         return await self._send_recv({"RequestType": "GetProfileList"})
+
+    async def get_profile_audit(self) -> dict:
+        return self.audit_profile_list(await self.get_profile_list())
+
+    @classmethod
+    def audit_profile_list(cls, profile_list: dict) -> dict:
+        profile_metadata = profile_list.get("ProfileMetadata") or {}
+        profile_manifest = profile_list.get("ProfileManifest") or {}
+        ordered_identifiers = profile_list.get("OrderedIdentifiers") or []
+        unordered_identifiers = sorted((set(profile_metadata) | set(profile_manifest)) - set(ordered_identifiers))
+        identifiers = list(
+            dict.fromkeys([
+                *ordered_identifiers,
+                *unordered_identifiers,
+            ])
+        )
+
+        profiles = []
+        payload_type_counts: Counter[str] = Counter()
+        findings = []
+        flags = dict.fromkeys(AUDIT_FLAG_NAMES, False)
+
+        for fallback_identifier in identifiers:
+            metadata = profile_metadata.get(fallback_identifier) or {}
+            manifest = profile_manifest.get(fallback_identifier) or {}
+            payloads = list(cls._iter_profile_payloads(metadata)) or list(cls._iter_profile_payloads(manifest))
+            payload_summaries = [cls._payload_summary(payload) for payload in payloads]
+            payload_types = sorted({
+                payload_summary["type"] for payload_summary in payload_summaries if payload_summary.get("type")
+            })
+
+            summary = {
+                "identifier": metadata.get("PayloadIdentifier") or fallback_identifier,
+                "payload_count": len(payload_summaries),
+                "payload_types": payload_types,
+                "payloads": payload_summaries,
+            }
+            for source_key, output_key in PROFILE_SUMMARY_KEYS.items():
+                if source_key in metadata and output_key != "identifier":
+                    summary[output_key] = metadata[source_key]
+
+            flags["has_removal_disallowed_profiles"] = (
+                flags["has_removal_disallowed_profiles"] or summary.get("removal_disallowed") is True
+            )
+
+            for payload_summary in payload_summaries:
+                payload_type = payload_summary.get("type")
+                if payload_type is not None:
+                    payload_type_counts[payload_type] += 1
+                if payload_type in CERTIFICATE_PAYLOAD_TYPES:
+                    flags["has_certificates"] = True
+
+                for category, severity, flag_name, payload_types_to_flag in AUDIT_PAYLOAD_RULES:
+                    if payload_type not in payload_types_to_flag:
+                        continue
+                    flags[flag_name] = True
+                    findings.append({
+                        "category": category,
+                        "payload_display_name": payload_summary.get("display_name"),
+                        "payload_identifier": payload_summary.get("identifier"),
+                        "payload_type": payload_type,
+                        "profile_identifier": summary["identifier"],
+                        "severity": severity,
+                    })
+
+            profiles.append(summary)
+
+        return {
+            "findings": findings,
+            "flags": flags,
+            "payload_count": sum(payload_type_counts.values()),
+            "payload_types": dict(sorted(payload_type_counts.items())),
+            "profile_count": len(profiles),
+            "profiles": profiles,
+        }
+
+    @classmethod
+    def _iter_profile_payloads(cls, value: Any):
+        if isinstance(value, list):
+            for item in value:
+                yield from cls._iter_profile_payloads(item)
+            return
+
+        if not isinstance(value, dict):
+            return
+
+        payload_type = value.get("PayloadType")
+        if payload_type is not None and payload_type != "Configuration":
+            yield value
+
+        for child_key in ("PayloadContent", "PayloadItems"):
+            yield from cls._iter_profile_payloads(value.get(child_key))
+
+    @staticmethod
+    def _payload_summary(payload: dict) -> dict:
+        return {
+            output_key: payload[source_key]
+            for source_key, output_key in PAYLOAD_SUMMARY_KEYS.items()
+            if source_key in payload
+        }
 
     async def install_profile(self, payload: bytes) -> None:
         await self._send_recv({"RequestType": "InstallProfile", "Payload": payload})

--- a/tests/services/test_mobile_config.py
+++ b/tests/services/test_mobile_config.py
@@ -1,0 +1,174 @@
+from pymobiledevice3.services.mobile_config import MobileConfigService
+
+
+def test_profile_audit_empty_response() -> None:
+    audit = MobileConfigService.audit_profile_list({
+        "OrderedIdentifiers": [],
+        "ProfileManifest": {},
+        "ProfileMetadata": {},
+        "Status": "Acknowledged",
+    })
+
+    assert audit == {
+        "findings": [],
+        "flags": {
+            "has_certificates": False,
+            "has_dns_settings": False,
+            "has_global_http_proxy": False,
+            "has_mdm": False,
+            "has_removal_disallowed_profiles": False,
+            "has_restrictions": False,
+            "has_root_certificates": False,
+            "has_vpn": False,
+            "has_web_content_filter": False,
+            "has_wifi": False,
+        },
+        "payload_count": 0,
+        "payload_types": {},
+        "profile_count": 0,
+        "profiles": [],
+    }
+
+
+def test_profile_audit_summarizes_profile_payloads_without_raw_content() -> None:
+    audit = MobileConfigService.audit_profile_list({
+        "OrderedIdentifiers": ["com.example.profile"],
+        "ProfileManifest": {},
+        "ProfileMetadata": {
+            "com.example.profile": {
+                "PayloadContent": [
+                    {
+                        "PayloadDisplayName": "Management",
+                        "PayloadIdentifier": "com.example.profile.mdm",
+                        "PayloadType": "com.apple.mdm",
+                        "PayloadUUID": "payload-1",
+                        "PayloadVersion": 1,
+                        "ServerURL": "https://mdm.example.invalid",
+                    },
+                    {
+                        "PayloadDisplayName": "Root CA",
+                        "PayloadIdentifier": "com.example.profile.root",
+                        "PayloadType": "com.apple.security.root",
+                        "PayloadUUID": "payload-2",
+                        "PayloadVersion": 1,
+                        "PayloadContent": b"certificate-bytes",
+                    },
+                    {
+                        "IPSec": {
+                            "AuthenticationMethod": "SharedSecret",
+                            "SharedSecret": "secret",
+                        },
+                        "PayloadDisplayName": "VPN",
+                        "PayloadIdentifier": "com.example.profile.vpn",
+                        "PayloadType": "com.apple.vpn.managed",
+                        "PayloadUUID": "payload-3",
+                        "PayloadVersion": 1,
+                    },
+                ],
+                "PayloadDisplayName": "Example Profile",
+                "PayloadIdentifier": "com.example.profile",
+                "PayloadOrganization": "Example Org",
+                "PayloadRemovalDisallowed": True,
+                "PayloadType": "Configuration",
+                "PayloadUUID": "profile-uuid",
+                "PayloadVersion": 1,
+            },
+        },
+        "Status": "Acknowledged",
+    })
+
+    assert audit["profile_count"] == 1
+    assert audit["payload_count"] == 3
+    assert audit["payload_types"] == {
+        "com.apple.mdm": 1,
+        "com.apple.security.root": 1,
+        "com.apple.vpn.managed": 1,
+    }
+    assert audit["flags"]["has_certificates"] is True
+    assert audit["flags"]["has_mdm"] is True
+    assert audit["flags"]["has_removal_disallowed_profiles"] is True
+    assert audit["flags"]["has_root_certificates"] is True
+    assert audit["flags"]["has_vpn"] is True
+    assert [finding["category"] for finding in audit["findings"]] == [
+        "mdm",
+        "root_certificate",
+        "vpn",
+    ]
+    assert audit["profiles"] == [
+        {
+            "display_name": "Example Profile",
+            "identifier": "com.example.profile",
+            "organization": "Example Org",
+            "payload_count": 3,
+            "payload_types": [
+                "com.apple.mdm",
+                "com.apple.security.root",
+                "com.apple.vpn.managed",
+            ],
+            "payloads": [
+                {
+                    "display_name": "Management",
+                    "identifier": "com.example.profile.mdm",
+                    "type": "com.apple.mdm",
+                    "uuid": "payload-1",
+                    "version": 1,
+                },
+                {
+                    "display_name": "Root CA",
+                    "identifier": "com.example.profile.root",
+                    "type": "com.apple.security.root",
+                    "uuid": "payload-2",
+                    "version": 1,
+                },
+                {
+                    "display_name": "VPN",
+                    "identifier": "com.example.profile.vpn",
+                    "type": "com.apple.vpn.managed",
+                    "uuid": "payload-3",
+                    "version": 1,
+                },
+            ],
+            "removal_disallowed": True,
+            "uuid": "profile-uuid",
+            "version": 1,
+        },
+    ]
+
+    audit_text = str(audit)
+    assert "certificate-bytes" not in audit_text
+    assert "ServerURL" not in audit_text
+    assert "SharedSecret" not in audit_text
+    assert "secret" not in audit_text
+
+
+def test_profile_audit_uses_manifest_payloads_when_metadata_has_no_payload_content() -> None:
+    audit = MobileConfigService.audit_profile_list({
+        "OrderedIdentifiers": [],
+        "ProfileManifest": {
+            "com.example.wifi": {
+                "PayloadContent": [
+                    {
+                        "PayloadIdentifier": "com.example.wifi.payload",
+                        "PayloadType": "com.apple.wifi.managed",
+                    },
+                ],
+            },
+        },
+        "ProfileMetadata": {
+            "com.example.wifi": {
+                "PayloadDisplayName": "Wi-Fi Profile",
+                "PayloadIdentifier": "com.example.wifi",
+                "PayloadType": "Configuration",
+            },
+        },
+        "Status": "Acknowledged",
+    })
+
+    assert audit["flags"]["has_wifi"] is True
+    assert audit["payload_types"] == {"com.apple.wifi.managed": 1}
+    assert audit["profiles"][0]["payloads"] == [
+        {
+            "identifier": "com.example.wifi.payload",
+            "type": "com.apple.wifi.managed",
+        },
+    ]


### PR DESCRIPTION
## Summary

Adds a read-only `profile audit` command that summarizes installed configuration-profile metadata as JSON.

The command builds on the existing MCInstall `GetProfileList` request and reports a compact audit-oriented view instead of dumping the full raw profile response:

- profile and payload counts
- payload type counts
- per-profile payload summaries
- findings for MDM, VPN, global HTTP proxy, certificates/root certificates, DNS settings, web content filter, Wi-Fi, restrictions, and removal-disallowed profiles

## Why

`profile list` is useful for raw inspection, but callers that need a quick posture check currently have to parse the full MCInstall response themselves. This adds a stable service-level summary that keeps protocol handling in `MobileConfigService` and gives CLI users a direct, machine-readable command for high-signal profile inventory.

The output intentionally copies only summary fields such as payload type, identifier, display name, UUID, and version. It does not include raw payload contents such as certificates, server URLs, VPN nested settings, or other payload-specific data.

## Implementation details

- Adds `MobileConfigService.get_profile_audit()` for device-backed audit collection.
- Adds `MobileConfigService.audit_profile_list()` as a pure converter for `GetProfileList` responses.
- Preserves `OrderedIdentifiers` order and includes metadata-only or manifest-only profile entries.
- Falls back to `ProfileManifest` payload details when `ProfileMetadata` does not include payload content.
- Adds `pymobiledevice3 profile audit` as the CLI entry point.
- Adds a CLI recipe entry for the new command.

## Validation

- `python -m pytest -q tests/services/test_mobile_config.py`
- `python -m pytest -q tests/services/test_mobile_config.py tests/cli/test_cli.py`
- `python -m ruff check pymobiledevice3/services/mobile_config.py pymobiledevice3/cli/profile.py tests/services/test_mobile_config.py`
- `python -m ruff format --check pymobiledevice3/services/mobile_config.py pymobiledevice3/cli/profile.py tests/services/test_mobile_config.py`
- `python3 -m py_compile pymobiledevice3/services/mobile_config.py pymobiledevice3/cli/profile.py tests/services/test_mobile_config.py`
- `git diff --check`

Live validation was also run against a connected unlocked device. The command completed successfully and returned a valid empty audit result: `profile_count: 0`, `payload_count: 0`, no findings, and all audit flags set to `false`.