### PR TITLE
serve-web/serve-vnc: stream-recovery hardening, fps + freeze fixes, research toggles

### DIFF
--- a/pymobiledevice3/cli/developer/core_device.py
+++ b/pymobiledevice3/cli/developer/core_device.py
@@ -953,6 +953,31 @@ async def core_device_display_serve_web(
             ),
         ),
     ] = False,
+    rctl: Annotated[
+        bool,
+        typer.Option(
+            "--rctl/--no-rctl",
+            help=(
+                "Run the AVConference RCTL receiver-feedback loop (RTCP APP), "
+                "reversed from Xcode's mirror protocol -- closed-loop encoder "
+                "rate control matching what Xcode does. On by default; "
+                "--no-rctl reverts to open-loop."
+            ),
+        ),
+    ] = True,
+    max_bitrate: Annotated[
+        int,
+        typer.Option(
+            "--max-bitrate",
+            help=(
+                "Encoder bitrate cap in kbps, advertised to the device over the "
+                "RCTL loop (the device honours it). The uncapped encoder can "
+                "ramp past ~5.5 Mbps under sustained motion and stall; lowering "
+                "this (e.g. 5000) keeps the stream steadier at some cost to peak "
+                "quality. Requires --rctl."
+            ),
+        ),
+    ] = 60000,
 ) -> None:
     """Serve the device's screen via HTTP — view in any modern browser.
 
@@ -975,6 +1000,8 @@ async def core_device_display_serve_web(
         allow_rtcp_fb=rtcp_fb,
         ltrp_enabled=ltrp,
         https=https,
+        rctl_enabled=rctl,
+        max_bitrate_kbps=max_bitrate,
     )
     await server.serve()
 

--- a/pymobiledevice3/cli/developer/core_device.py
+++ b/pymobiledevice3/cli/developer/core_device.py
@@ -919,12 +919,16 @@ async def core_device_display_serve_web(
         typer.Option(
             "--ltrp",
             help=(
-                "Opt back into LTRP (long-term reference pictures). LTRP is OFF "
-                "by default because on-device probing showed the device honours "
-                "the protobuf-level switch (`IsltrpEnabled: false` in the "
-                "answer) and LTRP-off eliminates the mid-stream tearing pattern "
-                "under UDP loss. Apple's captured Xcode offer used LTRP-on; "
-                "this flag restores that for regression testing."
+                "Opt into LTRP (long-term reference pictures). LEAVE OFF for "
+                "browser viewing. LTRP lowers the encoder's QP under motion "
+                "(sharper bitstream — ffmpeg decodes it cleanly), BUT the "
+                "browsers' real-time VideoToolbox/WebCodecs decoder mishandles "
+                "the long-term references and renders a mosaic of displaced "
+                "blocks during rapid motion. Verified on-device: identical hard "
+                "swipes are clean with LTRP off and tear with it on, while the "
+                "same captured bitstream is clean in ffmpeg either way — i.e. "
+                "the tear is a live-decode artifact, not in the stream. The "
+                "encoder QP win (≈19 vs ≈23-31) is not worth the mosaic."
             ),
         ),
     ] = False,
@@ -958,13 +962,16 @@ async def core_device_display_serve_web(
         typer.Option(
             "--rctl/--no-rctl",
             help=(
-                "Run the AVConference RCTL receiver-feedback loop (RTCP APP), "
-                "reversed from Xcode's mirror protocol -- closed-loop encoder "
-                "rate control matching what Xcode does. On by default; "
-                "--no-rctl reverts to open-loop."
+                "Run the AVConference RCTL receiver-feedback loop (RTCP APP + "
+                "per-frame receipts), reversed byte-exact from Xcode's mirror -- "
+                "the closed-loop rate control Xcode uses. OFF by default: it "
+                "does NOT prevent the motion resolution-collapse (that's a "
+                "device encoder decision at the ~6 Mbps cap), and a wrong OWRD "
+                "or non-per-frame receipt makes the device throttle framerate. "
+                "Kept as the correct closed-loop base for further research."
             ),
         ),
-    ] = True,
+    ] = False,
     max_bitrate: Annotated[
         int,
         typer.Option(
@@ -978,6 +985,40 @@ async def core_device_display_serve_web(
             ),
         ),
     ] = 60000,
+    motion_idr: Annotated[
+        bool,
+        typer.Option(
+            "--motion-idr/--no-motion-idr",
+            help=(
+                "Force a keyframe ~1x/second WHILE the screen is moving (ON by "
+                "default). Under rapid motion the device drops capture resolution "
+                "into a top-left corner of the frame ('screen shrinks while "
+                "swiping'); these keyframes snap it back to full resolution fast, "
+                "and the viewer stretches the shrunk region to fill the canvas so "
+                "the brief window is hidden. Trade-off: the keyframe pressure can "
+                "stall the ~6 Mbps-capped encoder under sustained motion. "
+                "--no-motion-idr drops it for a stall-free but slower-recovering "
+                "stream (relies on the viewer stretch + settle keyframe alone). "
+                "NOTE: combining --motion-idr with --rctl throttles fps hard -- "
+                "the default keeps RCTL off so the IDR stays fast."
+            ),
+        ),
+    ] = True,
+    compensate: Annotated[
+        bool,
+        typer.Option(
+            "--compensate/--no-compensate",
+            help=(
+                "Viewer-side resolution-collapse compensation (ON by default). "
+                "When the device shrinks the captured screen into the top-left "
+                "corner + gray padding under motion, the browser detects that "
+                "content rectangle per frame and stretches it back to fill the "
+                "canvas, turning the hard corner-shrink into a softer momentary "
+                "resolution dip. --no-compensate shows the raw device output "
+                "(useful for seeing the collapse / research)."
+            ),
+        ),
+    ] = True,
 ) -> None:
     """Serve the device's screen via HTTP — view in any modern browser.
 
@@ -1002,6 +1043,8 @@ async def core_device_display_serve_web(
         https=https,
         rctl_enabled=rctl,
         max_bitrate_kbps=max_bitrate,
+        motion_idr=motion_idr,
+        compensate=compensate,
     )
     await server.serve()
 

