### PR TITLE
apps: add audit summary command

### DIFF
--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -43,6 +43,9 @@ pymobiledevice3 afc shell
 # List installed apps
 pymobiledevice3 apps list
 
+# Summarize installed apps and audit-relevant flags
+pymobiledevice3 apps audit --type User
+
 # Query specific app bundle IDs
 pymobiledevice3 apps query BUNDLE_ID1 BUNDLE_ID2
 

--- a/pymobiledevice3/cli/apps.py
+++ b/pymobiledevice3/cli/apps.py
@@ -46,6 +46,37 @@ async def apps_list(
     )
 
 
+@cli.command("audit")
+@async_command
+async def apps_audit(
+    service_provider: ServiceProviderDep,
+    app_type: Annotated[
+        Literal["System", "User", "Hidden", "Any"],
+        typer.Option(
+            "--type",
+            "-t",
+            help="Filter by application type (System/User/Hidden/Any).",
+        ),
+    ] = "Any",
+    calculate_sizes: Annotated[
+        bool,
+        typer.Option(help="Include app size information (slower)."),
+    ] = False,
+    show_placeholders: Annotated[
+        bool,
+        typer.Option(help="Include placeholder apps in the results."),
+    ] = False,
+) -> None:
+    """Summarize installed apps and audit-relevant flags."""
+    print_json(
+        await InstallationProxyService(lockdown=service_provider).get_apps_audit(
+            application_type=app_type,
+            calculate_sizes=calculate_sizes,
+            show_placeholders=show_placeholders,
+        )
+    )
+
+
 @cli.command("query")
 @async_command
 async def apps_query(

--- a/pymobiledevice3/services/installation_proxy.py
+++ b/pymobiledevice3/services/installation_proxy.py
@@ -1,10 +1,11 @@
 import os
 import uuid
+from collections import Counter
 from enum import Enum
 from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 from zipfile import ZIP_DEFLATED, BadZipFile, ZipFile
 
 from parameter_decorators import str_to_path
@@ -18,6 +19,52 @@ from pymobiledevice3.services.lockdown_service import LockdownService
 GET_APPS_ADDITIONAL_INFO = {"ReturnAttributes": ["CFBundleIdentifier", "StaticDiskUsage", "DynamicDiskUsage"]}
 
 TEMP_REMOTE_BASEDIR = "/PublicStaging/pymobiledevice3"
+APP_STORE_SIGNER_IDENTITIES = {"Apple iPhone OS Application Signing"}
+APP_SUMMARY_KEYS = {
+    "ApplicationType": "application_type",
+    "CFBundleDisplayName": "display_name",
+    "CFBundleIdentifier": "bundle_identifier",
+    "CFBundleName": "name",
+    "CFBundleShortVersionString": "short_version",
+    "CFBundleVersion": "version",
+    "DynamicDiskUsage": "dynamic_disk_usage",
+    "HasSettingsBundle": "has_settings_bundle",
+    "IsAppClip": "is_app_clip",
+    "IsDemotedApp": "is_demoted",
+    "IsPlaceholder": "is_placeholder",
+    "IsUpgradeable": "is_upgradeable",
+    "MinimumOSVersion": "minimum_os_version",
+    "SequenceNumber": "sequence_number",
+    "SignerIdentity": "signer_identity",
+    "StaticDiskUsage": "static_disk_usage",
+    "UIFileSharingEnabled": "file_sharing_enabled",
+}
+APP_PRIVACY_USAGE_KEYS = {
+    "NSAppleMusicUsageDescription": "media_library",
+    "NSBluetoothAlwaysUsageDescription": "bluetooth",
+    "NSBluetoothPeripheralUsageDescription": "bluetooth",
+    "NSCalendarsFullAccessUsageDescription": "calendar",
+    "NSCalendarsUsageDescription": "calendar",
+    "NSCalendarsWriteOnlyAccessUsageDescription": "calendar",
+    "NSCameraUsageDescription": "camera",
+    "NSContactsUsageDescription": "contacts",
+    "NSFaceIDUsageDescription": "face_id",
+    "NSHealthShareUsageDescription": "health",
+    "NSHealthUpdateUsageDescription": "health",
+    "NSHomeKitUsageDescription": "homekit",
+    "NSLocalNetworkUsageDescription": "local_network",
+    "NSLocationAlwaysAndWhenInUseUsageDescription": "location",
+    "NSLocationAlwaysUsageDescription": "location",
+    "NSLocationUsageDescription": "location",
+    "NSLocationWhenInUseUsageDescription": "location",
+    "NSMicrophoneUsageDescription": "microphone",
+    "NSMotionUsageDescription": "motion",
+    "NSPhotoLibraryAddUsageDescription": "photos",
+    "NSPhotoLibraryUsageDescription": "photos",
+    "NSRemindersUsageDescription": "reminders",
+    "NSSiriUsageDescription": "siri",
+    "NSSpeechRecognitionUsageDescription": "speech_recognition",
+}
 
 
 class ZipFileType(Enum):
@@ -510,3 +557,190 @@ class InstallationProxyService(LockdownService):
             for bundle_identifier, app in additional_info.items():
                 result[bundle_identifier].update(app)
         return result
+
+    async def get_apps_audit(
+        self,
+        application_type: str = "Any",
+        calculate_sizes: bool = False,
+        show_placeholders: bool = False,
+    ) -> dict:
+        return self.audit_apps(
+            await self.get_apps(
+                application_type=application_type,
+                calculate_sizes=calculate_sizes,
+                show_placeholders=show_placeholders,
+            )
+        )
+
+    @classmethod
+    def audit_apps(cls, apps: dict[str, dict]) -> dict:
+        application_type_counts: Counter[str] = Counter()
+        background_mode_counts: Counter[str] = Counter()
+        privacy_usage_counts: Counter[str] = Counter()
+        signer_identity_counts: Counter[str] = Counter()
+        findings = []
+        summaries = []
+        flags = {
+            "has_app_clips": False,
+            "has_beta_apps": False,
+            "has_debuggable_apps": False,
+            "has_demoted_apps": False,
+            "has_file_sharing_enabled_apps": False,
+            "has_non_app_store_user_apps": False,
+            "has_placeholder_apps": False,
+            "has_user_apps": False,
+        }
+
+        for fallback_bundle_identifier, app in sorted(apps.items()):
+            summary = cls._app_summary(fallback_bundle_identifier, app)
+            application_type = summary.get("application_type", "<missing>")
+            application_type_counts[application_type] += 1
+            flags["has_user_apps"] = flags["has_user_apps"] or application_type == "User"
+
+            signer_identity = summary.get("signer_identity")
+            if signer_identity is not None:
+                signer_identity_counts[signer_identity] += 1
+
+            background_modes = cls._string_list(app.get("UIBackgroundModes"))
+            if background_modes:
+                summary["background_modes"] = sorted(background_modes)
+                background_mode_counts.update(background_modes)
+
+            privacy_usages = sorted({category for key, category in APP_PRIVACY_USAGE_KEYS.items() if key in app})
+            if privacy_usages:
+                summary["privacy_usage_descriptions"] = privacy_usages
+                privacy_usage_counts.update(privacy_usages)
+
+            url_scheme_count = cls._url_scheme_count(app)
+            if url_scheme_count:
+                summary["url_scheme_count"] = url_scheme_count
+
+            entitlement_summary = cls._entitlement_summary(app.get("Entitlements"))
+            if entitlement_summary:
+                summary["entitlements"] = entitlement_summary
+
+            bundle_identifier = summary["bundle_identifier"]
+            if cls._is_true(app.get("IsPlaceholder")):
+                flags["has_placeholder_apps"] = True
+                findings.append(cls._finding("placeholder", "medium", bundle_identifier, application_type))
+            if cls._is_true(app.get("IsDemotedApp")):
+                flags["has_demoted_apps"] = True
+                findings.append(cls._finding("demoted", "low", bundle_identifier, application_type))
+            if cls._is_true(app.get("IsAppClip")):
+                flags["has_app_clips"] = True
+                findings.append(cls._finding("app_clip", "low", bundle_identifier, application_type))
+            if cls._is_true(app.get("UIFileSharingEnabled")):
+                flags["has_file_sharing_enabled_apps"] = True
+                findings.append(cls._finding("file_sharing_enabled", "low", bundle_identifier, application_type))
+            if cls._is_beta_app(app):
+                flags["has_beta_apps"] = True
+                findings.append(cls._finding("beta", "medium", bundle_identifier, application_type))
+            if cls._is_debuggable(app):
+                flags["has_debuggable_apps"] = True
+                findings.append(cls._finding("debuggable", "high", bundle_identifier, application_type))
+            if cls._is_non_app_store_user_app(summary):
+                flags["has_non_app_store_user_apps"] = True
+                findings.append(cls._finding("non_app_store_signer", "medium", bundle_identifier, application_type))
+
+            summaries.append(summary)
+
+        return {
+            "app_count": len(summaries),
+            "application_types": dict(sorted(application_type_counts.items())),
+            "background_modes": dict(sorted(background_mode_counts.items())),
+            "findings": findings,
+            "flags": flags,
+            "privacy_usage_descriptions": dict(sorted(privacy_usage_counts.items())),
+            "signer_identities": dict(sorted(signer_identity_counts.items())),
+            "apps": summaries,
+        }
+
+    @staticmethod
+    def _app_summary(fallback_bundle_identifier: str, app: dict) -> dict:
+        summary = {
+            output_key: app[source_key] for source_key, output_key in APP_SUMMARY_KEYS.items() if source_key in app
+        }
+        summary.setdefault("bundle_identifier", fallback_bundle_identifier)
+        return summary
+
+    @staticmethod
+    def _entitlement_summary(entitlements: Any) -> dict:
+        if not isinstance(entitlements, dict):
+            return {}
+
+        summary = {}
+        application_groups = InstallationProxyService._string_list(
+            entitlements.get("com.apple.security.application-groups")
+        )
+        associated_domains = InstallationProxyService._string_list(
+            entitlements.get("com.apple.developer.associated-domains")
+        )
+        keychain_access_groups = InstallationProxyService._string_list(entitlements.get("keychain-access-groups"))
+        if application_groups:
+            summary["application_group_count"] = len(application_groups)
+        if associated_domains:
+            summary["associated_domain_count"] = len(associated_domains)
+        if keychain_access_groups:
+            summary["keychain_access_group_count"] = len(keychain_access_groups)
+        if "aps-environment" in entitlements:
+            summary["has_aps_environment"] = True
+        if InstallationProxyService._is_true(entitlements.get("beta-reports-active")):
+            summary["beta_reports_active"] = True
+        if InstallationProxyService._is_true(entitlements.get("get-task-allow")):
+            summary["get_task_allow"] = True
+        return summary
+
+    @staticmethod
+    def _finding(category: str, severity: str, bundle_identifier: str, application_type: str) -> dict:
+        return {
+            "application_type": application_type,
+            "bundle_identifier": bundle_identifier,
+            "category": category,
+            "severity": severity,
+        }
+
+    @staticmethod
+    def _is_true(value: Any) -> bool:
+        if isinstance(value, str):
+            return value.lower() == "true"
+        return value is True
+
+    @staticmethod
+    def _is_beta_app(app: dict) -> bool:
+        entitlements = app.get("Entitlements")
+        beta_reports_active = isinstance(entitlements, dict) and InstallationProxyService._is_true(
+            entitlements.get("beta-reports-active")
+        )
+        return (
+            InstallationProxyService._is_true(app.get("BetaApp"))
+            or InstallationProxyService._is_true(app.get("IsBetaApp"))
+            or beta_reports_active
+        )
+
+    @staticmethod
+    def _is_debuggable(app: dict) -> bool:
+        entitlements = app.get("Entitlements")
+        return isinstance(entitlements, dict) and InstallationProxyService._is_true(entitlements.get("get-task-allow"))
+
+    @staticmethod
+    def _is_non_app_store_user_app(summary: dict) -> bool:
+        return (
+            summary.get("application_type") == "User"
+            and summary.get("signer_identity") is not None
+            and summary["signer_identity"] not in APP_STORE_SIGNER_IDENTITIES
+        )
+
+    @staticmethod
+    def _url_scheme_count(app: dict) -> int:
+        count = 0
+        for url_type in app.get("CFBundleURLTypes") or ():
+            if not isinstance(url_type, dict):
+                continue
+            count += len(InstallationProxyService._string_list(url_type.get("CFBundleURLSchemes")))
+        return count
+
+    @staticmethod
+    def _string_list(value: Any) -> list[str]:
+        if not isinstance(value, list):
+            return []
+        return [item for item in value if isinstance(item, str)]

--- a/tests/services/test_installation_proxy_audit.py
+++ b/tests/services/test_installation_proxy_audit.py
@@ -1,0 +1,163 @@
+from pymobiledevice3.services.installation_proxy import InstallationProxyService
+
+
+def test_apps_audit_empty_response() -> None:
+    audit = InstallationProxyService.audit_apps({})
+
+    assert audit == {
+        "app_count": 0,
+        "application_types": {},
+        "background_modes": {},
+        "findings": [],
+        "flags": {
+            "has_app_clips": False,
+            "has_beta_apps": False,
+            "has_debuggable_apps": False,
+            "has_demoted_apps": False,
+            "has_file_sharing_enabled_apps": False,
+            "has_non_app_store_user_apps": False,
+            "has_placeholder_apps": False,
+            "has_user_apps": False,
+        },
+        "privacy_usage_descriptions": {},
+        "signer_identities": {},
+        "apps": [],
+    }
+
+
+def test_apps_audit_summarizes_apps_without_raw_paths_or_entitlements() -> None:
+    audit = InstallationProxyService.audit_apps({
+        "com.example.store": {
+            "ApplicationType": "User",
+            "CFBundleDisplayName": "Store App",
+            "CFBundleIdentifier": "com.example.store",
+            "CFBundleShortVersionString": "1.2.3",
+            "CFBundleURLTypes": [
+                {
+                    "CFBundleURLName": "example",
+                    "CFBundleURLSchemes": ["storeapp", "storeapp-auth"],
+                },
+            ],
+            "CFBundleVersion": "123",
+            "Container": "/private/var/mobile/Containers/Data/Application/store",
+            "Entitlements": {
+                "application-identifier": "TEAMID.com.example.store",
+                "com.apple.developer.associated-domains": ["applinks:example.invalid"],
+                "com.apple.security.application-groups": ["group.com.example.store"],
+                "keychain-access-groups": ["TEAMID.com.example.store"],
+            },
+            "NSCameraUsageDescription": "camera",
+            "NSLocationWhenInUseUsageDescription": "location",
+            "Path": "/private/var/containers/Bundle/Application/store/Store.app",
+            "SignerIdentity": "Apple iPhone OS Application Signing",
+            "UIBackgroundModes": ["location", "fetch"],
+            "UIFileSharingEnabled": True,
+        },
+        "com.example.enterprise": {
+            "ApplicationType": "User",
+            "CFBundleDisplayName": "Enterprise App",
+            "CFBundleIdentifier": "com.example.enterprise",
+            "Entitlements": {
+                "beta-reports-active": True,
+                "get-task-allow": True,
+            },
+            "IsAppClip": True,
+            "IsDemotedApp": True,
+            "IsPlaceholder": True,
+            "SignerIdentity": "iPhone Distribution: Example Corp",
+        },
+        "com.apple.system": {
+            "ApplicationType": "System",
+            "CFBundleDisplayName": "System App",
+            "CFBundleIdentifier": "com.apple.system",
+        },
+    })
+
+    assert audit["app_count"] == 3
+    assert audit["application_types"] == {"System": 1, "User": 2}
+    assert audit["background_modes"] == {"fetch": 1, "location": 1}
+    assert audit["privacy_usage_descriptions"] == {"camera": 1, "location": 1}
+    assert audit["signer_identities"] == {
+        "Apple iPhone OS Application Signing": 1,
+        "iPhone Distribution: Example Corp": 1,
+    }
+    assert audit["flags"] == {
+        "has_app_clips": True,
+        "has_beta_apps": True,
+        "has_debuggable_apps": True,
+        "has_demoted_apps": True,
+        "has_file_sharing_enabled_apps": True,
+        "has_non_app_store_user_apps": True,
+        "has_placeholder_apps": True,
+        "has_user_apps": True,
+    }
+    assert [finding["category"] for finding in audit["findings"]] == [
+        "placeholder",
+        "demoted",
+        "app_clip",
+        "beta",
+        "debuggable",
+        "non_app_store_signer",
+        "file_sharing_enabled",
+    ]
+    assert audit["apps"] == [
+        {
+            "application_type": "System",
+            "bundle_identifier": "com.apple.system",
+            "display_name": "System App",
+        },
+        {
+            "application_type": "User",
+            "bundle_identifier": "com.example.enterprise",
+            "display_name": "Enterprise App",
+            "entitlements": {
+                "beta_reports_active": True,
+                "get_task_allow": True,
+            },
+            "is_app_clip": True,
+            "is_demoted": True,
+            "is_placeholder": True,
+            "signer_identity": "iPhone Distribution: Example Corp",
+        },
+        {
+            "application_type": "User",
+            "background_modes": ["fetch", "location"],
+            "bundle_identifier": "com.example.store",
+            "display_name": "Store App",
+            "entitlements": {
+                "application_group_count": 1,
+                "associated_domain_count": 1,
+                "keychain_access_group_count": 1,
+            },
+            "file_sharing_enabled": True,
+            "privacy_usage_descriptions": ["camera", "location"],
+            "short_version": "1.2.3",
+            "signer_identity": "Apple iPhone OS Application Signing",
+            "url_scheme_count": 2,
+            "version": "123",
+        },
+    ]
+
+    audit_text = str(audit)
+    assert "/private/var/" not in audit_text
+    assert "TEAMID.com.example.store" not in audit_text
+    assert "applinks:example.invalid" not in audit_text
+    assert "group.com.example.store" not in audit_text
+    assert "storeapp-auth" not in audit_text
+
+
+def test_apps_audit_uses_mapping_key_when_bundle_identifier_is_missing() -> None:
+    audit = InstallationProxyService.audit_apps({
+        "com.example.missing": {
+            "ApplicationType": "User",
+            "CFBundleDisplayName": "Missing Identifier",
+        },
+    })
+
+    assert audit["apps"] == [
+        {
+            "application_type": "User",
+            "bundle_identifier": "com.example.missing",
+            "display_name": "Missing Identifier",
+        },
+    ]


### PR DESCRIPTION
## Summary

Adds a read-only `apps audit` command that summarizes InstallationProxy app metadata as JSON.

The command builds on the existing `get_apps()` lookup path and reports a compact inventory view instead of dumping the full raw app metadata:

- app count and application-type counts
- per-app summaries with bundle ID, display name, versions, app type, signer identity, and selected state flags
- background-mode and privacy usage-description category counts
- signer identity counts
- findings for placeholder, demoted, app clip, file sharing, beta, debuggable, and non-App-Store-signed user apps

## Why

`apps list` is useful for raw inspection, but callers that need a quick app posture check currently have to parse the full InstallationProxy response themselves. This adds a stable service-level summary that keeps protocol handling in `InstallationProxyService` and gives CLI users a direct, machine-readable command for app inventory review.

The output intentionally summarizes sensitive or noisy metadata. It counts URL schemes, associated domains, application groups, and keychain groups instead of copying their raw values. It also excludes raw app paths, containers, and full entitlement dictionaries from the audit output.

## Implementation details

- Adds `InstallationProxyService.get_apps_audit()` for device-backed audit collection.
- Adds `InstallationProxyService.audit_apps()` as a pure converter for InstallationProxy lookup responses.
- Adds `pymobiledevice3 apps audit` with the existing application type filter plus `--calculate-sizes` and `--show-placeholders` options.
- Adds summary helpers for privacy usage-description categories, background modes, URL-scheme counts, and entitlement counts.
- Adds a CLI recipe entry for the new command.

## Validation

- `python -m pytest -q tests/services/test_installation_proxy_audit.py`
- `python -m pytest -q tests/services/test_installation_proxy_audit.py tests/cli/test_cli.py`
- `python -m ruff check pymobiledevice3/services/installation_proxy.py pymobiledevice3/cli/apps.py tests/services/test_installation_proxy_audit.py`
- `python -m ruff format --check pymobiledevice3/services/installation_proxy.py pymobiledevice3/cli/apps.py tests/services/test_installation_proxy_audit.py`
- `python3 -m py_compile pymobiledevice3/services/installation_proxy.py pymobiledevice3/cli/apps.py tests/services/test_installation_proxy_audit.py`
- `git diff --check`

Live validation was also run against a connected unlocked device:

- `python -m pymobiledevice3 apps audit --type User --show-placeholders`
- `python -m pymobiledevice3 apps audit --type User`

Both commands completed successfully. The tested device returned three user apps, all App Store signed, no findings, and all debug/beta/non-App-Store/placeholder/app-clip/demoted/file-sharing flags set to `false`.