### PR TITLE
core-device: add user-interface-style (dark/light) get + set

### DIFF
--- a/pymobiledevice3/cli/developer/core_device.py
+++ b/pymobiledevice3/cli/developer/core_device.py
@@ -13,6 +13,7 @@ from typer_injector import InjectingTyper
 from pymobiledevice3.cli.cli_common import RSDServiceProviderDep, async_command, print_json
 from pymobiledevice3.lockdown import create_using_usbmux
 from pymobiledevice3.remote.core_device.app_service import AppServiceService
+from pymobiledevice3.remote.core_device.configuration_service import ConfigurationService
 from pymobiledevice3.remote.core_device.device_info import DeviceInfoService
 from pymobiledevice3.remote.core_device.diagnostics_service import DiagnosticsServiceService
 from pymobiledevice3.remote.core_device.display_service import DisplayService
@@ -282,6 +283,20 @@ async def core_device_get_lockstate_task(service_provider: RemoteServiceDiscover
 async def core_device_get_lockstate(service_provider: RSDServiceProviderDep) -> None:
     """Get lockstate"""
     await core_device_get_lockstate_task(service_provider)
+
+
+@cli.command("user-interface-style")
+@async_command
+async def core_device_user_interface_style(
+    service_provider: RSDServiceProviderDep,
+    style: Annotated[Optional[str], typer.Argument(click_type=click.Choice(["dark", "light"]))] = None,
+) -> None:
+    """Get the active user-interface style; pass dark/light to set it."""
+    async with ConfigurationService(service_provider) as config:
+        if style is None:
+            print_json(await config.get_user_interface_style())
+        else:
+            await config.set_user_interface_style(style)
 
 
 async def core_device_list_apps_task(service_provider: RemoteServiceDiscoveryService) -> None:

--- a/pymobiledevice3/remote/core_device/configuration_service.py
+++ b/pymobiledevice3/remote/core_device/configuration_service.py
@@ -1,0 +1,36 @@
+from pymobiledevice3.remote.core_device.core_device_service import CoreDeviceService
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+
+
+class ConfigurationService(CoreDeviceService):
+    """
+    Read and write device configuration knobs exposed over CoreDevice
+    (currently: user-interface style — i.e. dark / light mode).
+    """
+
+    SERVICE_NAME = "com.apple.coredevice.configuration"
+
+    def __init__(self, rsd: RemoteServiceDiscoveryService):
+        super().__init__(rsd, self.SERVICE_NAME)
+
+    async def get_user_interface_style(self) -> str:
+        """
+        Get the active user-interface style of the device.
+
+        :return: ``"dark"`` or ``"light"``.
+        """
+        output = await self.invoke(action_identifier="com.apple.coredevice.action.getuserinterfacestyle")
+        return output["style"]
+
+    async def set_user_interface_style(self, style: str) -> None:
+        """
+        Set the device's user-interface style.
+
+        :param style: ``"dark"`` or ``"light"``.
+        """
+        if style not in ("dark", "light"):
+            raise ValueError(f"style must be 'dark' or 'light', got {style!r}")
+        await self.invoke(
+            input_={"style": style},
+            action_identifier="com.apple.coredevice.action.setuserinterfacestyle",
+        )

--- a/pymobiledevice3/remote/core_device/core_device_service.py
+++ b/pymobiledevice3/remote/core_device/core_device_service.py
@@ -21,7 +21,7 @@ CORE_DEVICE_VERSION = _generate_core_device_version_dict("629.3")
 class CoreDeviceService(RemoteService):
     async def invoke(
         self,
-        feature_identifier: str,
+        feature_identifier: Optional[str] = None,
         input_: Optional[dict] = None,
         action_identifier: Optional[str] = None,
     ) -> Any:
@@ -29,13 +29,14 @@ class CoreDeviceService(RemoteService):
             input_ = {}
         request = {
             "CoreDevice.CoreDeviceDDIProtocolVersion": XpcInt64Type(2),
-            "CoreDevice.action": {},
             "CoreDevice.coreDeviceVersion": CORE_DEVICE_VERSION,
             "CoreDevice.deviceIdentifier": str(uuid.uuid4()),
-            "CoreDevice.featureIdentifier": feature_identifier,
             "CoreDevice.input": input_,
             "CoreDevice.invocationIdentifier": str(uuid.uuid4()),
         }
+        if feature_identifier is not None:
+            request["CoreDevice.featureIdentifier"] = feature_identifier
+            request["CoreDevice.action"] = {}
         if action_identifier is not None:
             request["CoreDevice.actionIdentifier"] = action_identifier
         response = await self.service.send_receive_request(request)

--- a/pymobiledevice3/remote/core_device/screen_stream.py
+++ b/pymobiledevice3/remote/core_device/screen_stream.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Optional
 
 from pymobiledevice3.remote.core_device.aac_eld import AAC_ELD_ASC_48K_STEREO_480, AACELDDecoder
+from pymobiledevice3.remote.core_device.configuration_service import ConfigurationService
 from pymobiledevice3.remote.core_device.display_service import DisplayService
 from pymobiledevice3.remote.core_device.hevc_phantom import build_phantoms_for_bootstrap
 from pymobiledevice3.remote.core_device.hid_service import (
@@ -224,6 +225,7 @@ VIEWER_HTML = r"""<!doctype html>
 </div>
 <div id="util-tray">
  <button class="btn" id="sound-toggle" type="button">Enable Sound</button>
+ <button class="btn" id="style-toggle" type="button" title="toggle dark/light user-interface style">Style: ?</button>
  <button class="btn" id="forced-reset" type="button" title="rebuild decoder + new IDR">Forced Reset</button>
  <button class="btn" id="restart" type="button" title="full DisplayService restart">Force Restart</button>
 </div>
@@ -378,6 +380,34 @@ document.getElementById('restart').addEventListener('click', async () => {
     } catch (e) { log('restart err: ' + e.message); }
     setTimeout(() => location.reload(), 100);
 });
+
+// ----- Dark / light toggle: GET /style reads the current style,
+// POST /style with {"style":"dark"|"light"} flips it. Button label
+// shows the CURRENT style so the click reads as "toggle to the other".
+const styleBtn = document.getElementById('style-toggle');
+function setStyleLabel(s) { styleBtn.textContent = 'Style: ' + s; }
+async function refreshStyle() {
+    try {
+        const r = await fetch('/style', {cache: 'no-store'});
+        if (!r.ok) return;
+        const j = await r.json();
+        if (j && j.style) setStyleLabel(j.style);
+    } catch (e) { log('style get err: ' + (e.message || e)); }
+}
+styleBtn.addEventListener('click', async () => {
+    const cur = styleBtn.textContent.replace('Style: ', '').trim();
+    const next = cur === 'dark' ? 'light' : 'dark';
+    try {
+        const r = await fetch('/style', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({style: next}),
+        });
+        if (r.ok) { setStyleLabel(next); log('style: ' + next); }
+        else { log('style set HTTP ' + r.status); }
+    } catch (e) { log('style set err: ' + (e.message || e)); }
+});
+refreshStyle();
 
 // ----- Sound toggle: connect to /audio.bin which streams PRE-DECODED
 // PCM (s16le, 48 kHz, stereo interleaved). The server uses pyav's
@@ -1949,6 +1979,44 @@ class ScreenStreamServer:
             self._pli_tasks.add(bg)  # piggy-back on the existing keep-alive set
             bg.add_done_callback(self._pli_tasks.discard)
             writer.write(b"HTTP/1.1 202 Accepted\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+            await writer.drain()
+            writer.close()
+            return
+        if path == "/style":
+            try:
+                if method == "POST":
+                    body = await self._read_body(reader, headers)
+                    try:
+                        style = str(json.loads(body)["style"])
+                    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+                        writer.write(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                        await writer.drain()
+                        writer.close()
+                        logger.debug("style POST: bad body %r (%s)", body, exc)
+                        return
+                    async with ConfigurationService(self._rsd) as cfg:
+                        await cfg.set_user_interface_style(style)
+                    resp_body = json.dumps({"style": style}).encode()
+                else:
+                    async with ConfigurationService(self._rsd) as cfg:
+                        style = await cfg.get_user_interface_style()
+                    resp_body = json.dumps({"style": style}).encode()
+                writer.write(
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Content-Type: application/json\r\n"
+                    b"Cache-Control: no-store\r\n"
+                    b"Content-Length: " + str(len(resp_body)).encode() + b"\r\n"
+                    b"Connection: close\r\n\r\n" + resp_body
+                )
+            except Exception as exc:
+                logger.exception("style endpoint failed")
+                err = f"style endpoint error: {exc}".encode()
+                writer.write(
+                    b"HTTP/1.1 500 Internal\r\n"
+                    b"Content-Type: text/plain\r\n"
+                    b"Content-Length: " + str(len(err)).encode() + b"\r\n"
+                    b"Connection: close\r\n\r\n" + err
+                )
             await writer.drain()
             writer.close()
             return


### PR DESCRIPTION
New ConfigurationService (com.apple.coredevice.configuration) exposing get/set_user_interface_style via the get/setuserinterfacestyle DDI actions sniffed from devicectl. CoreDeviceService.invoke() now lets feature_identifier be omitted so the request envelope matches the sniff verbatim (no featureIdentifier / no action dict).

CLI: `core-device user-interface-style [dark|light]` — no arg prints the current style, passing dark/light sets it.

serve-web: util-tray Style button (GET /style on load, POST /style on click) flips dark/light without leaving the viewer.