### PR TITLE
feature: add `lockdown remotepairing` for the remotepairingdeviced control channel

### DIFF
--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -62,6 +62,21 @@ Use the following connection option:
 
 The tunnel creation command must run with elevated privileges because it creates a TUN/TAP interface.
 
+!!! tip "Bootstrap the RemotePairing record over USB (no Trust dialog)"
+
+    `remote start-tunnel` (the RSD/Wi-Fi path) needs a RemotePairing pair record. You can create it
+    over USB, promptlessly, via the `com.apple.dt.remotepairingdeviced.lockdown` control channel:
+
+    ```shell
+    python3 -m pymobiledevice3 lockdown remotepairing --pair
+    ```
+
+    Because this runs over the already-trusted lockdownd (USB) transport, pairing is promptless (no
+    on-device Trust dialog) and writes the same pair record `remote start-tunnel` / `remote pair` use.
+    Without `--pair` the command just performs a handshake and prints the device's control-channel info
+    (add `--raw` to keep the `deviceKVSData` blob base64-encoded). This control channel does not create
+    tunnels itself.
+
 ## Option 3: No-root userspace tunnel (`--userspace`)
 
 Options 1 and 2 need root/admin because they create a kernel TUN/TAP interface. `--userspace`

--- a/pymobiledevice3/cli/lockdown.py
+++ b/pymobiledevice3/cli/lockdown.py
@@ -1,4 +1,5 @@
 import ast
+import base64
 import datetime
 import logging
 import plistlib
@@ -16,9 +17,10 @@ from pymobiledevice3.cli.cli_common import (
     sudo_required,
 )
 from pymobiledevice3.cli.remote import tunnel_task
+from pymobiledevice3.exceptions import RemotePairingCompletedError
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.remote.common import TunnelProtocol
-from pymobiledevice3.remote.tunnel_service import CoreDeviceTunnelProxy
+from pymobiledevice3.remote.tunnel_service import CoreDeviceTunnelProxy, RemotePairingLockdownService
 from pymobiledevice3.services.heartbeat import HeartbeatService
 from pymobiledevice3.utils import run_in_loop
 
@@ -210,6 +212,57 @@ async def cli_start_tunnel(
 ) -> None:
     """start tunnel"""
     await async_cli_start_tunnel(service_provider, script_mode)
+
+
+def _decode_device_kvs_data(handshake_info: dict) -> dict:
+    """Decode the base64 binary-plist `deviceKVSData` blob in-place, if present."""
+    peer_device_info = handshake_info.get("peerDeviceInfo", {})
+    kvs = peer_device_info.get("deviceKVSData")
+    if isinstance(kvs, str):
+        try:
+            peer_device_info["deviceKVSData"] = plistlib.loads(base64.b64decode(kvs))
+        except Exception:
+            logger.warning("failed to decode deviceKVSData; leaving it raw")
+    return handshake_info
+
+
+@cli.command("remotepairing")
+@async_command
+async def cli_remotepairing(
+    service_provider: ServiceProviderDep,
+    pair: Annotated[
+        bool,
+        typer.Option(
+            "--pair", help="Perform RemotePairing pair-setup if not already paired (promptless over lockdownd)"
+        ),
+    ] = False,
+    raw: Annotated[bool, typer.Option("--raw", help="Do not decode the base64 deviceKVSData blob")] = False,
+) -> None:
+    """
+    Perform a RemotePairing handshake over the com.apple.dt.remotepairingdeviced.lockdown control
+    channel and print the device's handshake info (peer device info, wire protocol versions,
+    pairing capabilities). This control channel does not create tunnels - use `start-tunnel` for that.
+
+    With --pair, performs RemotePairing pair-setup when the device is not already paired. Because this
+    runs over the already-trusted lockdownd (USB) transport, pairing is promptless - no Trust dialog is
+    shown - and it writes the RemotePairing pair record used by `pymobiledevice3 remote start-tunnel`,
+    letting you bootstrap that record over USB without any on-device interaction.
+    """
+    service = await RemotePairingLockdownService.create(service_provider)
+    try:
+        try:
+            await service.connect(autopair=pair)
+        except RemotePairingCompletedError:
+            # The device closes the connection once pairing completes; re-establish it to read the info.
+            await service.close()
+            service = await RemotePairingLockdownService.create(service_provider)
+            await service.connect(autopair=False)
+        handshake_info = service.handshake_info
+        if not raw:
+            handshake_info = _decode_device_kvs_data(handshake_info)
+        print_json(handshake_info)
+    finally:
+        await service.close()
 
 
 @cli.command("assistive-touch")

