### PR TITLE
restore: Handle FileNotFoundError for usbmuxd

### DIFF
--- a/pymobiledevice3/usbmux.py
+++ b/pymobiledevice3/usbmux.py
@@ -175,7 +175,7 @@ class MuxConnection:
         sock.setblocking(False)
         try:
             await asyncio.get_running_loop().sock_connect(sock, address)
-        except ConnectionRefusedError as e:
+        except (ConnectionRefusedError, FileNotFoundError) as e:
             sock.close()
             raise ConnectionFailedToUsbmuxdError() from e
         except Exception:


### PR DESCRIPTION
## Summary

If a device is connected in recovery mode, usbmuxd may not be running. Then, the /var/run/usbmuxd file will not exist, and this operation will raise a FileNotFoundError. Catch the FileNotFoundError and raise it back as a ConnectionFailedToUsbmuxdError so that cli/restore.py can fall back to recovery mode (see 38b4a0467ae7).

## Testing

Verified restore works again after applying the patch.

## AI Assistance

none
