### PR TITLE
tunneld: reconnect usbmux monitor on dropped listen socket

### DIFF
--- a/pymobiledevice3/tunneld/server.py
+++ b/pymobiledevice3/tunneld/server.py
@@ -277,14 +277,19 @@ class TunneldCore:
                                 name=f"start-tunnel-task-{task_identifier}",
                             ),
                         )
-            except (BlockingIOError, StreamError) as e:
-                # Connection lost - will reconnect on next iteration
-                logger.debug(f"usbmux connection error: {e}, reconnecting...")
-                await asyncio.sleep(USBMUX_INTERVAL)
             except (ConnectionFailedToUsbmuxdError, OSError):
                 # This is exception is expected to occur repeatedly on linux running usbmuxd
-                # as long as there isn't any physical iDevice connected
+                # as long as there isn't any physical iDevice connected.
+                # NOTE: ConnectionFailedToUsbmuxdError subclasses MuxException, so this more
+                # specific handler must stay above the MuxException handler below.
                 logger.debug("failed to connect to usbmux. waiting for it to restart")
+                await asyncio.sleep(USBMUX_INTERVAL)
+            except (BlockingIOError, StreamError, MuxException) as e:
+                # Connection lost - will reconnect on next iteration.
+                # MuxException("socket connection broken") is raised when usbmuxd drops the
+                # listen socket on device replug/reboot (notably on Linux); reconnect instead
+                # of letting the monitor task die (see issue #1742).
+                logger.debug(f"usbmux connection error: {e}, reconnecting...")
                 await asyncio.sleep(USBMUX_INTERVAL)
             except asyncio.CancelledError:
                 break

--- a/tests/test_tunneld_monitor.py
+++ b/tests/test_tunneld_monitor.py
@@ -1,0 +1,59 @@
+import asyncio
+
+import pytest
+
+from pymobiledevice3.exceptions import MuxException
+from pymobiledevice3.tunneld import server as tunneld_server
+
+
+class _FakeMux:
+    """Minimal stand-in for a usbmux connection used by monitor_usbmux_task."""
+
+    def __init__(self, on_receive) -> None:
+        self._on_receive = on_receive
+        self.devices = []
+        self.closed = False
+
+    async def listen(self) -> None:
+        return None
+
+    async def receive_device_state_update(self) -> None:
+        await self._on_receive()
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_monitor_usbmux_task_reconnects_after_socket_broken(monkeypatch):
+    """Regression for issue #1742: a dropped usbmuxd listen socket raises
+    MuxException("socket connection broken"). The monitor task must catch it and
+    reconnect instead of dying, otherwise the tunnel never auto-recovers after a
+    device replug/reboot (notably on Linux)."""
+    # make the reconnect backoff instant
+    monkeypatch.setattr(tunneld_server, "USBMUX_INTERVAL", 0)
+
+    create_calls = 0
+
+    async def fake_receive() -> None:
+        # first connection: usbmuxd drops the socket
+        raise MuxException("socket connection broken")
+
+    async def fake_create_mux(usbmux_address=None):
+        nonlocal create_calls
+        create_calls += 1
+        if create_calls >= 2:
+            # the task successfully reconnected; stop the loop cleanly.
+            # CancelledError is caught by the task's own handler, which breaks the loop.
+            raise asyncio.CancelledError()
+        return _FakeMux(fake_receive)
+
+    monkeypatch.setattr(tunneld_server.usbmux, "create_mux", fake_create_mux)
+
+    core = tunneld_server.TunneldCore(wifi_monitor=False, usb_monitor=False, usbmux_monitor=True, mobdev2_monitor=False)
+
+    # The task should swallow the MuxException, sleep, attempt create_mux again, and
+    # then return cleanly once cancelled (rather than dying on the MuxException).
+    await core.monitor_usbmux_task()
+
+    assert create_calls >= 2, "monitor task did not reconnect after socket connection broken"


### PR DESCRIPTION
When usbmuxd drops the listen socket on device replug/reboot (notably on Linux, which uses an `AF_UNIX` socket), `receive_device_state_update()` raises `MuxException("socket connection broken")`. This exception was not handled in monitor_usbmux_task's outer loop, so the @asyncio_print_traceback decorator merely re-raised it and the monitor task died permanently -- the tunnel never auto-reconnected.

Add `MuxException` to the reconnect handler. The more specific `ConnectionFailedToUsbmuxdError` handler (a `MuxException` subclass) is reordered above it so the "no device connected" path keeps its dedicated log message.

Fixes #1742
