### PR TITLE
chore(deps): cap pmd-pytcp below 0.1.0 for API compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,4 +51,6 @@ av>=14.0.0 ; platform_system != "Darwin"
 # 0.0.6 floor: teardown robustness (rings survive fd-close races, dispatch never parks a
 # producer on the FSM lock, stop() unblocks socket waiters) plus the Windows writev()
 # fallthrough raising OSError instead of crashing the TX ring — the pmd-pytcp side of #1756.
-pmd-pytcp>=0.0.6 ; python_version >= "3.9"
+# <0.1.0 ceiling: pin to the 0.0.x line whose public API pymobiledevice3 integrates against;
+# 0.1.0 is reserved for the next (potentially breaking) API revision.
+pmd-pytcp>=0.0.6,<0.1.0 ; python_version >= "3.9"


### PR DESCRIPTION
Pins the `pmd-pytcp` dependency to the `0.0.x` line for API compatibility.

```diff
-pmd-pytcp>=0.0.6 ; python_version >= "3.9"
+pmd-pytcp>=0.0.6,<0.1.0 ; python_version >= "3.9"
```

pymobiledevice3 integrates against the current `0.0.x` public API of the fork. A future `0.1.0` is reserved for the next (potentially breaking) API revision, so this ceiling prevents it from being pulled in unvetted and silently breaking the userspace tunnel. The `>=0.0.6` floor is unchanged.