### PR TITLE
remote: optional no-root iOS 17+ userspace tunnel (via pmd-pytcp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ pymobiledevice3 apps list
 
 ### Support Matrix (Developer Services)
 
-`iOS >= 17` developer services require tunnel-based transport.
+`iOS >= 17` developer services require tunnel-based transport. The tunnel normally needs root/admin;
+on Python 3.14+ you can instead add `--userspace` to a developer command for a no-root, in-process
+tunnel (see the guide for what it supports).
 
 | Host OS | iOS 17.0-17.3.1 | iOS 17.4+ |
 | --- | --- | --- |

--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -1,7 +1,9 @@
 # iOS 17+ Developer Services via Tunnel
 
 Starting with iOS 17.0, Apple moved developer service access to CoreDevice/RemoteXPC flows.
-To use many `developer dvt` commands, establish a trusted tunnel first.
+To use many `developer dvt` commands, establish a trusted tunnel first — with root via `tunneld`
+(Option 1) or a manual tunnel (Option 2), or with **no root at all** via the in-process
+`--userspace` tunnel on Python 3.14+ (Option 3).
 
 Reference protocol details:
 [RemoteXPC](../../misc/RemoteXPC.md)
@@ -56,6 +58,51 @@ Use the following connection option:
 
 The tunnel creation command must run with elevated privileges because it creates a TUN/TAP interface.
 
+## Option 3: No-root userspace tunnel (`--userspace`)
+
+Options 1 and 2 need root/admin because they create a kernel TUN/TAP interface. `--userspace`
+instead establishes the iOS 17+ tunnel **in-process** using a pure-Python network stack (PyTCP),
+so it needs **no root/admin at all**. Just add the flag to a developer command:
+
+```shell
+python3 -m pymobiledevice3 developer dvt ls / --userspace
+```
+
+There is no separate tunnel process to start — the flag builds the tunnel inside the command and
+tears it down when it exits.
+
+Requirements:
+
+- **Python >= 3.14** (the `pmd-pytcp` dependency ships only on 3.14+). On older interpreters the
+  flag is unavailable and the command falls back to `tunneld`.
+- **iOS 17.0+** over USB (uses the CoreDeviceProxy lockdown service on 17.4+, or RemotePairing over
+  bonjour/Wi-Fi on 17.0–17.3.1).
+
+What works over `--userspace`: the host-initiated developer services (`dvt`, `fetch-symbols`,
+`core-device …`), and the device-initiated AV/HID paths — `display serve-web`, `display serve-vnc`,
+`display start-video-stream` / `start-audio-stream`, and the HID gesture commands.
+
+### Limitation: in-process only
+
+The device's tunnel address lives only inside the pymobiledevice3 process, so it is **not reachable
+from any other process** on your machine. Commands that hand the device address to an external tool
+therefore cannot use the userspace tunnel:
+
+- `developer debugserver lldb` and `developer debugserver start-server` (without `--local-port`)
+  **refuse** over `--userspace`, since they drive an external `lldb` that cannot reach the in-process
+  address. Use a kernel-routable tunnel (Option 1/2) for these — or, for `start-server`, pass
+  `--local-port`, which forwards debugserver to a local port and *does* work over `--userspace`.
+
+Because the tunnel is rebuilt per invocation (no persistent daemon), expect a little extra startup
+latency compared with attaching to an already-running `tunneld`.
+
+### From Python
+
+To establish this tunnel programmatically, use the `UserspaceRsdTunnel` handle — see the
+[`UserspaceRsdTunnel` example](../../misc/understanding_idevice_protocol_layers.md#remotexpc) in the
+protocol-layers guide, listed there alongside the other ways to obtain an RSD. The in-process-only
+limitation above applies equally to the Python API.
+
 ## Use tunnel details in commands
 
 ```shell
@@ -64,6 +111,9 @@ python3 -m pymobiledevice3 developer dvt ls / --tunnel ''
 
 # If tunneld is already running, this may work without --tunnel
 python3 -m pymobiledevice3 developer dvt ls /
+
+# No-root in-process tunnel (Python 3.14+); no tunneld/root required
+python3 -m pymobiledevice3 developer dvt ls / --userspace
 
 # Use manual RSD connection details
 python3 -m pymobiledevice3 developer dvt ls / --rsd fd7b:e5b:6f53::1 64337

--- a/misc/understanding_idevice_protocol_layers.md
+++ b/misc/understanding_idevice_protocol_layers.md
@@ -467,6 +467,33 @@ async def main() -> None:
       print(entry)
 ```
 
+All the tunnels above need root/admin, since they create a kernel TUN/TAP interface. On Python 3.14+ there's one
+more option that needs **no root at all**: add `--userspace` to any developer command to establish the iOS 17+ tunnel
+in-process over a pure-python network stack (PyTCP). There's no separate tunnel process - the flag builds the tunnel
+inside the command and tears it down on exit:
+
+```shell
+pymobiledevice3 developer dvt ls / --userspace
+```
+
+See [the dedicated guide](../docs/guides/ios17-tunnels.md) for what it supports and its limitations (most notably:
+the device address is reachable only from that process, so it can't be handed to external tools like `lldb`). This is
+of course also available via a python API, through the `UserspaceRsdTunnel` handle:
+
+```python
+from pymobiledevice3.remote.userspace_tunnel import UserspaceRsdTunnel
+from pymobiledevice3.services.os_trace import OsTraceService
+
+
+async def main() -> None:
+  # serial=None picks the first USB device; pass a UDID to target a specific one
+  # It's an async context manager (or keep the handle and use `await tunnel.aopen()` / `await tunnel.aclose()`)
+  async with UserspaceRsdTunnel(serial=None) as rsd:
+      # `rsd` is a RemoteServiceDiscoveryService - use it like any other LockdownServiceProvider
+      async for entry in OsTraceService(rsd).syslog():
+          print(entry)
+```
+
 Confused by all these "start-tunnel" permutations? Don't blame yourself - it's very confusing especially since there
 isn't only one way to achieve cross-platform for iOS 17.0-17.4.
 

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -53,6 +53,7 @@ from pymobiledevice3.exceptions import (
     PairingDialogResponsePendingError,
     PasswordRequiredError,
     QuicProtocolNotSupportedError,
+    RoutableTunnelRequiredError,
     RSDRequiredError,
     SetProhibitedError,
     StartServiceError,
@@ -350,6 +351,8 @@ def invoke_cli_with_error_handling() -> bool:
             "Developer Mode is disabled. You can try to enable it using: "
             "python3 -m pymobiledevice3 amfi enable-developer-mode"
         )
+    except RoutableTunnelRequiredError as e:
+        logger.error(str(e))
     except (InvalidServiceError, RSDRequiredError) as e:
         reason = ""
         if isinstance(e, RSDRequiredError):

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -22,7 +22,12 @@ try:
 except ImportError:  # pragma: no cover
     shellingham = None
 
-from pymobiledevice3.cli.cli_common import TUNNEL_ENV_VAR, isatty, set_color_flag, set_verbosity
+from pymobiledevice3.cli.cli_common import (
+    TUNNEL_ENV_VAR,
+    isatty,
+    set_color_flag,
+    set_verbosity,
+)
 from pymobiledevice3.exceptions import (
     AccessDeniedError,
     AfcException,
@@ -346,19 +351,22 @@ def invoke_cli_with_error_handling() -> bool:
             "python3 -m pymobiledevice3 amfi enable-developer-mode"
         )
     except (InvalidServiceError, RSDRequiredError) as e:
-        should_retry_over_tunneld = False
+        reason = ""
         if isinstance(e, RSDRequiredError):
-            logger.warning("Trying again over tunneld since RSD is required for this command")
-            should_retry_over_tunneld = True
+            reason = "RSD is required for this command"
         elif (
             (e.identifier is not None)
             and ("developer" in sys.argv)
             and ("--tunnel" not in sys.argv)
+            and ("--userspace" not in sys.argv)
             and device_might_need_tunneld(e.identifier)
         ):
-            logger.warning("Got an InvalidServiceError. Trying again over tunneld since it is a developer command")
-            should_retry_over_tunneld = True
-        if should_retry_over_tunneld:
+            reason = "it is a developer command on an iOS 17+ device"
+        # Retry once over tunneld (its env var doubles as the one-shot guard: already set
+        # means we are the retry failing again — don't loop). For a no-root tunnel instead,
+        # pass --userspace (slower; see its help).
+        if reason and not os.getenv(TUNNEL_ENV_VAR):
+            logger.warning(f"Trying again over tunneld since {reason} (pass --userspace for a no-root tunnel)")
             # use a single space because Typer/Click will ignore envvars of empty strings
             os.environ[TUNNEL_ENV_VAR] = e.identifier or " "
             main()

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -232,7 +232,7 @@ def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteSer
                     root/admin is required. Downloads (device->host, e.g. fetch-symbols) run at roughly the
                     kernel tunnel's throughput; host->device transfers (DDI mounts, file pushes) are slower, as
                     their send segments are kept small for reliable delivery through the pure-Python path. Use
-                    when you cannot run a privileged tunnel. Requires Python >= 3.14.
+                    when you cannot run a privileged tunnel.
                 """),
                 rich_help_panel=DEVICE_OPTIONS_PANEL_TITLE,
             ),
@@ -256,25 +256,16 @@ def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteSer
             return cli_loop.run_until_complete(_tunneld(tunnel))
 
         # Opt-in userspace tunnel (--userspace / PYMOBILEDEVICE3_USERSPACE): establish the
-        # tunnel in-process with the pure-Python stack — no root. Downloads run near the
-        # kernel tunnel's rate; host->device transfers are slower (see the flag's help). If it
-        # can't establish (PyTCP missing on Python < 3.14, or a failing platform), fall back
-        # to the kernel tunnel via tunneld.
+        # tunnel in-process with the pure-Python PyTCP stack — no root. Downloads run near the
+        # kernel tunnel's rate; host->device transfers are slower (see the flag's help). PyTCP
+        # (pmd-pytcp) is a regular dependency on Python 3.9+, so any failure here is a real
+        # establishment error and is surfaced rather than masked by a tunneld fallback.
         if userspace:
             # Target the same device the rest of the CLI would (see _cli_udid).
             serial = _cli_udid()
-            try:
-                # Imported here, not at module top: userspace_tunnel pulls in PyTCP, an optional
-                # dependency present only on Python >= 3.14. A missing PyTCP raises ImportError
-                # here and falls back to tunneld, same as any establishment failure.
-                from pymobiledevice3.remote import userspace_tunnel
+            from pymobiledevice3.remote import userspace_tunnel
 
-                return cli_loop.run_until_complete(userspace_tunnel.establish_userspace_rsd(serial=serial))
-            except Exception as e:
-                logging.getLogger(__name__).warning(
-                    "userspace tunnel unavailable (%s); falling back to tunneld", str(e) or type(e).__name__
-                )
-            return cli_loop.run_until_complete(_tunneld(""))
+            return cli_loop.run_until_complete(userspace_tunnel.establish_userspace_rsd(serial=serial))
 
         # Default: a required RSD uses the kernel tunnel via tunneld (needs a privileged
         # `remote tunneld`). Pass --userspace for a no-root tunnel instead.

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -33,6 +33,7 @@ from pymobiledevice3.utils import get_asyncio_loop
 
 UDID_ENV_VAR = "PYMOBILEDEVICE3_UDID"
 TUNNEL_ENV_VAR = "PYMOBILEDEVICE3_TUNNEL"
+USERSPACE_ENV_VAR = "PYMOBILEDEVICE3_USERSPACE"
 USBMUX_ENV_VAR = "PYMOBILEDEVICE3_USBMUX"
 USBMUXD_SOCKET_ADDRESS_ENV_VAR = "USBMUXD_SOCKET_ADDRESS"
 USBMUX_ENV_VARS = [USBMUX_ENV_VAR, USBMUXD_SOCKET_ADDRESS_ENV_VAR]
@@ -183,6 +184,20 @@ async def _tunneld(udid: Optional[str] = None) -> Optional[RemoteServiceDiscover
     return service_provider
 
 
+def _cli_udid() -> Optional[str]:
+    """The target device UDID for the in-process userspace tunnel. make_rsd_dependency can't
+    declare a --udid option (it would collide with the device dependencies that already define
+    it), and the Click context isn't reliably available during dependency resolution across
+    typer versions — so read --udid from argv, falling back to the env var the option uses.
+    (Mirrors the existing sys.argv inspection in __main__.)"""
+    for i, arg in enumerate(sys.argv):
+        if arg == "--udid" and i + 1 < len(sys.argv):
+            return sys.argv[i + 1]
+        if arg.startswith("--udid="):
+            return arg.split("=", 1)[1]
+    return os.getenv(UDID_ENV_VAR)
+
+
 def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteServiceDiscoveryService]]:
     def rsd_dependency(
         rsd: Annotated[
@@ -207,6 +222,21 @@ def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteSer
                 rich_help_panel=DEVICE_OPTIONS_PANEL_TITLE,
             ),
         ] = None,
+        userspace: Annotated[
+            bool,
+            typer.Option(
+                "--userspace",
+                envvar=USERSPACE_ENV_VAR,
+                help=dedent("""\
+                    Establish the iOS 17+ tunnel in-process with a pure-Python userspace network stack, so NO
+                    root/admin is required. Downloads (device->host, e.g. fetch-symbols) run at roughly the
+                    kernel tunnel's throughput; host->device transfers (DDI mounts, file pushes) are slower, as
+                    their send segments are kept small for reliable delivery through the pure-Python path. Use
+                    when you cannot run a privileged tunnel. Requires Python >= 3.14.
+                """),
+                rich_help_panel=DEVICE_OPTIONS_PANEL_TITLE,
+            ),
+        ] = False,
     ) -> Optional[RemoteServiceDiscoveryService]:
         if is_invoked_for_completion():
             # prevent lockdown connection establishment when in autocomplete mode
@@ -214,14 +244,42 @@ def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteSer
 
         if rsd is not None and tunnel is not None:
             raise UsageError("Illegal usage: --rsd is mutually exclusive with --tunnel.")
+        if userspace and (rsd is not None or tunnel is not None):
+            raise UsageError("Illegal usage: --userspace is mutually exclusive with --rsd/--tunnel.")
 
+        # Explicit tunnel sources take precedence.
         if rsd is not None:
             rsd_service = RemoteServiceDiscoveryService(rsd)
             cli_loop.run_until_complete(rsd_service.connect())
             return rsd_service
+        if tunnel is not None:
+            return cli_loop.run_until_complete(_tunneld(tunnel))
 
-        if tunnel is not None or not allow_none:
-            return cli_loop.run_until_complete(_tunneld(tunnel or ""))
+        # Opt-in userspace tunnel (--userspace / PYMOBILEDEVICE3_USERSPACE): establish the
+        # tunnel in-process with the pure-Python stack — no root. Downloads run near the
+        # kernel tunnel's rate; host->device transfers are slower (see the flag's help). If it
+        # can't establish (PyTCP missing on Python < 3.14, or a failing platform), fall back
+        # to the kernel tunnel via tunneld.
+        if userspace:
+            # Target the same device the rest of the CLI would (see _cli_udid).
+            serial = _cli_udid()
+            try:
+                # Imported here, not at module top: userspace_tunnel pulls in PyTCP, an optional
+                # dependency present only on Python >= 3.14. A missing PyTCP raises ImportError
+                # here and falls back to tunneld, same as any establishment failure.
+                from pymobiledevice3.remote import userspace_tunnel
+
+                return cli_loop.run_until_complete(userspace_tunnel.establish_userspace_rsd(serial=serial))
+            except Exception as e:
+                logging.getLogger(__name__).warning(
+                    "userspace tunnel unavailable (%s); falling back to tunneld", str(e) or type(e).__name__
+                )
+            return cli_loop.run_until_complete(_tunneld(""))
+
+        # Default: a required RSD uses the kernel tunnel via tunneld (needs a privileged
+        # `remote tunneld`). Pass --userspace for a no-root tunnel instead.
+        if not allow_none:
+            return cli_loop.run_until_complete(_tunneld(""))
 
     return rsd_dependency
 

--- a/pymobiledevice3/cli/developer/debugserver.py
+++ b/pymobiledevice3/cli/developer/debugserver.py
@@ -16,7 +16,7 @@ from plumbum import local
 from typer_injector import InjectingTyper
 
 from pymobiledevice3.cli.cli_common import RSDServiceProviderDep, ServiceProviderDep, async_command, print_json
-from pymobiledevice3.exceptions import RSDRequiredError
+from pymobiledevice3.exceptions import RoutableTunnelRequiredError, RSDRequiredError
 from pymobiledevice3.lockdown import create_using_usbmux
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
 from pymobiledevice3.services.debugserver_applist import DebugServerAppList
@@ -84,6 +84,13 @@ async def debugserver_start_server(
     elif Version(service_provider.product_version) >= Version("17.0"):
         if not isinstance(service_provider, RemoteServiceDiscoveryService):
             raise RSDRequiredError(service_provider.identifier)
+        if service_provider.is_in_process_tunnel:
+            raise RoutableTunnelRequiredError(
+                "Cannot print a remote LLDB connect address over a userspace tunnel: the device "
+                "address is only reachable from this process, not from your external lldb. Re-run "
+                "with --local-port to forward debugserver to a local port (this works over the "
+                "userspace tunnel), or use a kernel-routable tunnel (root `tunneld` / --tunnel)."
+            )
         debugserver_port = service_provider.get_service_port(service_name)
         print(DEBUGSERVER_CONNECTION_STEPS.format(host=service_provider.service.address[0], port=debugserver_port))
     else:
@@ -136,6 +143,15 @@ async def debugserver_lldb(
     if Version(service_provider.product_version) < Version("17.0"):
         logger.error("lldb is only supported on iOS >= 17.0")
         return
+
+    if isinstance(service_provider, RemoteServiceDiscoveryService) and service_provider.is_in_process_tunnel:
+        # The flow spawns an external lldb and feeds it `process connect connect://[<device>]:<port>`;
+        # that address lives only on this process's userspace stack and is unreachable from lldb.
+        raise RoutableTunnelRequiredError(
+            "debugserver lldb cannot run over a userspace tunnel: it drives an external lldb process, "
+            "which cannot reach the in-process tunnel address. Use a kernel-routable tunnel instead "
+            "(run `sudo pymobiledevice3 remote tunneld` and drop --userspace, or use --tunnel)."
+        )
 
     commands = []
     temp_dir = None

--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -467,6 +467,12 @@ class RSDRequiredError(PyMobileDevice3Exception):
         super().__init__()
 
 
+class RoutableTunnelRequiredError(PyMobileDevice3Exception):
+    """The action exposes the device's tunnel address to an external process (e.g. lldb), which
+    needs a kernel-routable tunnel. The active tunnel is an in-process userspace tunnel whose
+    address is only reachable from this process."""
+
+
 class SysdiagnoseTimeoutError(PyMobileDevice3Exception, TimeoutError):
     """Timeout collecting new sysdiagnose archive"""
 

--- a/pymobiledevice3/remote/core_device/file_service.py
+++ b/pymobiledevice3/remote/core_device/file_service.py
@@ -64,7 +64,10 @@ class FileServiceService(CoreDeviceService):
     async def retrieve_file(self, path: str = ".") -> bytes:
         response = await self.send_receive_request({"Cmd": "RetrieveFile", "Path": path, "SessionID": self.session})
         data_service = self.rsd.get_service_port("com.apple.coredevice.fileservice.data")
-        reader, writer = await asyncio.open_connection(self.service.address[0], data_service)
+        # Route through the RSD's dialer (set by the userspace tunnel to relay through its
+        # in-process stack); falls back to the stdlib default for the kernel-tunnel path.
+        open_connection = self.rsd.open_connection or asyncio.open_connection
+        reader, writer = await open_connection(self.service.address[0], data_service)
         writer.write(b"rwb!FILE" + struct.pack(">QQQQ", response["Response"], 0, response["NewFileID"], 0))
         await writer.drain()
         await reader.readexactly(0x24)

--- a/pymobiledevice3/remote/core_device/hevc_rps.py
+++ b/pymobiledevice3/remote/core_device/hevc_rps.py
@@ -92,12 +92,12 @@ class _BitReader:
         return (1 << zeros) - 1 + suffix
 
 
-@dataclass(slots=True)
+@dataclass()
 class _ShortTermRps:
     deltas: list[tuple[int, bool]] = field(default_factory=list)
 
 
-@dataclass(slots=True)
+@dataclass()
 class HevcSpsState:
     log2_max_pic_order_cnt_lsb: int = 8
     num_short_term_ref_pic_sets: int = 0

--- a/pymobiledevice3/remote/core_device/hid_service.py
+++ b/pymobiledevice3/remote/core_device/hid_service.py
@@ -22,7 +22,6 @@ Two RemoteXPC services are wrapped here:
 
 import asyncio
 import contextlib
-import socket
 import struct
 import time
 import uuid
@@ -568,35 +567,35 @@ async def touch_session(
     The stream's RTP payload is discarded by a background drain task — we just
     need a session to exist for the duration of the gestures.
     """
-    # Local import to avoid a circular dependency with display_service.
+    # Local imports to avoid a circular dependency with display_service / screen_stream.
     from pymobiledevice3.remote.core_device.display_service import DisplayService
+    from pymobiledevice3.remote.core_device.screen_stream import open_media_receiver
 
     sender_ip = rsd.service.address[0]
-    sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-    sock.bind(("::", 0))
-    bound_port = sock.getsockname()[1]
-    sock.setblocking(False)
-
-    async def _drain() -> None:
-        loop = asyncio.get_running_loop()
-        try:
-            while True:
-                await loop.sock_recv(sock, 65535)
-        except (asyncio.CancelledError, OSError):
-            pass
 
     display = DisplayService(rsd)
     await display.__aenter__()
     try:
-        local_ip = display.service.local_address[0]
+        # Bind the (discarded) RTP receiver on the right transport — pytcp stack over the
+        # userspace tunnel, host kernel socket otherwise — and advertise the matching address so
+        # the device can actually reach it (a host kernel socket is unreachable over userspace).
+        transport, receiver_ip = open_media_receiver(display, (1 * 1024 * 1024,))
+
+        async def _drain() -> None:
+            try:
+                while True:
+                    await transport.recv()
+            except (asyncio.CancelledError, OSError):
+                pass
+
         # Fail fast if the device's media-stream daemon is wedged — without
         # the timeout the call hangs indefinitely on a half-open RemoteXPC
         # channel. The user's standing advice is "reboot proactively".
         try:
             answer = await asyncio.wait_for(
                 display.start_video_stream(
-                    receiver_ip=local_ip,
-                    receiver_port=bound_port,
+                    receiver_ip=receiver_ip,
+                    receiver_port=transport.port,
                     sender_ip=sender_ip,
                     display_id=display_id,
                 ),
@@ -629,7 +628,7 @@ async def touch_session(
                 client_session_id = uuid.UUID(client_session_id)
             with contextlib.suppress(Exception):
                 await display.stop_media_stream(client_session_id)
-            sock.close()
+            transport.close()
     finally:
         with contextlib.suppress(BaseException):
             await display.__aexit__(None, None, None)

--- a/pymobiledevice3/remote/core_device/media_stream_offer.py
+++ b/pymobiledevice3/remote/core_device/media_stream_offer.py
@@ -76,6 +76,8 @@ The byte-for-byte equivalence between this builder (with default args) and
 the prior verbatim hex template is locked in by the doctest at the bottom.
 """
 
+from __future__ import annotations
+
 import plistlib
 import time
 import uuid

--- a/pymobiledevice3/remote/core_device/screen_stream.py
+++ b/pymobiledevice3/remote/core_device/screen_stream.py
@@ -27,7 +27,7 @@ import tempfile
 import uuid
 from collections import deque
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Protocol
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -313,40 +313,41 @@ async def capture_rtp_to_file(
     number of captured packets.
     """
     sender_ip = rsd.service.address[0]
-    sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-    sock.bind(("::", receiver_port))
-    bound_port = sock.getsockname()[1]
-    logger.info(f"Listening for RTP on [{sender_ip}] → ::{bound_port}")
-
     captured = 0
     async with DisplayService(rsd) as service:
-        local_ip = service.service.local_address[0]
-        answer = await service.start_video_stream(
-            receiver_ip=local_ip,
-            receiver_port=bound_port,
-            sender_ip=sender_ip,
-            display_id=display_id,
+        # Bind the RTP receiver on the right transport (pytcp stack over the userspace tunnel,
+        # host kernel socket otherwise) and advertise the matching address to the device.
+        transport, receiver_ip = open_media_receiver(
+            service, (4 * 1024 * 1024, 1 * 1024 * 1024), bind_port=receiver_port
         )
-        logger.info("Stream started; dumping RTP for %.1fs", duration)
-        sock.setblocking(False)
-        loop = asyncio.get_running_loop()
-        with open(output_path, "wb") as fp:
-            deadline = loop.time() + duration
-            while loop.time() < deadline:
-                remaining = deadline - loop.time()
-                try:
-                    data = await asyncio.wait_for(loop.sock_recv(sock, 65535), timeout=remaining)
-                except asyncio.TimeoutError:
-                    break
-                fp.write(len(data).to_bytes(4, "big") + data)
-                captured += 1
-        logger.info(f"Captured {captured} packets to {output_path}")
-        client_session_id = answer["connection"]["options"]["avcMediaStreamOptionClientSessionID"]["uuid"]
-        if not isinstance(client_session_id, uuid.UUID):
-            client_session_id = uuid.UUID(client_session_id)
-        with contextlib.suppress(Exception):
-            await service.stop_media_stream(client_session_id)
-    sock.close()
+        logger.info(f"Listening for RTP on [{receiver_ip}]:{transport.port}")
+        try:
+            answer = await service.start_video_stream(
+                receiver_ip=receiver_ip,
+                receiver_port=transport.port,
+                sender_ip=sender_ip,
+                display_id=display_id,
+            )
+            logger.info("Stream started; dumping RTP for %.1fs", duration)
+            loop = asyncio.get_running_loop()
+            with open(output_path, "wb") as fp:
+                deadline = loop.time() + duration
+                while loop.time() < deadline:
+                    remaining = deadline - loop.time()
+                    try:
+                        data = await asyncio.wait_for(transport.recv(), timeout=remaining)
+                    except asyncio.TimeoutError:
+                        break
+                    fp.write(len(data).to_bytes(4, "big") + data)
+                    captured += 1
+            logger.info(f"Captured {captured} packets to {output_path}")
+            client_session_id = answer["connection"]["options"]["avcMediaStreamOptionClientSessionID"]["uuid"]
+            if not isinstance(client_session_id, uuid.UUID):
+                client_session_id = uuid.UUID(client_session_id)
+            with contextlib.suppress(Exception):
+                await service.stop_media_stream(client_session_id)
+        finally:
+            transport.close()
     return captured
 
 
@@ -365,46 +366,133 @@ async def capture_audio_rtp_to_file(
     (10 ms). Used by ``pymobiledevice3 ... display start-audio-stream``.
     """
     sender_ip = rsd.service.address[0]
-    sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-    sock.bind(("::", receiver_port))
-    bound_port = sock.getsockname()[1]
-    logger.info(f"Listening for AUDIO RTP on [{sender_ip}] → ::{bound_port}")
-
     captured = 0
     async with DisplayService(rsd) as service:
-        local_ip = service.service.local_address[0]
-        answer = await service.start_audio_stream(
-            receiver_ip=local_ip,
-            receiver_port=bound_port,
-            sender_ip=sender_ip,
+        transport, receiver_ip = open_media_receiver(
+            service, (4 * 1024 * 1024, 1 * 1024 * 1024), bind_port=receiver_port
         )
-        cfg = answer["connection"].get("streamConfig", {})
-        logger.info(
-            "Audio stream started: PT=%s mode=%s sender_port=%s",
-            cfg.get("RxPayloadType"),
-            cfg.get("AudioStreamMode"),
-            cfg.get("SourcePort"),
-        )
-        sock.setblocking(False)
-        loop = asyncio.get_running_loop()
-        with open(output_path, "wb") as fp:
-            deadline = loop.time() + duration
-            while loop.time() < deadline:
-                remaining = deadline - loop.time()
-                try:
-                    data = await asyncio.wait_for(loop.sock_recv(sock, 65535), timeout=remaining)
-                except asyncio.TimeoutError:
-                    break
-                fp.write(len(data).to_bytes(4, "big") + data)
-                captured += 1
-        logger.info(f"Captured {captured} audio packets to {output_path}")
-        client_session_id = answer["connection"]["options"]["avcMediaStreamOptionClientSessionID"]["uuid"]
-        if not isinstance(client_session_id, uuid.UUID):
-            client_session_id = uuid.UUID(client_session_id)
-        with contextlib.suppress(Exception):
-            await service.stop_media_stream(client_session_id)
-    sock.close()
+        logger.info(f"Listening for AUDIO RTP on [{receiver_ip}]:{transport.port}")
+        try:
+            answer = await service.start_audio_stream(
+                receiver_ip=receiver_ip,
+                receiver_port=transport.port,
+                sender_ip=sender_ip,
+            )
+            cfg = answer["connection"].get("streamConfig", {})
+            logger.info(
+                "Audio stream started: PT=%s mode=%s sender_port=%s",
+                cfg.get("RxPayloadType"),
+                cfg.get("AudioStreamMode"),
+                cfg.get("SourcePort"),
+            )
+            loop = asyncio.get_running_loop()
+            with open(output_path, "wb") as fp:
+                deadline = loop.time() + duration
+                while loop.time() < deadline:
+                    remaining = deadline - loop.time()
+                    try:
+                        data = await asyncio.wait_for(transport.recv(), timeout=remaining)
+                    except asyncio.TimeoutError:
+                        break
+                    fp.write(len(data).to_bytes(4, "big") + data)
+                    captured += 1
+            logger.info(f"Captured {captured} audio packets to {output_path}")
+            client_session_id = answer["connection"]["options"]["avcMediaStreamOptionClientSessionID"]["uuid"]
+            if not isinstance(client_session_id, uuid.UUID):
+                client_session_id = uuid.UUID(client_session_id)
+            with contextlib.suppress(Exception):
+                await service.stop_media_stream(client_session_id)
+        finally:
+            transport.close()
     return captured
+
+
+class UdpMediaTransport(Protocol):
+    """The UDP transport the device-initiated AV media streams (RTP) flow over.
+
+    Two implementations: :class:`_KernelUdp` (host kernel socket, the default kernel-tunnel
+    path) and ``userspace_tunnel.UserspaceUdp`` (a socket on the pytcp stack, for the no-root
+    userspace tunnel). The media receive / RTCP loops are written against this interface so
+    they are transport-agnostic.
+    """
+
+    @property
+    def local_ip(self) -> str: ...
+
+    @property
+    def port(self) -> int: ...
+
+    async def recv(self, bufsize: int = 65535) -> bytes: ...
+
+    async def sendto(self, data: bytes, ip: str, port: int) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class _KernelUdp:
+    """:class:`UdpMediaTransport` over a host kernel UDP socket — the default kernel-tunnel path."""
+
+    def __init__(self, sock: socket.socket) -> None:
+        sock.setblocking(False)
+        self._sock = sock
+        self._loop = asyncio.get_event_loop()
+
+    @property
+    def local_ip(self) -> str:
+        return self._sock.getsockname()[0]
+
+    @property
+    def port(self) -> int:
+        return self._sock.getsockname()[1]
+
+    async def recv(self, bufsize: int = 65535) -> bytes:
+        return await self._loop.sock_recv(self._sock, bufsize)
+
+    async def sendto(self, data: bytes, ip: str, port: int) -> None:
+        await self._loop.sock_sendto(self._sock, data, (ip, port, 0, 0))
+
+    def close(self) -> None:
+        with contextlib.suppress(Exception):
+            self._sock.close()
+
+
+def open_media_receiver(
+    svc: DisplayService, rcvbuf_sizes: tuple[int, ...], bind_port: int = 0
+) -> tuple[UdpMediaTransport, str]:
+    """Open the UDP receiver the device streams RTP to, plus the address to advertise to it.
+
+    Over the userspace tunnel the device-initiated RTP must terminate on the pytcp stack — a
+    host kernel socket is unreachable from the device — so bind a socket on the stack and
+    advertise the stack address. Otherwise bind a host kernel socket (sized from
+    ``rcvbuf_sizes``, trying each until one is accepted) and advertise the RSD connection's
+    local address.
+
+    ``bind_port`` requests a specific host port on the kernel path; it is ignored over the
+    userspace tunnel, where the stack socket always picks its own port (read it from
+    ``transport.port``). Shared by every device-initiated media path (screen serve, RTP/audio
+    capture, the HID auth-gate stream, VNC) so they are transport-agnostic and userspace-safe.
+    """
+    try:
+        from pymobiledevice3.remote import userspace_tunnel
+
+        if userspace_tunnel.USERSPACE_ACTIVE:
+            if bind_port:
+                logger.debug("userspace tunnel: ignoring requested receiver port %s (stack picks its own)", bind_port)
+            transport = userspace_tunnel.UserspaceUdp()
+            return transport, transport.local_ip
+    except Exception:
+        logger.debug("userspace UDP receiver unavailable; using a host kernel socket", exc_info=True)
+    sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+    sock.bind(("::", bind_port))
+    # Pump SO_RCVBUF as high as the kernel allows (capped by kern.ipc.maxsockbuf, ~8 MB on
+    # macOS); a larger buffer tolerates longer event-loop stalls without kernel UDP drops.
+    for size in rcvbuf_sizes:
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, size)
+            break
+        except OSError:
+            continue
+    return _KernelUdp(sock), svc.service.local_address[0]
 
 
 # ---------------------------------------------------------------------------
@@ -492,7 +580,7 @@ class ScreenStreamServer:
         # Active device-stream session.
         self._active_service: Optional[DisplayService] = None
         self._active_session_id: Optional[uuid.UUID] = None
-        self._active_sock: Optional[socket.socket] = None
+        self._active_sock: Optional[UdpMediaTransport] = None
         self._active_recv_task: Optional[asyncio.Task] = None
         self._active_rtcp_task: Optional[asyncio.Task] = None
         self._stream_lock = asyncio.Lock()
@@ -503,7 +591,7 @@ class ScreenStreamServer:
         # broadcast as a length-prefixed chunk.
         self._audio_service: Optional[DisplayService] = None
         self._audio_session_id: Optional[uuid.UUID] = None
-        self._audio_sock: Optional[socket.socket] = None
+        self._audio_sock: Optional[UdpMediaTransport] = None
         self._audio_recv_task: Optional[asyncio.Task] = None
         self._audio_subscribers: dict[asyncio.Queue[bytes], None] = {}
         self._audio_lock = asyncio.Lock()
@@ -609,8 +697,7 @@ class ScreenStreamServer:
         self._reconnect_poll_interval = 2.0
 
     # ----- per-session UDP receiver -----------------------------------------
-    async def _udp_recv_and_depacketize(self, sock: socket.socket) -> None:
-        sock.setblocking(False)
+    async def _udp_recv_and_depacketize(self, transport: UdpMediaTransport) -> None:
         loop = asyncio.get_running_loop()
         fu_buffer = bytearray()
         current_au: list[bytes] = []
@@ -642,7 +729,7 @@ class ScreenStreamServer:
         stats_last_log = asyncio.get_running_loop().time()
         while True:
             try:
-                data = await loop.sock_recv(sock, 65535)
+                data = await transport.recv(65535)
             except (OSError, asyncio.CancelledError):
                 return
             except Exception:
@@ -821,14 +908,13 @@ class ScreenStreamServer:
         )
 
     async def _send_rtcp_pli(self) -> None:
-        sock = self._active_sock
-        if sock is None or self._rtcp_dest is None:
+        transport = self._active_sock
+        if transport is None or self._rtcp_dest is None:
             return
         if not (self._local_ssrc and self._remote_ssrc):
             return
         try:
-            loop = asyncio.get_running_loop()
-            await loop.sock_sendto(sock, self._build_rtcp_pli(), (*self._rtcp_dest, 0, 0))
+            await transport.sendto(self._build_rtcp_pli(), *self._rtcp_dest)
             logger.debug("sent RTCP PLI (requested fresh keyframe)")
         except OSError as exc:
             logger.debug("PLI send failed (%s)", exc)
@@ -873,9 +959,8 @@ class ScreenStreamServer:
             0,
         )
 
-    async def _rtcp_send_loop(self, sock: socket.socket) -> None:
+    async def _rtcp_send_loop(self, transport: UdpMediaTransport) -> None:
         """Periodically send RTCP RR to the device so the encoder doesn't time out."""
-        loop = asyncio.get_running_loop()
         while True:
             try:
                 await asyncio.sleep(1.0)
@@ -885,7 +970,7 @@ class ScreenStreamServer:
                 continue
             packet = self._build_rtcp_rr()
             try:
-                await loop.sock_sendto(sock, packet, (*self._rtcp_dest, 0, 0))
+                await transport.sendto(packet, *self._rtcp_dest)
             except OSError as exc:
                 logger.debug("RTCP send failed (%s); the socket may be torn down", exc)
                 return
@@ -913,13 +998,12 @@ class ScreenStreamServer:
             0,
         )
 
-    async def _audio_rtcp_send_loop(self, sock: socket.socket) -> None:
+    async def _audio_rtcp_send_loop(self, transport: UdpMediaTransport) -> None:
         """Periodically send RTCP RR for the audio stream. Without this
         the device reaps the audio session after ~20 s (RTCPTimeoutInterval)
         and the encoder silently stops emitting RTP audio packets --
         mediastreamstatus confirmed the audio session disappears from the
         sessions list when we don't RR."""
-        loop = asyncio.get_running_loop()
         while True:
             try:
                 await asyncio.sleep(1.0)
@@ -929,7 +1013,7 @@ class ScreenStreamServer:
                 continue
             packet = self._build_audio_rtcp_rr()
             try:
-                await loop.sock_sendto(sock, packet, (*self._audio_rtcp_dest, 0, 0))
+                await transport.sendto(packet, *self._audio_rtcp_dest)
             except OSError as exc:
                 logger.debug("audio RTCP send failed (%s); the socket may be torn down", exc)
                 return
@@ -948,7 +1032,7 @@ class ScreenStreamServer:
     # AudioToolbox-via-ctypes plumbing. Output here is s16le 48 kHz
     # stereo interleaved PCM, broadcast in length-prefixed chunks to
     # /audio.bin subscribers (~192 KB/s).
-    async def _audio_udp_recv(self, sock: socket.socket) -> None:
+    async def _audio_udp_recv(self, transport: UdpMediaTransport) -> None:
         """Receive RTP audio packets, strip the RTP header, decode the
         AAC-ELD AU via AudioToolbox, and broadcast the interleaved s16le
         PCM to /audio.bin subscribers."""
@@ -959,8 +1043,6 @@ class ScreenStreamServer:
             return
         logger.info("audio decoder ready: AudioToolbox AAC-ELD -> s16le 48k stereo")
 
-        sock.setblocking(False)
-        loop = asyncio.get_running_loop()
         # Volume changes on the device side can land us with a packet
         # the decoder rejects -- and once AudioConverter has errored, all
         # subsequent FillComplexBuffer calls fail too. Track consecutive
@@ -972,7 +1054,7 @@ class ScreenStreamServer:
 
         while True:
             try:
-                data = await loop.sock_recv(sock, 65535)
+                data = await transport.recv(65535)
             except (OSError, asyncio.CancelledError):
                 return
             except Exception:
@@ -1074,21 +1156,15 @@ class ScreenStreamServer:
             ):
                 return
             await self._stop_audio_stream()
-            sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-            sock.bind(("::", 0))
-            try:
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4 * 1024 * 1024)
-            except OSError:
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 1 * 1024 * 1024)
-            port = sock.getsockname()[1]
             svc = DisplayService(self._rsd)
             await svc.connect()
-            local_ip = svc.service.local_address[0]
+            transport, receiver_ip = open_media_receiver(svc, (4 * 1024 * 1024, 1 * 1024 * 1024))
+            port = transport.port
             # Same shared client_session_id as the video stream so the
             # device pairs them on its media-session manager (Xcode's
             # Mirror does this -- confirmed in the remotexpc sniff).
             answer = await svc.start_audio_stream(
-                receiver_ip=local_ip,
+                receiver_ip=receiver_ip,
                 receiver_port=port,
                 sender_ip=self._sender_ip,
                 client_session_id=self._shared_session_id,
@@ -1114,14 +1190,14 @@ class ScreenStreamServer:
             self._audio_rtcp_dest = (self._sender_ip, source_port) if source_port else None
             self._audio_service = svc
             self._audio_session_id = sid
-            self._audio_sock = sock
-            self._audio_recv_task = asyncio.create_task(self._audio_udp_recv(sock))
+            self._audio_sock = transport
+            self._audio_recv_task = asyncio.create_task(self._audio_udp_recv(transport))
             # Keep the audio session alive by RR'ing every second.
             # RTCPTimeoutInterval=20 s by default; without this the
             # device reaps the audio session, mediastreamstatus drops it,
             # and the encoder stops emitting (silently).
             if self._audio_rtcp_dest is not None and self._audio_local_ssrc and self._audio_remote_ssrc:
-                self._audio_rtcp_task = asyncio.create_task(self._audio_rtcp_send_loop(sock))
+                self._audio_rtcp_task = asyncio.create_task(self._audio_rtcp_send_loop(transport))
             else:
                 logger.warning(
                     "audio RTCP disabled (missing fields: SourcePort=%s LocalSSRC=%s RemoteSSRC=%s)",
@@ -1198,26 +1274,17 @@ class ScreenStreamServer:
                         q.get_nowait()
                 state.needs_key = True
 
-            # Fresh socket — no buffered packets from a previous session can
-            # corrupt the new session's FU reassembly.
-            sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-            sock.bind(("::", 0))
-            # Pump SO_RCVBUF as high as the kernel will allow (capped by
-            # kern.ipc.maxsockbuf, typically 8 MB on macOS). Larger buffer =
-            # tolerates longer event-loop stalls without kernel-level UDP drops.
-            try:
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 8 * 1024 * 1024)
-            except OSError:
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4 * 1024 * 1024)
-            port = sock.getsockname()[1]
-
             svc = DisplayService(self._rsd)
             await svc.connect()
-            local_ip = svc.service.local_address[0]
+
+            # Fresh media receiver — no buffered packets from a previous session can corrupt
+            # the new session's FU reassembly.
+            transport, receiver_ip = open_media_receiver(svc, (8 * 1024 * 1024, 4 * 1024 * 1024))
+            port = transport.port
             # Pass the shared client_session_id so the device sees us as
             # one Mirror client across audio + video, matching Xcode.
             answer = await svc.start_video_stream(
-                receiver_ip=local_ip,
+                receiver_ip=receiver_ip,
                 receiver_port=port,
                 sender_ip=self._sender_ip,
                 display_id=self._display_id,
@@ -1244,10 +1311,10 @@ class ScreenStreamServer:
             self._rtcp_dest = (self._sender_ip, source_port) if source_port else None
             self._active_service = svc
             self._active_session_id = sid
-            self._active_sock = sock
-            self._active_recv_task = asyncio.create_task(self._udp_recv_and_depacketize(sock))
+            self._active_sock = transport
+            self._active_recv_task = asyncio.create_task(self._udp_recv_and_depacketize(transport))
             if self._rtcp_dest is not None and self._local_ssrc and self._remote_ssrc:
-                self._active_rtcp_task = asyncio.create_task(self._rtcp_send_loop(sock))
+                self._active_rtcp_task = asyncio.create_task(self._rtcp_send_loop(transport))
             else:
                 logger.warning(
                     "RTCP feedback disabled (missing fields in streamConfig: SourcePort=%s LocalSSRC=%s RemoteSSRC=%s)",

--- a/pymobiledevice3/remote/core_device/vnc_server.py
+++ b/pymobiledevice3/remote/core_device/vnc_server.py
@@ -26,7 +26,6 @@ import asyncio
 import contextlib
 import logging
 import os
-import socket
 import struct
 import sys
 import uuid
@@ -65,7 +64,7 @@ from pymobiledevice3.remote.core_device.hid_service import (
     IndigoHIDService,
     UniversalHIDServiceService,
 )
-from pymobiledevice3.remote.core_device.screen_stream import depacketize_hevc
+from pymobiledevice3.remote.core_device.screen_stream import UdpMediaTransport, depacketize_hevc, open_media_receiver
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
 
 logger = logging.getLogger(__name__)
@@ -299,7 +298,7 @@ class VncStreamServer:
         # ``streamConfig`` after start_video_stream returns. Without
         # these we can't kick the encoder, and decoder-refresh becomes
         # a no-op.
-        self._active_sock: Optional[socket.socket] = None
+        self._active_transport: Optional[UdpMediaTransport] = None
         self._local_ssrc: int = 0
         self._remote_ssrc: int = 0
         self._rtcp_dest: Optional[tuple[str, int]] = None
@@ -354,7 +353,7 @@ class VncStreamServer:
         # video session on the device by sharing client_session_id.
         self._audio_player: Optional[AudioQueuePlayer] = None
         self._audio_decoder: Optional[AACELDDecoder] = None
-        self._audio_sock: Optional[socket.socket] = None
+        self._audio_transport: Optional[UdpMediaTransport] = None
         self._audio_local_ssrc: int = 0
         self._audio_remote_ssrc: int = 0
         self._audio_rtcp_dest: Optional[tuple[str, int]] = None
@@ -437,10 +436,9 @@ class VncStreamServer:
             c.wants_update.set()
 
     # ----- RTP recv + transcoder feed ---------------------------------------
-    async def _udp_recv_and_pipe(self, sock: socket.socket) -> None:
+    async def _udp_recv_and_pipe(self, transport: UdpMediaTransport) -> None:
         """Same depacketize loop as ScreenStreamServer: gather Annex-B
         AUs and feed the VT transcoder."""
-        sock.setblocking(False)
         loop = asyncio.get_running_loop()
         fu_buffer = bytearray()
         current_au: list[bytes] = []
@@ -457,7 +455,7 @@ class VncStreamServer:
         last_stat_t = loop.time()
         while True:
             try:
-                data = await loop.sock_recv(sock, 65535)
+                data = await transport.recv()
             except (OSError, asyncio.CancelledError):
                 return
             if len(data) < 12:
@@ -643,14 +641,13 @@ class VncStreamServer:
         )
 
     async def _send_rtcp_pli(self) -> None:
-        sock = self._active_sock
-        if sock is None or self._rtcp_dest is None:
+        transport = self._active_transport
+        if transport is None or self._rtcp_dest is None:
             return
         if not (self._local_ssrc and self._remote_ssrc):
             return
         try:
-            loop = asyncio.get_running_loop()
-            await loop.sock_sendto(sock, self._build_rtcp_pli(), (*self._rtcp_dest, 0, 0))
+            await transport.sendto(self._build_rtcp_pli(), *self._rtcp_dest)
             logger.debug("sent RTCP PLI (requested fresh keyframe)")
         except OSError as exc:
             logger.debug("PLI send failed (%s)", exc)
@@ -769,12 +766,11 @@ class VncStreamServer:
             self._fire_decoder_refresh(now, reason=reason)
 
     # ----- Audio: AAC-ELD recv + decode + play ------------------------------
-    async def _audio_udp_recv(self, sock: socket.socket) -> None:
+    async def _audio_udp_recv(self, transport: UdpMediaTransport) -> None:
         """Receive RTP audio packets, strip the RTP header, decode the
         AAC-ELD AU via AudioToolbox, and feed the PCM to the local
         AudioQueue. Mirrors :meth:`screen_stream.ScreenStreamServer._audio_udp_recv`
         but plays locally instead of broadcasting."""
-        sock.setblocking(False)
         loop = asyncio.get_running_loop()
         consecutive_errors = 0
         _ERR_RECREATE_THRESHOLD = 5
@@ -782,7 +778,7 @@ class VncStreamServer:
         last_stat_t = loop.time()
         while True:
             try:
-                data = await loop.sock_recv(sock, 65535)
+                data = await transport.recv()
             except (OSError, asyncio.CancelledError):
                 return
             if len(data) < 12:
@@ -872,8 +868,7 @@ class VncStreamServer:
             0,  # jitter / lsr / dlsr
         )
 
-    async def _audio_rtcp_send_loop(self, sock: socket.socket) -> None:
-        loop = asyncio.get_running_loop()
+    async def _audio_rtcp_send_loop(self, transport: UdpMediaTransport) -> None:
         sent = 0
         while True:
             try:
@@ -883,7 +878,7 @@ class VncStreamServer:
             if self._audio_rtcp_dest is None or self._audio_rtp_packets_received == 0:
                 continue
             try:
-                await loop.sock_sendto(sock, self._build_audio_rtcp_rr(), (*self._audio_rtcp_dest, 0, 0))
+                await transport.sendto(self._build_audio_rtcp_rr(), *self._audio_rtcp_dest)
                 sent += 1
                 # One log line per 30 RRs (every 30 s) confirms the
                 # session keepalive is firing -- useful when triaging
@@ -1325,24 +1320,18 @@ class VncStreamServer:
 
     # ----- top-level orchestration ------------------------------------------
     async def serve(self) -> None:
-        # 1) UDP socket for RTP/HEVC.
-        sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-        sock.bind(("::", 0))
-        with contextlib.suppress(OSError):
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 8 * 1024 * 1024)
-        port = sock.getsockname()[1]
-
-        # 2) Start device-side video stream. Generate a single
-        # client_session_id up front so the audio stream (started
-        # below) gets paired with the video session on the device --
-        # this is what Xcode's Mirror does.
+        # 1) Start device-side video stream + open the RTP receiver on the right transport:
+        # the pytcp stack over the userspace tunnel (a host kernel socket is unreachable from
+        # the device), a host kernel socket otherwise. Generate a single client_session_id up
+        # front so the audio stream (started below) gets paired with the video session on the
+        # device -- this is what Xcode's Mirror does.
         shared_session_id = uuid.uuid4()
         svc = DisplayService(self._rsd)
         await svc.connect()
-        local_ip = svc.service.local_address[0]
+        transport, receiver_ip = open_media_receiver(svc, (8 * 1024 * 1024, 4 * 1024 * 1024))
         answer = await svc.start_video_stream(
-            receiver_ip=local_ip,
-            receiver_port=port,
+            receiver_ip=receiver_ip,
+            receiver_port=transport.port,
             sender_ip=self._sender_ip,
             display_id=self._display_id,
             client_session_id=shared_session_id,
@@ -1369,7 +1358,7 @@ class VncStreamServer:
         self._local_ssrc = int(cfg.get("RemoteSSRC", 0))
         self._remote_ssrc = int(cfg.get("LocalSSRC", 0))
         self._rtcp_dest = (self._sender_ip, source_port) if source_port else None
-        self._active_sock = sock
+        self._active_transport = transport
         if self._rtcp_dest and self._local_ssrc and self._remote_ssrc:
             logger.info(
                 "RTCP feedback enabled: dest=%s, ours=%d, theirs=%d",
@@ -1396,16 +1385,12 @@ class VncStreamServer:
         audio_rtcp_task: Optional[asyncio.Task] = None
         if self._audio_enabled:
             try:
-                audio_sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-                audio_sock.bind(("::", 0))
-                with contextlib.suppress(OSError):
-                    audio_sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4 * 1024 * 1024)
-                audio_port = audio_sock.getsockname()[1]
                 audio_svc = DisplayService(self._rsd)
                 await audio_svc.connect()
+                audio_transport, audio_receiver_ip = open_media_receiver(audio_svc, (4 * 1024 * 1024, 1 * 1024 * 1024))
                 audio_answer = await audio_svc.start_audio_stream(
-                    receiver_ip=local_ip,
-                    receiver_port=audio_port,
+                    receiver_ip=audio_receiver_ip,
+                    receiver_port=audio_transport.port,
                     sender_ip=self._sender_ip,
                     client_session_id=shared_session_id,
                 )
@@ -1416,7 +1401,7 @@ class VncStreamServer:
                 self._audio_local_ssrc = int(audio_cfg.get("RemoteSSRC", 0))
                 self._audio_remote_ssrc = int(audio_cfg.get("LocalSSRC", 0))
                 self._audio_rtcp_dest = (self._sender_ip, a_source_port) if a_source_port else None
-                self._audio_sock = audio_sock
+                self._audio_transport = audio_transport
                 self._audio_svc = audio_svc
                 self._audio_session_id = audio_sid
                 self._audio_decoder = AACELDDecoder()
@@ -1436,19 +1421,19 @@ class VncStreamServer:
                         self._audio_player.close()
                     self._audio_player = None
                 self._audio_decoder = None
-                self._audio_sock = None
+                self._audio_transport = None
                 self._audio_svc = None
                 self._audio_session_id = None
 
         # 4) Background tasks.
         loop = asyncio.get_running_loop()
         self._loop = loop
-        feed_task = asyncio.create_task(self._udp_recv_and_pipe(sock))
+        feed_task = asyncio.create_task(self._udp_recv_and_pipe(transport))
         refresh_task = asyncio.create_task(self._decoder_refresh_loop())
-        if self._audio_enabled and self._audio_sock is not None:
-            audio_recv_task = asyncio.create_task(self._audio_udp_recv(self._audio_sock))
+        if self._audio_enabled and self._audio_transport is not None:
+            audio_recv_task = asyncio.create_task(self._audio_udp_recv(self._audio_transport))
             if self._audio_rtcp_dest and self._audio_local_ssrc and self._audio_remote_ssrc:
-                audio_rtcp_task = asyncio.create_task(self._audio_rtcp_send_loop(self._audio_sock))
+                audio_rtcp_task = asyncio.create_task(self._audio_rtcp_send_loop(self._audio_transport))
             else:
                 logger.warning(
                     "audio RTCP disabled (missing fields in streamConfig) -- session will be reaped after ~20 s"
@@ -1504,7 +1489,7 @@ class VncStreamServer:
                     self._transcoder.close()
                 self._transcoder = None
             with contextlib.suppress(Exception):
-                sock.close()
+                transport.close()
             if audio_recv_task is not None:
                 logger.debug("shutdown: stopping audio recv loop")
                 audio_recv_task.cancel()
@@ -1526,9 +1511,9 @@ class VncStreamServer:
                     await asyncio.wait_for(self._audio_svc.stop_media_stream(self._audio_session_id), timeout=3.0)
                 with contextlib.suppress(Exception):
                     await self._audio_svc.close()
-            if self._audio_sock is not None:
+            if self._audio_transport is not None:
                 with contextlib.suppress(Exception):
-                    self._audio_sock.close()
+                    self._audio_transport.close()
             logger.debug("shutdown: stopping device stream")
             with contextlib.suppress(Exception):
                 await asyncio.wait_for(svc.stop_media_stream(sid), timeout=3.0)

--- a/pymobiledevice3/remote/remote_service_discovery.py
+++ b/pymobiledevice3/remote/remote_service_discovery.py
@@ -3,7 +3,7 @@ import logging
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 from pymobiledevice3.bonjour import DEFAULT_BONJOUR_TIMEOUT, browse_remoted
 from pymobiledevice3.common import get_home_folder
@@ -33,10 +33,17 @@ RSD_PORT = 58783
 
 
 class RemoteServiceDiscoveryService(LockdownServiceProvider):
-    def __init__(self, address: tuple[str, int], name: Optional[str] = None) -> None:
+    def __init__(
+        self, address: tuple[str, int], name: Optional[str] = None, open_connection: Optional[Callable] = None
+    ) -> None:
         super().__init__()
         self.name = name
-        self.service = RemoteXPCConnection(address)
+        # ``asyncio.open_connection``-compatible dialer used for the RemoteXPC handshake and every
+        # service connection opened through this RSD (read by callers such as FileServiceService).
+        # ``None`` => stdlib ``asyncio.open_connection``; the userspace tunnel injects a relay dialer
+        # so device-bound connections route through its in-process stack without a global monkeypatch.
+        self.open_connection = open_connection
+        self.service = RemoteXPCConnection(address, open_connection=open_connection)
         self.peer_info: Optional[dict] = None
         self.lockdown: Optional[LockdownClient] = None
         self.all_values: Optional[dict] = None
@@ -148,7 +155,9 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         return {"Port": self.get_service_port(name), "EnableServiceSSL": False}
 
     async def create_service_connection(self, port: int) -> ServiceConnection:
-        return await ServiceConnection.create_using_tcp(self.service.address[0], port)
+        return await ServiceConnection.create_using_tcp(
+            self.service.address[0], port, open_connection=self.open_connection
+        )
 
     async def start_lockdown_service(self, name: str, include_escrow_bag: bool = False) -> ServiceConnection:
         service = await self.start_lockdown_service_without_checkin(name)
@@ -187,7 +196,9 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
             raise
 
     def start_remote_service(self, name: str) -> RemoteXPCConnection:
-        service = RemoteXPCConnection((self.service.address[0], self.get_service_port(name)))
+        service = RemoteXPCConnection(
+            (self.service.address[0], self.get_service_port(name)), open_connection=self.open_connection
+        )
         return service
 
     async def start_service(self, name: str) -> Union[RemoteXPCConnection, ServiceConnection]:

--- a/pymobiledevice3/remote/remote_service_discovery.py
+++ b/pymobiledevice3/remote/remote_service_discovery.py
@@ -49,6 +49,14 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         self.all_values: Optional[dict] = None
 
     @property
+    def is_in_process_tunnel(self) -> bool:
+        """True when this RSD reaches the device through an in-process dialer (the userspace
+        tunnel) rather than a kernel-routable interface. The device address (``self.service.address``)
+        is then only reachable from THIS process, so it must not be handed to external tools such as
+        lldb as a connect endpoint."""
+        return self.open_connection is not None
+
+    @property
     def product_version(self) -> str:
         return self.peer_info["Properties"]["OSVersion"]
 

--- a/pymobiledevice3/remote/remotexpc.py
+++ b/pymobiledevice3/remote/remotexpc.py
@@ -3,7 +3,7 @@ import contextlib
 import uuid
 from asyncio import IncompleteReadError
 from collections.abc import AsyncIterable
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 from construct import StreamError
 from hyperframe.frame import (
@@ -56,9 +56,13 @@ resp = await client.send_receive_request({"Command": "DoSomething"})
 
 
 class RemoteXPCConnection:
-    def __init__(self, address: tuple[str, int]):
+    def __init__(self, address: tuple[str, int], open_connection: Optional[Callable] = None):
         self._previous_frame_data = b""
         self.address = address
+        # ``asyncio.open_connection``-compatible dialer. Defaults to the stdlib function; the
+        # userspace tunnel injects one that relays device-bound connections through its in-process
+        # stack, so no global ``asyncio.open_connection`` monkeypatch is needed.
+        self._open_connection = open_connection or asyncio.open_connection
         self.next_message_id: dict[int, int] = {ROOT_CHANNEL: 0, REPLY_CHANNEL: 0}
         self.peer_info = None
         self._reader: Optional[asyncio.StreamReader] = None
@@ -75,7 +79,7 @@ class RemoteXPCConnection:
         await self.close()
 
     async def connect(self) -> None:
-        self._reader, self._writer = await asyncio.open_connection(self.address[0], self.address[1])
+        self._reader, self._writer = await self._open_connection(self.address[0], self.address[1])
         try:
             await self._do_handshake()
         except Exception:

--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -157,6 +157,29 @@ RPPairingPacket = Struct(
     "body" / Prefixed(Int16ub, GreedyBytes),
 )
 
+#: When True, :func:`create_tun_device` builds the tunnel's interface as a pure-Python
+#: userspace stack (``UserspaceTun``, no root) instead of a kernel ``utun`` (needs root/admin).
+#: The no-root establishment flow flips this on. Kept as a module-level flag so the tunnel
+#: device is selected by an explicit factory call rather than by monkeypatching a class.
+USE_USERSPACE_TUNNEL = False
+
+
+def create_tun_device(interface_name: str = DEFAULT_INTERFACE_NAME):
+    """Create the tunnel's link-layer device, consulting the user's kernel-vs-userspace choice.
+
+    Default: a kernel :class:`pytun_pmd3.TunTapDevice` (requires root/admin). When
+    :data:`USE_USERSPACE_TUNNEL` is set, a no-root userspace PyTCP stack. The userspace import
+    is deferred so the optional PyTCP dependency is pulled in only when actually requested.
+    """
+    if USE_USERSPACE_TUNNEL:
+        from pymobiledevice3.remote.userspace_tunnel import UserspaceTun
+
+        return UserspaceTun(interface_name)
+    if sys.platform == "win32":
+        # Only the win32 TunTapDevice implementation accepts an interface name.
+        return TunTapDevice(interface_name)
+    return TunTapDevice()
+
 
 class RemotePairingTunnel(ABC):
     def __init__(self):
@@ -201,11 +224,7 @@ class RemotePairingTunnel(ABC):
             self._logger.warning(f"got oserror in {asyncio.current_task().get_name()}")
 
     def start_tunnel(self, address: str, mtu: int, interface_name=DEFAULT_INTERFACE_NAME) -> None:
-        if sys.platform == "win32":
-            # Only win32 tunnel implementation supports interface name
-            self.tun = TunTapDevice(interface_name)
-        else:
-            self.tun = TunTapDevice()
+        self.tun = create_tun_device(interface_name)
         self.tun.addr = address
         self.tun.mtu = mtu
         self.tun.up()

--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -9,6 +9,7 @@ import os
 import platform
 import plistlib
 import secrets
+import select
 import ssl
 import struct
 import sys
@@ -204,13 +205,7 @@ class RemotePairingTunnel(ABC):
     async def tun_read_task(self) -> None:
         read_size = self.tun.mtu + len(LOOPBACK_HEADER)
         try:
-            if sys.platform != "win32":
-                while True:
-                    packet = await asyncio.to_thread(self.tun.read, read_size)
-                    assert packet.startswith(LOOPBACK_HEADER)
-                    packet = packet[len(LOOPBACK_HEADER) :]
-                    await self.send_packet_to_device(packet)
-            else:
+            if sys.platform == "win32":
                 while True:
                     packet = await self.tun.async_read()
                     if packet:
@@ -218,10 +213,77 @@ class RemotePairingTunnel(ABC):
                             # Make sure to output only IPv6 packets
                             continue
                         await self.send_packet_to_device(packet)
+            elif hasattr(self.tun, "fileno"):
+                # Kernel tun (pytun): read via the event loop's readable callback rather than
+                # a per-packet ``asyncio.to_thread`` hop. The thread-pool round-trip posts each
+                # read result back through the loop's ready queue, so under a busy loop (e.g.
+                # tunneld, which also runs the usb/wifi/usbmux/mobdev2 monitors and the HTTP
+                # server) every packet's read completion queues behind those callbacks and the
+                # upload collapses to a few MB/s. ``add_reader`` runs the read inline in the
+                # loop with no cross-thread handoff. The fd is left blocking — the callback
+                # only fires when it is readable, so a single ``os.read`` returns one queued
+                # packet without blocking, and the reverse ``self.tun.write`` path (which shares
+                # the fd) keeps its blocking semantics.
+                await self._tun_read_loop_via_reader(read_size)
+            else:
+                # Userspace tun (no pollable fd): blocking read off the loop via a worker thread.
+                while True:
+                    packet = await asyncio.to_thread(self.tun.read, read_size)
+                    assert packet.startswith(LOOPBACK_HEADER)
+                    packet = packet[len(LOOPBACK_HEADER) :]
+                    await self.send_packet_to_device(packet)
         except ConnectionResetError:
             self._logger.warning(f"got connection reset in {asyncio.current_task().get_name()}")
         except OSError:
             self._logger.warning(f"got oserror in {asyncio.current_task().get_name()}")
+
+    async def _tun_read_loop_via_reader(self, read_size: int) -> None:
+        loop = asyncio.get_running_loop()
+        fd = self.tun.fileno()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def on_readable() -> None:
+            # Drain every packet currently buffered on the fd in this one callback rather than
+            # one per loop iteration. Under a busy loop (tunneld) the iteration rate is only a
+            # few hundred/s, which would otherwise cap the relay regardless of link speed. The
+            # fd stays blocking (the reverse self.tun.write path shares it); select(timeout=0)
+            # reports whether another packet is ready so a read never blocks the loop.
+            while True:
+                try:
+                    packet = os.read(fd, read_size)
+                except (BlockingIOError, InterruptedError):
+                    return
+                except OSError:
+                    queue.put_nowait(None)
+                    return
+                if not packet:
+                    return
+                queue.put_nowait(packet)
+                if not select.select((fd,), (), (), 0)[0]:
+                    return
+
+        loop.add_reader(fd, on_readable)
+        try:
+            while True:
+                # Block only when the queue is empty; once a packet arrives, drain the whole
+                # backlog with get_nowait() before yielding again. ``await queue.get()`` yields
+                # to the loop, and under a busy loop (tunneld) a reschedule costs milliseconds —
+                # paying that per packet caps the relay at a few hundred packets/s. The reader
+                # callback keeps filling the queue while we are suspended, so draining it in one
+                # go amortises the reschedule across the whole burst.
+                packet = await queue.get()
+                while True:
+                    if packet is None:
+                        return
+                    if packet.startswith(LOOPBACK_HEADER):
+                        packet = packet[len(LOOPBACK_HEADER) :]
+                    await self.send_packet_to_device(packet)
+                    try:
+                        packet = queue.get_nowait()
+                    except asyncio.QueueEmpty:
+                        break
+        finally:
+            loop.remove_reader(fd)
 
     def start_tunnel(self, address: str, mtu: int, interface_name=DEFAULT_INTERFACE_NAME) -> None:
         self.tun = create_tun_device(interface_name)

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -17,6 +17,9 @@ wires together:
   device's tunnel address through a localhost socket into a PyTCP socket. This covers the RSD HTTP/2
   handshake and every ``ServiceConnection.create_using_tcp`` while leaving the process-global
   ``asyncio.open_connection`` untouched for any other code sharing the process.
+* :class:`UserspaceUdp` — a UDP socket on the stack for device-initiated inbound streams (the
+  AV media behind ``display serve-web``): the device pushes RTP to the stack address rather
+  than to an unreachable host kernel socket.
 
 pmd-pytcp ships only on Python >= 3.14, so it is an OPTIONAL dependency. This module imports
 pmd-pytcp at module level, so importing it REQUIRES pmd-pytcp; ``cli_common`` imports this
@@ -376,13 +379,91 @@ class UserspaceDialPlane:
 
 #: The userspace tunnel active in this process, or None. PyTCP's stack is a process-global
 #: singleton, so at most one exists; :class:`UserspaceRsdTunnel` sets this on open and clears
-#: it on close.
+#: it on close. Device-initiated stream code (``screen_stream``) reads it through
+#: :func:`userspace_stack_addr` / :data:`USERSPACE_ACTIVE` without holding a handle.
 _active_tunnel: Optional[UserspaceRsdTunnel] = None
 
 #: True while a userspace tunnel is active in this process. Mirrors ``_active_tunnel is not None``
 #: (kept as a plain flag so callers can read it as an attribute). The CLI also uses it to gate the
 #: hard exit in :func:`force_exit`.
 USERSPACE_ACTIVE = False
+
+
+def userspace_stack_addr() -> Optional[str]:
+    """The host-side stack address on the active userspace tunnel (what a device should stream
+    to), or None when no userspace tunnel is active."""
+    if _active_tunnel is not None and _active_tunnel.tun is not None:
+        return _active_tunnel.tun.addr
+    return None
+
+
+class UserspaceUdp:
+    """An async UDP socket on the userspace pytcp stack.
+
+    Device-initiated AV streams (serve-web/serve-vnc RTP) push UDP to a host endpoint. Over the
+    userspace tunnel that endpoint must live on the pytcp stack — a host kernel socket is
+    unreachable from the device. This binds a pytcp UDP socket on the stack address and presents
+    the recv/sendto surface ``screen_stream`` needs. A dedicated reader thread drains the socket
+    into an asyncio queue so the hot receive path is not a per-packet ``asyncio.to_thread`` hop.
+    """
+
+    def __init__(self, recv_queue_max: int = 8192) -> None:
+        addr = userspace_stack_addr()
+        if addr is None:
+            raise PyMobileDevice3Exception("userspace tunnel is not active")
+        self._sock = pytcp_socket(AF_INET6, SOCK_DGRAM)
+        self._sock.bind((addr, 0))
+        bound = self._sock.getsockname()
+        self._local_ip, self._port = bound[0], bound[1]
+        self._loop = asyncio.get_event_loop()
+        self._queue: asyncio.Queue = asyncio.Queue(maxsize=recv_queue_max)
+        self._closed = False
+        self._reader = threading.Thread(target=self._read_loop, name="userspace-udp-recv", daemon=True)
+        self._reader.start()
+
+    @property
+    def local_ip(self) -> str:
+        return self._local_ip
+
+    @property
+    def port(self) -> int:
+        return self._port
+
+    def _read_loop(self) -> None:
+        # Blocking recv off the pytcp stack in its own thread, handing each datagram to the
+        # event loop. The 0.5 s timeout paces the idle loop and lets it observe close(); a
+        # TimeoutError is the idle case (loop again), any other error means the socket is gone
+        # so the thread exits — the consumer task is cancelled on teardown, and a genuinely
+        # dead stream is restarted by screen_stream's stall watchdog.
+        while not self._closed:
+            try:
+                data = self._sock.recv(65535, timeout=0.5)
+            except TimeoutError:
+                continue
+            except Exception:
+                return
+            if not data:
+                continue
+            try:
+                self._loop.call_soon_threadsafe(self._enqueue, data)
+            except RuntimeError:
+                return  # event loop closed
+
+    def _enqueue(self, data: bytes) -> None:
+        with suppress(asyncio.QueueFull):
+            self._queue.put_nowait(data)
+
+    async def recv(self, bufsize: int = 65535) -> bytes:
+        # bufsize is accepted for socket-API parity; UDP datagrams are queued whole.
+        return await self._queue.get()
+
+    async def sendto(self, data: bytes, ip: str, port: int) -> None:
+        await asyncio.to_thread(self._sock.sendto, data, (ip, port))
+
+    def close(self) -> None:
+        self._closed = True
+        with suppress(Exception):
+            self._sock.close()
 
 
 async def _create_no_root_tunnel_provider(serial: Optional[str], autopair: bool):

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -1,0 +1,598 @@
+"""Userspace (root-free) tunnel backend for iOS 17+ RSD/RemotePairing tunnels.
+
+The standard tunnel writes raw IPv6 packets to a kernel ``utun``, which needs admin/root.
+This backend replaces the kernel interface with a pure-Python TCP/IP stack (PyTCP) so the
+tunnel and all host-initiated RSD developer services run as a normal user.
+
+The public entry point is :class:`UserspaceRsdTunnel` — a closeable handle (async context manager
+or ``aopen()``/``aclose()``) that owns the whole tunnel and exposes a connected RSD. The pieces it
+wires together:
+
+* :class:`UserspaceTun` — a drop-in for ``pytun_pmd3.TunTapDevice`` (same
+  ``mtu``/``addr``/``up``/``write``/``read``/``close`` surface) that bridges packets to a
+  PyTCP L2 stack over a datagram socketpair plus a 14-byte Ethernet shim. (PyTCP's mature
+  path is L2; its L3/TUN egress is buggy.)
+* :class:`UserspaceDialPlane` — an ``asyncio.open_connection``-compatible dialer (injected into the
+  RSD via ``open_connection=``, NOT monkeypatched onto the global) that relays connections to the
+  device's tunnel address through a localhost socket into a PyTCP socket. This covers the RSD HTTP/2
+  handshake and every ``ServiceConnection.create_using_tcp`` while leaving the process-global
+  ``asyncio.open_connection`` untouched for any other code sharing the process.
+
+pmd-pytcp ships only on Python >= 3.14, so it is an OPTIONAL dependency. This module imports
+pmd-pytcp at module level, so importing it REQUIRES pmd-pytcp; ``cli_common`` imports this
+module inside a try/except and falls back to the kernel tunnel when pmd-pytcp is absent. The
+fork is cross-platform on its own (it guards its Unix-only ``fcntl`` import, starts its worker
+threads as daemons, logs through the ``pmd_pytcp`` logger, and ships the MLD attribute), so no
+host-side compatibility shim is needed — only the throughput sysctls below, which ride the
+fork's public knobs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import logging
+import os
+import socket
+import struct
+import sys
+import threading
+from contextlib import AsyncExitStack, suppress
+from typing import Optional
+
+from pmd_net_addr import Ip6Address, Ip6IfAddr, MacAddress
+from pmd_pytcp import stack
+from pmd_pytcp.lib.interface_layer import InterfaceLayer
+from pmd_pytcp.lib.io_backend import register_interface_fd, unregister_interface_fd
+from pmd_pytcp.socket import AF_INET6, SOCK_DGRAM, SOCK_STREAM
+from pmd_pytcp.socket import socket as pytcp_socket
+from pmd_pytcp.stack import sysctl
+
+import pymobiledevice3.remote.tunnel_service as tunnel_service
+from pymobiledevice3.exceptions import InvalidServiceError, PyMobileDevice3Exception
+from pymobiledevice3.lockdown import create_using_usbmux
+from pymobiledevice3.osu.os_utils import get_os_utils
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+
+logger = logging.getLogger(__name__)
+
+# pmd-pytcp logs every enabled channel (SOCKET, TCP, ...) per packet at DEBUG through the
+# 'pmd_pytcp' logger; under pmd3's own debug verbosity that would flood the output with the
+# stack's internal traffic. Cap it at WARNING so the stack stays quiet inside pmd3 (raise it
+# manually for stack-level debugging). This is the logging-module equivalent of the silencing
+# the old pytcp_compat layer did.
+logging.getLogger("pmd_pytcp").setLevel(logging.WARNING)
+
+_ETH_IPV6 = 0x86DD
+_STACK_MAC = "02:00:00:00:00:01"
+_PEER_MAC = "02:00:00:00:00:02"
+
+#: Ceiling on the PyTCP interface MTU. The tunnel negotiates 16000; a large interface MTU
+#: makes downloads fast (the device sends big segments to us). Host->device segments are
+#: bounded separately by the tcp.snd_mss_max sysctl (:data:`MAX_SEND_MSS`), so a large
+#: value is safe here.
+INTERFACE_MTU = 16000
+
+#: Receive-window ceiling (PyTCP 'tcp.rcv_wnd_max'; default 65535). A download is bounded by
+#: window / RTT, so 64 KB throttles it; 4 MiB keeps a full bandwidth-delay-product in flight and
+#: stays within PyTCP's negotiated window-scale-7 reach (~8 MiB). Measured on an iOS 17+ DSC
+#: fetch: 64 KB window -> 8 MB/s, 4 MiB window -> 40 MB/s (kernel-tunnel parity).
+MAX_RECV_WINDOW = 4 * 1024 * 1024
+
+#: Cap on the host->device send MSS (PyTCP 'tcp.snd_mss_max'; 0 = uncapped). 1340 (= a 1400-byte
+#: IPv6 packet minus 40+20 headers) is the proven-safe send size; a larger interface MTU keeps
+#: downloads fast (big device->host segments) while uploads avoid RTO stalls on the forwarding
+#: path. The advertised receive MSS is untouched, so downloads stay fast.
+MAX_SEND_MSS = 1340
+
+
+def throughput_sysctls() -> dict[str, int]:
+    """The ``stack.init(sysctls=...)`` entries that tune the tunnel for bulk transfer.
+
+    These ride pmd-pytcp's public sysctls: ``tcp.rcv_wnd_max`` raises the advertised receive
+    window for fast downloads; ``tcp.snd_mss_max`` caps host->device segments so a large
+    interface MTU does not stall uploads. Any knob the installed pmd-pytcp does not register is
+    omitted (with a warning) so the tunnel runs untuned rather than failing.
+    """
+    wanted = {"tcp.rcv_wnd_max": MAX_RECV_WINDOW, "tcp.default.snd_mss_max": MAX_SEND_MSS}
+    # The registry lists base keys, so an interface-scope knob is checked by its base name.
+    base_key = {"tcp.rcv_wnd_max": "tcp.rcv_wnd_max", "tcp.default.snd_mss_max": "tcp.snd_mss_max"}
+    registered = sysctl.list_keys()
+    out: dict[str, int] = {}
+    for key, value in wanted.items():
+        if base_key[key] in registered:
+            out[key] = value
+        else:
+            logger.warning("userspace tunnel: installed pmd-pytcp lacks the %r sysctl; running untuned", base_key[key])
+    return out
+
+
+#: Datagram socketpair buffer, sized to hold a burst of a full receive window of packets.
+SOCKET_BUFFER_SIZE = 8 * 1024 * 1024
+
+#: Read/relay chunk size for the dial-plane bridge.
+_CHUNK = 65536
+
+#: pmd3's per-OS tun loopback header (macOS: b"\x00\x00\x00\x1e" = AF_INET6).
+LOOPBACK_HEADER = get_os_utils().loopback_header
+
+
+def _mac_to_bytes(mac: str) -> bytes:
+    return bytes(int(x, 16) for x in mac.split(":"))
+
+
+def _eth_header(dst_mac: str, src_mac: str) -> bytes:
+    return _mac_to_bytes(dst_mac) + _mac_to_bytes(src_mac) + struct.pack("!H", _ETH_IPV6)
+
+
+def _packet_socketpair() -> tuple[socket.socket, socket.socket]:
+    """A connected datagram socket pair preserving packet boundaries (one send == one recv).
+    Unix uses an AF_UNIX SOCK_DGRAM socketpair; Windows (no such socketpair) uses a connected
+    localhost UDP pair."""
+    try:
+        return socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
+    except (AttributeError, OSError):
+        a = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        b = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        a.bind(("127.0.0.1", 0))
+        b.bind(("127.0.0.1", 0))
+        a.connect(b.getsockname())
+        b.connect(a.getsockname())
+        return a, b
+
+
+class UserspaceTun:
+    """Drop-in for ``pytun_pmd3.TunTapDevice`` backed by a PyTCP L2 stack.
+
+    PyTCP's stack is a process-global singleton, so one tunnel per process is supported
+    (the normal case)."""
+
+    def __init__(self, interface_name: str = "utun-userspace") -> None:
+        self.name = interface_name
+        self._mtu = 1500
+        self._addr: Optional[str] = None
+        self._ifidx: Optional[int] = None
+        self._closed = False
+        self._peer, self._pend = _packet_socketpair()
+        for s in (self._peer, self._pend):
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, SOCKET_BUFFER_SIZE)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, SOCKET_BUFFER_SIZE)
+
+    # --- TunTapDevice-compatible surface ---
+    @property
+    def mtu(self) -> int:
+        return self._mtu
+
+    @mtu.setter
+    def mtu(self, value: int) -> None:
+        self._mtu = int(value)
+
+    @property
+    def addr(self) -> Optional[str]:
+        return self._addr
+
+    @addr.setter
+    def addr(self, address: str) -> None:
+        self._addr = address
+
+    def up(self) -> None:
+        self._mtu = min(self._mtu, INTERFACE_MTU)
+
+        if not getattr(stack, "_pmd3_inited", False):
+            # accept_dad off (point-to-point link, no DAD peer) + the throughput sysctls
+            # (public PyTCP knobs; omitted automatically on a PyTCP too old to have them).
+            sysctls = {"icmp6.default.accept_dad": 0, **throughput_sysctls()}
+            stack.init(sysctls=sysctls)
+            stack._pmd3_inited = True  # type: ignore[attr-defined]
+        register_interface_fd(self._pend)
+        self._ifidx = stack.add_interface(
+            fd=self._pend.fileno(),
+            layer=InterfaceLayer.L2,
+            mac_address=MacAddress(_STACK_MAC),
+            mtu=self._mtu,
+            ip6_support=True,
+            ip6_host=Ip6IfAddr(f"{self._addr}/64"),
+            ip6_lla_autoconfig=True,
+            ip6_gua_autoconfig=False,
+            ip4_support=False,
+        )
+        stack.start()
+        logger.debug("userspace tunnel up: pytcp L2 iface=%s addr=%s/64 mtu=%s", self._ifidx, self._addr, self._mtu)
+
+    def set_peer(self, device_addr: str) -> None:
+        """Install a static neighbor for the device (point-to-point; skips ND)."""
+        stack.neighbor.interface(self._ifidx).add(ip=Ip6Address(device_addr), mac=MacAddress(_PEER_MAC))
+
+    def write(self, data: bytes) -> None:
+        # inbound (device -> stack): strip pmd3 loopback header, add Ethernet, enqueue
+        ipv6 = data[len(LOOPBACK_HEADER) :] if data[: len(LOOPBACK_HEADER)] == LOOPBACK_HEADER else data
+        with suppress(OSError):
+            self._peer.send(_eth_header(_STACK_MAC, _PEER_MAC) + ipv6)
+
+    def _recv_ipv6(self) -> bytes:
+        # outbound (stack -> device): block for an Ethernet frame, return its IPv6 payload
+        while not self._closed:
+            try:
+                frame = self._peer.recv(65535)
+            except OSError:
+                return b""
+            if len(frame) < 14 or struct.unpack("!H", frame[12:14])[0] != _ETH_IPV6:
+                continue
+            return frame[14:]
+        return b""
+
+    def read(self, size: int) -> bytes:
+        # Unix tun_read_task path: returns loopback-prefixed IPv6 (caller strips the header).
+        ipv6 = self._recv_ipv6()
+        return LOOPBACK_HEADER + ipv6 if ipv6 else b""
+
+    async def async_read(self) -> bytes:
+        # Windows tun_read_task path: wants a RAW IPv6 packet (it checks the version nibble,
+        # no loopback header), delivered asynchronously.
+        return await asyncio.to_thread(self._recv_ipv6)
+
+    def connect_tcp(self, addr: str, port: int):
+        """Open a blocking PyTCP TCP socket to (addr, port) over this stack."""
+        s = pytcp_socket(AF_INET6, SOCK_STREAM)
+        s.connect((addr, port))
+        return s
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        # Wake a thread parked in _recv_ipv6: tun_read_task runs the blocking UserspaceTun.read in
+        # the default ThreadPoolExecutor, whose workers are NON-daemon and are joined at interpreter
+        # shutdown. Closing the socket from another thread does NOT reliably interrupt a blocked
+        # recv(), so the read would stay parked and that join would hang forever — which is why a
+        # hard exit (force_exit) was previously required. Push a 1-byte sentinel into the receiving
+        # end instead: _recv_ipv6's frame filter ignores it (len < 14) and the loop re-checks
+        # _closed and returns b"", so the worker finishes and the join completes promptly.
+        with suppress(OSError):
+            self._pend.send(b"\x00")
+        unregister_interface_fd(self._pend)
+        # Close the socketpair so PyTCP's RX/TX ring threads (parked in read/select on the fd)
+        # unblock, then stop the stack — otherwise stop() deadlocks on those threads.
+        for s in (self._peer, self._pend):
+            with suppress(Exception):
+                s.close()
+        try:
+            stack.stop()
+            stack._pmd3_inited = False  # type: ignore[attr-defined]
+        except Exception:
+            logger.debug("error stopping pytcp stack", exc_info=True)
+
+
+class UserspaceDialPlane:
+    """Provides an ``asyncio.open_connection``-compatible :meth:`dial` that bridges device-bound
+    connections to PyTCP sockets via localhost relays.
+
+    Pass :meth:`dial` to ``RemoteServiceDiscoveryService(open_connection=...)`` so ONLY connections
+    made through that RSD are relayed. This deliberately does NOT monkeypatch the process-global
+    ``asyncio.open_connection``: a library consumer who establishes a userspace tunnel keeps the
+    stdlib function untouched, so unrelated connections elsewhere in their process are unaffected.
+
+    Use as an async context manager so the localhost relay servers are torn down on exit."""
+
+    def __init__(self, tun: UserspaceTun, device_addr: str) -> None:
+        self._tun = tun
+        self._device_addr = str(device_addr)
+        self._relays: dict[tuple[str, int], int] = {}
+        self._servers: list[asyncio.AbstractServer] = []  # kept referenced so relays stay alive
+
+    async def __aenter__(self) -> UserspaceDialPlane:
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        for srv in self._servers:
+            srv.close()
+        for srv in self._servers:
+            with suppress(Exception):
+                await srv.wait_closed()
+        self._servers.clear()
+        self._relays.clear()
+
+    async def _relay_handler(self, port: int, creader: asyncio.StreamReader, cwriter: asyncio.StreamWriter) -> None:
+        loop = asyncio.get_running_loop()
+        try:
+            psock = await asyncio.to_thread(self._tun.connect_tcp, self._device_addr, port)
+        except Exception:
+            logger.debug("relay connect_tcp(%s:%s) failed", self._device_addr, port, exc_info=True)
+            cwriter.close()
+            return
+
+        # device -> client: PyTCP recv() blocks and does NOT unblock on close(), so pump it
+        # in a DAEMON thread bridged to asyncio via a queue. Daemon threads are killed at
+        # process exit without being joined, so shutdown never hangs.
+        rx_queue: asyncio.Queue = asyncio.Queue(maxsize=256)
+
+        def rx_pump() -> None:
+            try:
+                while True:
+                    data = psock.recv(_CHUNK)
+                    loop.call_soon_threadsafe(rx_queue.put_nowait, data)
+                    if not data:
+                        break
+            except Exception:
+                loop.call_soon_threadsafe(rx_queue.put_nowait, b"")
+
+        threading.Thread(target=rx_pump, daemon=True).start()
+
+        async def client_to_device() -> None:
+            try:
+                while True:
+                    data = await creader.read(_CHUNK)
+                    if not data:
+                        break
+                    await asyncio.to_thread(psock.send, data)
+            except Exception:
+                pass
+
+        async def device_to_client() -> None:
+            try:
+                while True:
+                    data = await rx_queue.get()
+                    if not data:
+                        break
+                    cwriter.write(data)
+                    await cwriter.drain()
+            except Exception:
+                pass
+
+        try:
+            await asyncio.gather(client_to_device(), device_to_client())
+        finally:
+            for closer in (psock.close, cwriter.close):
+                with suppress(Exception):
+                    closer()
+
+    async def _ensure_relay(self, port: int) -> int:
+        key = (self._device_addr, port)
+        if key in self._relays:
+            return self._relays[key]
+
+        async def handle(creader: asyncio.StreamReader, cwriter: asyncio.StreamWriter) -> None:
+            await self._relay_handler(port, creader, cwriter)
+
+        srv = await asyncio.start_server(handle, "127.0.0.1", 0)
+        self._servers.append(srv)
+        lport = srv.sockets[0].getsockname()[1]
+        self._relays[key] = lport
+        logger.debug("userspace relay %s:%s -> 127.0.0.1:%s", self._device_addr, port, lport)
+        return lport
+
+    async def dial(self, host=None, port=None, **kwargs):
+        """``asyncio.open_connection``-compatible dialer passed to the RSD via ``open_connection=``.
+
+        Connections to the device's tunnel address are relayed through the userspace stack;
+        everything else falls through to the stdlib ``asyncio.open_connection`` unchanged."""
+        if host is not None and str(host) == self._device_addr:
+            lport = await self._ensure_relay(port)
+            return await asyncio.open_connection("127.0.0.1", lport, **kwargs)
+        return await asyncio.open_connection(host, port, **kwargs)
+
+
+# --- high-level in-process establishment (the no-root RSD path) --------------------------
+
+#: The userspace tunnel active in this process, or None. PyTCP's stack is a process-global
+#: singleton, so at most one exists; :class:`UserspaceRsdTunnel` sets this on open and clears
+#: it on close.
+_active_tunnel: Optional[UserspaceRsdTunnel] = None
+
+#: True while a userspace tunnel is active in this process. Mirrors ``_active_tunnel is not None``
+#: (kept as a plain flag so callers can read it as an attribute). The CLI also uses it to gate the
+#: hard exit in :func:`force_exit`.
+USERSPACE_ACTIVE = False
+
+
+async def _create_no_root_tunnel_provider(serial: Optional[str], autopair: bool):
+    """Pick a tunnel provider that needs no root, mirroring ``remote start-tunnel``'s family:
+
+    * iOS 17.4+ over USB: :class:`~pymobiledevice3.remote.tunnel_service.CoreDeviceTunnelProxy`
+      (the ``com.apple.internal.devicecompute.CoreDeviceProxy`` lockdown service — no remoted).
+    * iOS 17.0-17.3 / Wi-Fi: RemotePairing over bonjour
+      (:func:`~pymobiledevice3.remote.tunnel_service.get_remote_pairing_tunnel_services`).
+
+    The RSD/USB path (``get_core_device_tunnel_services``) is intentionally NOT attempted: it
+    suspends remoted via :func:`stop_remoted`, which needs root on macOS — defeating the no-root
+    purpose. Returns ``(provider, lockdown_or_None)``; the lockdown is kept alive for the
+    CoreDeviceProxy provider and is ``None`` for the RemotePairing one.
+    """
+    lockdown = await create_using_usbmux(serial=serial, autopair=autopair)
+    try:
+        return await tunnel_service.CoreDeviceTunnelProxy.create(lockdown), lockdown
+    except InvalidServiceError:
+        # iOS < 17.4 has no CoreDeviceProxy lockdown service; fall back to the no-root WiFi path.
+        logger.info("CoreDeviceProxy unavailable (iOS < 17.4); falling back to RemotePairing over bonjour")
+        await lockdown.close()
+    except BaseException:
+        await lockdown.close()
+        raise
+
+    services = await tunnel_service.get_remote_pairing_tunnel_services(udid=serial)
+    if not services:
+        raise PyMobileDevice3Exception(
+            "no-root userspace tunnel unavailable: the device exposes no CoreDeviceProxy lockdown "
+            "service (needs iOS 17.4+) and no RemotePairing service was found over bonjour. Enable "
+            "Wi-Fi for the device and host on the same network, or run a privileged kernel tunnel via "
+            "`pymobiledevice3 remote tunneld`."
+        )
+    return services[0], None
+
+
+class UserspaceRsdTunnel:
+    """A no-root, in-process iOS 17+ RSD tunnel and its connected RSD, as one closeable handle.
+
+    Replaces the kernel ``utun`` (which needs root/admin) with a pure-Python PyTCP stack, so the
+    tunnel and every host-initiated developer service run as a normal user. Use it either way:
+
+    Async context manager (closes automatically)::
+
+        async with UserspaceRsdTunnel(serial=udid) as rsd:
+            ...  # rsd is a connected RemoteServiceDiscoveryService
+
+    Open / close handle::
+
+        tunnel = UserspaceRsdTunnel(serial=udid)
+        rsd = await tunnel.aopen()
+        try:
+            ...
+        finally:
+            await tunnel.aclose()
+
+    ``serial`` selects the target device (``None`` => first USB device); ``autopair`` sets up the
+    pairing on the fly if the device is not yet paired. Device selection (e.g. the CLI ``--udid`` /
+    ``PYMOBILEDEVICE3_UDID`` resolution) and the usbmux socket location (incl. a remote usbmuxd)
+    are resolved by the caller / usbmux layer, not here.
+
+    Constraints:
+
+    * **One tunnel per process.** PyTCP's stack is a process-global singleton; :meth:`aopen`
+      raises if a userspace tunnel is already active. Not re-entrant or thread-safe.
+    * **The device address is in-process only**, reachable only from this process's userspace
+      stack — never by an external tool. The RSD reports this via
+      :attr:`RemoteServiceDiscoveryService.is_in_process_tunnel`; don't hand its address to lldb.
+
+    Host-initiated developer services all work. Device-initiated inbound UDP (the AV media streams
+    behind ``display serve-web``) also works: the receiver is bound on the PyTCP stack via
+    :class:`UserspaceUdp` and the stack address is advertised to the device, so its RTP terminates
+    on the userspace stack instead of an unreachable host kernel socket.
+
+    The tunnel provider is selected like ``remote start-tunnel`` but restricted to the root-free
+    paths (see :func:`_create_no_root_tunnel_provider`): CoreDeviceTunnelProxy over lockdown on
+    iOS 17.4+, falling back to RemotePairing over bonjour on iOS 17.0-17.3 / Wi-Fi.
+    """
+
+    def __init__(self, serial: Optional[str] = None, autopair: bool = True) -> None:
+        self.serial = serial
+        self.autopair = autopair
+        self.rsd: Optional[RemoteServiceDiscoveryService] = None
+        self.tun: Optional[UserspaceTun] = None
+        self._exit_stack: Optional[AsyncExitStack] = None
+
+    async def aopen(self) -> RemoteServiceDiscoveryService:
+        """Establish the tunnel and return the connected RSD. Idempotent on this handle; raises
+        :class:`PyMobileDevice3Exception` if another userspace tunnel is already active."""
+        global _active_tunnel, USERSPACE_ACTIVE
+        if self.rsd is not None:
+            return self.rsd
+        if _active_tunnel is not None:
+            raise PyMobileDevice3Exception(
+                "a userspace tunnel is already active in this process (PyTCP's stack is a "
+                "process-global singleton; only one userspace tunnel per process is supported)"
+            )
+        # pmd-pytcp presence was proven at import time (this module imports it at module level;
+        # cli_common imports us inside a try/except that falls back to the kernel tunnel when that
+        # fails). Select the userspace tun via the factory flag — no class is monkeypatched;
+        # RemotePairingTunnel.start_tunnel() consults create_tun_device().
+        tunnel_service.USE_USERSPACE_TUNNEL = True
+        # Every resource is registered on one AsyncExitStack so aclose() unwinds them in LIFO
+        # order; a failure mid-setup unwinds whatever was already acquired.
+        stack = AsyncExitStack()
+        try:
+            provider, lockdown = await _create_no_root_tunnel_provider(self.serial, self.autopair)
+            stack.push_async_callback(provider.close)
+            if lockdown is not None:
+                stack.push_async_callback(lockdown.close)
+            tunnel_result = await stack.enter_async_context(provider.start_tcp_tunnel())
+            self.tun = tunnel_result.client.tun
+            self.tun.set_peer(tunnel_result.address)
+            dial_plane = await stack.enter_async_context(UserspaceDialPlane(self.tun, tunnel_result.address))
+            # Inject the relay dialer into THIS rsd only (no global asyncio.open_connection patch),
+            # so a library consumer's other connections in the same process stay on the stdlib default.
+            rsd = RemoteServiceDiscoveryService(
+                (tunnel_result.address, tunnel_result.port), open_connection=dial_plane.dial
+            )
+            stack.push_async_callback(rsd.close)
+            await rsd.connect()
+        except BaseException:
+            await stack.aclose()
+            tunnel_service.USE_USERSPACE_TUNNEL = False
+            self.tun = None
+            raise
+
+        self._exit_stack = stack
+        self.rsd = rsd
+        _active_tunnel = self
+        USERSPACE_ACTIVE = True
+        logger.debug("userspace RSD established (no root): %s rsd_port=%s", tunnel_result.address, tunnel_result.port)
+        return rsd
+
+    async def aclose(self) -> None:
+        """Tear down the tunnel and its RSD, releasing every resource in LIFO order and restoring
+        the kernel-tunnel factory default. Idempotent.
+
+        After this returns, no background thread remains blocked (closing the tun wakes the parked
+        reader), so the process can exit normally — embedders do NOT need :func:`force_exit`."""
+        global _active_tunnel, USERSPACE_ACTIVE
+        if self._exit_stack is None:
+            return
+        stack, self._exit_stack = self._exit_stack, None
+        self.rsd = None
+        self.tun = None
+        if _active_tunnel is self:
+            _active_tunnel = None
+            USERSPACE_ACTIVE = False
+            tunnel_service.USE_USERSPACE_TUNNEL = False
+        await stack.aclose()
+
+    #: ``open``/``close`` are aliases for :meth:`aopen`/:meth:`aclose` (still awaitable).
+    open = aopen
+    close = aclose
+
+    async def __aenter__(self) -> RemoteServiceDiscoveryService:
+        return await self.aopen()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.aclose()
+
+
+#: Holds the CLI's tunnel for the process lifetime (the CLI has no teardown hook and hard-exits
+#: via force_exit instead of calling aclose). Embedders hold their own UserspaceRsdTunnel.
+_cli_tunnel: Optional[UserspaceRsdTunnel] = None
+
+
+async def establish_userspace_rsd(serial: Optional[str] = None, autopair: bool = True) -> RemoteServiceDiscoveryService:
+    """CLI convenience: establish a userspace tunnel, keep it alive, and return its connected RSD.
+
+    Embedders should use :class:`UserspaceRsdTunnel` directly — it is a closeable handle / async
+    context manager. This wrapper exists for the CLI, which has no teardown hook: it stashes the
+    tunnel for the process lifetime and registers :func:`force_exit` so the CLI exits promptly at
+    the end without awaiting teardown (see :func:`_register_clean_exit`).
+    """
+    global _cli_tunnel
+    tunnel = UserspaceRsdTunnel(serial=serial, autopair=autopair)
+    rsd = await tunnel.aopen()
+    _cli_tunnel = tunnel
+    await _register_clean_exit()
+    return rsd
+
+
+async def _register_clean_exit() -> None:
+    # pmd3's tun_read_task parks a blocking UserspaceTun.read in the default ThreadPoolExecutor.
+    # At interpreter shutdown, threading._shutdown joins those executor threads BEFORE regular
+    # atexit handlers run, and that join blocks forever on the parked read. Register force_exit
+    # via threading's own shutdown hook so it runs before that join. Handlers run
+    # last-registered-first, so we first touch the default executor (await a no-op in it) to
+    # force concurrent.futures' own join-hook to register before ours — then ours wins.
+    atexit.register(force_exit)  # fallback
+    try:
+        await asyncio.to_thread(lambda: None)  # ensure the executor's shutdown hook registers first
+        threading._register_atexit(force_exit)  # type: ignore[attr-defined]
+    except Exception:
+        logger.debug("could not register threading shutdown hook", exc_info=True)
+
+
+def force_exit(code: int = 0) -> None:
+    """Flush output and hard-exit, skipping userspace tunnel teardown. No-op unless a userspace
+    tunnel is active. Used by the CLI, which keeps its tunnel for the process lifetime instead of
+    closing it; embedders should prefer :meth:`UserspaceRsdTunnel.aclose`, which tears down
+    cleanly and lets the process exit on its own."""
+    if not USERSPACE_ACTIVE:
+        return
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except Exception:
+        pass
+    os._exit(code)

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -21,9 +21,8 @@ wires together:
   AV media behind ``display serve-web``): the device pushes RTP to the stack address rather
   than to an unreachable host kernel socket.
 
-pmd-pytcp ships only on Python >= 3.14, so it is an OPTIONAL dependency. This module imports
-pmd-pytcp at module level, so importing it REQUIRES pmd-pytcp; ``cli_common`` imports this
-module inside a try/except and falls back to the kernel tunnel when pmd-pytcp is absent. The
+pmd-pytcp supports Python 3.9+ and is a regular pymobiledevice3 dependency, so this module
+imports it at module level and ``cli_common`` establishes the userspace tunnel directly. The
 fork is cross-platform on its own (it guards its Unix-only ``fcntl`` import, starts its worker
 threads as daemons, logs through the ``pmd_pytcp`` logger, and ships the MLD attribute), so no
 host-side compatibility shim is needed — only the throughput sysctls below, which ride the

--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -8,7 +8,7 @@ import struct
 import time
 import xml
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 from pygments import formatters, highlight, lexers
 
@@ -133,7 +133,11 @@ class ServiceConnection:
 
     @staticmethod
     async def create_using_tcp(
-        hostname: str, port: int, keep_alive: bool = True, create_connection_timeout: int = DEFAULT_TIMEOUT
+        hostname: str,
+        port: int,
+        keep_alive: bool = True,
+        create_connection_timeout: int = DEFAULT_TIMEOUT,
+        open_connection: Optional[Callable] = None,
     ) -> "ServiceConnection":
         """
         Create a ServiceConnection using a TCP connection.
@@ -142,11 +146,13 @@ class ServiceConnection:
         :param port: The port to connect to.
         :param keep_alive: Whether to enable TCP keep-alive.
         :param create_connection_timeout: The timeout for creating the connection.
+        :param open_connection: Optional ``asyncio.open_connection``-compatible dialer. Defaults to
+            ``asyncio.open_connection``; the userspace tunnel injects one that relays device-bound
+            connections through its in-process stack (avoiding a global monkeypatch).
         :return: A ServiceConnection object.
         """
-        reader, writer = await asyncio.wait_for(
-            asyncio.open_connection(hostname, port), timeout=create_connection_timeout
-        )
+        open_connection = open_connection or asyncio.open_connection
+        reader, writer = await asyncio.wait_for(open_connection(hostname, port), timeout=create_connection_timeout)
         sock = writer.get_extra_info("socket")
         if sock is None:
             await close_stream_writer(writer)

--- a/pymobiledevice3/usbmux.py
+++ b/pymobiledevice3/usbmux.py
@@ -1,5 +1,6 @@
 import abc
 import asyncio
+import os
 import plistlib
 import socket
 import struct
@@ -155,6 +156,11 @@ class MuxConnection:
 
     @staticmethod
     def _resolve_usbmux_address(usbmux_address: Optional[str] = None):
+        if usbmux_address is None:
+            # Honor the libusbmuxd-standard env var at the socket layer so every call
+            # site (not just the CLI --usbmux option) reaches a remote/relocated
+            # usbmuxd, e.g. usbmuxd exposed over TCP as HOST:PORT.
+            usbmux_address = os.getenv("USBMUXD_SOCKET_ADDRESS")
         if usbmux_address is not None:
             if ":" in usbmux_address:
                 hostname, port = usbmux_address.split(":")

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,6 @@ pywin32 ; platform_system == "Windows"
 av>=14.0.0 ; platform_system != "Darwin"
 # pmd-pytcp — the no-root userspace tunnel's TCP/IP stack, a minimal PyTCP fork
 # (https://github.com/doronz88/pmd-pytcp). Pulls its pmd-net-addr / pmd-net-proto siblings in
-# transitively. Requires Python >= 3.14; on older interpreters the import fails and the tunnel
-# transparently falls back to the kernel path (see cli_common).
-pmd-pytcp>=0.0.3 ; python_version >= "3.14"
+# transitively. Supported on Python 3.9+ (the whole pymobiledevice3 range); if the import or
+# stack init fails the tunnel transparently falls back to the kernel path (see cli_common).
+pmd-pytcp>=0.0.4 ; python_version >= "3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,8 @@ typer-injector>=0.2.0
 defusedxml
 pywin32 ; platform_system == "Windows"
 av>=14.0.0 ; platform_system != "Darwin"
+# pmd-pytcp — the no-root userspace tunnel's TCP/IP stack, a minimal PyTCP fork
+# (https://github.com/doronz88/pmd-pytcp). Pulls its pmd-net-addr / pmd-net-proto siblings in
+# transitively. Requires Python >= 3.14; on older interpreters the import fails and the tunnel
+# transparently falls back to the kernel path (see cli_common).
+pmd-pytcp>=0.0.3 ; python_version >= "3.14"

--- a/tests/test_userspace_tunnel.py
+++ b/tests/test_userspace_tunnel.py
@@ -1,0 +1,40 @@
+"""Tests for the userspace tunnel's throughput tuning.
+
+The tuning rides pmd-pytcp's public ``tcp.rcv_wnd_max`` / ``tcp.snd_mss_max`` sysctls; these
+tests pin that :func:`throughput_sysctls` emits values the installed pmd-pytcp actually accepts
+(and silently omits any a too-old pmd-pytcp lacks). The cross-platform/portability concerns that
+used to live in a host-side compatibility layer are now handled inside pmd-pytcp itself.
+"""
+
+import pytest
+
+# pmd-pytcp ships only on Python >= 3.14; skip the whole module when it's absent.
+pytest.importorskip("pmd_pytcp")
+
+from pmd_pytcp.stack import sysctl
+
+from pymobiledevice3.remote import userspace_tunnel
+
+
+def test_throughput_sysctls_only_emits_registered_knobs():
+    # Every emitted key must be accepted by stack.init's sysctl bag — i.e. its (base) knob is
+    # registered in the installed pmd-pytcp. This is what keeps an older fork from crashing.
+    registered = sysctl.list_keys()
+    for key in userspace_tunnel.throughput_sysctls():
+        base = key.replace(".default.", ".") if ".default." in key else key
+        assert base in registered, f"{key!r} emitted but {base!r} is not a registered sysctl"
+
+
+def test_throughput_sysctls_values_when_supported():
+    knobs = userspace_tunnel.throughput_sysctls()
+    if "tcp.rcv_wnd_max" not in sysctl.list_keys():
+        pytest.skip("installed pmd-pytcp predates the throughput sysctls")
+    assert knobs["tcp.rcv_wnd_max"] == userspace_tunnel.MAX_RECV_WINDOW
+    assert knobs["tcp.default.snd_mss_max"] == userspace_tunnel.MAX_SEND_MSS
+
+
+def test_throughput_sysctls_round_trip_through_sysctl_set():
+    # The emitted entries must apply cleanly the way stack.init(sysctls=...) applies them.
+    for key, value in userspace_tunnel.throughput_sysctls().items():
+        sysctl.set(key, value)
+    sysctl.reset_to_defaults()


### PR DESCRIPTION
## What

Adds an **opt-in, no-root** iOS 17+ RSD tunnel that runs entirely in-process on a pure-Python TCP/IP stack, so developer services work without a privileged `remote tunneld`. Enable with `--userspace` (or `PYMOBILEDEVICE3_USERSPACE=1`).

```
pymobiledevice3 developer dvt ls / --userspace
```

## How

- **`pytcp_compat`** is the single import point for the stack — the **[pmd-pytcp](https://github.com/doronz88/pmd-pytcp)** fork of PyTCP (pinned via git, `python_version >= "3.14"`). pmd-pytcp renames its packages (so it can't collide with an installed upstream PyTCP) and ships `io_backend`, so the stack runs **without monkeypatching the `os` module**.
- **`create_tun_device()`** factory in `tunnel_service` selects a kernel `TunTapDevice` (default) or the no-root `UserspaceTun` via a module flag — no class is monkeypatched, and the interface choice is decoupled from the tunnel provider.
- **`userspace_tunnel`** brings the tunnel up in-process: `UserspaceTun` is a TunTapDevice-compatible L2 bridge; `UserspaceDialPlane` relays device-bound `asyncio.open_connection` through it; `establish_userspace_rsd()` connects RSD. Provider selection mirrors `remote start-tunnel` but is restricted to root-free paths — `CoreDeviceTunnelProxy` on iOS 17.4+, falling back to RemotePairing-over-bonjour on 17.0–17.3 / Wi-Fi. All resources are owned by a single `AsyncExitStack`.
- Independently, **`usbmux`** now honors `USBMUXD_SOCKET_ADDRESS` at the socket layer (not just the CLI option).

## Notes / limitations

- Requires Python >= 3.14 (pmd-pytcp's floor). On older interpreters the import fails and the CLI **transparently falls back to `tunneld`**.
- Downloads run near the kernel tunnel's throughput; host→device transfers are slower (send MSS kept small for reliable delivery through the pure-Python path).
- Device-initiated inbound flows (serve-vnc/serve-web/screen AV) are not handled.

## Validation

Tested end-to-end against an iPhone on iOS 27: tunnel established, RSD connected, developer services served — no root, no `tunneld`, throughput-tuned.