--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -1172,6 +1172,47 @@ class RemotePairingManualPairingService(RemotePairingTunnelService):
         await RemotePairingProtocol.connect(self, autopair=autopair)
 
 
+class RemotePairingLockdownService(RemotePairingTunnelService):
+    """
+    The `remotepairingdeviced` control channel, reached over the USB lockdown transport via the
+    `com.apple.dt.remotepairingdeviced.lockdown` lockdown service.
+
+    This is the RemotePairing *control plane* - it speaks the same `RPPairing`-framed
+    `RemotePairingProtocol` as the WiFi/RSD services (handshake, pair-setup, pair-verify) but over
+    an already-established lockdown `ServiceConnection`. Unlike `CoreDeviceTunnelProxy`, it does not
+    create tunnels: the device reports `allowsIncomingTunnelConnections=False` and rejects listener
+    creation with "Tunnel listener creator not set". Use it to pair/verify and to read the device's
+    control-channel handshake info (peer device info, wire protocol versions, pairing capabilities).
+
+    Because it runs over the already-trusted lockdownd (USB) transport, pair-setup here is promptless
+    (no on-device Trust dialog) and produces the RemotePairing pair record consumed by the RSD tunnel
+    services (`RemotePairingTunnelService` / `CoreDeviceTunnelService`), i.e. `remote start-tunnel`.
+    """
+
+    SERVICE_NAME = "com.apple.dt.remotepairingdeviced.lockdown"
+
+    @classmethod
+    async def create(cls, lockdown: LockdownServiceProvider) -> "RemotePairingLockdownService":
+        return cls(await lockdown.start_lockdown_service(cls.SERVICE_NAME), lockdown.udid)
+
+    def __init__(self, service: ServiceConnection, remote_identifier: str) -> None:
+        super().__init__(remote_identifier, hostname="", port=0)
+        self._service = service
+        self._reader = service.reader
+        self._writer = service.writer
+
+    async def connect(self, autopair: bool = True) -> None:
+        # The lockdown ServiceConnection is already open; go straight to the RemotePairing handshake.
+        await RemotePairingProtocol.connect(self, autopair=autopair)
+
+    async def close(self) -> None:
+        if self._service is not None:
+            await self._service.close()
+            self._service = None
+        self._reader = None
+        self._writer = None
+
+
 class CoreDeviceTunnelProxy(StartTcpTunnel):
     SERVICE_NAME = "com.apple.internal.devicecompute.CoreDeviceProxy"
 


### PR DESCRIPTION
## What

Adds a client for the `com.apple.dt.remotepairingdeviced.lockdown` lockdown service — the **RemotePairing control plane** exposed over the USB lockdown transport — and a `pymobiledevice3 lockdown remotepairing` CLI command.

## Background

`remotepairingdeviced` vends several endpoints. `com.apple.internal.devicecompute.CoreDeviceProxy` (already wired as `lockdown start-tunnel`) is the *data plane* — it hands back a tunnel. `com.apple.dt.remotepairingdeviced.lockdown` is the *control plane*: it speaks the same `RPPairing`-framed `RemotePairingProtocol` as the Wi-Fi/RSD services (handshake / pair-verify / pair-setup), but over an already-open lockdown `ServiceConnection`.

It does **not** create tunnels — the device reports `allowsIncomingTunnelConnections=False` and rejects listener creation with `"Tunnel listener creator not set"` — so it's exposed as an info/pairing command rather than a tunnel one.

## Changes

- `RemotePairingLockdownService` in `remote/tunnel_service.py` — `RemotePairingProtocol` over the lockdown socket.
- `lockdown remotepairing` CLI:
  - prints the device's control-channel handshake info (peer device info, wire protocol versions, pairing capabilities)
  - decodes the base64 `deviceKVSData` binary plist by default; `--raw` to keep it encoded
  - `--pair` performs RemotePairing pair-setup
- Docs note in `guides/ios17-tunnels.md`.

## Why `--pair` is useful

Because it runs over the already-trusted lockdownd (USB) transport, pair-setup is **promptless** (no on-device Trust dialog) and it **writes the RemotePairing pair record consumed by `remote start-tunnel`** — letting you bootstrap that record over USB with no on-device interaction.

## Testing

Verified end-to-end against an iPhone Air (iPhone18,4) on iOS 27.0:
- handshake + KVS decode (and `--raw`)
- `--pair`: removed the existing record → pair-setup ran promptlessly → a fresh pair record was written → a subsequent verify-only run validated against it with no prompt.