### PR TITLE
docs: correct --userspace requirements and broaden CLI recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ pymobiledevice3 apps list
 ### Support Matrix (Developer Services)
 
 `iOS >= 17` developer services require tunnel-based transport. The tunnel normally needs root/admin;
-on Python 3.14+ you can instead add `--userspace` to a developer command for a no-root, in-process
-tunnel (see the guide for what it supports).
+you can instead add `--userspace` to a developer command for a no-root, in-process tunnel
+(see the guide for what it supports).
 
 | Host OS | iOS 17.0-17.3.1 | iOS 17.4+ |
 | --- | --- | --- |

--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -32,6 +32,25 @@ pymobiledevice3 diagnostics restart
 
 # Pull crash reports
 pymobiledevice3 crash pull /path/to/crashes
+
+# Show the process list (diagnosticsd API; no developer tunnel required)
+pymobiledevice3 processes ps
+
+# Match process pids by name (like pgrep)
+pymobiledevice3 processes pgrep SpringBoard
+```
+
+## Network Sniffing (PCAP)
+
+```shell
+# Sniff all device traffic and write a pcap
+pymobiledevice3 pcap --out capture.pcap
+
+# Sniff only a given process, stopping after 100 packets
+pymobiledevice3 pcap --process backboardd -c 100
+
+# Sniff a single interface
+pymobiledevice3 pcap -i en0
 ```
 
 ## Files, Apps, and Backup
@@ -59,6 +78,32 @@ pymobiledevice3 backup2 backup --only-regex '\\.(plist|db|db-shm|db-wal|sqlite|s
 
 # Restore backup
 pymobiledevice3 backup2 restore DIRECTORY
+```
+
+## Profiles and Configuration
+
+```shell
+# List installed configuration profiles
+pymobiledevice3 profile list
+
+# Install one or more profiles (.mobileconfig)
+pymobiledevice3 profile install my.mobileconfig
+
+# Remove a profile by its identifier/name
+pymobiledevice3 profile remove com.example.profile
+```
+
+## SpringBoard UI
+
+```shell
+# Print current screen orientation
+pymobiledevice3 springboard orientation
+
+# Save an app's icon to a PNG
+pymobiledevice3 springboard icon com.apple.mobilesafari safari-icon.png
+
+# Save the home-screen wallpaper to a PNG
+pymobiledevice3 springboard wallpaper-home-screen wallpaper.png
 ```
 
 ## Firmware Update

--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -3,7 +3,7 @@
 Starting with iOS 17.0, Apple moved developer service access to CoreDevice/RemoteXPC flows.
 To use many `developer dvt` commands, establish a trusted tunnel first — with root via `tunneld`
 (Option 1) or a manual tunnel (Option 2), or with **no root at all** via the in-process
-`--userspace` tunnel on Python 3.14+ (Option 3).
+`--userspace` tunnel (Option 3).
 
 Reference protocol details:
 [RemoteXPC](../../misc/RemoteXPC.md)
@@ -73,8 +73,9 @@ tears it down when it exits.
 
 Requirements:
 
-- **Python >= 3.14** (the `pmd-pytcp` dependency ships only on 3.14+). On older interpreters the
-  flag is unavailable and the command falls back to `tunneld`.
+- **Python >= 3.9** — the `pmd-pytcp` dependency that powers the userspace stack is installed on
+  every supported interpreter, so `--userspace` is always available. It does not fall back to
+  `tunneld`; if the in-process tunnel cannot be established, the error is surfaced.
 - **iOS 17.0+** over USB (uses the CoreDeviceProxy lockdown service on 17.4+, or RemotePairing over
   bonjour/Wi-Fi on 17.0–17.3.1).
 
@@ -112,7 +113,7 @@ python3 -m pymobiledevice3 developer dvt ls / --tunnel ''
 # If tunneld is already running, this may work without --tunnel
 python3 -m pymobiledevice3 developer dvt ls /
 
-# No-root in-process tunnel (Python 3.14+); no tunneld/root required
+# No-root in-process tunnel; no tunneld/root required
 python3 -m pymobiledevice3 developer dvt ls / --userspace
 
 # Use manual RSD connection details

--- a/misc/understanding_idevice_protocol_layers.md
+++ b/misc/understanding_idevice_protocol_layers.md
@@ -467,7 +467,7 @@ async def main() -> None:
       print(entry)
 ```
 
-All the tunnels above need root/admin, since they create a kernel TUN/TAP interface. On Python 3.14+ there's one
+All the tunnels above need root/admin, since they create a kernel TUN/TAP interface. There's one
 more option that needs **no root at all**: add `--userspace` to any developer command to establish the iOS 17+ tunnel
 in-process over a pure-python network stack (PyTCP). There's no separate tunnel process - the flag builds the tunnel
 inside the command and tears it down on exit:


### PR DESCRIPTION
Fixes the documentation issues raised in review.

## 1. Stale `--userspace` requirements (correctness bug)

The docs claimed `--userspace` needs **Python 3.14+** and that older interpreters **fall back to `tunneld`**. Both are wrong as of the pmd-pytcp 3.9 migration:

- `pyproject.toml` sets `requires-python = ">=3.9"` and `pmd-pytcp` is a normal dependency — there is no 3.14 gate, so `--userspace` is always available.
- `cli_common.py` surfaces establishment failures explicitly "rather than masked by a tunneld fallback" — there is no fallback.

Corrected in all four places: README support matrix, `docs/guides/ios17-tunnels.md` (intro, requirements, example comment), and `misc/understanding_idevice_protocol_layers.md`.

## 2. CLI recipe coverage

`cli-recipes.md` covered ~13 of 23 top-level groups. Added previously undocumented groups:

- `processes` (`ps`, `pgrep`)
- `pcap` (sniff to file, by process, by interface)
- `profile` (list / install / remove)
- `springboard` (orientation, icon, wallpaper)

All examples were verified against a connected device (`processes pgrep`, `springboard orientation`, `profile list`) or against the verified command signatures in source.

Docs-only.