### PR TITLE
service_connection: Prevent "Future exception was never retrieved" warnings

### DIFF
--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -205,6 +205,7 @@ class ServiceConnection:
                 fut.cancel()
             else:
                 fut.set_exception(e)
+                fut.exception()  # prevent "Future exception was never retrieved" warning
             raise
 
     async def aclose(self) -> None:


### PR DESCRIPTION
## Summary

`ServiceConnection` uses a future to synchronize concurrent connection attempts. If an exception occurs, it's propagated to all awaiters via `fut.set_exception(...)`. However, if there are no other awaiters, the future is discarded without the exception having been retrieved, and Python displays `Future was never retrieved ...`. Retrieving the exception immediately via `fut.exception()` prevents this warning from being displayed.

## AI Assistance

none