### PR TITLE
remote: optional no-root iOS 17+ tunnel via a pure-Python userspace stack (closes #1647)

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -22,7 +22,12 @@ try:
 except ImportError:  # pragma: no cover
     shellingham = None
 
-from pymobiledevice3.cli.cli_common import TUNNEL_ENV_VAR, isatty, set_color_flag, set_verbosity
+from pymobiledevice3.cli.cli_common import (
+    TUNNEL_ENV_VAR,
+    isatty,
+    set_color_flag,
+    set_verbosity,
+)
 from pymobiledevice3.exceptions import (
     AccessDeniedError,
     AfcException,
@@ -346,19 +351,22 @@ def invoke_cli_with_error_handling() -> bool:
             "python3 -m pymobiledevice3 amfi enable-developer-mode"
         )
     except (InvalidServiceError, RSDRequiredError) as e:
-        should_retry_over_tunneld = False
+        reason = ""
         if isinstance(e, RSDRequiredError):
-            logger.warning("Trying again over tunneld since RSD is required for this command")
-            should_retry_over_tunneld = True
+            reason = "RSD is required for this command"
         elif (
             (e.identifier is not None)
             and ("developer" in sys.argv)
             and ("--tunnel" not in sys.argv)
+            and ("--userspace" not in sys.argv)
             and device_might_need_tunneld(e.identifier)
         ):
-            logger.warning("Got an InvalidServiceError. Trying again over tunneld since it is a developer command")
-            should_retry_over_tunneld = True
-        if should_retry_over_tunneld:
+            reason = "it is a developer command on an iOS 17+ device"
+        # Retry once over tunneld (its env var doubles as the one-shot guard: already set
+        # means we are the retry failing again — don't loop). For a no-root tunnel instead,
+        # pass --userspace (slower; see its help).
+        if reason and not os.getenv(TUNNEL_ENV_VAR):
+            logger.warning(f"Trying again over tunneld since {reason} (pass --userspace for a no-root tunnel)")
             # use a single space because Typer/Click will ignore envvars of empty strings
             os.environ[TUNNEL_ENV_VAR] = e.identifier or " "
             main()

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -33,6 +33,7 @@ from pymobiledevice3.utils import get_asyncio_loop
 
 UDID_ENV_VAR = "PYMOBILEDEVICE3_UDID"
 TUNNEL_ENV_VAR = "PYMOBILEDEVICE3_TUNNEL"
+USERSPACE_ENV_VAR = "PYMOBILEDEVICE3_USERSPACE"
 USBMUX_ENV_VAR = "PYMOBILEDEVICE3_USBMUX"
 USBMUXD_SOCKET_ADDRESS_ENV_VAR = "USBMUXD_SOCKET_ADDRESS"
 USBMUX_ENV_VARS = [USBMUX_ENV_VAR, USBMUXD_SOCKET_ADDRESS_ENV_VAR]
@@ -183,6 +184,20 @@ async def _tunneld(udid: Optional[str] = None) -> Optional[RemoteServiceDiscover
     return service_provider
 
 
+def _cli_udid() -> Optional[str]:
+    """The target device UDID for the in-process userspace tunnel. make_rsd_dependency can't
+    declare a --udid option (it would collide with the device dependencies that already define
+    it), and the Click context isn't reliably available during dependency resolution across
+    typer versions — so read --udid from argv, falling back to the env var the option uses.
+    (Mirrors the existing sys.argv inspection in __main__.)"""
+    for i, arg in enumerate(sys.argv):
+        if arg == "--udid" and i + 1 < len(sys.argv):
+            return sys.argv[i + 1]
+        if arg.startswith("--udid="):
+            return arg.split("=", 1)[1]
+    return os.getenv(UDID_ENV_VAR)
+
+
 def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteServiceDiscoveryService]]:
     def rsd_dependency(
         rsd: Annotated[
@@ -207,6 +222,21 @@ def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteSer
                 rich_help_panel=DEVICE_OPTIONS_PANEL_TITLE,
             ),
         ] = None,
+        userspace: Annotated[
+            bool,
+            typer.Option(
+                "--userspace",
+                envvar=USERSPACE_ENV_VAR,
+                help=dedent("""\
+                    Establish the iOS 17+ tunnel in-process with a pure-Python userspace network stack, so NO
+                    root/admin is required. Downloads (device->host, e.g. fetch-symbols) run at roughly the
+                    kernel tunnel's throughput; host->device transfers (DDI mounts, file pushes) are slower, as
+                    their send segments are kept small for reliable delivery through the pure-Python path. Use
+                    when you cannot run a privileged tunnel. Requires Python >= 3.14.
+                """),
+                rich_help_panel=DEVICE_OPTIONS_PANEL_TITLE,
+            ),
+        ] = False,
     ) -> Optional[RemoteServiceDiscoveryService]:
         if is_invoked_for_completion():
             # prevent lockdown connection establishment when in autocomplete mode
@@ -214,14 +244,42 @@ def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteSer
 
         if rsd is not None and tunnel is not None:
             raise UsageError("Illegal usage: --rsd is mutually exclusive with --tunnel.")
+        if userspace and (rsd is not None or tunnel is not None):
+            raise UsageError("Illegal usage: --userspace is mutually exclusive with --rsd/--tunnel.")
 
+        # Explicit tunnel sources take precedence.
         if rsd is not None:
             rsd_service = RemoteServiceDiscoveryService(rsd)
             cli_loop.run_until_complete(rsd_service.connect())
             return rsd_service
+        if tunnel is not None:
+            return cli_loop.run_until_complete(_tunneld(tunnel))
 
-        if tunnel is not None or not allow_none:
-            return cli_loop.run_until_complete(_tunneld(tunnel or ""))
+        # Opt-in userspace tunnel (--userspace / PYMOBILEDEVICE3_USERSPACE): establish the
+        # tunnel in-process with the pure-Python stack — no root. Downloads run near the
+        # kernel tunnel's rate; host->device transfers are slower (see the flag's help). If it
+        # can't establish (PyTCP missing on Python < 3.14, or a failing platform), fall back
+        # to the kernel tunnel via tunneld.
+        if userspace:
+            # Target the same device the rest of the CLI would (see _cli_udid).
+            serial = _cli_udid()
+            try:
+                # Imported here, not at module top: userspace_tunnel pulls in PyTCP, an optional
+                # dependency present only on Python >= 3.14. A missing PyTCP raises ImportError
+                # here and falls back to tunneld, same as any establishment failure.
+                from pymobiledevice3.remote import userspace_tunnel
+
+                return cli_loop.run_until_complete(userspace_tunnel.establish_userspace_rsd(serial=serial))
+            except Exception as e:
+                logging.getLogger(__name__).warning(
+                    "userspace tunnel unavailable (%s); falling back to tunneld", str(e) or type(e).__name__
+                )
+            return cli_loop.run_until_complete(_tunneld(""))
+
+        # Default: a required RSD uses the kernel tunnel via tunneld (needs a privileged
+        # `remote tunneld`). Pass --userspace for a no-root tunnel instead.
+        if not allow_none:
+            return cli_loop.run_until_complete(_tunneld(""))
 
     return rsd_dependency
 

