### PR TITLE
acquisition: add artifact manifest command

### DIFF
--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -32,6 +32,9 @@ pymobiledevice3 diagnostics restart
 
 # Pull crash reports
 pymobiledevice3 crash pull /path/to/crashes
+
+# Create a JSON manifest for collected artifacts
+pymobiledevice3 acquisition manifest /path/to/backup /path/to/crashes --output manifest.json
 ```
 
 ## Files, Apps, and Backup

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -98,6 +98,7 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"], "max_content_width": 
 # Mapping of index options to import file names
 CLI_GROUPS = {
     "activation": "activation",
+    "acquisition": "acquisition",
     "afc": "afc",
     "amfi": "amfi",
     "apps": "apps",

--- a/pymobiledevice3/acquisition.py
+++ b/pymobiledevice3/acquisition.py
@@ -1,0 +1,159 @@
+import datetime
+import hashlib
+from pathlib import Path
+from typing import Any, Optional
+
+MANIFEST_SCHEMA_VERSION = 1
+DIRECTORY_DIGEST_ALGORITHM = "sha256-relative-path-manifest-v1"
+BACKUP_MARKER_FILES = {"Info.plist", "Manifest.plist", "Status.plist"}
+DEVICE_CONTEXT_KEYS = {
+    "BuildVersion": "build_version",
+    "DeviceClass": "device_class",
+    "ProductType": "product_type",
+    "ProductVersion": "product_version",
+}
+DEVICE_IDENTIFIER_KEYS = {
+    "DeviceName": "device_name",
+    "SerialNumber": "serial_number",
+    "UniqueChipID": "unique_chip_id",
+    "UniqueDeviceID": "unique_device_id",
+}
+
+
+def build_acquisition_manifest(
+    artifacts: list[Path],
+    *,
+    device: Optional[dict] = None,
+    hash_files: bool = True,
+) -> dict:
+    manifest = {
+        "artifacts": [summarize_artifact(artifact, hash_files=hash_files) for artifact in artifacts],
+        "generated_at": _utc_now(),
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+    }
+    if device is not None:
+        manifest["device"] = device
+    return manifest
+
+
+def build_device_context(values: dict[str, Any], *, include_identifiers: bool = False) -> dict:
+    context = _copy_selected_keys(values, DEVICE_CONTEXT_KEYS)
+    if include_identifiers:
+        context.update(_copy_selected_keys(values, DEVICE_IDENTIFIER_KEYS))
+    return context
+
+
+def summarize_artifact(path: Path, *, hash_files: bool = True) -> dict:
+    resolved_path = path.expanduser()
+    if resolved_path.is_dir():
+        return _summarize_directory(resolved_path, hash_files=hash_files)
+    return _summarize_file(resolved_path, hash_file=hash_files)
+
+
+def classify_artifact(path: Path) -> str:
+    if path.is_dir():
+        if _is_itunes_backup(path):
+            return "itunes_backup"
+        if any(child.is_dir() and _is_itunes_backup(child) for child in path.iterdir()):
+            return "itunes_backup_root"
+        return "directory"
+
+    suffixes = [suffix.lower() for suffix in path.suffixes]
+    name = path.name.lower()
+    if any(suffix in {".crash", ".ips", ".panic"} for suffix in suffixes):
+        return "crash_report"
+    if "sysdiagnose" in name and suffixes:
+        return "sysdiagnose_archive"
+    if path.suffix.lower() == ".plist":
+        return "plist"
+    return "file"
+
+
+def _summarize_file(path: Path, *, hash_file: bool) -> dict:
+    stat = path.stat()
+    summary = {
+        "kind": classify_artifact(path),
+        "modified_at": _timestamp(stat.st_mtime),
+        "name": path.name,
+        "path": str(path),
+        "size": stat.st_size,
+        "type": "file",
+    }
+    if hash_file:
+        summary["sha256"] = _hash_file(path)
+    return summary
+
+
+def _summarize_directory(path: Path, *, hash_files: bool) -> dict:
+    stat = path.stat()
+    file_count = 0
+    directory_count = 0
+    total_size = 0
+    digest = hashlib.sha256()
+
+    for child in _iter_directory(path):
+        relative_path = child.relative_to(path).as_posix()
+        if child.is_dir():
+            directory_count += 1
+            if hash_files:
+                digest.update(b"D\0")
+                digest.update(relative_path.encode())
+                digest.update(b"\0")
+            continue
+
+        file_count += 1
+        child_stat = child.stat()
+        total_size += child_stat.st_size
+        if not hash_files:
+            continue
+        file_hash = _hash_file(child)
+        digest.update(b"F\0")
+        digest.update(relative_path.encode())
+        digest.update(b"\0")
+        digest.update(str(child_stat.st_size).encode())
+        digest.update(b"\0")
+        digest.update(file_hash.encode())
+        digest.update(b"\0")
+
+    summary = {
+        "directory_count": directory_count,
+        "file_count": file_count,
+        "kind": classify_artifact(path),
+        "modified_at": _timestamp(stat.st_mtime),
+        "name": path.name,
+        "path": str(path),
+        "total_size": total_size,
+        "type": "directory",
+    }
+    if hash_files:
+        summary["digest_algorithm"] = DIRECTORY_DIGEST_ALGORITHM
+        summary["sha256"] = digest.hexdigest()
+    return summary
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as infile:
+        while chunk := infile.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _iter_directory(path: Path):
+    yield from sorted(path.rglob("*"), key=lambda child: child.relative_to(path).as_posix())
+
+
+def _is_itunes_backup(path: Path) -> bool:
+    return all((path / marker).is_file() for marker in BACKUP_MARKER_FILES)
+
+
+def _copy_selected_keys(values: dict[str, Any], keys: dict[str, str]) -> dict:
+    return {output_key: values[source_key] for source_key, output_key in keys.items() if source_key in values}
+
+
+def _timestamp(timestamp: float) -> str:
+    return datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).isoformat()
+
+
+def _utc_now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()

--- a/pymobiledevice3/cli/acquisition.py
+++ b/pymobiledevice3/cli/acquisition.py
@@ -1,0 +1,82 @@
+import json
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+from typer_injector import InjectingTyper
+
+from pymobiledevice3.acquisition import build_acquisition_manifest, build_device_context
+from pymobiledevice3.cli.cli_common import UDID_ENV_VAR, async_command, print_json
+from pymobiledevice3.lockdown import create_using_usbmux
+
+cli = InjectingTyper(
+    name="acquisition",
+    help="Create acquisition metadata for collected artifacts.",
+    no_args_is_help=True,
+)
+
+
+@cli.callback()
+def acquisition() -> None:
+    """Create acquisition metadata for collected artifacts."""
+
+
+@cli.command("manifest")
+@async_command
+async def acquisition_manifest(
+    artifacts: Annotated[
+        list[Path],
+        typer.Argument(
+            exists=True,
+            file_okay=True,
+            dir_okay=True,
+            readable=True,
+            resolve_path=True,
+            help="Files or directories to include in the manifest.",
+        ),
+    ],
+    output: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--output",
+            "-o",
+            dir_okay=False,
+            writable=True,
+            help="Write manifest JSON to a file instead of stdout.",
+        ),
+    ] = None,
+    include_device: Annotated[
+        bool,
+        typer.Option(help="Include non-identifying Lockdown device context from the connected USB device."),
+    ] = False,
+    include_identifiers: Annotated[
+        bool,
+        typer.Option(help="Include device identifiers such as UDID, serial number, ECID, and device name."),
+    ] = False,
+    udid: Annotated[
+        Optional[str],
+        typer.Option(
+            "--udid",
+            envvar=UDID_ENV_VAR,
+            help="Target USB device UDID when including device context.",
+        ),
+    ] = None,
+    hash_files: Annotated[
+        bool,
+        typer.Option(
+            "--hash/--no-hash",
+            help="Compute SHA-256 hashes for files and deterministic directory digests.",
+        ),
+    ] = True,
+) -> None:
+    """Create a JSON manifest for local acquisition artifacts."""
+    device = None
+    if include_device or include_identifiers:
+        async with await create_using_usbmux(serial=udid) as lockdown:
+            device = build_device_context(lockdown.all_values, include_identifiers=include_identifiers)
+
+    manifest = build_acquisition_manifest(artifacts, device=device, hash_files=hash_files)
+    if output is None:
+        print_json(manifest)
+    else:
+        output.write_text(json.dumps(manifest, sort_keys=True, indent=4) + "\n")

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,0 +1,110 @@
+import hashlib
+
+from pymobiledevice3.acquisition import (
+    DIRECTORY_DIGEST_ALGORITHM,
+    build_acquisition_manifest,
+    build_device_context,
+    classify_artifact,
+)
+
+
+def test_build_acquisition_manifest_summarizes_files_and_directories(tmp_path) -> None:
+    file_path = tmp_path / "note.txt"
+    file_path.write_bytes(b"hello")
+    directory = tmp_path / "collection"
+    directory.mkdir()
+    nested = directory / "nested"
+    nested.mkdir()
+    (nested / "data.bin").write_bytes(b"abc")
+
+    manifest = build_acquisition_manifest([file_path, directory])
+
+    assert manifest["schema_version"] == 1
+    assert "generated_at" in manifest
+    assert manifest["artifacts"][0] == {
+        "kind": "file",
+        "modified_at": manifest["artifacts"][0]["modified_at"],
+        "name": "note.txt",
+        "path": str(file_path),
+        "sha256": hashlib.sha256(b"hello").hexdigest(),
+        "size": 5,
+        "type": "file",
+    }
+    assert manifest["artifacts"][1] == {
+        "digest_algorithm": DIRECTORY_DIGEST_ALGORITHM,
+        "directory_count": 1,
+        "file_count": 1,
+        "kind": "directory",
+        "modified_at": manifest["artifacts"][1]["modified_at"],
+        "name": "collection",
+        "path": str(directory),
+        "sha256": manifest["artifacts"][1]["sha256"],
+        "total_size": 3,
+        "type": "directory",
+    }
+
+
+def test_build_acquisition_manifest_can_skip_hashes(tmp_path) -> None:
+    file_path = tmp_path / "note.txt"
+    file_path.write_bytes(b"hello")
+    directory = tmp_path / "collection"
+    directory.mkdir()
+    (directory / "data.bin").write_bytes(b"abc")
+
+    manifest = build_acquisition_manifest([file_path, directory], hash_files=False)
+
+    assert "sha256" not in manifest["artifacts"][0]
+    assert "sha256" not in manifest["artifacts"][1]
+    assert "digest_algorithm" not in manifest["artifacts"][1]
+
+
+def test_classify_artifact_detects_common_acquisition_artifacts(tmp_path) -> None:
+    backup = tmp_path / "backup"
+    backup.mkdir()
+    for marker in ("Info.plist", "Manifest.plist", "Status.plist"):
+        (backup / marker).write_bytes(b"")
+    backup_root = tmp_path / "backup-root"
+    backup_root.mkdir()
+    nested_backup = backup_root / "device-udid"
+    nested_backup.mkdir()
+    for marker in ("Info.plist", "Manifest.plist", "Status.plist"):
+        (nested_backup / marker).write_bytes(b"")
+    crash = tmp_path / "panic-full.ips"
+    crash.write_text("{}")
+    sysdiagnose = tmp_path / "sysdiagnose_2026.tar.gz"
+    sysdiagnose.write_bytes(b"archive")
+
+    assert classify_artifact(backup) == "itunes_backup"
+    assert classify_artifact(backup_root) == "itunes_backup_root"
+    assert classify_artifact(crash) == "crash_report"
+    assert classify_artifact(sysdiagnose) == "sysdiagnose_archive"
+
+
+def test_build_device_context_redacts_identifiers_by_default() -> None:
+    values = {
+        "BuildVersion": "23A000",
+        "DeviceClass": "iPhone",
+        "DeviceName": "Example iPhone",
+        "ProductType": "iPhone99,9",
+        "ProductVersion": "26.0",
+        "SerialNumber": "SERIAL",
+        "UniqueChipID": 123,
+        "UniqueDeviceID": "UDID",
+    }
+
+    assert build_device_context(values) == {
+        "build_version": "23A000",
+        "device_class": "iPhone",
+        "product_type": "iPhone99,9",
+        "product_version": "26.0",
+    }
+    assert build_device_context(values, include_identifiers=True) == {
+        "build_version": "23A000",
+        "device_class": "iPhone",
+        "device_name": "Example iPhone",
+        "product_type": "iPhone99,9",
+        "product_version": "26.0",
+        "serial_number": "SERIAL",
+        "unique_chip_id": 123,
+        "unique_device_id": "UDID",
+    }


### PR DESCRIPTION
## Summary

Adds a read-only `acquisition manifest` command for exporting a normalized JSON manifest for locally collected artifacts.

The command can summarize files and directories with:

- artifact path, name, type, and inferred kind
- file size and SHA-256 hash
- directory file count, directory count, total size, and deterministic directory digest
- generated timestamp and schema version
- optional non-identifying connected-device context

## Why

Several CLI workflows produce local artifacts such as backups, crash reports, sysdiagnose archives, and other copied files. Callers currently have to build their own manifest if they want a stable handoff record for what was collected. This adds a small, reusable manifest generator that works offline for already collected artifacts and can optionally include live Lockdown context when a device is connected.

Device identifiers are not included by default. `--include-device` only adds non-identifying context such as build version, device class, product type, and product version. `--include-identifiers` is explicit for workflows that require UDID, serial number, ECID, or device name.

## Implementation details

- Adds `pymobiledevice3.acquisition` with pure helpers for artifact classification and manifest generation.
- Adds the new `pymobiledevice3 acquisition manifest` CLI group/command.
- Registers the `acquisition` group in the top-level command map.
- Supports `--output` for writing JSON to a file, otherwise prints JSON to stdout.
- Supports `--hash/--no-hash` for hash cost control.
- Detects common artifact kinds such as iTunes backup directories, backup roots, crash reports, sysdiagnose archives, and plist files.
- Computes directory digests from sorted relative path entries and file hashes so output is deterministic.
- Adds a CLI recipe entry for the new command.

## Validation

- `python -m pytest -q tests/test_acquisition.py`
- `python -m pytest -q tests/test_acquisition.py tests/cli/test_cli.py`
- `python -m ruff check pymobiledevice3/acquisition.py pymobiledevice3/cli/acquisition.py tests/test_acquisition.py pymobiledevice3/__main__.py`
- `python -m ruff format --check pymobiledevice3/acquisition.py pymobiledevice3/cli/acquisition.py tests/test_acquisition.py pymobiledevice3/__main__.py`
- `python3 -m py_compile pymobiledevice3/acquisition.py pymobiledevice3/cli/acquisition.py tests/test_acquisition.py pymobiledevice3/__main__.py`
- `git diff --check`

CLI validation:

- `python -m pymobiledevice3 acquisition --help`
- `python -m pymobiledevice3 acquisition manifest --help`
- `python -m pymobiledevice3 acquisition manifest pyproject.toml docs/guides/cli-recipes.md --output /tmp/pmd3-acquisition-manifest.json`

Live validation was also run against a connected unlocked device:

- `python -m pymobiledevice3 acquisition manifest pyproject.toml --include-device --output /tmp/pmd3-acquisition-manifest-device.json`

The live command completed successfully and included only non-identifying device context by default.