### PR TITLE
lockdown: Add Vision Pro device class

### DIFF
--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -78,6 +78,7 @@ class DeviceClass(Enum):
     IPOD = "iPod"
     WATCH = "Watch"
     APPLE_TV = "AppleTV"
+    VISION_PRO = "RealityDevice"
     UNKNOWN = "Unknown"
 
 


### PR DESCRIPTION
## Summary

As reported by lockdown:

```
$ pymobiledevice3 lockdown info
...
    "DeviceClass": "RealityDevice",
```

Note, this requires https://github.com/libimobiledevice/usbmuxd/pull/282 to be merged. It does not seem like the usbmuxd project is very active right now.

## Testing

As above

## AI Assistance

none