--- a/pymobiledevice3/remote/pytcp_compat.py
+++ b/pymobiledevice3/remote/pytcp_compat.py
@@ -1,0 +1,277 @@
+"""PyTCP compatibility layer for the userspace tunnel.
+
+PyTCP is Linux-first, so this module quarantines the cross-platform shims the tunnel needs
+(an ``os.eventfd`` emulation, socket-backed interface I/O for Windows, a Windows ``fcntl``
+stub, a daemon-thread wrapper for clean teardown, and an MLD-attribute bug workaround). The
+tunnel itself (``remote/userspace_tunnel.py``) uses only PyTCP's public API plus the helpers
+here.
+
+Throughput tuning is NOT done here: it rides PyTCP's public ``tcp.rcv_wnd_max`` /
+``tcp.snd_mss_max`` sysctls (see :func:`throughput_sysctls`), passed through
+``stack.init(sysctls=...)``. Older PyTCP releases that predate those knobs simply run
+untuned (slower) — :func:`throughput_sysctls` omits any the installed PyTCP doesn't register.
+
+This module imports PyTCP at module level, so importing it REQUIRES PyTCP (Python >= 3.14).
+That is intentional: only :mod:`pymobiledevice3.remote.userspace_tunnel` imports it, and only
+``cli_common`` imports that — inside a try/except that falls back to the kernel tunnel when
+PyTCP is absent. The Windows ``fcntl`` stub below must run before the PyTCP imports.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import sys
+import threading
+import types
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
+
+# Windows: PyTCP does a top-level ``import fcntl`` (Unix-only) in pytcp.stack, so this stub
+# MUST be installed before ``import pytcp`` below. We never hit fcntl's ioctl path (we inject
+# our own interface fd rather than create a kernel TAP).
+if os.name == "nt":
+    try:
+        import fcntl  # noqa: F401
+    except ImportError:
+        _fcntl_stub = types.ModuleType("fcntl")
+        _fcntl_stub.ioctl = lambda *a, **k: 0  # type: ignore[attr-defined]
+        sys.modules["fcntl"] = _fcntl_stub
+
+# This module is the single point that imports PyTCP — after the Windows fcntl stub above.
+# The PyTCP API surface the tunnel uses is re-exported here so userspace_tunnel imports it
+# from a first-party module and never has to reproduce the stub-before-import ordering.
+from net_addr import Ip6Address, Ip6IfAddr, MacAddress  # noqa: F401  (re-exported)
+from pytcp import stack
+from pytcp.lib.interface_layer import InterfaceLayer  # noqa: F401  (re-exported)
+from pytcp.runtime.packet_handler import PacketHandlerL3
+from pytcp.socket import AF_INET6, SOCK_STREAM  # noqa: F401  (re-exported)
+from pytcp.socket import socket as pytcp_socket  # noqa: F401  (re-exported)
+from pytcp.stack import sysctl
+
+logger = logging.getLogger(__name__)
+
+#: Receive-window ceiling (PyTCP 'tcp.rcv_wnd_max'; default 65535). A download is bounded by
+#: window / RTT, so 64 KB throttles it; 4 MiB keeps a full bandwidth-delay-product in flight
+#: and stays within PyTCP's negotiated window-scale-7 reach (~8 MiB). Measured on an iOS 17+
+#: DSC fetch: 64 KB window -> 8 MB/s, 4 MiB window -> 40 MB/s (kernel-tunnel parity).
+MAX_RECV_WINDOW = 4 * 1024 * 1024
+
+#: Cap on the host->device send MSS (PyTCP 'tcp.snd_mss_max'; 0 = uncapped). A large interface
+#: MTU makes downloads fast (big device->host segments), but ~16 KB host->device segments stall
+#: in RTO backoff over the forwarding path; 1340 (= 1400-byte IPv6 packet minus 40+20 headers)
+#: is the proven-safe send size. The advertised receive MSS is untouched, so downloads stay fast.
+MAX_SEND_MSS = 1340
+
+
+def needs_socket_io() -> bool:
+    """Whether PyTCP's interface I/O must go through sockets rather than os.read/os.writev.
+
+    True on Windows (os.writev is absent and os.read can't touch a socket handle). Set
+    ``PYMOBILEDEVICE3_FORCE_SOCK_IO=1`` to exercise this path on Unix without a Windows box.
+    """
+    return os.name == "nt" or os.environ.get("PYMOBILEDEVICE3_FORCE_SOCK_IO") == "1"
+
+
+# Interface fds the os.read/os.writev shim must treat as sockets (recv/sendall). Keyed by
+# fileno; the tunnel registers its socketpair end here on the socket-I/O path.
+_interface_fds: dict[int, socket.socket] = {}
+
+
+def register_interface_fd(sock: socket.socket) -> None:
+    """Route the os.read/os.writev shim's I/O for ``sock``'s fd through the socket itself.
+    No-op unless on the socket-I/O path."""
+    if needs_socket_io():
+        _interface_fds[sock.fileno()] = sock
+
+
+def unregister_interface_fd(sock: socket.socket) -> None:
+    """Drop ``sock`` from the shim (call before closing it, while the fileno is still valid,
+    so a recycled fd can't divert another caller's os.read)."""
+    _interface_fds.pop(sock.fileno(), None)
+
+
+@contextmanager
+def daemonize_new_threads() -> Iterator[None]:
+    """Force threads created within the block to be daemons.
+
+    PyTCP starts non-daemon worker threads (RX/TX rings, timer, packet handler) during
+    stack bring-up that its stop() does not fully join, which would hang interpreter exit.
+    Daemon threads are killed at exit instead. Wrap stack.init()/start() with this.
+    """
+    orig_thread = threading.Thread
+
+    class _DaemonThread(orig_thread):  # type: ignore[misc, valid-type]
+        def __init__(self, *a, **k):
+            k["daemon"] = True
+            super().__init__(*a, **k)
+
+    threading.Thread = _DaemonThread  # type: ignore[misc]
+    try:
+        yield
+    finally:
+        threading.Thread = orig_thread  # type: ignore[misc]
+
+
+_applied = False
+
+
+def apply() -> None:
+    """Install the PyTCP/OS portability shims. Idempotent.
+
+    Call once before bringing up the stack. PyTCP must be importable (Python >= 3.14); the
+    caller guarantees that by only reaching the userspace path when PyTCP is present.
+    """
+    global _applied
+    if _applied:
+        return
+    _silence_pytcp_stderr_logging()
+    _install_eventfd_shim()
+    if needs_socket_io():
+        _install_interface_io_shim()
+    _patch_missing_mld_attribute()
+    _applied = True
+
+
+def throughput_sysctls() -> dict[str, int]:
+    """The ``stack.init(sysctls=...)`` entries that tune the tunnel for bulk transfer.
+
+    Uses PyTCP's public sysctls (``tcp.rcv_wnd_max`` raises the advertised receive window for
+    fast downloads; ``tcp.snd_mss_max`` caps host->device segments so a large interface MTU
+    does not stall uploads). Any knob the installed PyTCP does not register is omitted (with a
+    warning) so an older release runs untuned rather than failing — the keys land once a PyTCP
+    that carries them is installed.
+    """
+    wanted = {"tcp.rcv_wnd_max": MAX_RECV_WINDOW, "tcp.default.snd_mss_max": MAX_SEND_MSS}
+    # The registry lists base keys, so an interface-scope knob is checked by its base name.
+    base_key = {"tcp.rcv_wnd_max": "tcp.rcv_wnd_max", "tcp.default.snd_mss_max": "tcp.snd_mss_max"}
+    registered = sysctl.list_keys()
+    out: dict[str, int] = {}
+    for key, value in wanted.items():
+        if base_key[key] in registered:
+            out[key] = value
+        else:
+            logger.warning(
+                "userspace tunnel: installed PyTCP lacks the %r sysctl; running untuned "
+                "(upgrade PyTCP for full throughput)",
+                base_key[key],
+            )
+    return out
+
+
+def _silence_pytcp_stderr_logging() -> None:
+    # PyTCP prints every log channel per-packet straight to stderr, bypassing pmd3's
+    # logging. Mute it unless pmd3 is at debug verbosity (e.g. `-v`).
+    if logging.getLogger().getEffectiveLevel() > logging.DEBUG:
+        stack.LOG__CHANNEL = set()
+
+
+def _patch_missing_mld_attribute() -> None:
+    # PyTCP's L3 packet handler references an MLD attribute that doesn't exist, crashing the
+    # address-setup thread. Provide a default (referenced during IPv6 multicast join even on
+    # our L2 path).
+    if not hasattr(PacketHandlerL3, "_mld__v1_querier_present_until_ms"):
+        PacketHandlerL3._mld__v1_querier_present_until_ms = None  # type: ignore[attr-defined]
+
+
+def _install_eventfd_shim() -> None:
+    # os.eventfd is Linux-only; PyTCP uses it as a selectable wakeup. Real eventfd is fine on
+    # Linux unless we're forcing the socket-I/O path. Otherwise emulate it: a socketpair on
+    # the socket-I/O path (Windows select() accepts only sockets), else a non-blocking pipe.
+    if hasattr(os, "eventfd") and not needs_socket_io():
+        return
+
+    os.EFD_NONBLOCK = getattr(os, "EFD_NONBLOCK", 0o4000)
+    os.EFD_CLOEXEC = getattr(os, "EFD_CLOEXEC", 0o2000000)
+
+    if needs_socket_io():
+        pairs: dict[int, tuple[socket.socket, socket.socket]] = {}
+
+        def _eventfd(initval: int = 0, flags: int = 0) -> int:
+            r, w = socket.socketpair()
+            r.setblocking(False)
+            pairs[r.fileno()] = (r, w)
+            for _ in range(initval):
+                try:
+                    w.send(b"\x01")
+                except OSError:
+                    break
+            return r.fileno()
+
+        def _eventfd_write(fd: int, value: int) -> None:
+            with suppress(OSError):  # already signaled / closed
+                pairs[fd][1].send(b"\x01")
+
+        def _eventfd_read(fd: int) -> int:
+            reader = pairs[fd][0]
+            total = 0
+            try:
+                while True:
+                    chunk = reader.recv(4096)
+                    if not chunk:
+                        break
+                    total += len(chunk)
+            except (BlockingIOError, OSError):
+                pass
+            return total or 1
+
+    else:
+        write_ends: dict[int, int] = {}
+
+        def _eventfd(initval: int = 0, flags: int = 0) -> int:
+            r, w = os.pipe()
+            os.set_blocking(r, False)
+            os.set_blocking(w, False)
+            write_ends[r] = w
+            for _ in range(initval):
+                try:
+                    os.write(w, b"\x01")
+                except BlockingIOError:
+                    break
+            return r
+
+        def _eventfd_write(fd: int, value: int) -> None:
+            with suppress(BlockingIOError):  # already signaled
+                os.write(write_ends[fd], b"\x01")
+
+        def _eventfd_read(fd: int) -> int:
+            total = 0
+            try:
+                while True:
+                    chunk = os.read(fd, 4096)
+                    if not chunk:
+                        break
+                    total += len(chunk)
+            except BlockingIOError:
+                pass
+            return total or 1
+
+    os.eventfd = _eventfd  # type: ignore[attr-defined]
+    os.eventfd_write = _eventfd_write  # type: ignore[attr-defined]
+    os.eventfd_read = _eventfd_read  # type: ignore[attr-defined]
+
+
+def _install_interface_io_shim() -> None:
+    # PyTCP reads/writes the interface fd with os.read / os.writev. On Windows os.writev is
+    # absent and os.read can't touch a socket handle, so divert ONLY our registered interface
+    # fds (see register_interface_fd) to blocking socket recv/sendall; every other fd
+    # delegates to the real implementation.
+    real_read = os.read
+
+    def _read(fd: int, n: int):  # type: ignore[misc]
+        sock = _interface_fds.get(fd)
+        return sock.recv(n) if sock is not None else real_read(fd, n)
+
+    real_writev = getattr(os, "writev", None)
+
+    def _writev(fd: int, buffers):  # type: ignore[misc]
+        sock = _interface_fds.get(fd)
+        if sock is not None:
+            data = b"".join(buffers)
+            sock.sendall(data)
+            return len(data)
+        return real_writev(fd, buffers)  # type: ignore[misc]
+
+    os.read = _read  # type: ignore[assignment]
+    os.writev = _writev  # type: ignore[attr-defined]

--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -157,6 +157,29 @@ RPPairingPacket = Struct(
     "body" / Prefixed(Int16ub, GreedyBytes),
 )
 
+#: When True, :func:`create_tun_device` builds the tunnel's interface as a pure-Python
+#: userspace stack (``UserspaceTun``, no root) instead of a kernel ``utun`` (needs root/admin).
+#: The no-root establishment flow flips this on. Kept as a module-level flag so the tunnel
+#: device is selected by an explicit factory call rather than by monkeypatching a class.
+USE_USERSPACE_TUNNEL = False
+
+
+def create_tun_device(interface_name: str = DEFAULT_INTERFACE_NAME):
+    """Create the tunnel's link-layer device, consulting the user's kernel-vs-userspace choice.
+
+    Default: a kernel :class:`pytun_pmd3.TunTapDevice` (requires root/admin). When
+    :data:`USE_USERSPACE_TUNNEL` is set, a no-root userspace PyTCP stack. The userspace import
+    is deferred so the optional PyTCP dependency is pulled in only when actually requested.
+    """
+    if USE_USERSPACE_TUNNEL:
+        from pymobiledevice3.remote.userspace_tunnel import UserspaceTun
+
+        return UserspaceTun(interface_name)
+    if sys.platform == "win32":
+        # Only the win32 TunTapDevice implementation accepts an interface name.
+        return TunTapDevice(interface_name)
+    return TunTapDevice()
+
 
 class RemotePairingTunnel(ABC):
     def __init__(self):
@@ -201,11 +224,7 @@ class RemotePairingTunnel(ABC):
             self._logger.warning(f"got oserror in {asyncio.current_task().get_name()}")
 
     def start_tunnel(self, address: str, mtu: int, interface_name=DEFAULT_INTERFACE_NAME) -> None:
-        if sys.platform == "win32":
-            # Only win32 tunnel implementation supports interface name
-            self.tun = TunTapDevice(interface_name)
-        else:
-            self.tun = TunTapDevice()
+        self.tun = create_tun_device(interface_name)
         self.tun.addr = address
         self.tun.mtu = mtu
         self.tun.up()

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -1,0 +1,464 @@
+"""Userspace (root-free) tunnel backend for iOS 17+ RSD/RemotePairing tunnels.
+
+The standard tunnel writes raw IPv6 packets to a kernel ``utun``, which needs admin/root.
+This backend replaces the kernel interface with a pure-Python TCP/IP stack (PyTCP) so the
+tunnel and all host-initiated RSD developer services run as a normal user.
+
+Two pieces:
+
+* :class:`UserspaceTun` — a drop-in for ``pytun_pmd3.TunTapDevice`` (same
+  ``mtu``/``addr``/``up``/``write``/``read``/``close`` surface) that bridges packets to a
+  PyTCP L2 stack over a datagram socketpair plus a 14-byte Ethernet shim. (PyTCP's mature
+  path is L2; its L3/TUN egress is buggy.)
+* :class:`UserspaceDialPlane` — wraps :func:`asyncio.open_connection` so connections to the
+  device's tunnel address are relayed through a localhost socket into a PyTCP socket. This
+  covers the RSD HTTP/2 handshake and every ``ServiceConnection.create_using_tcp``.
+
+PyTCP ships only on Python >= 3.14, so it is an OPTIONAL dependency. This module imports
+:mod:`pymobiledevice3.remote.pytcp_compat` (which imports PyTCP) at module level, so importing
+it REQUIRES PyTCP; ``cli_common`` imports this module inside a try/except and falls back to the
+kernel tunnel when PyTCP is absent. All PyTCP/OS-internal workarounds — and the single PyTCP
+import point that the symbols below are re-exported from — live in ``pytcp_compat``, not here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import logging
+import os
+import socket
+import struct
+import sys
+import threading
+from contextlib import AsyncExitStack, suppress
+from typing import Optional
+
+import pymobiledevice3.remote.pytcp_compat as pytcp_compat
+import pymobiledevice3.remote.tunnel_service as tunnel_service
+from pymobiledevice3.exceptions import InvalidServiceError, PyMobileDevice3Exception
+from pymobiledevice3.lockdown import create_using_usbmux
+from pymobiledevice3.osu.os_utils import get_os_utils
+from pymobiledevice3.remote.pytcp_compat import (  # PyTCP symbols, re-exported post-fcntl-stub
+    AF_INET6,
+    SOCK_STREAM,
+    InterfaceLayer,
+    Ip6Address,
+    Ip6IfAddr,
+    MacAddress,
+    pytcp_socket,
+    stack,
+)
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+
+logger = logging.getLogger(__name__)
+
+_ETH_IPV6 = 0x86DD
+_STACK_MAC = "02:00:00:00:00:01"
+_PEER_MAC = "02:00:00:00:00:02"
+
+#: Ceiling on the PyTCP interface MTU. The tunnel negotiates 16000; a large interface MTU
+#: makes downloads fast (the device sends big segments to us). Host->device segments are
+#: bounded separately by the tcp.snd_mss_max sysctl (pytcp_compat.MAX_SEND_MSS), so a large
+#: value is safe here.
+INTERFACE_MTU = 16000
+
+#: Datagram socketpair buffer, sized to hold a burst of a full receive window of packets.
+SOCKET_BUFFER_SIZE = 8 * 1024 * 1024
+
+#: Read/relay chunk size for the dial-plane bridge.
+_CHUNK = 65536
+
+#: pmd3's per-OS tun loopback header (macOS: b"\x00\x00\x00\x1e" = AF_INET6).
+LOOPBACK_HEADER = get_os_utils().loopback_header
+
+
+def _mac_to_bytes(mac: str) -> bytes:
+    return bytes(int(x, 16) for x in mac.split(":"))
+
+
+def _eth_header(dst_mac: str, src_mac: str) -> bytes:
+    return _mac_to_bytes(dst_mac) + _mac_to_bytes(src_mac) + struct.pack("!H", _ETH_IPV6)
+
+
+def _packet_socketpair() -> tuple[socket.socket, socket.socket]:
+    """A connected datagram socket pair preserving packet boundaries (one send == one recv).
+    Unix uses an AF_UNIX SOCK_DGRAM socketpair; Windows (no such socketpair) uses a connected
+    localhost UDP pair."""
+    try:
+        return socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
+    except (AttributeError, OSError):
+        a = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        b = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        a.bind(("127.0.0.1", 0))
+        b.bind(("127.0.0.1", 0))
+        a.connect(b.getsockname())
+        b.connect(a.getsockname())
+        return a, b
+
+
+class UserspaceTun:
+    """Drop-in for ``pytun_pmd3.TunTapDevice`` backed by a PyTCP L2 stack.
+
+    PyTCP's stack is a process-global singleton, so one tunnel per process is supported
+    (the normal case)."""
+
+    def __init__(self, interface_name: str = "utun-userspace") -> None:
+        pytcp_compat.apply()
+        self.name = interface_name
+        self._mtu = 1500
+        self._addr: Optional[str] = None
+        self._ifidx: Optional[int] = None
+        self._closed = False
+        self._peer, self._pend = _packet_socketpair()
+        for s in (self._peer, self._pend):
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, SOCKET_BUFFER_SIZE)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, SOCKET_BUFFER_SIZE)
+
+    # --- TunTapDevice-compatible surface ---
+    @property
+    def mtu(self) -> int:
+        return self._mtu
+
+    @mtu.setter
+    def mtu(self, value: int) -> None:
+        self._mtu = int(value)
+
+    @property
+    def addr(self) -> Optional[str]:
+        return self._addr
+
+    @addr.setter
+    def addr(self, address: str) -> None:
+        self._addr = address
+
+    def up(self) -> None:
+        self._mtu = min(self._mtu, INTERFACE_MTU)
+
+        with pytcp_compat.daemonize_new_threads():
+            if not getattr(stack, "_pmd3_inited", False):
+                # accept_dad off (point-to-point link, no DAD peer) + the throughput sysctls
+                # (public PyTCP knobs; omitted automatically on a PyTCP too old to have them).
+                sysctls = {"icmp6.default.accept_dad": 0, **pytcp_compat.throughput_sysctls()}
+                stack.init(sysctls=sysctls)
+                stack._pmd3_inited = True  # type: ignore[attr-defined]
+            pytcp_compat.register_interface_fd(self._pend)
+            self._ifidx = stack.add_interface(
+                fd=self._pend.fileno(),
+                layer=InterfaceLayer.L2,
+                mac_address=MacAddress(_STACK_MAC),
+                mtu=self._mtu,
+                ip6_support=True,
+                ip6_host=Ip6IfAddr(f"{self._addr}/64"),
+                ip6_lla_autoconfig=True,
+                ip6_gua_autoconfig=False,
+                ip4_support=False,
+            )
+            stack.start()
+        logger.info("userspace tunnel up: pytcp L2 iface=%s addr=%s/64 mtu=%s", self._ifidx, self._addr, self._mtu)
+
+    def set_peer(self, device_addr: str) -> None:
+        """Install a static neighbor for the device (point-to-point; skips ND)."""
+        stack.neighbor.interface(self._ifidx).add(ip=Ip6Address(device_addr), mac=MacAddress(_PEER_MAC))
+
+    def write(self, data: bytes) -> None:
+        # inbound (device -> stack): strip pmd3 loopback header, add Ethernet, enqueue
+        ipv6 = data[len(LOOPBACK_HEADER) :] if data[: len(LOOPBACK_HEADER)] == LOOPBACK_HEADER else data
+        with suppress(OSError):
+            self._peer.send(_eth_header(_STACK_MAC, _PEER_MAC) + ipv6)
+
+    def _recv_ipv6(self) -> bytes:
+        # outbound (stack -> device): block for an Ethernet frame, return its IPv6 payload
+        while not self._closed:
+            try:
+                frame = self._peer.recv(65535)
+            except OSError:
+                return b""
+            if len(frame) < 14 or struct.unpack("!H", frame[12:14])[0] != _ETH_IPV6:
+                continue
+            return frame[14:]
+        return b""
+
+    def read(self, size: int) -> bytes:
+        # Unix tun_read_task path: returns loopback-prefixed IPv6 (caller strips the header).
+        ipv6 = self._recv_ipv6()
+        return LOOPBACK_HEADER + ipv6 if ipv6 else b""
+
+    async def async_read(self) -> bytes:
+        # Windows tun_read_task path: wants a RAW IPv6 packet (it checks the version nibble,
+        # no loopback header), delivered asynchronously.
+        return await asyncio.to_thread(self._recv_ipv6)
+
+    def connect_tcp(self, addr: str, port: int):
+        """Open a blocking PyTCP TCP socket to (addr, port) over this stack."""
+        s = pytcp_socket(AF_INET6, SOCK_STREAM)
+        s.connect((addr, port))
+        return s
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        pytcp_compat.unregister_interface_fd(self._pend)
+        # Close the socketpair FIRST so PyTCP's RX/TX ring threads (parked in read/select on
+        # the fd) unblock, then stop the stack — otherwise stop() deadlocks on those threads.
+        for s in (self._peer, self._pend):
+            with suppress(Exception):
+                s.close()
+        try:
+            stack.stop()
+            stack._pmd3_inited = False  # type: ignore[attr-defined]
+        except Exception:
+            logger.debug("error stopping pytcp stack", exc_info=True)
+
+
+class UserspaceDialPlane:
+    """Redirects device-bound ``asyncio.open_connection`` to localhost relays that bridge to
+    PyTCP sockets. Use as an async context manager: ``__aenter__`` installs the redirect and
+    ``__aexit__`` restores ``asyncio.open_connection`` and tears the relay servers down."""
+
+    def __init__(self, tun: UserspaceTun, device_addr: str) -> None:
+        self._tun = tun
+        self._device_addr = str(device_addr)
+        self._relays: dict[tuple[str, int], int] = {}
+        self._servers: list[asyncio.AbstractServer] = []  # kept referenced so relays stay alive
+        self._real_open_connection = asyncio.open_connection
+        self._installed = False
+
+    async def __aenter__(self) -> UserspaceDialPlane:
+        if not self._installed:
+            asyncio.open_connection = self._open_connection  # type: ignore[assignment]
+            self._installed = True
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        if not self._installed:
+            return
+        asyncio.open_connection = self._real_open_connection  # type: ignore[assignment]
+        self._installed = False
+        for srv in self._servers:
+            srv.close()
+        for srv in self._servers:
+            with suppress(Exception):
+                await srv.wait_closed()
+        self._servers.clear()
+        self._relays.clear()
+
+    async def _relay_handler(self, port: int, creader: asyncio.StreamReader, cwriter: asyncio.StreamWriter) -> None:
+        loop = asyncio.get_running_loop()
+        try:
+            psock = await asyncio.to_thread(self._tun.connect_tcp, self._device_addr, port)
+        except Exception:
+            logger.debug("relay connect_tcp(%s:%s) failed", self._device_addr, port, exc_info=True)
+            cwriter.close()
+            return
+
+        # device -> client: PyTCP recv() blocks and does NOT unblock on close(), so pump it
+        # in a DAEMON thread bridged to asyncio via a queue. Daemon threads are killed at
+        # process exit without being joined, so shutdown never hangs.
+        rx_queue: asyncio.Queue = asyncio.Queue(maxsize=256)
+
+        def rx_pump() -> None:
+            try:
+                while True:
+                    data = psock.recv(_CHUNK)
+                    loop.call_soon_threadsafe(rx_queue.put_nowait, data)
+                    if not data:
+                        break
+            except Exception:
+                loop.call_soon_threadsafe(rx_queue.put_nowait, b"")
+
+        threading.Thread(target=rx_pump, daemon=True).start()
+
+        async def client_to_device() -> None:
+            try:
+                while True:
+                    data = await creader.read(_CHUNK)
+                    if not data:
+                        break
+                    await asyncio.to_thread(psock.send, data)
+            except Exception:
+                pass
+
+        async def device_to_client() -> None:
+            try:
+                while True:
+                    data = await rx_queue.get()
+                    if not data:
+                        break
+                    cwriter.write(data)
+                    await cwriter.drain()
+            except Exception:
+                pass
+
+        try:
+            await asyncio.gather(client_to_device(), device_to_client())
+        finally:
+            for closer in (psock.close, cwriter.close):
+                with suppress(Exception):
+                    closer()
+
+    async def _ensure_relay(self, port: int) -> int:
+        key = (self._device_addr, port)
+        if key in self._relays:
+            return self._relays[key]
+
+        async def handle(creader: asyncio.StreamReader, cwriter: asyncio.StreamWriter) -> None:
+            await self._relay_handler(port, creader, cwriter)
+
+        srv = await asyncio.start_server(handle, "127.0.0.1", 0)
+        self._servers.append(srv)
+        lport = srv.sockets[0].getsockname()[1]
+        self._relays[key] = lport
+        logger.debug("userspace relay %s:%s -> 127.0.0.1:%s", self._device_addr, port, lport)
+        return lport
+
+    async def _open_connection(self, host=None, port=None, **kwargs):
+        if host is not None and str(host) == self._device_addr:
+            lport = await self._ensure_relay(port)
+            return await self._real_open_connection("127.0.0.1", lport, **kwargs)
+        return await self._real_open_connection(host, port, **kwargs)
+
+
+# --- high-level in-process establishment (the default no-root RSD path) -----------------
+
+#: Owns the established tunnel's resources (transport, tunnel, dial plane, RSD) for the
+#: process duration; keeping them referenced also keeps their background tasks running.
+#: :func:`aclose_userspace` unwinds it.
+_EXIT_STACK: Optional[AsyncExitStack] = None
+
+#: True once a userspace tunnel has been established in this process. The CLI uses this to
+#: force a hard exit at teardown (PyTCP/asyncio teardown otherwise hangs).
+USERSPACE_ACTIVE = False
+
+
+async def _create_no_root_tunnel_provider(serial: Optional[str], autopair: bool):
+    """Pick a tunnel provider that needs no root, mirroring ``remote start-tunnel``'s family:
+
+    * iOS 17.4+ over USB: :class:`~pymobiledevice3.remote.tunnel_service.CoreDeviceTunnelProxy`
+      (the ``com.apple.internal.devicecompute.CoreDeviceProxy`` lockdown service — no remoted).
+    * iOS 17.0-17.3 / Wi-Fi: RemotePairing over bonjour
+      (:func:`~pymobiledevice3.remote.tunnel_service.get_remote_pairing_tunnel_services`).
+
+    The RSD/USB path (``get_core_device_tunnel_services``) is intentionally NOT attempted: it
+    suspends remoted via :func:`stop_remoted`, which needs root on macOS — defeating the no-root
+    purpose. Returns ``(provider, lockdown_or_None)``; the lockdown is kept alive for the
+    CoreDeviceProxy provider and is ``None`` for the RemotePairing one.
+    """
+    lockdown = await create_using_usbmux(serial=serial, autopair=autopair)
+    try:
+        return await tunnel_service.CoreDeviceTunnelProxy.create(lockdown), lockdown
+    except InvalidServiceError:
+        # iOS < 17.4 has no CoreDeviceProxy lockdown service; fall back to the no-root WiFi path.
+        logger.info("CoreDeviceProxy unavailable (iOS < 17.4); falling back to RemotePairing over bonjour")
+        await lockdown.close()
+    except BaseException:
+        await lockdown.close()
+        raise
+
+    services = await tunnel_service.get_remote_pairing_tunnel_services(udid=serial)
+    if not services:
+        raise PyMobileDevice3Exception(
+            "no-root userspace tunnel unavailable: the device exposes no CoreDeviceProxy lockdown "
+            "service (needs iOS 17.4+) and no RemotePairing service was found over bonjour. Enable "
+            "Wi-Fi for the device and host on the same network, or run a privileged kernel tunnel via "
+            "`pymobiledevice3 remote tunneld`."
+        )
+    return services[0], None
+
+
+async def establish_userspace_rsd(serial: Optional[str] = None, autopair: bool = True):
+    """Establish an iOS 17+ RSD tunnel IN-PROCESS over a userspace stack — no root.
+
+    Returns a connected :class:`RemoteServiceDiscoveryService`. The tunnel and dial plane
+    are kept alive for the process lifetime; since graceful teardown is not yet clean,
+    callers (the CLI) should hard-exit via :func:`force_exit` when done.
+
+    The tunnel provider is selected like ``remote start-tunnel``, but restricted to the
+    root-free paths (see :func:`_create_no_root_tunnel_provider`): CoreDeviceTunnelProxy over
+    lockdown on iOS 17.4+, falling back to RemotePairing over bonjour on iOS 17.0-17.3 / Wi-Fi.
+
+    NOTE: device-initiated inbound flows (serve-vnc/serve-web/screen_stream AV) are NOT
+    handled — they bind a UDP receiver and advertise its address to the device, which a
+    userspace stack would need per-site changes to serve. Host-initiated developer services
+    (the common case) all work.
+    """
+    global USERSPACE_ACTIVE, _EXIT_STACK
+    # PyTCP presence was already proven at import time (this module imports pytcp_compat, which
+    # imports PyTCP); cli_common imports us inside a try/except that falls back to the kernel
+    # tunnel when that import fails. Select the userspace tun in tunnel_service's factory — no
+    # class is monkeypatched; RemotePairingTunnel.start_tunnel() consults create_tun_device().
+    tunnel_service.USE_USERSPACE_TUNNEL = True
+
+    # `serial` selects the target device (None => first USB device). Device selection — incl.
+    # the --udid / PYMOBILEDEVICE3_UDID resolution — is the caller's job (cli_common._cli_udid);
+    # this low-level entry point does not read CLI env vars itself. The usbmux socket location
+    # (incl. a remote usbmuxd) is resolved centrally in MuxConnection._resolve_usbmux_address.
+
+    # Every resource is registered on a single AsyncExitStack that owns process-lifetime
+    # teardown (see aclose_userspace). On any failure during setup, the stack unwinds what was
+    # already acquired, in LIFO order; on success it is stashed in _EXIT_STACK.
+    stack = AsyncExitStack()
+    try:
+        provider, lockdown = await _create_no_root_tunnel_provider(serial, autopair)
+        stack.push_async_callback(provider.close)
+        if lockdown is not None:
+            stack.push_async_callback(lockdown.close)
+        tunnel_result = await stack.enter_async_context(provider.start_tcp_tunnel())
+        tun = tunnel_result.client.tun
+        tun.set_peer(tunnel_result.address)
+        await stack.enter_async_context(UserspaceDialPlane(tun, tunnel_result.address))
+        rsd = RemoteServiceDiscoveryService((tunnel_result.address, tunnel_result.port))
+        stack.push_async_callback(rsd.close)
+        await rsd.connect()
+    except BaseException:
+        await stack.aclose()
+        raise
+
+    _EXIT_STACK = stack
+    USERSPACE_ACTIVE = True
+
+    await _register_clean_exit()
+    logger.info("userspace RSD established (no root): %s rsd_port=%s", tunnel_result.address, tunnel_result.port)
+    return rsd
+
+
+async def aclose_userspace() -> None:
+    """Graceful teardown of the userspace tunnel's resources (the inverse of
+    :func:`establish_userspace_rsd`). Closes everything the establish stack acquired in LIFO
+    order. The CLI currently hard-exits via :func:`force_exit` instead — see its docstring —
+    but this provides the clean path for embedders and tests."""
+    global _EXIT_STACK, USERSPACE_ACTIVE
+    if _EXIT_STACK is None:
+        return
+    stack, _EXIT_STACK = _EXIT_STACK, None
+    USERSPACE_ACTIVE = False
+    await stack.aclose()
+
+
+async def _register_clean_exit() -> None:
+    # pmd3's tun_read_task parks a blocking UserspaceTun.read in the default ThreadPoolExecutor.
+    # At interpreter shutdown, threading._shutdown joins those executor threads BEFORE regular
+    # atexit handlers run, and that join blocks forever on the parked read. Register force_exit
+    # via threading's own shutdown hook so it runs before that join. Handlers run
+    # last-registered-first, so we first touch the default executor (await a no-op in it) to
+    # force concurrent.futures' own join-hook to register before ours — then ours wins.
+    atexit.register(force_exit)  # fallback
+    try:
+        await asyncio.to_thread(lambda: None)  # ensure the executor's shutdown hook registers first
+        threading._register_atexit(force_exit)  # type: ignore[attr-defined]
+    except Exception:
+        logger.debug("could not register threading shutdown hook", exc_info=True)
+
+
+def force_exit(code: int = 0) -> None:
+    """Flush output and hard-exit, bypassing the (currently non-graceful) userspace stack
+    teardown. No-op unless a userspace tunnel was established."""
+    if not USERSPACE_ACTIVE:
+        return
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except Exception:
+        pass
+    os._exit(code)

