### PR TITLE
userspace_tunnel: fix relay teardown hanging the event loop

### DIFF
--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -46,7 +46,7 @@ from pmd_net_addr import Ip6Address, Ip6IfAddr, MacAddress
 from pmd_pytcp import stack
 from pmd_pytcp.lib.interface_layer import InterfaceLayer
 from pmd_pytcp.lib.io_backend import register_interface_fd, unregister_interface_fd
-from pmd_pytcp.socket import AF_INET6, SOCK_DGRAM, SOCK_STREAM
+from pmd_pytcp.socket import AF_INET6, SHUT_RDWR, SHUT_WR, SOCK_DGRAM, SOCK_STREAM
 from pmd_pytcp.socket import socket as pytcp_socket
 from pmd_pytcp.stack import sysctl
 
@@ -281,6 +281,7 @@ class UserspaceDialPlane:
         self._device_addr = str(device_addr)
         self._relays: dict[tuple[str, int], int] = {}
         self._servers: list[asyncio.AbstractServer] = []  # kept referenced so relays stay alive
+        self._relay_tasks: set[asyncio.Task] = set()  # in-flight handlers, cancelled on exit
 
     async def __aenter__(self) -> UserspaceDialPlane:
         return self
@@ -288,6 +289,16 @@ class UserspaceDialPlane:
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         for srv in self._servers:
             srv.close()
+        # Cancel the in-flight relay handlers BEFORE wait_closed(): since Python 3.12.1
+        # Server.wait_closed() also waits for every active connection handler, and a relay
+        # parked on device traffic never finishes on its own — teardown would hang until the
+        # caller's timeout (issue #1756). Cancelling here (instead of leaving orphan tasks for
+        # the loop's shutdown to cancel) also guarantees each handler's psock cleanup runs
+        # while the stack is still up, and that no relay task outlives the dial plane.
+        for task in list(self._relay_tasks):
+            task.cancel()
+        if self._relay_tasks:
+            await asyncio.gather(*self._relay_tasks, return_exceptions=True)
         for srv in self._servers:
             with suppress(Exception):
                 await srv.wait_closed()
@@ -304,21 +315,28 @@ class UserspaceDialPlane:
             return
 
         # device -> client: PyTCP recv() blocks and does NOT unblock on close(), so pump it
-        # in a DAEMON thread bridged to asyncio via a queue. Daemon threads are killed at
-        # process exit without being joined, so shutdown never hangs.
+        # in a DAEMON thread bridged to asyncio via a queue. The recv is polled with a
+        # timeout so the thread re-checks ``closing`` and exits shortly after teardown —
+        # otherwise one parked thread would leak per relayed connection (issue #1756 hit 120
+        # of them). Daemon so process exit never joins on it either way.
         rx_queue: asyncio.Queue = asyncio.Queue(maxsize=256)
+        closing = threading.Event()
 
         def rx_pump() -> None:
             try:
-                while True:
-                    data = psock.recv(_CHUNK)
+                while not closing.is_set():
+                    try:
+                        data = psock.recv(_CHUNK, timeout=1.0)
+                    except TimeoutError:
+                        continue
                     loop.call_soon_threadsafe(rx_queue.put_nowait, data)
                     if not data:
                         break
             except Exception:
-                loop.call_soon_threadsafe(rx_queue.put_nowait, b"")
+                with suppress(RuntimeError):  # event loop may already be closed
+                    loop.call_soon_threadsafe(rx_queue.put_nowait, b"")
 
-        threading.Thread(target=rx_pump, daemon=True).start()
+        threading.Thread(target=rx_pump, name=f"userspace-relay-rx-{port}", daemon=True).start()
 
         async def client_to_device() -> None:
             try:
@@ -329,6 +347,13 @@ class UserspaceDialPlane:
                     await asyncio.to_thread(psock.send, data)
             except Exception:
                 pass
