### PR TITLE
irecv: Fix sending zero-length packet for 512-multiple payloads

### DIFF
--- a/pymobiledevice3/irecv.py
+++ b/pymobiledevice3/irecv.py
@@ -189,6 +189,10 @@ class IRecv:
                 else:
                     self.ctrl_transfer(0x21, 1, wValue=packet_index, wIndex=0, data_or_wLength=chunk)
 
+        if self.mode.is_recovery and len(buf) % 512 == 0:
+            # Terminating zero-length packet.
+            self._device.write(0x04, b"", timeout=USB_TIMEOUT)
+
         if not self.mode.is_recovery:
             logger.debug("waiting for status == 5")
             while self.status != 5:


### PR DESCRIPTION
## Summary

When the recovery-mode payload is an exact multiple of the bulk OUT max packet size (512? on the high-speed iBoot interface), the final data transfer ends on a full-size packet, so the device cannot detect end-of-transfer from a short packet. It seems that, without an explicit zero-length packet, iBoot keeps the OUT endpoint open waiting for more data and STALLs the command that follows (observed as EPIPE on the subsequent "firmware" command)

Note that libirecovery does exactly this in irecv_send_buffer(), added in https://github.com/libimobiledevice/libirecovery/commit/12ed446fb17b8ea34728641cf4ca836eedab7aeb

## Testing

Tested by successfully erase-restoring an Apple Vision Pro.

```
$ pymobiledevice3 -v restore update --erase -i ../Apple_Vision_Pro_26.5_23O471_Restore.ipsw
```

## AI Assistance

Claude Opus 4.8 identified the issue (after a lot of side-tracks...) and drafted the commit summary. Changes were manually applied and tested.