--- a/pymobiledevice3/usbmux.py
+++ b/pymobiledevice3/usbmux.py
@@ -1,5 +1,6 @@
 import abc
 import asyncio
+import os
 import plistlib
 import socket
 import struct
@@ -155,6 +156,11 @@ class MuxConnection:
 
     @staticmethod
     def _resolve_usbmux_address(usbmux_address: Optional[str] = None):
+        if usbmux_address is None:
+            # Honor the libusbmuxd-standard env var at the socket layer so every call
+            # site (not just the CLI --usbmux option) reaches a remote/relocated
+            # usbmuxd, e.g. usbmuxd exposed over TCP as HOST:PORT.
+            usbmux_address = os.getenv("USBMUXD_SOCKET_ADDRESS")
         if usbmux_address is not None:
             if ":" in usbmux_address:
                 hostname, port = usbmux_address.split(":")

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,9 @@ typer-injector>=0.2.0
 defusedxml
 pywin32 ; platform_system == "Windows"
 av>=14.0.0 ; platform_system != "Darwin"
+# PyTCP (no-sudo userspace tunnel) requires Python >= 3.14; on older Pythons it is
+# absent and the tunnel transparently falls back to the kernel path (see cli_common).
+# Throughput tuning rides PyTCP's public 'tcp.rcv_wnd_max' / 'tcp.snd_mss_max' sysctls
+# (pytcp_compat.throughput_sysctls); releases that predate those knobs just run untuned, so
+# no upper pin — a newer PyTCP that carries them lets the fast path kick in automatically.
+PyTCP>=3.0.7 ; python_version >= "3.14"

