### PR TITLE
docs: guide agents to prefer --userspace for developer commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,20 @@ Guidance for AI coding agents and automation contributors working in this reposi
 - DVT-related functionality:
   - Use `DtxServiceProvider`/`DvtProvider` patterns in `pymobiledevice3/services/dvt/`.
 
+## Running Developer Commands Against Devices
+
+- Developer/DVT commands on iOS 17+ devices require an RSD tunnel. Prefer
+  `--userspace` over a `tunneld` tunnel: it establishes the tunnel in-process
+  with a pure-Python userspace network stack and needs **no `sudo`/root**, so
+  agents can run unattended.
+  - Example: `pymobiledevice3 developer dvt oslog --userspace`.
+  - You can also set `PYMOBILEDEVICE3_USERSPACE=1` instead of passing the flag.
+- Only fall back to a privileged `tunneld` (which needs root) when `--userspace`
+  is not viable — e.g. when you need higher host->device throughput, since
+  userspace host->device transfers (DDI mounts, file pushes) are deliberately
+  slower.
+- `--userspace` is mutually exclusive with `--rsd`/`--tunnel`.
+
 ## Testing Expectations
 
 - Add or update tests when behavior changes.


### PR DESCRIPTION
## What

Adds a **Running Developer Commands Against Devices** section to `AGENTS.md`.

## Why

Developer/DVT commands on iOS 17+ require an RSD tunnel. A `tunneld` tunnel needs root (`sudo`), which blocks unattended agents. `--userspace` establishes the tunnel in-process with a pure-Python userspace network stack and needs no root — so it should be the default for agents.

## Guidance added

- Prefer `--userspace` (or `PYMOBILEDEVICE3_USERSPACE=1`) for developer commands; e.g. `pymobiledevice3 developer dvt oslog --userspace`.
- Fall back to privileged `tunneld` only when higher host->device throughput is needed (userspace host->device transfers are deliberately slower).
- Note that `--userspace` is mutually exclusive with `--rsd`/`--tunnel`.

Docs-only; wording grounded in the `--userspace` flag help in `cli_common.py`.