### PR TITLE
Restore: Fix shell `irecv` variable

### DIFF
--- a/pymobiledevice3/cli/restore.py
+++ b/pymobiledevice3/cli/restore.py
@@ -205,7 +205,7 @@ def restore_shell(device: DeviceDep) -> None:
     start_ipython_shell(
         header=highlight(SHELL_USAGE, lexers.PythonLexer(), formatters.Terminal256Formatter(style="native")),
         user_ns={
-            "irecv": device,
+            "irecv": device.irecv,
         },
     )
 


### PR DESCRIPTION
## Summary

Commit fac18022a216f1f520f2de069c0a755888abb334 changed the type of the "irecv" value provided to shell from IRecv to Device. Revert it back.

## Testing

Prior to patch:
```
python -m pymobiledevice3 restore shell
# use `irecv` variable to access Restore mode API
# for example:
print(irecv.getenv('build-version'))

Python 3.14.5 (main, May 10 2026, 18:26:20) [GCC 16.1.1 20260430]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.14.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: The `%timeit` magic has a `-o` flag, which returns the results, making it easy to plot. See `%timeit?`.
In [1]: irecv.reboot()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[1], line 1
----> 1 irecv.reboot()
```

After patch:
```
python -m pymobiledevice3 restore shell
# use `irecv` variable to access Restore mode API
# for example:
print(irecv.getenv('build-version'))

Python 3.14.5 (main, May 10 2026, 18:26:20) [GCC 16.1.1 20260430]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.14.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: The `%timeit` magic has a `-o` flag, which returns the results, making it easy to plot. See `%timeit?`.
In [1]: irecv.reboot()

```


## AI Assistance

None
