### PR TITLE
restore: Properly fall back to Recovery mode if usbmuxd is not available

### DIFF
--- a/pymobiledevice3/cli/restore.py
+++ b/pymobiledevice3/cli/restore.py
@@ -61,11 +61,11 @@ async def _device_dependency_async(
         # prevent lockdown connection establishment when in autocomplete mode
         return None
 
-    logger.debug("searching among connected devices via lockdownd")
-    devices = [dev for dev in await usbmux.list_devices() if dev.connection_type == "USB"]
-    if len(devices) > 1:
-        raise click.ClickException("Multiple device detected")
     try:
+        logger.debug("searching among connected devices via lockdownd")
+        devices = [dev for dev in await usbmux.list_devices() if dev.connection_type == "USB"]
+        if len(devices) > 1:
+            raise click.ClickException("Multiple device detected")
         for device in devices:
             try:
                 lockdown = await create_using_usbmux(serial=device.serial, connection_type="USB")


### PR DESCRIPTION
## Summary

`usbmux.list_devices` will already initiate a usbmuxd connection. If no devices are available, the function would improperly exit without trying Recovery mode. Move it in the try / except block.

## Testing

Before:

```
$ pymobiledevice3 -v restore shell
2026-07-10 12:53:19 laptop pymobiledevice3.cli.restore[150491] DEBUG searching among connected devices via lockdownd
2026-07-10 12:53:19 laptop __main__[150491] ERROR Failed to connect to usbmuxd socket. Make sure it's running.
```

After:

```
$ pymobiledevice3 -v restore shell
2026-07-10 13:00:08 laptop pymobiledevice3.cli.restore[151923] DEBUG searching among connected devices via lockdownd
2026-07-10 13:00:08 laptop pymobiledevice3.cli.restore[151923] DEBUG waiting for device to be available in Recovery mode
2026-07-10 13:00:08 laptop pymobiledevice3.irecv[151923] DEBUG set_configuration: 1
2026-07-10 13:00:08 laptop pymobiledevice3.irecv[151923] DEBUG set_interface_altsetting: 0 0
# use `irecv` variable to access Restore mode API
# for example:
print(irecv.getenv('build-version'))

Python 3.14.6 (main, Jun 15 2026, 11:36:54) [GCC 16.1.1 20260430]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.14.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: You can find how to type a Unicode symbol by back-completing it, eg `\Ⅷ<tab>` will expand to `\ROMAN NUMERAL EIGHT`.

In [1]: print(irecv.getenv('build-version'))
bytearray(b'iBoot-13822.67.1\x00')
```

## AI Assistance

Claude Opus 4.8 identified the issue. Changes were manually applied and tested.