--- a/tests/test_pytcp_compat.py
+++ b/tests/test_pytcp_compat.py
@@ -1,0 +1,47 @@
+"""Tests for the PyTCP compatibility layer behind the userspace tunnel.
+
+The throughput tuning rides PyTCP's public ``tcp.rcv_wnd_max`` / ``tcp.snd_mss_max``
+sysctls; these tests pin that :func:`throughput_sysctls` emits values the installed PyTCP
+actually accepts (and silently omits any a too-old PyTCP lacks), plus that the portability
+shims install idempotently.
+"""
+
+import pytest
+
+# PyTCP ships only on Python >= 3.14; skip the whole module when it's absent.
+pytest.importorskip("pytcp")
+
+from pytcp.stack import sysctl
+
+from pymobiledevice3.remote import pytcp_compat
+
+
+def test_throughput_sysctls_only_emits_registered_knobs():
+    # Every emitted key must be accepted by stack.init's sysctl bag — i.e. its (base) knob is
+    # registered in the installed PyTCP. This is what keeps an older PyTCP from crashing.
+    registered = sysctl.list_keys()
+    for key in pytcp_compat.throughput_sysctls():
+        base = key.replace(".default.", ".") if ".default." in key else key
+        assert base in registered, f"{key!r} emitted but {base!r} is not a registered sysctl"
+
+
+def test_throughput_sysctls_values_when_supported():
+    knobs = pytcp_compat.throughput_sysctls()
+    if "tcp.rcv_wnd_max" not in sysctl.list_keys():
+        pytest.skip("installed PyTCP predates the throughput sysctls")
+    assert knobs["tcp.rcv_wnd_max"] == pytcp_compat.MAX_RECV_WINDOW
+    assert knobs["tcp.default.snd_mss_max"] == pytcp_compat.MAX_SEND_MSS
+
+
+def test_throughput_sysctls_round_trip_through_sysctl_set():
+    # The emitted entries must apply cleanly the way stack.init(sysctls=...) applies them.
+    for key, value in pytcp_compat.throughput_sysctls().items():
+        sysctl.set(key, value)
+    sysctl.reset_to_defaults()
+
+
+def test_apply_installs_eventfd_shim_and_is_idempotent():
+    pytcp_compat.apply()
+    pytcp_compat.apply()  # must not raise or double-install
+    # apply() guarantees PyTCP's selectable wakeup primitive exists on every platform.
+    assert hasattr(__import__("os"), "eventfd")


