### PR TITLE
crash: add sysdiagnose result summary

### DIFF
--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -32,6 +32,9 @@ pymobiledevice3 diagnostics restart
 
 # Pull crash reports
 pymobiledevice3 crash pull /path/to/crashes
+
+# Pull a sysdiagnose archive and print a JSON result summary
+pymobiledevice3 crash sysdiagnose /path/to/sysdiagnose.tar.gz --json
 ```
 
 ## Files, Apps, and Backup

--- a/pymobiledevice3/cli/crash.py
+++ b/pymobiledevice3/cli/crash.py
@@ -4,7 +4,7 @@ from typing import Annotated, Optional
 import typer
 from typer_injector import InjectingTyper
 
-from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command
+from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command, print_json
 from pymobiledevice3.services.crash_reports import CrashReportsManager, CrashReportsShell
 
 cli = InjectingTyper(
@@ -186,8 +186,17 @@ async def crash_sysdiagnose(
             help="Maximum time in seconds to wait for the completion of sysdiagnose archive",
         ),
     ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help="Print a JSON summary with remote path, local artifact metadata, and stage durations.",
+        ),
+    ] = False,
 ) -> None:
     """get a sysdiagnose archive from device (requires user interaction)"""
     print("Press Power+VolUp+VolDown for 0.215 seconds")
     async with CrashReportsManager(service_provider) as crash_manager:
-        await crash_manager.get_new_sysdiagnose(str(out), erase=erase, timeout=timeout)
+        result = await crash_manager.get_new_sysdiagnose(str(out), erase=erase, timeout=timeout)
+        if json_output:
+            print_json(result)

--- a/pymobiledevice3/services/crash_reports.py
+++ b/pymobiledevice3/services/crash_reports.py
@@ -1,10 +1,12 @@
 import asyncio
+import datetime
 import logging
 import posixpath
 import re
 import time
 from collections.abc import AsyncGenerator
 from json import JSONDecodeError
+from pathlib import Path
 from typing import Callable, ClassVar, Optional
 
 from pycrashreport.crash_report import CrashReportBase, get_crash_report_from_buf
@@ -29,6 +31,9 @@ SYSDIAGNOSE_IN_PROGRESS_MAX_TTL_SECS = 600
 
 # on iOS17, we need to wait for a moment before trying to fetch the sysdiagnose archive
 IOS17_SYSDIAGNOSE_DELAY = 3
+SYSDIAGNOSE_STAGE_DETECTING_ARCHIVE = "detecting_archive"
+SYSDIAGNOSE_STAGE_WAITING_FOR_COMPLETION = "waiting_for_completion"
+SYSDIAGNOSE_STAGE_PULLING_ARCHIVE = "pulling_archive"
 
 
 class CrashReportsManager:
@@ -237,7 +242,7 @@ class CrashReportsManager:
         *,
         timeout: Optional[float] = None,
         callback: Optional[Callable[[float], None]] = None,
-    ) -> None:
+    ) -> dict:
         """
         Monitor the creation of a newly created sysdiagnose archive and pull it
         :param out: filename
@@ -250,21 +255,54 @@ class CrashReportsManager:
         end_time = None
         if timeout is not None:
             end_time = start_time + timeout
-        sysdiagnose_filename = await self._get_new_sysdiagnose_filename(end_time)
+        stage_started_at = start_time
+        stage_durations = {}
+        timeout_phase = SYSDIAGNOSE_STAGE_DETECTING_ARCHIVE
+
+        try:
+            sysdiagnose_filename = await self._get_new_sysdiagnose_filename(end_time)
+            stage_started_at = self._record_sysdiagnose_stage_duration(
+                stage_durations, SYSDIAGNOSE_STAGE_DETECTING_ARCHIVE, stage_started_at
+            )
+
+            if callback is not None:
+                callback(time.monotonic() - start_time)
+
+            self.logger.info("sysdiagnose tarball creation has been started")
+            timeout_phase = SYSDIAGNOSE_STAGE_WAITING_FOR_COMPLETION
+            await self._wait_for_sysdiagnose_to_finish(timeout)
+            stage_started_at = self._record_sysdiagnose_stage_duration(
+                stage_durations, SYSDIAGNOSE_STAGE_WAITING_FOR_COMPLETION, stage_started_at
+            )
+
+            if callback is not None:
+                callback(time.monotonic() - start_time)
+
+            timeout_phase = SYSDIAGNOSE_STAGE_PULLING_ARCHIVE
+            await self.pull(out, entry=sysdiagnose_filename, erase=erase)
+            self._record_sysdiagnose_stage_duration(
+                stage_durations, SYSDIAGNOSE_STAGE_PULLING_ARCHIVE, stage_started_at
+            )
+        except SysdiagnoseTimeoutError as e:
+            e.phase = timeout_phase
+            raise
 
         if callback is not None:
             callback(time.monotonic() - start_time)
 
-        self.logger.info("sysdiagnose tarball creation has been started")
-        await self._wait_for_sysdiagnose_to_finish(timeout)
-
-        if callback is not None:
-            callback(time.monotonic() - start_time)
-
-        await self.pull(out, entry=sysdiagnose_filename, erase=erase)
-
-        if callback is not None:
-            callback(time.monotonic() - start_time)
+        local_path = self._resolve_local_pull_path(out, sysdiagnose_filename)
+        return {
+            "artifact": self._local_file_metadata(local_path),
+            "duration": round(time.monotonic() - start_time, 3),
+            "erase": erase,
+            "remote_path": sysdiagnose_filename,
+            "stages": stage_durations,
+            "status": "completed",
+            "timeout": {
+                "phase": None,
+                "seconds": timeout,
+            },
+        }
 
     async def _wait_for_sysdiagnose_to_finish(self, end_time: Optional[float] = None) -> None:
         async with NotificationProxyService(self.lockdown, timeout=end_time) as service:
@@ -314,6 +352,29 @@ class CrashReportsManager:
 
     def _check_timeout(self, end_time: Optional[float] = None) -> bool:
         return end_time is not None and time.monotonic() > end_time
+
+    @staticmethod
+    def _record_sysdiagnose_stage_duration(stage_durations: dict, stage_name: str, stage_started_at: float) -> float:
+        now = time.monotonic()
+        stage_durations[stage_name] = round(now - stage_started_at, 3)
+        return now
+
+    @staticmethod
+    def _resolve_local_pull_path(out: str, remote_path: str) -> Path:
+        local_path = Path(out)
+        if local_path.is_dir():
+            return local_path / posixpath.basename(remote_path)
+        return local_path
+
+    @staticmethod
+    def _local_file_metadata(path: Path) -> dict:
+        stat = path.stat()
+        return {
+            "modified_at": datetime.datetime.fromtimestamp(stat.st_mtime, datetime.timezone.utc).isoformat(),
+            "name": path.name,
+            "path": str(path),
+            "size": stat.st_size,
+        }
 
 
 class CrashReportsShell(AfcShell):

--- a/tests/services/test_crash_reports.py
+++ b/tests/services/test_crash_reports.py
@@ -5,13 +5,20 @@ from datetime import datetime, timezone
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Optional
+from unittest.mock import Mock
 
 import pytest
 import pytest_asyncio
 
-from pymobiledevice3.exceptions import AfcFileNotFoundError
+from pymobiledevice3.exceptions import AfcFileNotFoundError, SysdiagnoseTimeoutError
 from pymobiledevice3.lockdown import LockdownClient
-from pymobiledevice3.services.crash_reports import CrashReportsManager
+from pymobiledevice3.services import crash_reports as crash_reports_module
+from pymobiledevice3.services.crash_reports import (
+    SYSDIAGNOSE_STAGE_DETECTING_ARCHIVE,
+    SYSDIAGNOSE_STAGE_PULLING_ARCHIVE,
+    SYSDIAGNOSE_STAGE_WAITING_FOR_COMPLETION,
+    CrashReportsManager,
+)
 
 BASENAME = "__pymobiledevice3_tests"
 PATH_COMPONENT = f"/{BASENAME}"
@@ -58,6 +65,14 @@ def _nested_paths(root: str, depth: int) -> list[str]:
     for _ in range(1, depth):
         paths.append(posixpath.join(paths[-1], BASENAME))
     return paths
+
+
+class FakeTime:
+    def __init__(self, monotonic_values: list[float]) -> None:
+        self.monotonic_values = iter(monotonic_values)
+
+    def monotonic(self) -> float:
+        return next(self.monotonic_values)
 
 
 async def test_ls_default(crash_manager: CrashReportsManager, remote_temp_directory: str) -> None:
@@ -315,3 +330,104 @@ async def test_parse_latest_no_matches(
 
     with pytest.raises(ValueError):
         await crash_manager.parse_latest(path=remote_temp_directory, match=match, match_insensitive=match_insensitive)
+
+
+async def test_get_new_sysdiagnose_returns_summary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    crash_manager = CrashReportsManager(Mock())
+    remote_path = "DiagnosticLogs/sysdiagnose/sysdiagnose_test.tar.gz"
+
+    monkeypatch.setattr(crash_reports_module, "time", FakeTime([10.0, 10.5, 14.0, 15.25, 15.3]))
+
+    async def get_new_sysdiagnose_filename(end_time: float) -> str:
+        assert end_time == 70.0
+        return remote_path
+
+    async def wait_for_sysdiagnose_to_finish(timeout: float) -> None:
+        assert timeout == 60.0
+
+    async def pull(out: str, entry: str = "/", erase: bool = False, **_: object) -> None:
+        assert entry == remote_path
+        assert erase is False
+        (Path(out) / posixpath.basename(remote_path)).write_bytes(b"sysdiagnose")
+
+    monkeypatch.setattr(crash_manager, "_get_new_sysdiagnose_filename", get_new_sysdiagnose_filename)
+    monkeypatch.setattr(crash_manager, "_wait_for_sysdiagnose_to_finish", wait_for_sysdiagnose_to_finish)
+    monkeypatch.setattr(crash_manager, "pull", pull)
+
+    result = await crash_manager.get_new_sysdiagnose(str(tmp_path), erase=False, timeout=60.0)
+
+    artifact_path = tmp_path / posixpath.basename(remote_path)
+    assert result == {
+        "artifact": {
+            "modified_at": result["artifact"]["modified_at"],
+            "name": artifact_path.name,
+            "path": str(artifact_path),
+            "size": len(b"sysdiagnose"),
+        },
+        "duration": 5.3,
+        "erase": False,
+        "remote_path": remote_path,
+        "stages": {
+            SYSDIAGNOSE_STAGE_DETECTING_ARCHIVE: 0.5,
+            SYSDIAGNOSE_STAGE_WAITING_FOR_COMPLETION: 3.5,
+            SYSDIAGNOSE_STAGE_PULLING_ARCHIVE: 1.25,
+        },
+        "status": "completed",
+        "timeout": {
+            "phase": None,
+            "seconds": 60.0,
+        },
+    }
+    assert result["artifact"]["modified_at"].endswith("+00:00")
+
+
+async def test_get_new_sysdiagnose_annotates_detect_timeout_phase(monkeypatch: pytest.MonkeyPatch) -> None:
+    crash_manager = CrashReportsManager(Mock())
+
+    async def get_new_sysdiagnose_filename(end_time: float) -> str:
+        raise SysdiagnoseTimeoutError("Timeout finding in-progress sysdiagnose filename")
+
+    monkeypatch.setattr(crash_manager, "_get_new_sysdiagnose_filename", get_new_sysdiagnose_filename)
+
+    with pytest.raises(SysdiagnoseTimeoutError) as exc_info:
+        await crash_manager.get_new_sysdiagnose("unused", timeout=1.0)
+
+    assert exc_info.value.phase == SYSDIAGNOSE_STAGE_DETECTING_ARCHIVE
+
+
+async def test_get_new_sysdiagnose_annotates_wait_timeout_phase(monkeypatch: pytest.MonkeyPatch) -> None:
+    crash_manager = CrashReportsManager(Mock())
+    remote_path = "DiagnosticLogs/sysdiagnose/sysdiagnose_test.tar.gz"
+
+    monkeypatch.setattr(crash_reports_module, "time", FakeTime([10.0, 10.5]))
+
+    async def get_new_sysdiagnose_filename(end_time: float) -> str:
+        return remote_path
+
+    async def wait_for_sysdiagnose_to_finish(timeout: float) -> None:
+        raise SysdiagnoseTimeoutError("Timeout waiting for sysdiagnose completion")
+
+    monkeypatch.setattr(crash_manager, "_get_new_sysdiagnose_filename", get_new_sysdiagnose_filename)
+    monkeypatch.setattr(crash_manager, "_wait_for_sysdiagnose_to_finish", wait_for_sysdiagnose_to_finish)
+
+    with pytest.raises(SysdiagnoseTimeoutError) as exc_info:
+        await crash_manager.get_new_sysdiagnose("unused", timeout=60.0)
+
+    assert exc_info.value.phase == SYSDIAGNOSE_STAGE_WAITING_FOR_COMPLETION
+
+
+def test_resolve_local_pull_path_uses_directory_basename(tmp_path: Path) -> None:
+    assert CrashReportsManager._resolve_local_pull_path(
+        str(tmp_path), "DiagnosticLogs/sysdiagnose/sysdiagnose_test.tar.gz"
+    ) == (tmp_path / "sysdiagnose_test.tar.gz")
+
+
+def test_resolve_local_pull_path_keeps_file_destination(tmp_path: Path) -> None:
+    output_path = tmp_path / "custom.tar.gz"
+
+    assert (
+        CrashReportsManager._resolve_local_pull_path(
+            str(output_path), "DiagnosticLogs/sysdiagnose/sysdiagnose_test.tar.gz"
+        )
+        == output_path
+    )


### PR DESCRIPTION
## Summary

Adds an optional machine-readable result summary for `crash sysdiagnose`.

`CrashReportsManager.get_new_sysdiagnose()` now returns structured details about the collected archive, and the CLI exposes those details through `crash sysdiagnose --json` while preserving the existing default output.

## Why

Sysdiagnose collection is a multi-stage operation: the tool detects the newly created in-progress archive, waits for device-side completion, then pulls the final tarball. Before this change, callers only received progress/log output and the service method returned `None`, so automation could not reliably record which archive was collected, where it was written locally, or how long each stage took.

The JSON summary gives scripts and forensic workflows a stable completion record without changing the existing human-readable command behavior.

## What Changed

- Added stage constants for sysdiagnose collection phases.
- Updated `CrashReportsManager.get_new_sysdiagnose()` to return a structured summary containing:
  - completion status
  - remote sysdiagnose path
  - local artifact path, name, size, and UTC modification time
  - erase flag
  - timeout request metadata
  - total duration
  - per-stage durations for archive detection, completion wait, and archive pull
- Added local path resolution that follows AFC pull behavior: existing directories receive the remote basename, while non-directory destinations are treated as explicit file paths.
- Annotated `SysdiagnoseTimeoutError` instances with the phase active at the time of timeout.
- Added `crash sysdiagnose --json` to print the returned summary with `print_json()`.
- Documented the new command in the CLI recipes.
- Added focused unit coverage for summary generation, timeout phase annotation, and local artifact path resolution.

## Validation

Local checks:

```text
PYTHONPATH=. .venv/bin/python -m pytest -q \
  tests/services/test_crash_reports.py::test_get_new_sysdiagnose_returns_summary \
  tests/services/test_crash_reports.py::test_get_new_sysdiagnose_annotates_detect_timeout_phase \
  tests/services/test_crash_reports.py::test_get_new_sysdiagnose_annotates_wait_timeout_phase \
  tests/services/test_crash_reports.py::test_resolve_local_pull_path_uses_directory_basename \
  tests/services/test_crash_reports.py::test_resolve_local_pull_path_keeps_file_destination