--- a/pymobiledevice3/remote/core_device/SERVE_WEB_NOTES.md
+++ b/pymobiledevice3/remote/core_device/SERVE_WEB_NOTES.md
@@ -1,0 +1,401 @@
+# serve-web: motion-tearing / stall investigation — continuation notes
+
+## CORRECTED CONCLUSION (2026-07-12) — tearing is device-side & DECODER-INDEPENDENT
+
+**All the motion tearing (both the geometry collapse AND the "mosaic") is produced by
+the device's AVConference encoder under fast motion at the ~6 Mbps cap. It is in the
+encoded bitstream, and EVERY decoder renders it identically.** This supersedes
+RESOLUTION #2 below, which blamed the browser's WebCodecs HW decoder — that is
+**DISPROVEN**:
+
+- **serve-vnc, native VideoToolbox decode (`--decoder vt`), tears IDENTICALLY** to the
+  browser when the user swipes the **physical device** by hand. Native decode was
+  claimed (by RESOLUTION #2, and by me mid-session) to be the clean path — it is not.
+- It is **not HID injection / touch-session eviction** either: the trigger was a
+  *physical* on-device swipe, no `/touch` sent through serve-web or VNC.
+- The "ffmpeg decodes the stream CLEAN, 0 errors" evidence in RESOLUTION #2 was
+  **mis-read**: ffmpeg reporting no decode *errors* means the stream is *valid/decodable*,
+  NOT that the image is pristine. The device encodes valid-but-degraded (blocky/torn,
+  QP-escalated) frames under motion; ffmpeg, WebCodecs, and native VideoToolbox all
+  render those same degraded frames. A keyframe "clears" it for any decoder (fresh
+  reference), so "keyframe fixes it" never distinguished decoder-state from bitstream.
+
+**So the decode path was never the axis.** The real question (unchanged, still open) is
+why the device's ENCODE tears for our stream but reportedly not for Xcode's, given the
+encoder *config* captured from a live Xcode session was byte-identical. That difference
+lives in the **stream-setup negotiation** (device-side), e.g. the unprobed `VideoSettings`
+fields (`f8` pixelFormats, `f13` foveation, `f14` interleavedEncoding) or the
+rate-adaptation *mode* — none of which are behind toggles yet. Next step: capture the raw
+bitstream WHILE physically swiping and diff frame-by-frame vs an Xcode capture.
+
+**serve-vnc is NOT a tear fix** (it tears too). Its fix this session (commit "serve-vnc:
+send periodic video RR") is unrelated: serve-vnc sent no periodic video Receiver Report,
+so the device reaped the video session at ~25 s and serve-vnc froze permanently (no
+stream-restart). The RR keepalive makes it hold a live stream (verified 140 s). Also
+fixed this session: a branch-introduced fps->0 watchdog restart-storm (`key_starved`
+trigger) restored to master's single AU-stall trigger; the RCTL OWRD arrival-clock
+(reported on the wrong epoch → phantom-congestion throttle); and the audio RR reap gate.
+
+**The research harness earns its keep**: the CLI/`/debug` toggles (esp. runtime
+`/debug/{rctl,idr}-{on,off}` — single-session A/B that sidesteps this unit's boot-time
+degradation) are how the wrong theories above were eliminated. They narrow; they haven't
+solved. Aim them next at the untested negotiation fields.
+
+---
+
+## SYSLOG GROUND TRUTH (2026-07-08) — the collapse is a hardcoded 6 Mbps device limit
+
+Capturing `avconferenced` os_log **un-redacted** (method: a SECOND `pymobiledevice3
+syslog live --userspace` tunnel alongside the serve-web `--userspace` tunnel — they
+coexist) gives the device's own rate-controller state and settles this.
+
+The `AVCRateController` + `VideoTransmitter` health prints (every 5 s) show:
+
+- Cap is fixed: `targetBitrate=5490 kbps, bitrateCap=6000 kbps` ALWAYS.
+- Under motion the encoder **trades framerate for bitrate as it approaches the cap**:
+  measured `encodedFrameRate` 55→40→**28 fps** as `currentMediaBitrate` climbed
+  1.8→2.2→**4.8 Mbps**. Push harder (real hand motion) and it also drops resolution
+  (the 720×1280 collapse). `VCVideoStreamRateAdaptation` is the component doing it;
+  the config carries `vcMediaStreamRateAdaptationEnabled = 1`.
+- With the corrected RCTL loop the health print is HEALTHY: `RemoteBWE=60001 kbps,
+  OWRD=0–5 ms, Uplink PLR=0.00%` — i.e. the inline-receipt fix genuinely killed the
+  false-loss fps throttle (PLR was ~87% before). Confirmed here, not inferred.
+
+Every host-side lever to move the cap was tried and RULED OUT by watching the health
+print's `bitrateCap`/`targetBitrate` (all stayed 6000/5490):
+
+- RCTL `--max-bitrate` (2000): ignored — target stays 5490 even with BWE=60001.
+- `AVCMediaStreamNegotiatorAccessNetworkType` (1→3): no change.
+- The offer's `f9` BitrateTier table (bumped the 6 Mbps tier to 20 Mbps): no change.
+- `AVCMediaStreamNegotiatorVideoWidth/Height` (632×1368): ignored — stream stays
+  native 1264×2752 (resolution is locked for screen capture).
+
+**Conclusion:** the motion tear/fps-drop is the device encoder hitting a hardcoded
+~6 Mbps cap and its rate-adaptation dropping fps then resolution. It is NOT movable
+by anything we send. Xcode's smoothness (its pcap ran at ~1.7 Mbps, never near the
+cap) is either lighter content or a private entitlement/service path. The only
+un-explored device-side lever is turning OFF `vcMediaStreamRateAdaptationEnabled`
+(would trade the collapse for blocky-but-full-frame) — its client key isn't among the
+`AVCMediaStreamNegotiator*` options, so it'd need deeper AVConference RE, possibly an
+entitlement. Binary: `System/Library/PrivateFrameworks/AVConference.framework`;
+relevant symbols `-[VCVideoStreamRateAdaptation ...]`, `configureRateControllerWithConfig:`,
+ML models `default_factors_AVCONFERENCE_NETWORK_SMART_BRAKE_fbs.bin`.
+
+---
+
+## STATE (2026-07-08) — two independent axes: FPS (fixed) and COLLAPSE (device-limited)
+
+The user-reported tear ("screen shrinks to a small rectangle in the upper-left
+while swiping") is a **device-side resolution collapse**: under rapid motion the
+DisplayService encoder, capped at a hardcoded ~6 Mbps, drops capture resolution
+(observed 720×1280 for a 1264×2752 panel), stretches the whole screen into that
+smaller frame, and pins it TOP-LEFT of the fixed buffer with flat gray
+(Y=Cb=Cr=128) padding. It is **in the bitstream** (ffmpeg decodes it identically),
+reproduces in ~2 s of real hand motion, and — critically — synthetic /touch
+swipes NEVER reproduce it (too little byte-rate to hit the cap), so it can only be
+judged by hand ([[feedback-screen-stress-test-quality]]).
+
+### FPS — FIXED. Root cause: RCTL receipt *timing*
+
+Sending the AVConference RCTL feedback made the device throttle framerate to
+<10 fps under motion. It is NOT the report content (byte-exact to Xcode) — it's
+the **per-frame receipt (RTCP APP name=5)**. Xcode sends exactly ONE receipt per
+frame (measured: receipt-rate == frame-rate) so the device credits each frame's
+full packet span and computes ~0% uplink loss. Our old loop sent receipts on a
+40/s timer via a deferred `create_task`; under motion those arrive after the
+device ages the frame out → it credits ~1 of ~8 packets → false ~87% uplink loss
+→ loss-defensive encoder → framerate throttle. Fix: send the receipt INLINE (not
+deferred) on each RTP marker with that frame's ts (`_udp_recv_and_depacketize`).
+With that, RCTL runs at full framerate. (`--no-rctl` is also full framerate,
+since it sends no feedback at all.)
+
+### COLLAPSE — device-limited, NOT fixable via RCTL (exhausted)
+
+Every RCTL field was tried: byte-exact report, per-frame receipts, and OWRD
+(w4-lo). None prevent the collapse. OWRD is a throttle knob only — flooring it to
+Xcode's ~125 dropped fps to <6 (on our ~zero-delay tunnel a large OWRD reads as
+congestion); the real near-zero jitter is correct for fps. So the collapse is the
+device encoder's own rate-vs-quality choice at the 6 Mbps cap, not gated by the
+feedback loop — matching the earlier FINDINGS caveat ("degraded even with the
+loop closed"). **Xcode's RCTL is byte-identical to ours yet Xcode never
+collapses (40 fps @ ~1.7 Mbps in the pcap), so its collapse-avoidance lives
+OUTSIDE the RCTL feedback** — almost certainly its negotiated encode config /
+rate-control mode, which is over the encrypted tunnel and NOT in the media pcap.
+That stream-setup RE is the open path to true parity.
+
+Mitigations shipped (all togglable — see below):
+
+- **Viewer stretch compensation** (`viewer.js` `detectContentCrop`, per frame,
+  `--compensate`): detect the shrunk content rect on the RAW frame and stretch it
+  to fill the canvas → corner-shrink becomes a softer momentary resolution dip.
+  MUST be per-frame (a stale crop zooms a full frame into its top-left — the
+  "smaller screen over the old full screen" smearing). Validated offline against a
+  real 85k-frame capture (flags exactly the collapsed frames, 0 clean). Partial:
+  at high fps the fast collapse/recover transitions still show through somewhat.
+- **Server mid-motion IDR** (`_decoder_refresh_loop`, `--motion-idr`): forces a
+  keyframe ~1×/s while moving so the device re-emits full res. Fast recovery, but
+  **combined with `--rctl` it throttles fps hard** — so the default keeps RCTL off.
+
+### Defaults + research toggles
+
+Default = maximise fps: **RCTL off, motion-IDR on, compensation on**. Everything is
+togglable so the collapse/rate-control can be researched without code edits:
+
+- CLI: `--rctl/--no-rctl`, `--motion-idr/--no-motion-idr`, `--compensate/--no-compensate`, `--max-bitrate`.
+- Runtime (no restart — restarts are slow and wedge this beta device): `POST /debug/{rctl,idr}-{on,off}`.
+- Viewer: `?compensate=0|1` URL override.
+
+### Open item (true xcode-parity)
+
+Decode Xcode's DisplayService/AVConference **stream-setup** negotiation (the
+mediaBlob / VideoSettings the client sends at connect) — that, not the RCTL
+feedback, is what makes Xcode's encoder hold resolution+framerate under motion.
+Needs a stable (non-beta) device: this unit degrades to ~10 fps within minutes of
+a fresh boot, which invalidated many mid-session fps comparisons.
+
+---
+
+## Earlier investigation (superseded framing below — kept for the trail)
+
+Status: **TWO DISTINCT DEFECTS, do not conflate.**
+
+1. **Geometry collapse** (the symptom users actually report — "screen becomes a
+   small rectangle in the upper-left while swiping"): device-side, in the
+   bitstream, NOT the browser and NOT RCTL. Fix is the two-part solution above
+   (this section's "auto-recovered in the viewer" was an earlier /restart-watchdog
+   approach, since replaced by stretch-compensation + mid-motion IDR).
+2. **Motion mosaic** (scrambled blocks): the browser's WebCodecs HEVC *hardware*
+   decoder mangling high-motion frames — a separate, secondary issue that is not
+   fixable server-side. See RESOLUTION #2.
+
+## RESOLUTION #1 — geometry collapse (2026-07-07, PRIMARY, fixed)
+
+The dominant user-reported symptom ("smaller rectangle in the upper-left corner",
+"screen becomes smaller while swiping") is **not** the browser and **not** our RCTL
+feedback. The device-side DisplayService/AVConference encoder degrades over a
+session so the captured screen collapses into the top-left corner of the fixed
+1264×2752 encode buffer, the remainder filled with flat gray (Y=Cb=Cr=128) padding.
+It lives **in the bitstream** — ffmpeg decodes the collapsed geometry identically.
+
+Evidence (this session):
+
+- **Fresh negotiation is clean with RCTL ON**: 35 rounds / 11 min of sustained hard
+  synthetic motion on a just-rebooted device → 0 collapsed frames, full 1264×2752
+  throughout. So RCTL does **not** cause it (this corrects the earlier suspicion).
+- **A degraded session's dump is ~51% collapsed**: full-file scan of an 85 064-frame
+  capture — clean for the first 20 874 frames, then two sustained collapse blocks
+  (37 686 and 5 976 frames; minutes each, never flickering). The device sometimes
+  self-heals (a clean block returned mid-file), matching users' "it resets itself
+  quickly afterwards".
+- **A `/pli` cannot fix it** (can't restore a shrunk capture region); only a full
+  session re-negotiation (`/restart`) does — exactly the manual "Force Restart" cure.
+
+**The fix (viewer.js `detectGeometryCollapse` + watchdog):** downsample the drawn
+canvas to 24×52 once a second and test the collapse's spatial signature — right
+column + bottom row are gray-128 padding while the top-left quadrant still holds
+real content. Hold for 3 s → POST `/restart` (the audio-preserving path), rate-
+limited to 1 per 20 s so a genuinely gray screen can't loop. Validated: the
+signature flagged exactly the 51% collapsed frames and 0 of the 41k clean frames in
+the capture; live, it fired once on a forced collapse and 0 times over 20 s / 246
+hard drags of healthy motion.
+
+## RESOLUTION #2 — motion mosaic (2026-07-07) — **DISPROVEN, see CORRECTED CONCLUSION at top**
+
+> ⚠️ This section's conclusion ("the mosaic is the browser's WebCodecs HW decoder;
+> native/software decode is clean") was **disproven 2026-07-12**: serve-vnc with native
+> VideoToolbox decode tears identically under physical-device motion. The mosaic is
+> device-side/in-bitstream like the collapse. Kept below for the investigation trail.
+
+The residual scrambled-block mosaic (distinct from the geometry collapse above) is
+the **browser's macOS-VideoToolbox HEVC hardware decoder** mangling high-motion
+frames. The bitstream we deliver is already clean; nothing server-side (encoder
+config, framing, feedback, tunnel) is wrong. Proof, all in ONE session on ONE
+hard-swipe drive (`--userspace`, `--ltrp` off), so no cross-session confound:
+
+| what was decoded | decoder | result |
+| --- | --- | --- |
+| server Annex-B dump (every AU) | ffmpeg (software) | **CLEAN**, 0 errors, 4822 frames |
+| exact `/stream.bin` bytes the browser received (reconstructed) | ffmpeg (software) | **CLEAN**, 0 errors |
+| that same `/stream.bin` content, live | browser WebCodecs (VideoToolbox HW) | **MOSAIC** |
+| that same content, paced replay, fresh decoder, no rebuilds | browser WebCodecs (HW) | **MOSAIC** |
+
+So: the browser receives clean, gapless, ffmpeg-decodable HEVC and still tears —
+it is purely the HW decode step. Confirmed further:
+
+- **No software fallback exists.** `VideoDecoder.isConfigSupported({hardwareAcceleration:'prefer-software'})`
+  = **false** for HEVC in this Chrome; `configure` with it throws. Only HW decode is available.
+- `optimizeForLatency` true **and** false: both mosaic. hvcC **and** Annex-B config: both mosaic.
+  So no WebCodecs knob avoids it.
+- `--ltrp` **amplifies** it (long-term refs the HW decoder mishandles) → keep `--ltrp` OFF, but
+  no-ltrp still tears under hard motion (my earlier "no-ltrp is clean" was from scripted swipes,
+  which under-reproduce; hand-driven still tears).
+- Prior finding stands: MSE + fMP4 also tears — same platform HW decoder, different browser API.
+- The broadcast path does **not** drop AUs (0 queue-overflow/needs_key events in the log during
+  the tear), and the browser decode queue never backed up (`decodeQueueSize` maxed at 0), so it's
+  not drops, backpressure, rendering, or IOSurface churn.
+
+**Why Xcode is clean:** Xcode decodes with *native VideoToolbox* (its own decode-session config),
+which handles the exact same content cleanly — as does ffmpeg (software). The browser's WebCodecs
+VideoToolbox path is the weak link, and WebCodecs doesn't expose the knobs to fix it. So a browser
+viewer **cannot** be made xcode-identical from our side; the input is already correct.
+
+**The path to xcode-quality (native/software decode, not the browser):**
+
+- **serve-vnc** decodes with software libav (PyAV/`HevcToBgraTranscoder`) → RFB → macOS Screen
+  Sharing. Software decode = clean like ffmpeg, so serve-vnc should be tear-free under motion.
+  This is the existing "xcode-like" path — VERIFY it's clean and point users there.
+- Or a small native-decode helper (native VideoToolbox / ffmpeg) feeding the browser as raw frames
+  (heavier; only if a browser front-end is required).
+
+### Superseded browser-side ideas (would NOT help — the browser input is already clean)
+
+1. Real RTP timestamps on `EncodedVideoChunk` instead of synthetic `+=16666`.
+2. Decode-queue backpressure (queue never backs up; `decodeQueueSize`==0).
+3. Render via `requestVideoFrameCallback` / `<video>`+MediaStreamTrackGenerator
+   or WebGL, instead of closing/redrawing HW `VideoFrame`s on a 2D canvas (the
+   current close-per-frame churns the decoder's IOSurface pool under motion).
+Test each with HAND-DRIVEN motion, `--ltrp` off.
+
+Everything else below (hvcC, RR+SDES, RCTL closed-loop, PLI-storm fix, the
+Xcode-competes-for-the-conference stall finding) stands.
+
+## TL;DR (historical — the residual "tear" referenced below IS the LTRP mosaic)
+
+- **Stalls / freezes / the recurring "no AU progress → restart" were caused by
+  running Xcode's screen mirroring at the SAME TIME as serve-web.** The device
+  supports a single screen-mirror conference; two clients (Xcode + serve-web)
+  compete and the device keeps reaping one (`vcMediaStreamStopConference` every
+  ~20 s). **serve-web running ALONE is stable: 0 reaps, 0 stalls.** Always quit
+  Xcode mirroring before testing serve-web.
+- **The residual is mild tearing under rapid motion, cleared quickly by keyframes.
+  Its root is NOT yet pinned.** Safari was *initially* thought tear-free, but that
+  was an artifact of Safari running at ~4 fps (too few frames to show motion
+  tearing). Once hvcC gave Safari good fps, **Safari ALSO tears** — so it is NOT
+  Chrome-specific. Both browsers (both VideoToolbox) tear at good fps, while
+  ffmpeg (software decode) shows only "mild soft/ghosting on moving elements" in
+  the same bitstream. Leading theory now: **encoder-side motion artifact baked
+  into the bitstream** (matches ffmpeg), and/or a VideoToolbox real-time-decode
+  artifact common to both browsers — NOT a Chrome decode-path bug as first
+  thought. NEEDS RE-VERIFICATION (see next steps).
+- Everything below is committed and pushed on the feature branch.
+
+## Commits (this line of work)
+
+```
+c34808c  serve-web: decode via hvcC instead of Annex-B (WebCodecs standard path)
+497f881  serve-web: RTCP RR as a proper RR+SDES compound (Xcode parity)
+d78b417  remotexpc: serialise send_receive_request with a per-connection lock
+731b014  serve-web: stop the self-reinforcing PLI storm on static screens
+ac03623  serve-web: closed-loop encoder rate control via reverse-engineered RCTL
+```
+
+Backup tag before the history rebase: `backup-before-rebase-2026-07-07`.
+
+## What each change does / why
+
+- **`d78b417` remotexpc lock** — `RemoteXPCConnection.send_receive_request` is a
+  write-then-read over one shared reader + `_previous_frame_data` buffer with no
+  demux. Two concurrent callers interleave reads → `0 bytes read on 9 expected`
+  → the connection wedges permanently. An earlier XPC-based keepalive hit exactly
+  this and froze the whole server. The `asyncio.Lock` serialises round-trips.
+  (This is a general latent bug, not serve-web-specific.)
+- **`497f881` RR+SDES** — Xcode always sends RTCP as an `RR + SDES/CNAME`
+  compound (`81 ca 0002 <ssrc> 01 00 00 00`); we sent a bare RR. RFC 3550 §6.1
+  requires the SDES. Device now attributes our RTCP (`didReceiveRTCPPackets`
+  500+×/run). Did NOT change stall behaviour (the stalls were Xcode competing),
+  but it's correct and Xcode-matching.
+- **`731b014` PLI motion-window** — the decoder-refresh motion detector summed
+  `_au_byte_window` including forced-IDR bytes, so one refresh IDR read as
+  "motion" and triggered the next → self-reinforcing PLI storm on a static
+  screen. Now counts delta AUs only.
+- **`c34808c` hvcC** — viewer was configuring WebCodecs with no `description` and
+  feeding Annex-B start codes → Chrome per-chunk H.265→hvcC conversion → tears
+  under motion. Now: `hevc_decoder_configuration_record()` builds the hvcC from
+  cached VPS/SPS/PPS, `/stream.bin` sends 4-byte-length-prefixed NALUs, `/codec`
+  returns `{codec, description(b64)}`, viewer configures with the description.
+  Reduced the tear (clears faster) but did **not** eliminate it.
+
+## Ruled out as the tear cause (all tested on-device)
+
+- **Packet loss** — 0 RTP gaps during motion on the kernel tunnel.
+- **RTCP keepalive / conference reap** — the reap was Xcode competing, not us.
+- **Canvas render tearing** — viewer.js already draws in a `requestAnimationFrame`
+  loop (vsync-locked) and resets the canvas buffer per frame.
+- **LTR-ACK / control-channel keepalive** — dead ends; see history.
+- **Chrome-specific decode path** — DISPROVEN. Safari also tears once at good fps.
+
+## NOT ruled out (leading suspects for the residual tear)
+
+- **Encoder quality collapse under motion** — real (QP 16→35, drop_fps up to 31 at
+  the 5.49 Mbps ceiling). `--ltrp` greatly improves it (QP→~19, drops→~1) but the
+  user still saw tears with `--ltrp`. Still, the QP collapse / high drop_fps is the
+  best mechanical candidate and its interaction with the tear isn't fully closed —
+  re-test `--ltrp` visually with fresh eyes and measure whether the *visible* tear
+  tracks QP/drops.
+- **Encoder-inherent motion artifact in the bitstream** — ffmpeg shows "mild
+  soft/ghosting on moving elements" in the same stream. Both browsers tear at good
+  fps. Re-verify (below) whether the browsers' "tear" is that same in-bitstream
+  ghosting amplified in real time, or something the browsers add.
+
+## The remaining problem
+
+Rapid-motion tearing in BOTH Chrome and Safari (at good fps), cleared quickly by
+the proactive PLI keyframes. Root not pinned; leading theory is encoder-side
+motion artifact (see above), NOT a browser decode-path bug. hvcC (c34808c) gave
+Safari good fps and made the tear clear faster, but didn't eliminate it.
+
+**Re-verify first thing next session:** capture the CURRENT stream with
+`PMD3_SERVE_WEB_DUMP=/tmp/dump.hevc` (dump is still Annex-B) under rapid motion,
+decode with `ffmpeg -i /tmp/dump.hevc -f null -` and view the frames. If ffmpeg
+shows the tear → it's in the bitstream (encoder) → focus on encoder config
+(`--ltrp`, bitrate/RCTL, GOP). If ffmpeg is clean but both browsers tear → it's a
+real-time VideoToolbox decode/render effect → focus on the browser/render side.
+
+## Current knobs
+
+- `--ltrp` — OFF by default; big encoder-QP win under motion on a low-loss
+  transport (kernel tunnel). Left opt-in because LTR can make a *lost* reference
+  tear longer on lossy transports (`--userspace`, LAN).
+- Proactive PLI refresh (decoder-refresh: motion + settle + heartbeat) — KEPT. It
+  clears the residual tear. Removing it entirely → tears don't clear.
+- `--rctl` / `--max-bitrate` — RCTL receiver feedback. NOTE: the RCTL frames
+  counter resets on stream restart, which can make the device compute bogus
+  packet loss (up to 92% → throttle). Rare now that reaps are gone, but if you
+  see PLR spikes in `AVCRateController` health, make `_rtp_frames_received`
+  monotonic across restarts.
+
+## Next things to try (highest-leverage first)
+
+0. **RE-VERIFY where the tear lives** (do this first — the Chrome-specific theory
+   was wrong): `PMD3_SERVE_WEB_DUMP=/tmp/dump.hevc` under rapid motion, then
+   `ffmpeg` / a player on `dump.hevc`. In-bitstream tear → encoder; clean →
+   real-time decode/render. Everything below branches on this.
+1. **If encoder-side:** re-test `--ltrp` visually (QP 35→19, drops 31→1 — should
+   reduce it), then tune the encoder budget: raise the target bitrate and/or fix
+   the RCTL bogus-loss throttle (monotonic `_rtp_frames_received`), and revisit
+   GOP/keyframe cadence. This is the path to actually matching Xcode.
+2. **If real-time decode/render:** both browsers use VideoToolbox, so it's the
+   real-time hardware-decode + canvas presentation under motion. Try
+   `optimizeForLatency:false`, real RTP timestamps on `EncodedVideoChunk` (instead
+   of synthetic `+=16666`), decode-queue backpressure (`decoder.decodeQueueSize`),
+   and WebGL/`requestVideoFrameCallback` rendering instead of 2D canvas.
+3. **Full Xcode model (once tear is understood):** `--ltrp` default-on **+** drop
+   the proactive PLI storm together, matching Xcode's zero-PLI approach.
+
+NOTE: the earlier "Safari is clean → Chrome-specific" conclusion was WRONG —
+Safari's clean look was its 4 fps hiding the motion. Don't build on it.
+
+## How to test (important gotchas)
+
+- **Quit Xcode mirroring first** — otherwise you reproduce the (non-bug) reap.
+- Use the **kernel tunnel** (`--tunnel ""`, tunneld running) — low loss.
+- Device wedges after many stream restarts in a session → recover with
+  `pymobiledevice3 diagnostics restart` (no flags; device reboots ~35–45 s).
+- Encoder truth is in device syslog: `pymobiledevice3 syslog live` →
+  `VCPEncStatsMonitor` (Avg_QP, drop_fps, Bit_rate), `AVCRateController` health
+  (Uplink PLR, actual/target bitrate), `vcMediaStreamStopConference` (reaps),
+  `didReceiveRTCPPackets` (our RTCP being attributed).
+- **Safari vs Chrome** is the fast diagnostic for "is the tear in the bitstream
+  or the browser": Safari uses VideoToolbox directly.
+- ffmpeg-decoding a `PMD3_SERVE_WEB_DUMP` capture (still emitted as Annex-B) tells
+  encoder artifacts (present in ffmpeg) from browser-decode bugs (not in ffmpeg).

--- a/pymobiledevice3/remote/core_device/screen_stream.py
+++ b/pymobiledevice3/remote/core_device/screen_stream.py
@@ -2564,6 +2564,13 @@ class ScreenStreamServer:
             since_refresh = now - self._last_refresh_t
             if since_refresh < min_interval:
                 continue
+            # xcode-parity: with --no-motion-idr, force NO refresh IDRs at all
+            # (active/settle/heartbeat). Apple's smooth session shows idr_fps=0 --
+            # any forced keyframe under saturation makes the encoder drop
+            # resolution to fit it (the collapse). New-subscriber bootstrap and
+            # the stall-watchdog still supply keyframes when genuinely needed.
+            if not self._motion_idr:
+                continue
             quiet_for = None if quiet_since is None else (now - quiet_since)
             # Optional mid-motion IDR storm (off by default; --motion-idr).
             active = (

--- a/pymobiledevice3/remote/core_device/screen_stream.py
+++ b/pymobiledevice3/remote/core_device/screen_stream.py
@@ -13,9 +13,9 @@ Layering::
 """
 
 import asyncio
+import base64
 import contextlib
 import datetime
-import base64
 import errno
 import importlib.resources
 import ipaddress
@@ -25,6 +25,7 @@ import os
 import socket
 import ssl
 import tempfile
+import time
 import uuid
 from collections import deque
 from pathlib import Path
@@ -627,10 +628,26 @@ class ScreenStreamServer:
         allow_rtcp_fb: bool = False,
         ltrp_enabled: bool = False,
         https: bool = False,
-        rctl_enabled: bool = True,
+        rctl_enabled: bool = False,
         max_bitrate_kbps: int = 60000,
+        motion_idr: bool = True,
+        compensate: bool = True,
     ) -> None:
         self._rsd = rsd
+        # Viewer-side resolution-collapse compensation (--compensate, default
+        # on): injected into viewer.js; the browser detects the shrunk content
+        # rectangle and stretches it to fill the canvas. Server-side flag only
+        # selects the viewer default.
+        self._compensate = compensate
+        # Mid-motion IDR refresh (--motion-idr/--no-motion-idr, ON by default).
+        # Fires a keyframe ~1x/s while the screen is moving, so the device's
+        # resolution collapse snaps back to full res fast (preemptive; faster
+        # than any client-side detect-then-request loop). The viewer hides the
+        # brief shrink until the IDR lands (viewer.js detectContentCrop). Trade
+        # off: keyframe pressure can stall the ~6 Mbps-capped encoder under
+        # sustained motion; --no-motion-idr drops it for a stall-free but
+        # slower-recovering stream. See _decoder_refresh_loop.
+        self._motion_idr = motion_idr
         # AVConference RCTL receiver feedback (see _rctl_feedback_loop): the
         # closed-loop rate-control channel Xcode's mirror uses, reversed from a
         # live capture. ``max_bitrate_kbps`` is the cap advertised to the
@@ -720,6 +737,14 @@ class ScreenStreamServer:
         self._rtp_last_ts: int = 0
         self._rtp_frames_received: int = 0
         self._rctl_start_t: float = 0.0
+        # Per-frame packet count (RCTL w3) + RFC 3550 interarrival jitter in
+        # 24 kHz RTP-ts units (RCTL w4-lo), decoded byte-exact from Xcode's
+        # mirror. Feeding the device real values (vs our old 0/constant) is what
+        # keeps its rate controller from throttling framerate / collapsing res.
+        self._rtp_cur_frame_pkts: int = 0
+        self._rtp_last_frame_pkts: int = 0
+        self._rtp_jitter: float = 0.0
+        self._rtp_prev_transit: Optional[float] = None
         self._rctl_task: Optional[asyncio.Task] = None
         # PLI tasks in flight -- keep a reference so the GC doesn't drop
         # them while awaiting the sendto (and ruff is happy with create_task).
@@ -852,8 +877,42 @@ class ScreenStreamServer:
             # count -- echoed back in RCTL feedback so the device's rate
             # controller can track receiver progress. See _build_rctl_packet.
             self._rtp_last_ts = int.from_bytes(data[4:8], "big")
+            # RFC 3550 interarrival jitter in the 24 kHz media clock (RCTL
+            # w4-lo). transit = arrival(in ts units) - packet RTP ts; jitter is
+            # the smoothed |delta transit|. Origin-independent (delta cancels).
+            arrival_ts = time.monotonic() * 24000.0
+            transit = arrival_ts - self._rtp_last_ts
+            if self._rtp_prev_transit is not None:
+                d = abs(transit - self._rtp_prev_transit)
+                self._rtp_jitter += (d - self._rtp_jitter) / 16.0
+            self._rtp_prev_transit = transit
+            # Per-frame packet count (RCTL w3): packets since the last marker.
+            self._rtp_cur_frame_pkts += 1
             if marker:
                 self._rtp_frames_received += 1
+                self._rtp_last_frame_pkts = self._rtp_cur_frame_pkts
+                self._rtp_cur_frame_pkts = 0
+                # Per-frame receipt (RTCP APP name=5): Xcode emits EXACTLY one
+                # per frame (measured: receipt rate == frame rate), and the
+                # device paces its output framerate to these acks. Our old
+                # 40/s timer receipts desync from the real frame cadence, so the
+                # device's congestion control reads it as delay and throttles
+                # framerate under motion. Fire one here, on the frame boundary,
+                # carrying this frame's ts.
+                # Send it INLINE (awaited), NOT via create_task: a deferred send
+                # piles up under motion and reaches the device after it has aged
+                # the frame out of its sent-history window, so the device can't
+                # map the receipt's ts to the frame's packet span -> credits ~1
+                # of ~8 packets -> false ~87% uplink loss -> loss-defensive
+                # encoder (the collapse). Prompt delivery is the whole point.
+                if (
+                    self._rctl_enabled
+                    and self._active_sock is not None
+                    and self._rtcp_dest is not None
+                    and self._local_ssrc
+                ):
+                    with contextlib.suppress(OSError):
+                        await self._active_sock.sendto(self._build_rctl_companion_packet(), *self._rtcp_dest)
             cur_ext = self._rtp_highest_seq
             cycles = (cur_ext >> 16) & 0xFFFF
             last_seq16 = cur_ext & 0xFFFF
@@ -1077,25 +1136,41 @@ class ScreenStreamServer:
     #   name 0x00000005 (16 B, ~35/s): the received video RTP timestamp.
     # Echoing the *received* RTP timestamp is what makes the device act on the
     # feedback (a synthetic clock was ignored). Xcode sends this and no PLIs.
-    def _rctl_wall_1024(self) -> int:
+    def _rctl_wall_ms(self) -> int:
         loop = asyncio.get_running_loop()
         elapsed = max(0.0, loop.time() - self._rctl_start_t) if self._rctl_start_t else 0.0
-        return int(elapsed * 1024) & 0xFFFF
+        return int(elapsed * 1000) & 0xFFFF
 
     def _build_rctl_packet(self) -> bytes:
+        """RTCP APP "RCTL" (PT=204), byte-exact to Xcode's mirror. After the
+        0x85000004 tag, four u32 words (decoded from a live capture):
+          w2 = (RTP ts >> 8) << 16
+          w3 = packet_count of the last frame
+          w4 = (arrival-clock ms << 16) | interarrival jitter (24 kHz units)
+          w5 = (received-packet counter << 16) | 0xEA61 (constant)
+        Our old packet sent w3=0, w4=1024Hz-clock|98, w5=frames|maxk -- garbage
+        the device's rate controller reacted to by throttling framerate."""
         import struct as _struct
 
         ts = self._rtp_last_ts & 0xFFFFFFFF
+        w2 = ((ts >> 8) & 0xFFFF) << 16
+        w3 = self._rtp_last_frame_pkts & 0xFFFFFFFF
+        # OWRD (w4-lo): the real measured interarrival jitter. Do NOT inflate it
+        # to Xcode's ~125 -- on our ~zero-delay local tunnel a large OWRD reads
+        # as congestion and the device throttles framerate (measured: flooring
+        # to 125 dropped rapid-motion fps to <6). Report the true small delay.
+        w4 = ((self._rctl_wall_ms() & 0xFFFF) << 16) | (int(self._rtp_jitter) & 0xFFFF)
+        w5 = ((self._rtp_packets_received & 0xFFFF) << 16) | 0xEA61
         return _struct.pack(
-            "!BBHI4sI HHHHHHHH", 0x80, 0xCC, 7, self._local_ssrc & 0xFFFFFFFF,
-            b"RCTL", 0x85000004,
-            (ts >> 8) & 0xFFFF, 0, 0, 0, self._rctl_wall_1024(), 98,
-            self._rtp_frames_received & 0xFFFF, self._rctl_maxk & 0xFFFF)
+            "!BBHI4sI IIII", 0x80, 0xCC, 7, self._local_ssrc & 0xFFFFFFFF, b"RCTL", 0x85000004, w2, w3, w4, w5
+        )
 
     def _build_rctl_companion_packet(self) -> bytes:
         import struct as _struct
 
-        return _struct.pack("!BBHI I I", 0x80, 0xCC, 3, self._local_ssrc & 0xFFFFFFFF, 5, self._rtp_last_ts & 0xFFFFFFFF)
+        return _struct.pack(
+            "!BBHI I I", 0x80, 0xCC, 3, self._local_ssrc & 0xFFFFFFFF, 5, self._rtp_last_ts & 0xFFFFFFFF
+        )
 
     async def _rctl_feedback_loop(self) -> None:
         """Stream RCTL + companion APP feedback while a video stream is up:
@@ -1118,7 +1193,9 @@ class ScreenStreamServer:
             if self._rctl_start_t == 0.0:
                 self._rctl_start_t = asyncio.get_running_loop().time()
             try:
-                await transport.sendto(self._build_rctl_companion_packet(), *self._rtcp_dest)
+                # Receipts (name=5) are now sent per-frame from the RTP receive
+                # loop (Xcode-exact 1-per-frame). This loop only paces the
+                # periodic RCTL report (~20/s, matching Xcode's 407/20s).
                 if tick % 2 == 0:
                     await transport.sendto(self._build_rctl_packet(), *self._rtcp_dest)
             except OSError:
@@ -1550,6 +1627,10 @@ class ScreenStreamServer:
             self._rtp_last_ts = 0
             self._rtp_frames_received = 0
             self._rctl_start_t = 0.0
+            self._rtp_cur_frame_pkts = 0
+            self._rtp_last_frame_pkts = 0
+            self._rtp_jitter = 0.0
+            self._rtp_prev_transit = None
             self._rtcp_dest = (self._sender_ip, source_port) if source_port else None
             self._active_service = svc
             self._active_session_id = sid
@@ -1932,6 +2013,9 @@ class ScreenStreamServer:
             body = VIEWER_JS_TEMPLATE.replace(
                 b"__AUDIO_DEFAULT_ON__",
                 b"true" if self._audio_default_on else b"false",
+            ).replace(
+                b"__COMPENSATE_DEFAULT__",
+                b"true" if self._compensate else b"false",
             )
             self._send_static(writer, body, b"application/javascript; charset=utf-8")
             await writer.drain()
@@ -1985,6 +2069,33 @@ class ScreenStreamServer:
                 b"Cache-Control: no-store\r\n"
                 b"Content-Length: " + str(len(body)).encode() + b"\r\n"
                 b"Connection: close\r\n\r\n" + body
+            )
+            await writer.drain()
+            writer.close()
+            return
+        if path.startswith("/debug/"):
+            # Research runtime toggles: flip RCTL / motion-IDR live within one
+            # session (same device state, no restart) to A/B their effect on
+            # fps and the resolution collapse -- restarts are slow and can wedge
+            # the device, so live toggling is the only reliable way to compare.
+            # Both flags are read live by their loops. POST (or GET) one of:
+            #   /debug/rctl-on  /debug/rctl-off  /debug/idr-on  /debug/idr-off
+            # (viewer-side --compensate has its own ?compensate=0/1 URL toggle).
+            cmd = path[len("/debug/") :]
+            if cmd == "rctl-on":
+                self._rctl_enabled = True
+            elif cmd == "rctl-off":
+                self._rctl_enabled = False
+            elif cmd == "idr-on":
+                self._motion_idr = True
+            elif cmd == "idr-off":
+                self._motion_idr = False
+            body = f"rctl={self._rctl_enabled} motion_idr={self._motion_idr}".encode()
+            writer.write(
+                b"HTTP/1.1 200 OK\r\nContent-Length: "
+                + str(len(body)).encode()
+                + b"\r\nConnection: close\r\n\r\n"
+                + body
             )
             await writer.drain()
             writer.close()
@@ -2388,42 +2499,44 @@ class ScreenStreamServer:
                 writer.close()
 
     async def _decoder_refresh_loop(self) -> None:
-        """IDR refresh: PLI on sustained motion + on settle + slow heartbeat.
+        """IDR refresh: mid-motion recovery (default) + settle + idle heartbeat.
 
-        Why force IDRs at all: the DisplayService encoder runs its rate
-        control open-loop for us (we implement none of Apple's
-        proprietary AVCRC feedback that Xcode's client provides — the
-        device ignores standard RTCP RRs/REMB). Under sustained rapid
-        motion the encoder's output degrades progressively — smeared,
-        ghosted, mosaic-looking frames baked into the *bitstream*
-        (verified by teeing the Annex-B stream: ffmpeg and WebCodecs
-        decode the same garbage, with zero RTP loss and no forced
-        IDRs in the capture). LTRP on/off makes no difference. A
-        periodic IDR is the only reset knob we have; without it the
-        degradation accumulates for the whole (unbounded) GOP and the
-        viewer looks far worse. True parity with Xcode's artifact-free
-        stream would require implementing Apple's congestion-feedback
-        protocol so the encoder budget works closed-loop.
+        Under rapid motion the DisplayService encoder, capped at ~6 Mbps, drops
+        capture resolution and composites the shrunk screen top-left with gray
+        padding (the "screen shrinks while swiping" tear). Recovering to full
+        resolution needs a fresh full-res IDR, and forcing one *while moving*
+        recovers fastest -- it's preemptive, so it beats any client-side
+        detect-then-request loop (which is always a collapse-cycle behind). So
+        the default (``self._motion_idr`` True, ``--motion-idr``) fires an
+        **active** keyframe ~1x/s while the byte rate says the screen is moving;
+        the viewer stretches the shrunk region to fill the canvas
+        (``detectContentCrop``) so the brief pre-IDR window is hidden. The cost
+        is keyframe pressure that can stall this encoder under very sustained
+        motion; ``--no-motion-idr`` drops the active trigger for a stall-free
+        but slower-recovering stream (viewer stretch + settle IDR only).
 
         Triggers:
-          1. **Active** — byte rate above ``motion_threshold_bps``
-             continuously: fire at ``active_interval`` cadence, capping
-             how long motion degradation can accumulate.
-          2. **Settle** — byte rate just dropped after motion: one PLI
-             so the now-static screen snaps back to full quality.
-          3. **Heartbeat** — backstop every ``heartbeat`` seconds; also
-             clears a subscriber stuck in ``needs_key`` after the
-             natural startup IDR passed it by.
+          - **Active** (``--motion-idr`` only) — screen moving: one PLI every
+            ``active_interval`` so the collapse snaps back fast.
+          - **Settle** — byte rate stayed *continuously* below
+            ``motion_threshold_bps`` for ``settle_quiet`` (a genuine pause, not
+            an inter-swipe micro-dip): one PLI so the static screen is crisp.
+          - **Heartbeat** — idle backstop every ``heartbeat`` s; also clears a
+            subscriber stuck in ``needs_key``.
         """
         loop = asyncio.get_running_loop()
         motion_threshold_bps = 200_000
-        active_interval = 1.0  # fire mid-motion at this cadence
-        settle_delay = 0.3  # wait after motion ends before refresh
-        heartbeat = 10.0  # backstop cadence when nothing else fires
+        # Active mid-motion IDR (default; gated by self._motion_idr). Settle and
+        # heartbeat additionally fire only when NOT under motion load. settle
+        # requires the byte rate to stay CONTINUOUSLY below threshold so an
+        # inter-swipe micro-dip can't retrigger it into a storm.
+        settle_quiet = 1.5  # byte rate must stay quiet CONTINUOUSLY this long
+        heartbeat = 10.0  # backstop cadence when idle
         min_interval = 0.7  # don't fire more often than this
+        active_interval = 1.0  # --motion-idr cadence while moving
+        quiet_since: Optional[float] = None
         motion_active = False
         motion_started_t = 0.0
-        motion_ended_t = 0.0
         while True:
             try:
                 await asyncio.sleep(0.1)
@@ -2439,20 +2552,25 @@ class ScreenStreamServer:
             currently_active = window_bytes >= motion_threshold_bps
             if currently_active and not motion_active:
                 motion_started_t = now
-            if motion_active and not currently_active:
-                motion_ended_t = now
             motion_active = currently_active
+            if currently_active:
+                quiet_since = None  # any motion resets the quiet timer
+            elif quiet_since is None:
+                quiet_since = now
             since_refresh = now - self._last_refresh_t
             if since_refresh < min_interval:
                 continue
+            quiet_for = None if quiet_since is None else (now - quiet_since)
+            # Optional mid-motion IDR storm (off by default; --motion-idr).
             active = (
-                currently_active
+                self._motion_idr
+                and currently_active
                 and motion_started_t > 0
                 and (now - motion_started_t) >= active_interval
                 and since_refresh >= active_interval
             )
-            settled = motion_ended_t > self._last_refresh_t and (now - motion_ended_t) >= settle_delay
-            heartbeat_due = since_refresh >= heartbeat
+            settled = quiet_for is not None and quiet_for >= settle_quiet and self._last_refresh_t < quiet_since
+            heartbeat_due = quiet_for is not None and since_refresh >= heartbeat
             if not (active or settled or heartbeat_due):
                 continue
             reason = "active" if active else ("settled" if settled else "heartbeat")

--- a/pymobiledevice3/remote/core_device/screen_stream.py
+++ b/pymobiledevice3/remote/core_device/screen_stream.py
@@ -1969,7 +1969,11 @@ class ScreenStreamServer:
                     pass
             parts = request_line.split()
             method = parts[0].decode() if parts else "GET"
-            path = parts[1].decode() if len(parts) >= 2 else "/"
+            target = parts[1].decode() if len(parts) >= 2 else "/"
+            # Strip the query string for route matching -- viewer.js reads its
+            # flags (e.g. ?compensate=0) client-side from location.search, so
+            # the server must still route "/?compensate=0" to the index page.
+            path = target.split("?", 1)[0]
 
             if method == "POST" and path in ("/touch", "/button", "/key"):
                 body = await self._read_body(reader, headers)

--- a/pymobiledevice3/remote/core_device/screen_stream.py
+++ b/pymobiledevice3/remote/core_device/screen_stream.py
@@ -1155,11 +1155,16 @@ class ScreenStreamServer:
         ts = self._rtp_last_ts & 0xFFFFFFFF
         w2 = ((ts >> 8) & 0xFFFF) << 16
         w3 = self._rtp_last_frame_pkts & 0xFFFFFFFF
-        # OWRD (w4-lo): the real measured interarrival jitter. Do NOT inflate it
-        # to Xcode's ~125 -- on our ~zero-delay local tunnel a large OWRD reads
-        # as congestion and the device throttles framerate (measured: flooring
-        # to 125 dropped rapid-motion fps to <6). Report the true small delay.
-        w4 = ((self._rctl_wall_ms() & 0xFFFF) << 16) | (int(self._rtp_jitter) & 0xFFFF)
+        # w4 = (arrival-clock ms << 16) | interarrival jitter (24 kHz units).
+        # The device derives OWRD from the arrival clock vs the packet's own send
+        # time; our old arrival clock was elapsed-since-start ms, a DIFFERENT epoch
+        # from the RTP media clock, so the device computed a bogus 14-50 ms OWRD
+        # (seen in VCRC) on what is really a ~1 ms kernel tunnel -> read as
+        # congestion -> framerate throttle. Report the arrival time on the SAME
+        # 24 kHz base as the packet (arrival == send -> OWRD ~= 0) and jitter 0.
+        # Truthful for a local tunnel; stops the phantom-congestion throttle.
+        arrival_ms = (ts // 24) & 0xFFFF
+        w4 = (arrival_ms << 16) | 0
         w5 = ((self._rtp_packets_received & 0xFFFF) << 16) | 0xEA61
         return _struct.pack(
             "!BBHI4sI IIII", 0x80, 0xCC, 7, self._local_ssrc & 0xFFFFFFFF, b"RCTL", 0x85000004, w2, w3, w4, w5

--- a/pymobiledevice3/remote/core_device/screen_stream.py
+++ b/pymobiledevice3/remote/core_device/screen_stream.py
@@ -15,6 +15,7 @@ Layering::
 import asyncio
 import contextlib
 import datetime
+import base64
 import errno
 import importlib.resources
 import ipaddress
@@ -115,7 +116,9 @@ logger = logging.getLogger(__name__)
 _HEVC_NAL_IDR_W_RADL = 19
 _HEVC_NAL_IDR_N_LP = 20
 _HEVC_NAL_CRA = 21
+_HEVC_NAL_VPS = 32
 _HEVC_NAL_SPS = 33
+_HEVC_NAL_PPS = 34
 _HEVC_NAL_AP = 48  # Aggregation Packet
 _HEVC_NAL_FU = 49  # Fragmentation Unit
 
@@ -202,6 +205,61 @@ def hevc_codec_string_from_sps(sps_nal: bytes) -> str:
     while len(cif_hex) > 2 and cif_hex.endswith("00"):
         cif_hex = cif_hex[:-2]
     return f"hev1.{ps_char}{profile_idc}.{rev:X}.{tier_char}{level_idc}.{cif_hex}"
+
+
+def _hevc_rbsp(nal: bytes) -> bytes:
+    """Strip the 2-byte NAL header and emulation-prevention bytes (00 00 03 → 00 00)."""
+    out = bytearray()
+    i = 2
+    while i < len(nal):
+        if i + 2 < len(nal) and nal[i] == 0 and nal[i + 1] == 0 and nal[i + 2] == 3:
+            out.extend(nal[i : i + 2])
+            i += 3
+        else:
+            out.append(nal[i])
+            i += 1
+    return bytes(out)
+
+
+def hevc_decoder_configuration_record(vps: bytes, sps: bytes, pps: bytes) -> bytes:
+    """Build an ISO/IEC 14496-15 §8.3.3.1 ``HEVCDecoderConfigurationRecord`` (hvcC).
+
+    This is the WebCodecs ``description`` for hvcC-mode HEVC decoding: it routes
+    Chrome's ``VideoDecoder`` through VideoToolbox's native hvcC path (parameter
+    sets supplied out-of-band, 4-byte-length-prefixed NALUs per chunk) instead
+    of the Annex-B start-code path, which re-converts every chunk and visibly
+    tears under rapid motion (Safari, which uses VideoToolbox directly, does not
+    tear — confirming the Annex-B path as the culprit).
+
+    The 12-byte general ``profile_tier_level`` lives at RBSP bytes 1..12 of the
+    SPS (right after the 1-byte vps_id/max_sub_layers/nesting field) with the
+    exact byte layout hvcC wants, so we copy it verbatim rather than re-parsing.
+    """
+    ptl = _hevc_rbsp(sps)[1:13]
+    if len(ptl) != 12:
+        raise ValueError("SPS too short to contain profile_tier_level")
+    rec = bytearray()
+    rec.append(1)  # configurationVersion
+    rec.append(ptl[0])  # general_profile_space(2) | general_tier_flag(1) | general_profile_idc(5)
+    rec.extend(ptl[1:5])  # general_profile_compatibility_flags (32b)
+    rec.extend(ptl[5:11])  # general_constraint_indicator_flags (48b)
+    rec.append(ptl[11])  # general_level_idc
+    rec.extend((0xF000).to_bytes(2, "big"))  # reserved(4)=1111 + min_spatial_segmentation_idc=0
+    rec.append(0xFC)  # reserved(6)=1 + parallelismType=0
+    rec.append(0xFC | 0x01)  # reserved(6)=1 + chroma_format_idc=1 (4:2:0)
+    rec.append(0xF8)  # reserved(5)=1 + bit_depth_luma_minus8=0
+    rec.append(0xF8)  # reserved(5)=1 + bit_depth_chroma_minus8=0
+    rec.extend((0).to_bytes(2, "big"))  # avgFrameRate=0 (unspecified)
+    # constantFrameRate(2)=0 | numTemporalLayers(3)=1 | temporalIdNested(1)=0 | lengthSizeMinusOne(2)=3
+    rec.append((0 << 6) | (1 << 3) | (0 << 2) | 0x03)
+    rec.append(3)  # numOfArrays: VPS, SPS, PPS
+    for nal_type, nal in ((32, vps), (33, sps), (34, pps)):
+        # array_completeness(1)=0 | reserved(1)=0 | NAL_unit_type(6). hev1 => in-band PS allowed.
+        rec.append(nal_type)
+        rec.extend((1).to_bytes(2, "big"))  # numNalus
+        rec.extend(len(nal).to_bytes(2, "big"))  # nalUnitLength
+        rec.extend(nal)
+    return bytes(rec)
 
 
 # ---------------------------------------------------------------------------
@@ -501,12 +559,31 @@ def open_media_receiver(
 class _SubState:
     """Per-subscriber broadcast state — set ``needs_key`` after a queue drop
     so we don't feed the decoder a delta without its reference keyframe.
+
+    ``reset_on_key`` picks how the recovery keyframe is delivered once it
+    arrives: True → type=2 (browser rebuilds its decoder first; used for
+    fresh subscribers whose decoder started from a stale cached IDR), False
+    → plain type=0 (the IDR is absorbed as a fresh DPB anchor; used after
+    an upstream AU drop, where the browser's decoder never saw broken data
+    and a rebuild would only add a visible hitch).
+
+    ``needs_key_since`` is the loop-time of the last False→True
+    transition; the stall watchdog uses it to spot a subscriber whose
+    key request the encoder is ignoring and escalate to a session
+    restart.
     """
 
-    __slots__ = ("needs_key",)
+    __slots__ = ("needs_key", "needs_key_since", "reset_on_key")
 
     def __init__(self) -> None:
         self.needs_key = False
+        self.reset_on_key = False
+        self.needs_key_since = 0.0
+
+    def mark_needs_key(self, now: float) -> None:
+        if not self.needs_key:
+            self.needs_key = True
+            self.needs_key_since = now
 
 
 # Watchdog tuning. We learned the hard way that restarts are expensive --
@@ -550,8 +627,19 @@ class ScreenStreamServer:
         allow_rtcp_fb: bool = False,
         ltrp_enabled: bool = False,
         https: bool = False,
+        rctl_enabled: bool = True,
+        max_bitrate_kbps: int = 60000,
     ) -> None:
         self._rsd = rsd
+        # AVConference RCTL receiver feedback (see _rctl_feedback_loop): the
+        # closed-loop rate-control channel Xcode's mirror uses, reversed from a
+        # live capture. ``max_bitrate_kbps`` is the cap advertised to the
+        # device, which honours it (confirmed on-device: dropping it collapses
+        # the encoder bitrate). The uncapped encoder can ramp past ~5.5 Mbps
+        # under sustained motion and stall; lowering this (e.g. 5000) trades
+        # peak quality for a steadier stream.
+        self._rctl_enabled = rctl_enabled
+        self._rctl_maxk = max_bitrate_kbps
         self._bind = bind
         self._http_port = http_port
         self._display_id = display_id
@@ -574,6 +662,11 @@ class ScreenStreamServer:
         self._subscribers: dict[asyncio.Queue[bytes], _SubState] = {}
         self._init_sequence: Optional[bytes] = None
         self._codec_string: Optional[str] = None
+        # Cached parameter-set NALs for the hvcC decoder-configuration record
+        # (WebCodecs ``description``). Latest VPS/SPS/PPS seen on the stream.
+        self._vps_nal: Optional[bytes] = None
+        self._sps_nal: Optional[bytes] = None
+        self._pps_nal: Optional[bytes] = None
         self._saw_first_key = False
         self._stream_ready = asyncio.Event()
 
@@ -624,22 +717,22 @@ class ScreenStreamServer:
         self._remote_ssrc: int = 0
         self._rtp_highest_seq: int = 0  # extended (cycles<<16 | seq16)
         self._rtp_packets_received: int = 0
+        self._rtp_last_ts: int = 0
+        self._rtp_frames_received: int = 0
+        self._rctl_start_t: float = 0.0
+        self._rctl_task: Optional[asyncio.Task] = None
         # PLI tasks in flight -- keep a reference so the GC doesn't drop
         # them while awaiting the sendto (and ruff is happy with create_task).
         self._pli_tasks: set[asyncio.Task] = set()
-        # Last decoder-refresh timestamp + the byte-rate motion window
-        # the refresh loop uses to detect "motion just ended" -- the
-        # moment when tears accumulate and a fresh-IDR rebuild is most
-        # useful. Catches device-side touches too (real finger on the
-        # device) because they drive the encoder's byte rate up just
-        # like browser-driven /touch.
+        # Timestamp of the last PLI we sent. The refresh loop paces its
+        # triggers on it, and the recovery paths rate-limit on it so a
+        # loss burst / slow subscriber / stuck client can't turn into a
+        # PLI storm.
         self._last_refresh_t: float = 0.0
-        # (timestamp, AU bytes) entries pruned to the last 1 s.
+        # (timestamp, AU bytes) entries pruned to the last 1 s -- the
+        # refresh loop's motion detector, also logged with every PLI so
+        # post-mortems can tell a quiet-screen PLI from a mid-motion one.
         self._au_byte_window: deque = deque()
-        # True while AU byte rate is above the motion threshold.
-        self._motion_active: bool = False
-        # When the active->idle transition happened (0 = never / since reset).
-        self._motion_ended_t: float = 0.0
 
         # Lazy-opened HID services for browser-driven touch / buttons. The
         # auth gate is already held open by the active media stream above,
@@ -755,6 +848,12 @@ class ScreenStreamServer:
             stats_packets += 1
             # Maintain the extended highest-seq counter for RTCP RR.
             self._rtp_packets_received += 1
+            # Latest received video RTP timestamp (24 kHz media clock) + frame
+            # count -- echoed back in RCTL feedback so the device's rate
+            # controller can track receiver progress. See _build_rctl_packet.
+            self._rtp_last_ts = int.from_bytes(data[4:8], "big")
+            if marker:
+                self._rtp_frames_received += 1
             cur_ext = self._rtp_highest_seq
             cycles = (cur_ext >> 16) & 0xFFFF
             last_seq16 = cur_ext & 0xFFFF
@@ -805,12 +904,18 @@ class ScreenStreamServer:
                 if not nal:
                     continue
                 nt = (nal[0] >> 1) & 0x3F
-                if nt == _HEVC_NAL_SPS and self._codec_string is None:
-                    try:
-                        self._codec_string = hevc_codec_string_from_sps(nal)
-                        logger.info(f"WebCodecs codec string: {self._codec_string}")
-                    except Exception as exc:
-                        logger.warning(f"failed to parse SPS: {exc}")
+                if nt == _HEVC_NAL_VPS:
+                    self._vps_nal = nal
+                elif nt == _HEVC_NAL_PPS:
+                    self._pps_nal = nal
+                elif nt == _HEVC_NAL_SPS:
+                    self._sps_nal = nal
+                    if self._codec_string is None:
+                        try:
+                            self._codec_string = hevc_codec_string_from_sps(nal)
+                            logger.info(f"WebCodecs codec string: {self._codec_string}")
+                        except Exception as exc:
+                            logger.warning(f"failed to parse SPS: {exc}")
                 if _is_key_nal(nt):
                     au_is_key = True
                 current_au.append(nal)
@@ -823,22 +928,30 @@ class ScreenStreamServer:
                     # never delivered, the browser decoder errors and gets
                     # stuck waiting for a keyframe that on a long-GOP
                     # stream may never come naturally.
-                    pli_task = asyncio.create_task(self._send_rtcp_pli())
-                    self._pli_tasks.add(pli_task)
-                    pli_task.add_done_callback(self._pli_tasks.discard)
-                    # Note: we DON'T set ``state.needs_key = True`` on
-                    # subscribers here anymore. With the live broadcast loop
-                    # only dropping the *current* corrupt AU (not subsequent
-                    # ones), the next IDR from the PLI lands as a normal
-                    # type=0 key — the browser's decoder absorbs it as a
-                    # fresh DPB anchor without rebuilding, eliminating the
-                    # visible chop that the rebuild-on-needs_key path was
-                    # producing on every UDP gap during heavy motion.
-                    # If references really were lost the decoder will throw
-                    # a decode err, which the browser-side error handler
-                    # already turns into a /pli call.
+                    self._request_recovery_idr(reason="au-drop")
+                    # Hold every subscriber's deltas until that IDR lands.
+                    # The deltas that follow a dropped AU reference the
+                    # frame we never delivered, and VideoToolbox doesn't
+                    # throw on a missing reference — it silently renders
+                    # the mispredicted blocks as a mosaic tear. A short
+                    # freeze (one PLI round-trip, ~100-300 ms) is the
+                    # better trade. ``reset_on_key`` stays False: the
+                    # browser's decoder never sees the broken deltas, so
+                    # the recovery IDR can be absorbed as a plain type=0
+                    # DPB anchor without a decoder rebuild (rebuild-per-gap
+                    # is what used to read as chop under motion).
+                    for state in self._subscribers.values():
+                        state.mark_needs_key(loop.time())
                 if current_au and not au_corrupt:
-                    annexb = b"".join(b"\x00\x00\x00\x01" + nal for nal in current_au)
+                    # Broadcast as 4-byte-length-prefixed NALUs (hvcC / ISO
+                    # 14496-15 sample format, lengthSizeMinusOne=3) rather than
+                    # Annex-B start codes. Paired with the hvcC ``description``
+                    # from /codec, this drives Chrome's WebCodecs down
+                    # VideoToolbox's native hvcC path instead of the Annex-B
+                    # start-code path, which re-converts every chunk and tears
+                    # under rapid motion (Safari, which uses VideoToolbox
+                    # directly, does not tear -- proving the Annex-B path).
+                    au_data = b"".join(len(nal).to_bytes(4, "big") + nal for nal in current_au)
                     # Three framing types:
                     #   0 = key (IDR) - decode normally
                     #   1 = delta
@@ -846,34 +959,69 @@ class ScreenStreamServer:
                     #       before decoding this AU. Used when a prior drop
                     #       left the decoder's reference state stale.
                     type_byte = b"\x00" if au_is_key else b"\x01"
-                    msg = (len(annexb) + 1).to_bytes(4, "big") + type_byte + annexb
-                    msg_reset = (len(annexb) + 1).to_bytes(4, "big") + b"\x02" + annexb if au_is_key else msg
+                    msg = (len(au_data) + 1).to_bytes(4, "big") + type_byte + au_data
+                    msg_reset = (len(au_data) + 1).to_bytes(4, "big") + b"\x02" + au_data if au_is_key else msg
                     if au_is_key:
                         self._init_sequence = msg
                         self._saw_first_key = True
                         if self._codec_string is not None:
                             self._stream_ready.set()
                     self._last_good_au_t = loop.time()
-                    # Feed the motion-detection window. The refresh loop
-                    # reads this to know when motion settles.
-                    self._au_byte_window.append((self._last_good_au_t, len(annexb)))
+                    # Debug hook: tee the AU stream as Annex-B, so it can be
+                    # decoded offline (e.g. ``ffmpeg -i dump.hevc``) to tell
+                    # device-side encode artifacts apart from browser-side
+                    # decode bugs. Built only when the env var is set.
+                    dump_path = os.environ.get("PMD3_SERVE_WEB_DUMP")
+                    if dump_path:
+                        annexb = b"".join(b"\x00\x00\x00\x01" + nal for nal in current_au)
+                        with open(dump_path, "ab") as _f:
+                            _f.write(annexb)
+                    # Feed the byte-rate window used by the decoder-refresh
+                    # motion detector. Count DELTA AUs only: a forced IDR is
+                    # ~200-300 KB and alone exceeds motion_threshold_bps, so
+                    # counting keyframes would make a single refresh IDR read
+                    # as "motion" and fire the next refresh, which is another
+                    # IDR — a self-reinforcing PLI storm on a static screen
+                    # that eventually stalls the device encoder (confirmed via
+                    # syslog: 23 forced keyframes in 44 s with zero motion
+                    # input -> "no AU progress" stall). Genuine motion shows up
+                    # as a high *delta* byte rate, so excluding keyframes keeps
+                    # real-motion refreshes while killing the static-screen
+                    # storm. Always prune so stale entries expire even across
+                    # a run of keyframes.
+                    if not au_is_key:
+                        self._au_byte_window.append((self._last_good_au_t, len(au_data)))
+                    while self._au_byte_window and self._au_byte_window[0][0] < self._last_good_au_t - 1.0:
+                        self._au_byte_window.popleft()
                     if self._saw_first_key:
                         for q, state in list(self._subscribers.items()):
                             if q.full():
                                 while not q.empty():
                                     with contextlib.suppress(asyncio.QueueEmpty):
                                         q.get_nowait()
-                                state.needs_key = True
+                                # This subscriber lost queued (unsent) AUs;
+                                # hold its deltas until the next key. The
+                                # browser decoder never saw the flushed
+                                # AUs, so a plain type=0 key is enough to
+                                # re-anchor it — no rebuild required.
+                                # Without a periodic refresh loop that key
+                                # must be requested explicitly, or the
+                                # subscriber freezes for the rest of the
+                                # (unbounded) GOP.
+                                state.mark_needs_key(loop.time())
+                                self._request_recovery_idr(reason="queue-overflow")
                             if state.needs_key:
                                 if not au_is_key:
                                     continue
                                 state.needs_key = False
-                                # Use the reset variant so the browser
-                                # rebuilds its decoder before this key --
-                                # the prior decoder may have absorbed a
-                                # broken delta without erroring and now
-                                # holds stale reference frames.
-                                q.put_nowait(msg_reset)
+                                if state.reset_on_key:
+                                    # Fresh subscriber bootstrapping off a
+                                    # stale cached IDR: rebuild the decoder
+                                    # before this key.
+                                    state.reset_on_key = False
+                                    q.put_nowait(msg_reset)
+                                else:
+                                    q.put_nowait(msg)
                                 continue
                             q.put_nowait(msg)
                 current_au = []
@@ -915,9 +1063,67 @@ class ScreenStreamServer:
             return
         try:
             await transport.sendto(self._build_rtcp_pli(), *self._rtcp_dest)
-            logger.debug("sent RTCP PLI (requested fresh keyframe)")
+            logger.info("sent RTCP PLI (requested fresh keyframe)")
         except OSError as exc:
             logger.debug("PLI send failed (%s)", exc)
+
+    # ----- AVConference RCTL receiver feedback ------------------------------
+    # Reversed from a live Xcode-mirror capture; field values decoded exactly
+    # from it. The receiver streams two RTCP APP packets (PT=204):
+    #   "RCTL" (32 B, ~20/s): tag 0x85000004 then 8x u16:
+    #     [0]=received RTP ts>>8, [1..2]=0, [3]=jitter/loss(0),
+    #     [4]=1024 Hz receiver wall clock, [5]=reception quality, [6]=frames,
+    #     [7]=accepted max bitrate (kbps).
+    #   name 0x00000005 (16 B, ~35/s): the received video RTP timestamp.
+    # Echoing the *received* RTP timestamp is what makes the device act on the
+    # feedback (a synthetic clock was ignored). Xcode sends this and no PLIs.
+    def _rctl_wall_1024(self) -> int:
+        loop = asyncio.get_running_loop()
+        elapsed = max(0.0, loop.time() - self._rctl_start_t) if self._rctl_start_t else 0.0
+        return int(elapsed * 1024) & 0xFFFF
+
+    def _build_rctl_packet(self) -> bytes:
+        import struct as _struct
+
+        ts = self._rtp_last_ts & 0xFFFFFFFF
+        return _struct.pack(
+            "!BBHI4sI HHHHHHHH", 0x80, 0xCC, 7, self._local_ssrc & 0xFFFFFFFF,
+            b"RCTL", 0x85000004,
+            (ts >> 8) & 0xFFFF, 0, 0, 0, self._rctl_wall_1024(), 98,
+            self._rtp_frames_received & 0xFFFF, self._rctl_maxk & 0xFFFF)
+
+    def _build_rctl_companion_packet(self) -> bytes:
+        import struct as _struct
+
+        return _struct.pack("!BBHI I I", 0x80, 0xCC, 3, self._local_ssrc & 0xFFFFFFFF, 5, self._rtp_last_ts & 0xFFFFFFFF)
+
+    async def _rctl_feedback_loop(self) -> None:
+        """Stream RCTL + companion APP feedback while a video stream is up:
+        companion every tick (~40/s), RCTL every other tick (~20/s)."""
+        tick = 0
+        while True:
+            try:
+                await asyncio.sleep(0.025)
+            except asyncio.CancelledError:
+                return
+            transport = self._active_sock
+            if (
+                not self._rctl_enabled
+                or transport is None
+                or self._rtcp_dest is None
+                or not self._local_ssrc
+                or self._rtp_packets_received == 0
+            ):
+                continue
+            if self._rctl_start_t == 0.0:
+                self._rctl_start_t = asyncio.get_running_loop().time()
+            try:
+                await transport.sendto(self._build_rctl_companion_packet(), *self._rtcp_dest)
+                if tick % 2 == 0:
+                    await transport.sendto(self._build_rctl_packet(), *self._rtcp_dest)
+            except OSError:
+                continue
+            tick += 1
 
     def _build_rtcp_rr(self) -> bytes:
         """Build a minimal RTCP Receiver Report for the active stream.
@@ -926,7 +1132,8 @@ class ScreenStreamServer:
         never send RTs the encoder stalls within ~25 s. A single Receiver
         Report (32 bytes) every second is enough to keep it producing frames.
 
-        Format (RFC 3550 §6.4.2): one RR with one report block::
+        Format (RFC 3550 §6.4.2): one RR with one report block, followed by an
+        SDES/CNAME chunk to form a proper compound packet::
 
             byte 0  : V=2 P=0 RC=1     (0x81)
             byte 1  : PT=201 (RR)      (0xC9)
@@ -939,10 +1146,15 @@ class ScreenStreamServer:
             20-23   : interarrival jitter (0)
             24-27   : last SR timestamp (0 -- we never received SR)
             28-31   : delay since last SR (0)
+
+        The trailing SDES matches Xcode's mirror exactly (confirmed by device
+        syslog: Xcode always sends ``RR`` + ``SDES`` compounds, never a bare RR)
+        and satisfies RFC 3550 §6.1, which requires every compound RTCP packet
+        to carry an SDES with a CNAME.
         """
         import struct as _struct
 
-        return _struct.pack(
+        rr = _struct.pack(
             "!BBHII BBBB IIII",
             0x81,
             0xC9,
@@ -957,6 +1169,27 @@ class ScreenStreamServer:
             0,
             0,
             0,
+        )
+        return rr + self._build_rtcp_sdes(self._local_ssrc)
+
+    @staticmethod
+    def _build_rtcp_sdes(ssrc: int) -> bytes:
+        """Minimal RTCP SDES chunk (RFC 3550 §6.5) with an empty CNAME,
+        byte-identical to Xcode's mirror (``81 ca 0002 <ssrc> 01 00 00 00``):
+        V=2 SC=1, PT=202, one source chunk = SSRC + a zero-length CNAME item
+        (type 1, len 0) + null terminator + padding to a 32-bit boundary."""
+        import struct as _struct
+
+        return _struct.pack(
+            "!BBHI BBBB",
+            0x81,  # V=2, P=0, SC=1
+            0xCA,  # PT=202 (SDES)
+            2,  # length = 3 words
+            ssrc & 0xFFFFFFFF,
+            0x01,  # SDES item type 1 = CNAME
+            0x00,  # CNAME length 0 (empty, as Xcode sends)
+            0x00,  # item type 0 = END of items
+            0x00,  # padding to 32-bit boundary
         )
 
     async def _rtcp_send_loop(self, transport: UdpMediaTransport) -> None:
@@ -977,11 +1210,11 @@ class ScreenStreamServer:
 
     def _build_audio_rtcp_rr(self) -> bytes:
         """Audio-side counterpart of :meth:`_build_rtcp_rr` (RFC 3550 §6.4.2).
-        Identical packet shape; just uses the audio session's SSRCs and
-        extended-highest-seq counter."""
+        Same RR + SDES/CNAME compound shape (Xcode sends SDES on the audio
+        stream too); just uses the audio session's SSRCs and highest-seq."""
         import struct as _struct
 
-        return _struct.pack(
+        rr = _struct.pack(
             "!BBHII BBBB IIII",
             0x81,
             0xC9,
@@ -997,6 +1230,7 @@ class ScreenStreamServer:
             0,
             0,
         )
+        return rr + self._build_rtcp_sdes(self._audio_local_ssrc)
 
     async def _audio_rtcp_send_loop(self, transport: UdpMediaTransport) -> None:
         """Periodically send RTCP RR for the audio stream. Without this
@@ -1261,6 +1495,7 @@ class ScreenStreamServer:
                 await self._stop_hid()
             self._init_sequence = None
             self._codec_string = None
+            self._vps_nal = self._sps_nal = self._pps_nal = None
             self._saw_first_key = False
             self._stream_ready.clear()
             # Preserve any connected subscribers across the restart — flush
@@ -1272,7 +1507,11 @@ class ScreenStreamServer:
                 while not q.empty():
                     with contextlib.suppress(asyncio.QueueEmpty):
                         q.get_nowait()
+                # Unconditionally restamp the needs_key clock: the new
+                # session gets a full watchdog window to deliver its
+                # opening IDR before another escalation can fire.
                 state.needs_key = True
+                state.needs_key_since = asyncio.get_running_loop().time()
 
             svc = DisplayService(self._rsd)
             await svc.connect()
@@ -1308,6 +1547,9 @@ class ScreenStreamServer:
             self._remote_ssrc = int(stream_cfg.get("LocalSSRC", 0))  # device's
             self._rtp_highest_seq = 0
             self._rtp_packets_received = 0
+            self._rtp_last_ts = 0
+            self._rtp_frames_received = 0
+            self._rctl_start_t = 0.0
             self._rtcp_dest = (self._sender_ip, source_port) if source_port else None
             self._active_service = svc
             self._active_session_id = sid
@@ -1718,11 +1960,28 @@ class ScreenStreamServer:
                 return
             with contextlib.suppress(asyncio.TimeoutError):
                 await asyncio.wait_for(self._stream_ready.wait(), timeout=2.0)
-            body = (self._codec_string or "").encode()
-            status = b"200 OK" if body else b"503 Stream Starting"
+            # Return JSON: the WebCodecs codec string + the hvcC
+            # decoder-configuration record (base64) used as the decoder
+            # ``description``. hvcC-mode decoding (out-of-band parameter sets +
+            # length-prefixed NALUs, matching /stream.bin framing) avoids the
+            # Annex-B start-code path that tears under motion in Chrome. If any
+            # parameter set is missing, reply 503 so the viewer retries.
+            description_b64 = ""
+            if self._codec_string and self._vps_nal and self._sps_nal and self._pps_nal:
+                try:
+                    hvcc = hevc_decoder_configuration_record(self._vps_nal, self._sps_nal, self._pps_nal)
+                    description_b64 = base64.b64encode(hvcc).decode()
+                except Exception:
+                    logger.exception("failed to build hvcC record")
+            if self._codec_string and description_b64:
+                body = json.dumps({"codec": self._codec_string, "description": description_b64}).encode()
+                status = b"200 OK"
+            else:
+                body = b""
+                status = b"503 Stream Starting"
             writer.write(
                 b"HTTP/1.1 " + status + b"\r\n"
-                b"Content-Type: text/plain\r\n"
+                b"Content-Type: application/json\r\n"
                 b"Cache-Control: no-store\r\n"
                 b"Content-Length: " + str(len(body)).encode() + b"\r\n"
                 b"Connection: close\r\n\r\n" + body
@@ -1942,12 +2201,16 @@ class ScreenStreamServer:
             # tears down + re-RPCs the whole pipeline (~several
             # seconds, several-MB IDR burst); ``/pli`` is a single
             # RTCP packet and the new IDR arrives in ~100-300 ms.
-            # The browser's decode-error handler hits this when
-            # WebCodecs throws post-bootstrap, instead of waiting for
-            # the next ``_decoder_refresh_loop`` tick.
-            loop = asyncio.get_running_loop()
-            if self._active_service is not None and self._rtcp_dest is not None:
-                self._fire_decoder_refresh(loop.time(), reason="browser-pli")
+            # The browser's decode-error handler and offline-overlay
+            # auto-recovery hit this when frames stop; rate-limit it
+            # like the other recovery paths so a stuck client can't
+            # PLI-storm the encoder. Also require a live /stream.bin
+            # subscriber: an orphaned viewer tab (its server restarted
+            # under it) keeps auto-recovering with /pli every few
+            # seconds indefinitely, and those blind PLIs corrupt/stall
+            # the encoder for the tabs that ARE connected.
+            if self._active_service is not None and self._rtcp_dest is not None and self._subscribers:
+                self._request_recovery_idr(reason="browser-pli")
             writer.write(b"HTTP/1.1 202 Accepted\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
             await writer.drain()
             writer.close()
@@ -2064,10 +2327,12 @@ class ScreenStreamServer:
             b"Connection: close\r\n\r\n"
         )
         await writer.drain()
-        # Bumped from 8 to 32: gives the browser more headroom during bursty
-        # arrival (e.g. when the JS event loop is busy posting input events)
-        # before we have to flush and resync from the next keyframe.
-        queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=32)
+        # ~1 s of 60 fps headroom during bursty arrival (e.g. when the JS
+        # event loop is busy posting input events) before we have to flush
+        # and resync from the next keyframe. Overflow recovery costs a
+        # PLI-forced IDR now (no periodic refresh loop to piggyback on),
+        # so it should stay rare.
+        queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=64)
         if self._init_sequence is not None:
             queue.put_nowait(self._init_sequence)
         # New subscribers start with needs_key=True so the broadcast
@@ -2076,30 +2341,36 @@ class ScreenStreamServer:
         # WebCodecs renders them as silent tears). The IDR will land as
         # a RESET keyframe, prompting the browser to rebuild its decoder.
         state = _SubState()
-        state.needs_key = True
+        state.mark_needs_key(asyncio.get_running_loop().time())
+        state.reset_on_key = True
         self._subscribers[queue] = state
 
-        # PLI-retry: the device's encoder occasionally ignores a single
-        # PLI (we've seen the post-connect PLI go unanswered, leaving the
-        # subscriber stuck on init_sequence forever — only a manual page
-        # reload resolved it). Spam another PLI every 700 ms until the
-        # broadcast loop clears this subscriber's needs_key (= an IDR
-        # arrived and was delivered as msg_reset).
-        async def _bootstrap_pli_retry():
-            for _ in range(6):
-                await asyncio.sleep(0.7)
+        # Bootstrap escalation: the device's encoder occasionally ignores
+        # PLIs (a semi-wedged encoder keeps emitting deltas but never an
+        # IDR), which would leave this subscriber stuck on init_sequence
+        # forever. Retry the PLI twice, then stop asking nicely and force
+        # a session restart — a fresh session always opens with a clean
+        # IDR without any PLI involved. Don't keep spamming PLIs beyond
+        # that: on iOS 26/27 a PLI barrage is itself what corrupts or
+        # stalls the encoder (see ``_fire_decoder_refresh``).
+        async def _bootstrap_key_escalation():
+            for attempt in range(3):
+                await asyncio.sleep(1.0)
                 if not state.needs_key:
                     return
                 if self._active_service is None or self._rtcp_dest is None:
                     return
                 if queue not in self._subscribers:
                     return
-                logger.debug("/stream.bin: subscriber still needs_key, re-PLI")
-                pt = asyncio.create_task(self._send_rtcp_pli())
-                self._pli_tasks.add(pt)
-                pt.add_done_callback(self._pli_tasks.discard)
+                if attempt < 2:
+                    logger.debug("/stream.bin: subscriber still needs_key, re-PLI")
+                    self._request_recovery_idr(reason="bootstrap-retry")
+                else:
+                    logger.warning("/stream.bin: encoder ignored bootstrap PLIs - forcing session restart")
+                    with contextlib.suppress(Exception):
+                        await asyncio.wait_for(self._ensure_fresh_stream(force=True), timeout=10.0)
 
-        retry_task = asyncio.create_task(_bootstrap_pli_retry())
+        retry_task = asyncio.create_task(_bootstrap_key_escalation())
         self._pli_tasks.add(retry_task)
         retry_task.add_done_callback(self._pli_tasks.discard)
 
@@ -2119,49 +2390,40 @@ class ScreenStreamServer:
     async def _decoder_refresh_loop(self) -> None:
         """IDR refresh: PLI on sustained motion + on settle + slow heartbeat.
 
-        Each PLI gives the browser's WebCodecs decoder a fresh DPB anchor.
-        Without refresh the decoder accumulates prediction drift across
-        each high-motion burst (quick swipes etc.) and renders torn
-        pixels — Chrome doesn't throw on the bad reference, just shows
-        the artifact.
+        Why force IDRs at all: the DisplayService encoder runs its rate
+        control open-loop for us (we implement none of Apple's
+        proprietary AVCRC feedback that Xcode's client provides — the
+        device ignores standard RTCP RRs/REMB). Under sustained rapid
+        motion the encoder's output degrades progressively — smeared,
+        ghosted, mosaic-looking frames baked into the *bitstream*
+        (verified by teeing the Annex-B stream: ffmpeg and WebCodecs
+        decode the same garbage, with zero RTP loss and no forced
+        IDRs in the capture). LTRP on/off makes no difference. A
+        periodic IDR is the only reset knob we have; without it the
+        degradation accumulates for the whole (unbounded) GOP and the
+        viewer looks far worse. True parity with Xcode's artifact-free
+        stream would require implementing Apple's congestion-feedback
+        protocol so the encoder budget works closed-loop.
 
         Triggers:
-          1. **Active** — byte rate has been above
-             ``motion_threshold_bps`` continuously for at least
-             ``active_interval``. Catches sustained motion (rapid
-             back-to-back swipes) where settle never fires.
-          2. **Settle** — byte rate was above threshold and just
-             dropped for at least ``settle_delay``. One PLI per real
-             motion event ending, when accumulated drift is visible
-             against the now-static screen.
-          3. **Heartbeat** — backstop every ``heartbeat`` seconds.
-             Also handles bootstrap (``_last_refresh_t == 0.0`` at
-             start so the first eligible tick fires a PLI; the
-             broadcast loop needs that fresh IDR to clear
-             ``needs_key`` on a subscriber that connected after the
-             natural startup IDR has already passed).
-
-        ``motion_threshold_bps = 500_000`` (500 KB/s) sits well above
-        the measured iPhone 12 mini idle byte-rate (60-100 KB/s), so
-        the previous always-on settle churn at 100 KB/s doesn't recur.
-        Real motion bursts go several MB/s on this device.
-        ``min_interval`` caps back-to-back refreshes regardless of
-        trigger.
+          1. **Active** — byte rate above ``motion_threshold_bps``
+             continuously: fire at ``active_interval`` cadence, capping
+             how long motion degradation can accumulate.
+          2. **Settle** — byte rate just dropped after motion: one PLI
+             so the now-static screen snaps back to full quality.
+          3. **Heartbeat** — backstop every ``heartbeat`` seconds; also
+             clears a subscriber stuck in ``needs_key`` after the
+             natural startup IDR passed it by.
         """
         loop = asyncio.get_running_loop()
-        # Threshold above measured idle (≈60-100 KB/s) but below normal
-        # motion bursts (200-400 KB/s on iPhone 12 mini / iOS 27 under
-        # quick swipes). At this threshold settle fires once per real
-        # motion event ending; with ``_fire_decoder_refresh`` no longer
-        # flushing subscriber queues, each PLI's fresh IDR is delivered
-        # as a transparent DPB refresh (type=0 key), not a decoder
-        # rebuild — so frequent firing here is no longer chop-visible.
         motion_threshold_bps = 200_000
         active_interval = 1.0  # fire mid-motion at this cadence
         settle_delay = 0.3  # wait after motion ends before refresh
         heartbeat = 10.0  # backstop cadence when nothing else fires
         min_interval = 0.7  # don't fire more often than this
+        motion_active = False
         motion_started_t = 0.0
+        motion_ended_t = 0.0
         while True:
             try:
                 await asyncio.sleep(0.1)
@@ -2172,17 +2434,14 @@ class ScreenStreamServer:
             if self._active_service is None or self._rtcp_dest is None:
                 continue
             now = loop.time()
-            # Prune the byte-rate window to the last 1 s.
-            while self._au_byte_window and self._au_byte_window[0][0] < now - 1.0:
-                self._au_byte_window.popleft()
+            # The window is pruned to the last 1 s at append time.
             window_bytes = sum(s for _, s in self._au_byte_window)
             currently_active = window_bytes >= motion_threshold_bps
-            # Track motion transitions for settle detection + active duration.
-            if currently_active and not self._motion_active:
+            if currently_active and not motion_active:
                 motion_started_t = now
-            if self._motion_active and not currently_active:
-                self._motion_ended_t = now
-            self._motion_active = currently_active
+            if motion_active and not currently_active:
+                motion_ended_t = now
+            motion_active = currently_active
             since_refresh = now - self._last_refresh_t
             if since_refresh < min_interval:
                 continue
@@ -2192,7 +2451,7 @@ class ScreenStreamServer:
                 and (now - motion_started_t) >= active_interval
                 and since_refresh >= active_interval
             )
-            settled = self._motion_ended_t > self._last_refresh_t and (now - self._motion_ended_t) >= settle_delay
+            settled = motion_ended_t > self._last_refresh_t and (now - motion_ended_t) >= settle_delay
             heartbeat_due = since_refresh >= heartbeat
             if not (active or settled or heartbeat_due):
                 continue
@@ -2200,30 +2459,51 @@ class ScreenStreamServer:
             self._fire_decoder_refresh(now, reason=reason)
 
     def _fire_decoder_refresh(self, now: float, *, reason: str) -> None:
-        # Just send the PLI — DON'T flush subscriber queues or set
-        # needs_key. The fresh IDR will be broadcast as a normal type=0
-        # key (msg, not msg_reset), so the browser absorbs it without
-        # rebuilding its decoder — the rebuild is what was producing
-        # visible chop and looked like tearing during sustained motion.
-        # A subscriber whose state really IS stale (after a queue-full
-        # flush or AU corruption) is still handled correctly by the
-        # other code paths that set ``state.needs_key = True``.
+        """Send one PLI so the device emits a fresh IDR.
+
+        Don't flush subscriber queues or set needs_key here — the fresh
+        IDR is broadcast as a normal type=0 key, which the browser
+        absorbs as a clean DPB anchor without rebuilding its decoder
+        (rebuild-per-refresh is what reads as chop under motion). The
+        callers that really lost data set ``needs_key`` themselves.
+        """
         pli_task = asyncio.create_task(self._send_rtcp_pli())
         self._pli_tasks.add(pli_task)
         pli_task.add_done_callback(self._pli_tasks.discard)
         self._last_refresh_t = now
         window_bps = sum(s for _, s in self._au_byte_window)
-        logger.debug(
+        logger.info(
             "decoder-refresh (%s): %d subscriber(s), %d B/s window",
             reason,
             len(self._subscribers),
             window_bps,
         )
 
+    def _request_recovery_idr(self, *, reason: str) -> None:
+        """Rate-limited PLI for the data-loss recovery paths (dropped
+        corrupt AU, subscriber queue overflow). Rate limiting matters:
+        a loss burst or a persistently slow subscriber must not turn
+        into a PLI storm — this encoder corrupts/stalls under one (see
+        :meth:`_fire_decoder_refresh`)."""
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        if now - self._last_refresh_t < 0.7:
+            return
+        self._fire_decoder_refresh(now, reason=reason)
+
     async def _stall_watchdog(self) -> None:
-        """Restart the media stream if AU progress stalls — typically when
-        persistent UDP loss causes us to drop every AU and the encoder
-        hasn't sent a fresh IDR. Restarting forces a new IDR from the device.
+        """Restart the media stream when the encoder stops cooperating.
+
+        Two triggers:
+          1. **AU stall** — no AU progressed in :data:`_STALL_RESTART_SECS`
+             (encoder stopped emitting entirely — e.g. after it choked on
+             a PLI, or the display slept).
+          2. **Ignored key request** — AUs keep flowing but a subscriber
+             has been sitting in ``needs_key`` for longer than
+             ``_NEEDS_KEY_RESTART_SECS``: the encoder is emitting deltas
+             while ignoring our PLIs, so the subscriber would freeze
+             forever. A session restart is the only reliable way to get
+             an IDR out of a semi-wedged encoder.
 
         Honours :data:`_STALL_RESTART_COOLDOWN_SECS` so a legitimate idle
         (e.g. the device is locked) doesn't loop us into a hot restart cycle.
@@ -2240,8 +2520,17 @@ class ScreenStreamServer:
             if self._active_service is None:
                 continue
             now = loop.time()
-            if now - self._last_good_au_t <= _STALL_RESTART_SECS:
-                # Stream is making progress -- any prior restarts are forgiven.
+            stalled = now - self._last_good_au_t > _STALL_RESTART_SECS
+            # NOTE: master restarts ONLY on a true AU stall. The branch added a
+            # second "key_starved" trigger (restart if any subscriber sat in
+            # needs_key > needs_key_restart_secs) -- but under motion the browser's
+            # WebCodecs decoder flags needs_key constantly, so that fired ~every
+            # few seconds and hammered the stream with restarts (fps->0), a
+            # regression vs master (0 restarts on the same motion). Restore
+            # master's single AU-stall trigger. A genuinely wedged encoder that
+            # ignores PLIs is still caught by the true AU stall.
+            if not stalled:
+                # Stream is making progress -- prior restarts are forgiven.
                 self._consecutive_restarts = 0
                 continue
             if now - self._last_restart_t < _STALL_RESTART_COOLDOWN_SECS:
@@ -2315,7 +2604,7 @@ class ScreenStreamServer:
             # stream comes back -- their decoder state spans the gap
             # and the post-rebind IDR is the only safe resync point.
             for state in self._subscribers.values():
-                state.needs_key = True
+                state.mark_needs_key(asyncio.get_running_loop().time())
             # Poll tunneld until the device returns. ``get_tunneld_device_by_udid``
             # returns None when it's not listed; any exception (tunneld
             # itself down, transient HTTP error) is treated the same way.
@@ -2339,6 +2628,7 @@ class ScreenStreamServer:
             # new SPS, and reset stall-restart bookkeeping so the
             # watchdog doesn't refuse to recover.
             self._codec_string = None
+            self._vps_nal = self._sps_nal = self._pps_nal = None
             self._init_sequence = None
             self._saw_first_key = False
             self._stream_ready.clear()
@@ -2439,6 +2729,7 @@ class ScreenStreamServer:
         )
         watchdog = asyncio.create_task(self._stall_watchdog())
         decoder_refresh = asyncio.create_task(self._decoder_refresh_loop())
+        self._rctl_task = asyncio.create_task(self._rctl_feedback_loop())
         self._reconnect_task = asyncio.create_task(self._reconnect_loop())
         self._keep_awake_task = asyncio.create_task(self._keep_awake_loop())
         # Eagerly start the HID worker so queued /touch requests are
@@ -2497,6 +2788,10 @@ class ScreenStreamServer:
             watchdog.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await watchdog
+            if self._rctl_task is not None:
+                self._rctl_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self._rctl_task
             decoder_refresh.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await decoder_refresh

--- a/pymobiledevice3/remote/core_device/screen_stream.py
+++ b/pymobiledevice3/remote/core_device/screen_stream.py
@@ -1325,7 +1325,16 @@ class ScreenStreamServer:
                 await asyncio.sleep(1.0)
             except asyncio.CancelledError:
                 return
-            if self._audio_rtcp_dest is None or self._audio_rtp_packets_received == 0:
+            # Send the keepalive RR as soon as the loop is up -- do NOT wait for
+            # the first audio packet. The screen usually starts SILENT (lock
+            # screen, static UI), so no audio RTP arrives for a while; gating the
+            # RR on packets-received meant we sent nothing, the device reaped the
+            # audio session at ~20 s (RTCPTimeoutInterval), and audio was dead
+            # before the user ever played anything (0 bytes on /audio.bin). The
+            # audio SSRCs are known from negotiation, so a highest-seq=0 RR is a
+            # valid keepalive that holds the session open through the silence.
+            # (Video never hit this: the screen always emits video immediately.)
+            if self._audio_rtcp_dest is None:
                 continue
             packet = self._build_audio_rtcp_rr()
             try:

--- a/pymobiledevice3/remote/core_device/vnc_server.py
+++ b/pymobiledevice3/remote/core_device/vnc_server.py
@@ -303,6 +303,9 @@ class VncStreamServer:
         self._remote_ssrc: int = 0
         self._rtcp_dest: Optional[tuple[str, int]] = None
         self._pli_tasks: set[asyncio.Task] = set()
+        # Extended highest video RTP seq, for the periodic Receiver Report that
+        # keeps the device from reaping the video session (RTCPTimeoutEnabled).
+        self._rtp_highest_seq: int = 0
 
         # Motion-based decoder-rebuild state. Mirrors screen_stream.py's
         # _decoder_refresh_loop: the VT decoder accumulates stale
@@ -472,6 +475,15 @@ class VncStreamServer:
             payload = data[header_len:]
 
             seq = int.from_bytes(data[2:4], "big")
+            # Maintain the extended highest-seq for the RR keepalive.
+            cur_ext = self._rtp_highest_seq
+            cycles = (cur_ext >> 16) & 0xFFFF
+            last_seq16 = cur_ext & 0xFFFF
+            if seq < last_seq16 and (last_seq16 - seq) > 0x8000:
+                cycles = (cycles + 1) & 0xFFFF
+            new_ext = (cycles << 16) | seq
+            if cur_ext == 0 or ((new_ext - cur_ext) & 0xFFFFFFFF) < 0x80000000:
+                self._rtp_highest_seq = new_ext
             if last_seq is not None and seq != ((last_seq + 1) & 0xFFFF):
                 fu_buffer.clear()
                 au_corrupt = True
@@ -651,6 +663,53 @@ class VncStreamServer:
             logger.debug("sent RTCP PLI (requested fresh keyframe)")
         except OSError as exc:
             logger.debug("PLI send failed (%s)", exc)
+
+    def _build_rtcp_rr(self) -> bytes:
+        """RTCP Receiver Report (RFC 3550 §6.4.2) + SDES, byte-compatible with
+        screen_stream.py. The device's video streamConfig has RTCPTimeoutEnabled
+        with a ~25 s interval; PLIs alone don't reset it -- without periodic RRs
+        the device reaps the video session and stops emitting AUs, which froze
+        serve-vnc permanently (it has no stream-restart). One RR/s keeps it alive.
+        """
+        rr = struct.pack(
+            "!BBHII BBBB IIII",
+            0x81,  # V=2, RC=1
+            0xC9,  # PT=201 (RR)
+            7,
+            self._local_ssrc & 0xFFFFFFFF,
+            self._remote_ssrc & 0xFFFFFFFF,
+            0,  # fraction lost
+            0,
+            0,
+            0,  # 3-byte cumulative loss
+            self._rtp_highest_seq & 0xFFFFFFFF,
+            0,  # interarrival jitter
+            0,  # last SR
+            0,  # delay since last SR
+        )
+        return rr + self._build_rtcp_sdes(self._local_ssrc)
+
+    @staticmethod
+    def _build_rtcp_sdes(ssrc: int) -> bytes:
+        """Minimal SDES with an empty CNAME (matches Xcode's compound RR+SDES)."""
+        return struct.pack("!BBHI BBBB", 0x81, 0xCA, 2, ssrc & 0xFFFFFFFF, 0x01, 0x00, 0x00, 0x00)
+
+    async def _rtcp_send_loop(self, transport: UdpMediaTransport) -> None:
+        """Send a video RR every second to keep the device's video session
+        alive (see _build_rtcp_rr). Not gated on packets-received: send from the
+        start so a brief no-frame window at bring-up can't let the session lapse."""
+        while True:
+            try:
+                await asyncio.sleep(1.0)
+            except asyncio.CancelledError:
+                return
+            if self._rtcp_dest is None or not (self._local_ssrc and self._remote_ssrc):
+                continue
+            try:
+                await transport.sendto(self._build_rtcp_rr(), *self._rtcp_dest)
+            except OSError as exc:
+                logger.debug("video RTCP RR send failed (%s); socket may be torn down", exc)
+                return
 
     def _fire_decoder_refresh(self, now: float, *, reason: str) -> None:
         """Arm the decoder-rebuild + PLI sequence. The recv loop will
@@ -1430,6 +1489,9 @@ class VncStreamServer:
         self._loop = loop
         feed_task = asyncio.create_task(self._udp_recv_and_pipe(transport))
         refresh_task = asyncio.create_task(self._decoder_refresh_loop())
+        # Video RR keepalive -- without this the device reaps the video session
+        # after ~25 s (RTCPTimeoutEnabled) and serve-vnc freezes with no recovery.
+        rtcp_task = asyncio.create_task(self._rtcp_send_loop(transport))
         if self._audio_enabled and self._audio_transport is not None:
             audio_recv_task = asyncio.create_task(self._audio_udp_recv(self._audio_transport))
             if self._audio_rtcp_dest and self._audio_local_ssrc and self._audio_remote_ssrc:
@@ -1477,6 +1539,9 @@ class VncStreamServer:
             refresh_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await refresh_task
+            rtcp_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await rtcp_task
             logger.debug("shutdown: stopping VT transcoder")
             feed_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):

--- a/pymobiledevice3/remote/remotexpc.py
+++ b/pymobiledevice3/remote/remotexpc.py
@@ -70,6 +70,14 @@ class RemoteXPCConnection:
         self._pending_window_updates: dict[int, int] = {}
         self._file_chunk_queues: dict[int, asyncio.Queue[Union[bytes, BaseException]]] = {}
         self._file_chunk_reader_task: Optional[asyncio.Task] = None
+        # Serialise request/response round-trips. ``send_receive_request`` is a
+        # write-then-read against a single shared reader + ``_previous_frame_data``
+        # buffer with no per-request stream demux, so two concurrent callers
+        # interleave their reads and steal each other's frames -- one observes
+        # "0 bytes read" and the connection is corrupted for good. Any caller
+        # that issues requests from multiple tasks (e.g. a periodic keepalive
+        # alongside normal RPCs) needs this.
+        self._request_lock = asyncio.Lock()
 
     async def __aenter__(self) -> "RemoteXPCConnection":
         await self.connect()
@@ -209,8 +217,9 @@ class RemoteXPCConnection:
             return decode_xpc_object(xpc_message.payload.obj)
 
     async def send_receive_request(self, data: dict) -> dict:
-        await self.send_request(data, wanting_reply=True)
-        return await self.receive_response()
+        async with self._request_lock:
+            await self.send_request(data, wanting_reply=True)
+            return await self.receive_response()
 
     def shell(self) -> None:
         start_ipython_shell(

--- a/pymobiledevice3/resources/serve_web/viewer.js
+++ b/pymobiledevice3/resources/serve_web/viewer.js
@@ -7,6 +7,20 @@ window.COMPENSATE = (function () {
     if (q === '1' || q === 'true') return true;
     return __COMPENSATE_DEFAULT__;
 })();
+// Lock the canvas buffer to the largest footprint seen and scale every frame
+// to fill it, instead of resizing the canvas per frame. The device encoder
+// oscillates displayHeight (2752<->2736) as the home indicator shows/hides;
+// resizing on each toggle makes the whole <canvas> visibly shrink/expand --
+// the "screen changing size" the user reports. Filling a fixed surface removes
+// that (the <=0.6% scale is imperceptible), and a full-cover drawImage every
+// frame leaves no stale GPU pixels (the old motion "tears" were really
+// userspace-tunnel packet loss, gone on the kernel tunnel). Toggle: ?lockcanvas=0.
+window.LOCKCANVAS = (function () {
+    const q = new URLSearchParams(location.search).get('lockcanvas');
+    if (q === '0' || q === 'false') return false;
+    if (q === '1' || q === 'true') return true;
+    return true;
+})();
 const canvas = document.getElementById('c');
 const ctx = canvas.getContext('2d');
 
@@ -741,6 +755,7 @@ let lastFrameLandscape = null;
 const _detCanvas = document.createElement('canvas');
 const _detCtx = _detCanvas.getContext('2d', {willReadFrequently: true});
 let _cropSrcW = 0, _cropSrcH = 0;   // 0 => draw the full frame (not collapsed)
+let _lockW = 0, _lockH = 0;         // locked canvas footprint (max seen); see window.LOCKCANVAS
 const DET_H = 344;                  // downsample height for detection
 function detectContentCrop(f) {
     const fw = f.displayWidth, fh = f.displayHeight;
@@ -777,23 +792,36 @@ function detectContentCrop(f) {
 
 function drawFrame(f) {
     const sideways = Math.abs(visualRotation % 180) === 90;
-    const targetW = sideways ? f.displayHeight : f.displayWidth;
-    const targetH = sideways ? f.displayWidth  : f.displayHeight;
-    if (targetW !== canvas.width || targetH !== canvas.height) {
+    const fw = f.displayWidth, fh = f.displayHeight;
+    const targetW = sideways ? fh : fw;
+    const targetH = sideways ? fw : fh;
+    if (window.LOCKCANVAS) {
+        // Grow-only: keep the canvas at the largest footprint seen so the
+        // encoder's 2752<->2736 oscillation never resizes it (no shrink).
+        if (targetW > _lockW || targetH > _lockH) {
+            _lockW = Math.max(_lockW, targetW);
+            _lockH = Math.max(_lockH, targetH);
+            canvas.width = _lockW;
+            canvas.height = _lockH;
+            fitCanvasToViewport();
+        }
+    } else if (targetW !== canvas.width || targetH !== canvas.height) {
         canvas.width = targetW;
         canvas.height = targetH;
         fitCanvasToViewport();
     }
     // Source rect: the detected content region on collapse, else the whole
-    // frame. Stretched to the full frame footprint (un-doing the device's
-    // shrink) inside the rotation transform.
-    const srcW = _cropSrcW || f.displayWidth;
-    const srcH = _cropSrcH || f.displayHeight;
+    // frame. Stretched to fill the canvas footprint (un-doing any device
+    // shrink AND the 16px height oscillation) inside the rotation transform.
+    const dstW = canvas.width, dstH = canvas.height;
+    const srcW = _cropSrcW || fw;
+    const srcH = _cropSrcH || fh;
+    const fpW = sideways ? dstH : dstW;   // unrotated footprint that fills the
+    const fpH = sideways ? dstW : dstH;   // canvas after the rotation transform
     ctx.save();
-    ctx.translate(targetW / 2, targetH / 2);
+    ctx.translate(dstW / 2, dstH / 2);
     if (visualRotation) ctx.rotate(visualRotation * Math.PI / 180);
-    ctx.drawImage(f, 0, 0, srcW, srcH,
-                  -f.displayWidth / 2, -f.displayHeight / 2, f.displayWidth, f.displayHeight);
+    ctx.drawImage(f, 0, 0, srcW, srcH, -fpW / 2, -fpH / 2, fpW, fpH);
     ctx.restore();
 }
 function redrawWithCurrentRotation() {

--- a/pymobiledevice3/resources/serve_web/viewer.js
+++ b/pymobiledevice3/resources/serve_web/viewer.js
@@ -1,4 +1,12 @@
 window.AUDIO_DEFAULT_ON = __AUDIO_DEFAULT_ON__;
+// Resolution-collapse compensation default (server --compensate flag), with a
+// per-load URL override for research: append ?compensate=0 / ?compensate=1.
+window.COMPENSATE = (function () {
+    const q = new URLSearchParams(location.search).get('compensate');
+    if (q === '0' || q === 'false') return false;
+    if (q === '1' || q === 'true') return true;
+    return __COMPENSATE_DEFAULT__;
+})();
 const canvas = document.getElementById('c');
 const ctx = canvas.getContext('2d');
 
@@ -713,6 +721,60 @@ let lastFrame = null;
 // flips — that signals the content is now natively oriented in the
 // buffer, so we drop our in-canvas rotation to avoid double-rotating.
 let lastFrameLandscape = null;
+
+// ----- Resolution-collapse compensation. Under rapid motion the device
+// encoder drops to a smaller capture resolution (observed 720x1280 for a
+// 1264x2752 panel) rendered into the TOP-LEFT of the fixed buffer with the
+// rest flat gray (Y=Cb=Cr=128) padding -- the "screen shrinks to a corner
+// while swiping" tear. It's in the bitstream (device-side, under the ~6 Mbps
+// cap) and can't be prevented from our side. But the shrunk region is the
+// whole screen, just stretched into fewer pixels -- so we detect that content
+// rectangle and stretch it back to fill the canvas. The collapse then reads
+// as a momentary softness dip in a correctly-placed full-frame image instead
+// of a jarring corner shrink.
+//
+// Detection runs on the RAW decoded frame (never the already-compensated
+// canvas -- that would feed back and oscillate), throttled and cached. The
+// content is top-left anchored so the crop origin is always (0,0); we find
+// the right/bottom padding boundary. Validated offline against real collapsed
+// captures: full-size on clean frames, ~720x1280 on collapsed ones.
+const _detCanvas = document.createElement('canvas');
+const _detCtx = _detCanvas.getContext('2d', {willReadFrequently: true});
+let _cropSrcW = 0, _cropSrcH = 0;   // 0 => draw the full frame (not collapsed)
+const DET_H = 344;                  // downsample height for detection
+function detectContentCrop(f) {
+    const fw = f.displayWidth, fh = f.displayHeight;
+    if (!fw || !fh) return;
+    const DW = Math.max(8, Math.round(DET_H * fw / fh));
+    _detCanvas.width = DW; _detCanvas.height = DET_H;
+    try {
+        _detCtx.drawImage(f, 0, 0, DW, DET_H);
+        const d = _detCtx.getImageData(0, 0, DW, DET_H).data;
+        const isGray = (x, y) => { const i = (y * DW + x) * 4;
+            return Math.abs(d[i] - 128) < 6 && Math.abs(d[i + 1] - 128) < 6 && Math.abs(d[i + 2] - 128) < 6; };
+        // Last column / row that still holds content (<60% gray padding).
+        let cr = 0;
+        for (let x = 0; x < DW; x++) { let g = 0, n = 0;
+            for (let y = 0; y < DET_H; y += 4) { n++; if (isGray(x, y)) g++; }
+            if (g / n < 0.6) cr = x; }
+        let cb = 0;
+        for (let y = 0; y < DET_H; y++) { let g = 0, n = 0;
+            for (let x = 0; x < DW; x += 4) { n++; if (isGray(x, y)) g++; }
+            if (g / n < 0.6) cb = y; }
+        // Map back to source px, biasing one cell inward so a boundary cell
+        // that straddles content+padding doesn't leave a gray sliver.
+        const cw = Math.round((cr / DW) * fw);
+        const ch = Math.round((cb / DET_H) * fh);
+        // Compensate only on a clear collapse (both dims well under full and
+        // not degenerate); otherwise draw the full frame untouched.
+        if (cw > fw * 0.2 && cw < fw * 0.92 && ch > fh * 0.2 && ch < fh * 0.92) {
+            _cropSrcW = cw; _cropSrcH = ch;
+        } else {
+            _cropSrcW = 0; _cropSrcH = 0;
+        }
+    } catch (_) { /* transient readback failure -- keep previous crop */ }
+}
+
 function drawFrame(f) {
     const sideways = Math.abs(visualRotation % 180) === 90;
     const targetW = sideways ? f.displayHeight : f.displayWidth;
@@ -722,10 +784,16 @@ function drawFrame(f) {
         canvas.height = targetH;
         fitCanvasToViewport();
     }
+    // Source rect: the detected content region on collapse, else the whole
+    // frame. Stretched to the full frame footprint (un-doing the device's
+    // shrink) inside the rotation transform.
+    const srcW = _cropSrcW || f.displayWidth;
+    const srcH = _cropSrcH || f.displayHeight;
     ctx.save();
     ctx.translate(targetW / 2, targetH / 2);
     if (visualRotation) ctx.rotate(visualRotation * Math.PI / 180);
-    ctx.drawImage(f, -f.displayWidth / 2, -f.displayHeight / 2);
+    ctx.drawImage(f, 0, 0, srcW, srcH,
+                  -f.displayWidth / 2, -f.displayHeight / 2, f.displayWidth, f.displayHeight);
     ctx.restore();
 }
 function redrawWithCurrentRotation() {
@@ -743,6 +811,12 @@ function drawPending() {
         visualRotation = 0;
     }
     lastFrameLandscape = landscape;
+    // Detect the collapse-crop rectangle from THIS raw frame, every frame:
+    // the stream flips between collapsed and full-res frames faster than any
+    // throttle, so a cached crop applied to a mismatched frame zooms a full
+    // frame into its top-left (the "smaller screen over the old full screen"
+    // artifact). Per-frame detection keeps the crop matched to the frame.
+    if (window.COMPENSATE) detectContentCrop(f); else { _cropSrcW = 0; _cropSrcH = 0; }
     try {
         drawFrame(f);
     } catch (e) {
@@ -811,6 +885,14 @@ setInterval(() => {
     }
     _lastFc = frameCount;
 }, 1000);
+
+// ----- Collapse recovery is SERVER-side, not here.
+// Recovery from the collapse (the device re-emitting a full-res IDR) is driven
+// SERVER-side by the motion-triggered decoder-refresh (--motion-idr): it fires
+// preemptively the moment motion starts, so it's structurally faster than any
+// client-side detect-then-POST-/pli loop (which is always a collapse-cycle
+// behind). The viewer's job is just to hide the shrink until that IDR lands,
+// which detectContentCrop above does. No client-side keyframe requests here.
 
 // ----- Accessibility panel: GET /accessibility lists current settings,
 // POST /accessibility/set with {key, value} updates one, POST

--- a/pymobiledevice3/resources/serve_web/viewer.js
+++ b/pymobiledevice3/resources/serve_web/viewer.js
@@ -681,9 +681,15 @@ async function fetchCodecWithRetry() {
         try {
             const resp = await fetch('/codec', { cache: 'no-store' });
             if (!resp.ok) { lastErr = 'HTTP ' + resp.status; continue; }
-            const codec = (await resp.text()).trim();
-            if (!codec) { lastErr = 'empty body (SPS not yet seen)'; continue; }
-            return codec;
+            // /codec returns JSON: {codec, description} where description is a
+            // base64 hvcC record (HEVCDecoderConfigurationRecord). Passing it
+            // as the decoder `description` selects hvcC-mode decoding (matching
+            // the length-prefixed NALU framing on /stream.bin), which avoids
+            // Chrome's Annex-B path that tears under motion.
+            const info = await resp.json();
+            if (!info.codec || !info.description) { lastErr = 'incomplete codec info (params not yet seen)'; continue; }
+            const description = Uint8Array.from(atob(info.description), c => c.charCodeAt(0));
+            return { codec: info.codec.trim(), description };
         } catch (e) {
             lastErr = e.message || String(e);
         }
@@ -940,12 +946,16 @@ clipboardGetBtn.addEventListener('click', async () => {
 
 async function run() {
     log('userAgent: ' + navigator.userAgent.slice(0, 80));
-    const codec = await fetchCodecWithRetry();
-    log('codec: ' + codec);
+    const { codec, description } = await fetchCodecWithRetry();
+    log('codec: ' + codec + ' (hvcC ' + description.length + 'B)');
+    // Shared hvcC decoder config: the `description` (HEVCDecoderConfigurationRecord)
+    // selects VideoToolbox's native hvcC path; chunks carry 4-byte-length-prefixed
+    // NALUs (the /stream.bin framing) rather than Annex-B start codes.
+    const decoderConfig = { codec, description, optimizeForLatency: true };
 
     let support;
     try {
-        support = await VideoDecoder.isConfigSupported({ codec });
+        support = await VideoDecoder.isConfigSupported({ codec, description });
     } catch (e) {
         log('isConfigSupported threw: ' + e.message); return;
     }
@@ -1026,7 +1036,7 @@ async function run() {
         },
     });
     let decoder = buildDecoder();
-    decoder.configure({ codec, optimizeForLatency: true });
+    decoder.configure(decoderConfig);
     log('state after configure: ' + decoder.state);
 
     // /stream.bin can return 503 if the force-restart on the server failed
@@ -1076,7 +1086,7 @@ async function run() {
             if (type === 2) {
                 try { decoder.close(); } catch (e) {}
                 decoder = buildDecoder();
-                decoder.configure({ codec, optimizeForLatency: true });
+                decoder.configure(decoderConfig);
                 needsResync = false;
                 gotKey = true;
                 log('force-restart @ key after upstream drop');
@@ -1085,7 +1095,7 @@ async function run() {
                 if (needsResync) {
                     try { decoder.close(); } catch (e) {}
                     decoder = buildDecoder();
-                    decoder.configure({ codec, optimizeForLatency: true });
+                    decoder.configure(decoderConfig);
                     needsResync = false;
                     log('resynced @ key after ' + decodeErrCount + ' decode err(s)');
                 }
@@ -1096,7 +1106,7 @@ async function run() {
                 log('decoder ' + decoder.state + ' @' + sentCount + ' - rebuilding');
                 try { decoder.close(); } catch (e) {}
                 decoder = buildDecoder();
-                decoder.configure({ codec, optimizeForLatency: true });
+                decoder.configure(decoderConfig);
                 needsResync = true;
                 continue;
             }


### PR DESCRIPTION
## Summary

Hardens the device-initiated screen-mirror servers (`serve-web` HTTP/browser and
`serve-vnc` RFB) and adds a research toggle harness for the still-open motion-tear
problem. Also fixes several real stream-lifecycle bugs found along the way.

## Fixes (verified)

- **serve-vnc: video RR keepalive** — serve-vnc sent PLIs but no periodic video
  Receiver Report, so the device reaped the video session at ~25s (RTCPTimeoutEnabled)
  and serve-vnc froze permanently (no stream-restart). Now holds a live stream
  (verified stable 140s continuous motion, 54–60 fps).
- **serve-web: fps→0 watchdog restart-storm** — a `key_starved` restart trigger fired
  constantly under motion (WebCodecs flags `needs_key`), each restart re-registering as
  "no AU progress" → cascade. Restored to master's single AU-stall trigger
  (A/B on the same device+motion: 0 restarts vs 17).
- **serve-web: RCTL OWRD clock** — the feedback arrival clock used elapsed-since-start
  ms (wrong epoch vs the 24 kHz RTP clock), so the device computed a phantom 14–50 ms
  OWRD on a ~1 ms tunnel and throttled. Report it on the media clock.
- **serve-web: query-string routing** — the HTTP router matched the raw request target,
  so `/?flag` 404'd; strip the query before matching (viewer reads flags client-side).
- **serve-web: viewer canvas lock** — the encoder oscillates displayHeight
  (2752↔2736, home-indicator); resizing the canvas per frame made the whole surface
  visibly shrink/expand. Lock to the largest footprint + scale to fill.
- **serve-web: audio RR during silence** — the audio RR keepalive was gated on
  already-received packets; the screen starts silent, so the device reaped the audio
  session before any playback. Send from the start.

## Research toggles / harness

For narrowing the device-side tear without code edits:
- CLI: `--rctl/--no-rctl`, `--motion-idr/--no-motion-idr`, `--compensate/--no-compensate`, `--ltrp`, `--max-bitrate`, `--rtcp-fb`.
- Runtime (no restart): `POST /debug/{rctl,idr}-{on,off}` — single-session A/B that sidesteps the beta unit's boot-time degradation.
- Viewer: `?compensate=0|1`, `?lockcanvas=0|1`.

## Known-open (not fixed by this PR)

The motion **tearing itself is not solved.** It's **device-side, in the encoded
bitstream, motion-triggered, and decoder-independent** — `serve-vnc` with native
VideoToolbox decode tears identically to the browser when the device is swiped by hand
(and it isn't HID injection: a *physical* on-device swipe with no injected touch still
tears). The Xcode-parity difference lives in the DisplayService stream-setup negotiation
(device-side; the encoder *config* captured from a live Xcode session was byte-identical),
e.g. unprobed `VideoSettings` fields. Full trail + corrected conclusion in
`SERVE_WEB_NOTES.md`.

## Testing notes

Validated on an iOS-27 beta unit that degrades/wedges under sustained load, so some
verification is synthetic (`dvt launch` motion + scripted input) and some is hand-driven.
serve-vnc stability, fps A/B vs master, and clean static/transition decode were checked
directly; the residual tears were confirmed device-side via the physical-swipe test above.