+            finally:
+                # Propagate the client's EOF to the device as a FIN (half-close). The device
+                # then finishes its side and its FIN unblocks rx_pump with b"", letting
+                # device_to_client — and the whole handler — complete. Without this the
+                # handler waits on device traffic forever after the client is gone (#1756).
+                with suppress(Exception):
+                    await asyncio.to_thread(psock.shutdown, SHUT_WR)
 
         async def device_to_client() -> None:
             try:
@@ -340,13 +365,34 @@ class UserspaceDialPlane:
                     await cwriter.drain()
             except Exception:
                 pass
+            finally:
+                # Mirror of the half-close above: the device's EOF must reach the client, or
+                # client_to_device keeps waiting on a client that has no reason to close.
+                with suppress(Exception):
+                    if cwriter.can_write_eof():
+                        cwriter.write_eof()
 
         try:
             await asyncio.gather(client_to_device(), device_to_client())
         finally:
-            for closer in (psock.close, cwriter.close):
+            closing.set()
+            with suppress(Exception):
+                cwriter.close()
+
+            # Tear the PyTCP socket down OFF the event loop: every psock entry point takes
+            # the session's FSM lock, which can be held for a long time while the stack shuts
+            # down — running it inline wedged the loop during teardown (#1756: py-spy showed
+            # the main thread stuck in psock.close -> tcp_fsm). A plain fire-and-forget daemon
+            # thread (not to_thread) so it runs even when this handler is being cancelled and
+            # nothing ever waits on it. shutdown(SHUT_RDWR) also wakes a recv()-parked rx_pump
+            # with EOF before close marks the socket down.
+            def teardown_psock() -> None:
                 with suppress(Exception):
-                    closer()
+                    psock.shutdown(SHUT_RDWR)
+                with suppress(Exception):
+                    psock.close()
+
+            threading.Thread(target=teardown_psock, name=f"userspace-relay-teardown-{port}", daemon=True).start()
 
     async def _ensure_relay(self, port: int) -> int:
         key = (self._device_addr, port)
@@ -354,7 +400,14 @@ class UserspaceDialPlane:
             return self._relays[key]
 
         async def handle(creader: asyncio.StreamReader, cwriter: asyncio.StreamWriter) -> None:
-            await self._relay_handler(port, creader, cwriter)
+            # Track the handler task so __aexit__ can cancel any relay still in flight
+            # (start_server's own task bookkeeping offers no cross-version cancel API).
+            task = asyncio.current_task()
+            self._relay_tasks.add(task)
+            try:
+                await self._relay_handler(port, creader, cwriter)
+            finally:
+                self._relay_tasks.discard(task)
 
         srv = await asyncio.start_server(handle, "127.0.0.1", 0)
         self._servers.append(srv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,4 +48,7 @@ av>=14.0.0 ; platform_system != "Darwin"
 # (https://github.com/doronz88/pmd-pytcp). Pulls its pmd-net-addr / pmd-net-proto siblings in
 # transitively. Supported on Python 3.9+ (the whole pymobiledevice3 range); if the import or
 # stack init fails the tunnel transparently falls back to the kernel path (see cli_common).
-pmd-pytcp>=0.0.4 ; python_version >= "3.9"
+# 0.0.6 floor: teardown robustness (rings survive fd-close races, dispatch never parks a
+# producer on the FSM lock, stop() unblocks socket waiters) plus the Windows writev()
+# fallthrough raising OSError instead of crashing the TX ring — the pmd-pytcp side of #1756.
+pmd-pytcp>=0.0.6 ; python_version >= "3.9"

--- a/tests/test_userspace_tunnel.py
+++ b/tests/test_userspace_tunnel.py
@@ -1,10 +1,19 @@
-"""Tests for the userspace tunnel's throughput tuning.
+"""Tests for the userspace tunnel: throughput tuning and relay-teardown behavior.
 
 The tuning rides pmd-pytcp's public ``tcp.rcv_wnd_max`` / ``tcp.snd_mss_max`` sysctls; these
 tests pin that :func:`throughput_sysctls` emits values the installed pmd-pytcp actually accepts
 (and silently omits any a too-old pmd-pytcp lacks). The cross-platform/portability concerns that
 used to live in a host-side compatibility layer are now handled inside pmd-pytcp itself.
+
+The relay-teardown tests are regressions for issue #1756 (userspace tunnel cleanup hanging the
+event loop / leaking one parked rx_pump thread per relayed connection). They drive
+:class:`UserspaceDialPlane` against a fake PyTCP socket reproducing the semantics that caused
+the hang: a blocking ``recv()`` that does NOT unblock on ``close()``.
 """
+
+import asyncio
+import threading
+import time
 
 import pytest
 
@@ -14,6 +23,7 @@ pytest.importorskip("pmd_pytcp")
 from pmd_pytcp.stack import sysctl
 
 from pymobiledevice3.remote import userspace_tunnel
+from pymobiledevice3.remote.userspace_tunnel import UserspaceDialPlane
 
 
 def test_throughput_sysctls_only_emits_registered_knobs():
@@ -38,3 +48,153 @@ def test_throughput_sysctls_round_trip_through_sysctl_set():
     for key, value in userspace_tunnel.throughput_sysctls().items():
         sysctl.set(key, value)
     sysctl.reset_to_defaults()
+
+
+# --- relay teardown regressions (issue #1756) ---------------------------------------------
+
+DEVICE_ADDR = "fd00::1"
+
+
+class FakePyTcpSocket:
+    """The pmd-pytcp TCP socket surface the relay uses, with the semantics that caused #1756:
+    ``recv()`` blocks (optionally with a timeout) and does NOT unblock on ``close()`` — only
+    inbound data/EOF or a ``shutdown(SHUT_RD/SHUT_RDWR)`` wakes it."""
+
+    def __init__(self) -> None:
+        self._cond = threading.Condition()
+        self._rx: list = []
+        self._eof = False
+        self.sent: list = []
+        self.shutdown_calls: list = []
+        self.closed = threading.Event()
+
+    # --- device-side test controls ---
+    def feed(self, data: bytes) -> None:
+        with self._cond:
+            self._rx.append(data)
+            self._cond.notify_all()
+
+    def feed_eof(self) -> None:
+        with self._cond:
+            self._eof = True
+            self._cond.notify_all()
+
+    # --- relay-facing surface ---
+    def recv(self, bufsize: int, timeout=None) -> bytes:
+        with self._cond:
+            if not self._cond.wait_for(lambda: self._rx or self._eof, timeout=timeout):
+                raise TimeoutError("TCP Socket - Receive operation timed out.")
+            if self._rx:
+                return self._rx.pop(0)
+            return b""
+
+    def send(self, data: bytes) -> int:
+        self.sent.append(bytes(data))
+        return len(data)
+
+    def shutdown(self, how) -> None:
+        self.shutdown_calls.append(int(how))
+        if int(how) in (0, 2):  # SHUT_RD / SHUT_RDWR wake a parked recv() with EOF
+            self.feed_eof()
+
+    def close(self) -> None:
+        self.closed.set()
+
+
+class FakeTun:
+    """Just enough of :class:`UserspaceTun` for :class:`UserspaceDialPlane`."""
+
+    def __init__(self) -> None:
+        self.socks: list = []
+
+    def connect_tcp(self, addr: str, port: int) -> FakePyTcpSocket:
+        sock = FakePyTcpSocket()
+        self.socks.append(sock)
+        return sock
+
+
+async def _poll_until(predicate, timeout: float = 5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        value = predicate()
+        if value:
+            return value
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition not met within timeout")
+
+
+def _relay_rx_threads() -> list:
+    return [t for t in threading.enumerate() if t.name.startswith("userspace-relay-rx-")]
+
+
+async def test_relay_full_conversation_and_clean_completion():
+    # ping/pong through the relay, then a client-initiated close: the client EOF must reach
+    # the device as a half-close (SHUT_WR), and once the device answers with its own EOF the
+    # handler must finish on its own — with the pytcp socket closed and no task left behind.
+    tun = FakeTun()
+    async with UserspaceDialPlane(tun, DEVICE_ADDR) as dial_plane:
+        reader, writer = await dial_plane.dial(DEVICE_ADDR, 1234)
+        psock = (await _poll_until(lambda: tun.socks))[0]
+
+        writer.write(b"ping")
+        await writer.drain()
+        await _poll_until(lambda: psock.sent == [b"ping"])
+        psock.feed(b"pong")
+        assert await reader.readexactly(4) == b"pong"
+
+        writer.close()
+        # client EOF -> device half-close (SHUT_WR=1 or SHUT_RDWR=2)
+        await _poll_until(lambda: any(how in (1, 2) for how in psock.shutdown_calls))
+        psock.feed_eof()  # the device finishes its side
+        await _poll_until(lambda: not dial_plane._relay_tasks)  # handler completed unaided
+        assert psock.closed.wait(timeout=5)
+
+
+async def test_device_eof_reaches_client():
+    # The device closing its side must propagate to the client as EOF (write_eof), otherwise
+    # the client never learns the stream ended and the pair idles forever.
+    tun = FakeTun()
+    async with UserspaceDialPlane(tun, DEVICE_ADDR) as dial_plane:
+        reader, writer = await dial_plane.dial(DEVICE_ADDR, 1111)
+        psock = (await _poll_until(lambda: tun.socks))[0]
+        psock.feed(b"data")
+        psock.feed_eof()
+        assert await asyncio.wait_for(reader.read(), timeout=5) == b"data"  # read() to EOF
+        writer.close()
+
+
+async def test_dial_plane_exit_cancels_parked_relay():
+    # Regression for the #1756 hang: with a relay parked on device traffic (recv blocked, no
+    # EOF in sight), __aexit__ used to hang in Server.wait_closed() (which waits for in-flight
+    # handlers since Python 3.12.1) and left the handler task to be cancelled at loop close —
+    # where its inline psock cleanup wedged the loop. Exit must complete promptly, leave no
+    # relay task behind, and still tear the pytcp socket down.
+    tun = FakeTun()
+    dial_plane = UserspaceDialPlane(tun, DEVICE_ADDR)
+    await dial_plane.__aenter__()
+    _reader, writer = await dial_plane.dial(DEVICE_ADDR, 5678)
+    await _poll_until(lambda: tun.socks)
+
+    await asyncio.wait_for(dial_plane.__aexit__(None, None, None), timeout=5)
+
+    assert not dial_plane._relay_tasks
+    assert tun.socks[0].closed.wait(timeout=5)
+    writer.close()
+
+
+async def test_rx_pump_threads_exit_after_teardown():
+    # Regression for the #1756 thread pile-up (120 parked rx_pump threads): after the dial
+    # plane exits, every relay rx thread must unwind — the teardown SHUT_RDWR wakes parked
+    # ones and the polling recv() lets the rest observe the closing flag.
+    baseline = _relay_rx_threads()
+    tun = FakeTun()
+    async with UserspaceDialPlane(tun, DEVICE_ADDR) as dial_plane:
+        writers = []
+        for _ in range(5):
+            _reader, writer = await dial_plane.dial(DEVICE_ADDR, 9999)
+            writers.append(writer)
+        await _poll_until(lambda: len(tun.socks) == 5)
+        assert len(_relay_rx_threads()) >= 5
+    await _poll_until(lambda: _relay_rx_threads() == baseline, timeout=10)
+    for writer in writers:
+        writer.close()


### PR DESCRIPTION
Fixes #1756.

## The failure chain

The reporter's minimal repro (`aopen()` → `aclose()` on Windows/Python 3.14) hits three intertwined problems, all in the dial-plane relay:

1. **`aclose()` times out.** A relay handler never finished on its own: the client's EOF was never propagated to the device, so the device never sent its FIN, `rx_pump` stayed parked in the PyTCP `recv()` (which does not unblock on `close()`), and the handler waited on `asyncio.gather()` forever. Since **Python 3.12.1, `Server.wait_closed()` also waits for in-flight connection handlers**, so `UserspaceDialPlane.__aexit__` hung until the caller's `wait_for` timeout.

2. **The event loop wedges at shutdown.** The timed-out `aclose()` left the relay tasks orphaned; when the loop closed (pytest-asyncio's `_cancel_all_tasks`), their cancellation ran `finally: psock.close()` **inline on the loop thread** — which blocks acquiring the PyTCP session FSM lock while the already-stopped stack can make no progress. This is exactly the reporter's py-spy dump: `MainThread` stuck in `_relay_handler` → `psock.close` → `tcp_fsm`.

3. **One leaked thread per relayed connection.** `rx_pump` used an untimed blocking `recv()`, so every relay left a daemon thread parked in `recv()` for the process lifetime (the py-spy dump showed 120 of them).

## The fixes (this repo)

- `client_to_device` propagates the client's EOF to the device as a half-close (`shutdown(SHUT_WR)`); the device answers with its FIN, which unblocks `rx_pump` with EOF and lets the handler complete unaided. `device_to_client` mirrors this with `write_eof()` toward the client.
- `UserspaceDialPlane` now tracks its in-flight relay tasks and cancels them in `__aexit__` before `wait_closed()`, so teardown is prompt and no orphan task is left for the loop's shutdown to trip over.
- The handler's psock cleanup (`shutdown(SHUT_RDWR)` + `close()`) runs in a fire-and-forget daemon thread — never on the event loop, and unconditionally even when the handler is being cancelled. The `SHUT_RDWR` also wakes a `recv()`-parked `rx_pump` with EOF.
- `rx_pump` polls `recv()` with a timeout and re-checks a closing flag, so the thread always exits shortly after teardown (and it's now named `userspace-relay-rx-<port>` for debuggability).

## The fixes (pmd-pytcp 0.0.6, now floored in requirements.txt)

The pmd-pytcp side landed in [doronz88/pmd-pytcp#2](https://github.com/doronz88/pmd-pytcp/pull/2) and [doronz88/pmd-pytcp#3](https://github.com/doronz88/pmd-pytcp/pull/3), shipped as [v0.0.5](https://github.com/doronz88/pmd-pytcp/releases/tag/v0.0.5) and [v0.0.6](https://github.com/doronz88/pmd-pytcp/releases/tag/v0.0.6) (green CI across Linux/macOS/Windows × Python 3.9–3.14):

- RX/TX rings survive interface-fd/eventfd close races — the `RX Ring ... WinError 10038` unhandled-exception traceback from the issue;
- `TxRing.dispatch` can no longer park a producer forever on a worker-exit race (the FSM-lock wedge underlying the py-spy dump);
- `stack.stop()` aborts open TCP sockets so blocked `recv()`/`connect()` callers unblock with a connection error instead of surviving teardown parked forever;
- (0.0.6) the `writev()` fallthrough raises the closed-fd `OSError` the TX ring absorbs as a drop, instead of the `os.writev` `AttributeError` that killed the TX Ring worker on Windows when 0.0.5's stop()-time socket aborts raced the tunnel's interface-fd unregistration — the follow-up traceback from the issue's re-test.

This PR floors `pmd-pytcp>=0.0.6` accordingly.

## Tests

New regression tests drive `UserspaceDialPlane` against a fake PyTCP socket reproducing the blocking-`recv` semantics:

- full ping/pong conversation, client-initiated close → half-close propagation → handler completes unaided;
- device EOF reaches the client as EOF;
- `__aexit__` with a relay parked on device traffic completes within a bounded time, leaves no task behind, and still tears the psock down (the #1756 hang);
- rx threads all exit after teardown (the 120-thread pile-up).

`pytest tests/test_userspace_tunnel.py` → 7 passed, including against the released pmd-pytcp 0.0.6 from PyPI.