# 5 passed

PYTHONPATH=. .venv/bin/python -m ruff check \
  pymobiledevice3/services/crash_reports.py \
  pymobiledevice3/cli/crash.py \
  tests/services/test_crash_reports.py
# All checks passed

PYTHONPATH=. .venv/bin/python -m ruff format --check \
  pymobiledevice3/services/crash_reports.py \
  pymobiledevice3/cli/crash.py \
  tests/services/test_crash_reports.py \
  docs/guides/cli-recipes.md
# 4 files already formatted

PYTHONPATH=. .venv/bin/python -m py_compile \
  pymobiledevice3/services/crash_reports.py \
  pymobiledevice3/cli/crash.py \
  tests/services/test_crash_reports.py
# no errors

git diff --check
# no whitespace errors

PYTHONPATH=. .venv/bin/python -m pymobiledevice3 crash sysdiagnose --help
# confirmed --json appears in command help
```

Live USB validation was performed against a connected iPhone with:

```text
PYTHONPATH=. .venv/bin/python -m pymobiledevice3 crash sysdiagnose /data/iphone/analysis/sysdiagnose_summary_live --json
```

The command detected the in-progress sysdiagnose archive, registered for `com.apple.sysdiagnose.sysdiagnoseStopped`, waited for completion, pulled the final archive successfully, and exited with code 0. The emitted JSON included `status: completed`, the remote archive path, local artifact metadata, total duration, and all three stage timing fields.