### PR DESCRIPTION
## What
Adds an **opt-in**, no-root / no-admin path for the iOS 17+ developer-services tunnel
(closes #1647). The standard tunnel writes raw IPv6 to a kernel `utun`, which needs admin
(utun/ifconfig on macOS, CAP_NET_ADMIN on Linux, wintun on Windows). With `--userspace`,
the tunnel is instead terminated by a pure-Python userspace TCP/IP stack (PyTCP), so it
and all RSD developer services can run as a normal user.

`--userspace` is **off by default**: the pure-Python stack processes every packet in Python
and is much slower than the kernel tunnel, so the flag's help warns of a large throughput
hit. Without it, behavior is unchanged (kernel tunnel via tunneld). With it, if the
userspace stack can't establish it transparently falls back to the kernel tunnel.

## How
- `UserspaceTun` is a drop-in for `pytun_pmd3.TunTapDevice`, bridging packets to a PyTCP
  L2 stack over a datagram socketpair.
- A dial plane wraps `asyncio.open_connection` so device-bound connections (the RSD HTTP/2
  handshake + every `ServiceConnection.create_using_tcp`) route through the stack.
- In-process only (a userspace stack can't be shared across processes): `start-tunnel` /
  `tunneld` daemons keep the kernel path; `--userspace` per-command flows use userspace.

## Platforms — all verified no-sudo/admin (with --userspace) against an iOS 17+ device
macOS, Linux, and Windows: `remote rsd-info`, `developer dvt proclist`, and
`developer dvt launch` all run as a normal user. On Linux/Windows the device is reached
over usbmux (incl. usbmux-over-TCP); the userspace stack needs no privileges anywhere.

## Dependency notes (happy to adjust)
- Adds **PyTCP** (GPL-3.0 — same as this project; zero third-party deps).
- PyTCP needs **Python >= 3.14**, so it's gated with a `python_version >= "3.14"` marker —
  on older Pythons it's simply absent and `--userspace` falls back to the kernel path;
  `pip install` is unaffected on every Python.
- PyTCP is Linux-first, so non-Linux platforms get small lazy shims (eventfd, an MLD attr;
  on Windows: socket-based interface I/O + an `fcntl` stub). Open to vendoring vs
  upstreaming these to PyTCP.

## Also included
`MuxConnection._resolve_usbmux_address` now honors `USBMUXD_SOCKET_ADDRESS` at the socket
layer (libusbmuxd semantics), so internal call sites — not just the CLI `--usbmux` option —
reach a remote usbmuxd. Can split into its own PR if preferred.

## Known limitations / out of scope
- Performance: `--userspace` is significantly slower than the kernel tunnel (the reason it
  is opt-in) — fine for control/RPC, slow for bulk transfers.
- Device-initiated inbound UDP (AV: serve-vnc/serve-web/screen_stream) isn't served by the
  userspace stack (documented in the module); host-initiated developer services all work.
- Graceful library teardown of the PyTCP stack isn't clean yet, so the CLI hard-exits at
  the end — fine for CLI use, a follow-up for embedding.## What
Adds an **opt-in**, no-root / no-admin path for the iOS 17+ developer-services tunnel
(closes #1647). The standard tunnel writes raw IPv6 to a kernel `utun`, which needs admin
(utun/ifconfig on macOS, CAP_NET_ADMIN on Linux, wintun on Windows). With `--userspace`,
the tunnel is instead terminated by a pure-Python userspace TCP/IP stack (PyTCP), so it
and all RSD developer services can run as a normal user.

`--userspace` is **off by default**: the pure-Python stack processes every packet in Python
and is much slower than the kernel tunnel, so the flag's help warns of a large throughput
hit. Without it, behavior is unchanged (kernel tunnel via tunneld). With it, if the
userspace stack can't establish it transparently falls back to the kernel tunnel.

## How
- `UserspaceTun` is a drop-in for `pytun_pmd3.TunTapDevice`, bridging packets to a PyTCP
  L2 stack over a datagram socketpair.
- A dial plane wraps `asyncio.open_connection` so device-bound connections (the RSD HTTP/2
  handshake + every `ServiceConnection.create_using_tcp`) route through the stack.
- In-process only (a userspace stack can't be shared across processes): `start-tunnel` /
  `tunneld` daemons keep the kernel path; `--userspace` per-command flows use userspace.

## Platforms — all verified no-sudo/admin (with --userspace) against an iOS 17+ device
macOS, Linux, and Windows 11: `remote rsd-info`, `developer dvt proclist`, and
`developer dvt launch` all run as a normal user. On Linux/Windows the device is reached
over usbmux (incl. usbmux-over-TCP); the userspace stack needs no privileges anywhere.

## Dependency notes (happy to adjust)
- Adds **PyTCP** (GPL-3.0 — same as this project; zero third-party deps).
- PyTCP needs **Python >= 3.14**, so it's gated with a `python_version >= "3.14"` marker —
  on older Pythons it's simply absent and `--userspace` falls back to the kernel path;
  `pip install` is unaffected on every Python.
- PyTCP is Linux-first, so non-Linux platforms get small lazy shims (eventfd, an MLD attr;
  on Windows: socket-based interface I/O + an `fcntl` stub). Open to vendoring vs
  upstreaming these to PyTCP.

## Also included
`MuxConnection._resolve_usbmux_address` now honors `USBMUXD_SOCKET_ADDRESS` at the socket
layer (libusbmuxd semantics), so internal call sites — not just the CLI `--usbmux` option —
reach a remote usbmuxd. Can split into its own PR if preferred.

## Known limitations / out of scope
- Performance: `--userspace` is significantly slower than the kernel tunnel (the reason it
  is opt-in) — fine for control/RPC, slow for bulk transfers.
- Device-initiated inbound UDP (AV: serve-vnc/serve-web/screen_stream) isn't served by the
  userspace stack (documented in the module); host-initiated developer services all work.
- Graceful library teardown of the PyTCP stack isn't clean yet, so the CLI hard-exits at
  the end — fine for CLI use, a follow-up for embedding.