### PR TITLE
backup2: report APFS purgeable-aware free space on macOS

### DIFF
--- a/pymobiledevice3/services/device_link.py
+++ b/pymobiledevice3/services/device_link.py
@@ -1,7 +1,9 @@
 import ctypes
+import ctypes.util
 import datetime
 import shutil
 import struct
+import sys
 import warnings
 from collections.abc import Iterable, Mapping, Sequence
 from io import BufferedWriter
@@ -33,6 +35,59 @@ ERRNO_TO_DEVICE_ERROR = {
 DLMessage = Sequence[Any]
 ProgressCallback = Callable[[Any], None]
 DLHandler = Callable[[DLMessage], None]
+
+
+def _darwin_important_available_capacity(path: Path) -> Optional[int]:
+    """Return the purgeable-aware free space macOS is willing to hand to writes.
+
+    ``shutil.disk_usage().free`` (statvfs) excludes APFS purgeable space (local
+    Time Machine snapshots, evictable iCloud files) that the OS reclaims on
+    demand, so it under-reports available capacity by tens of GB. This mirrors
+    Finder/iTunes by reading NSURL's
+    ``NSURLVolumeAvailableCapacityForImportantUsageKey`` via the Objective-C
+    runtime. Returns ``None`` on any failure so callers fall back to statvfs.
+    """
+    try:
+        objc = ctypes.CDLL(ctypes.util.find_library("objc"))
+        foundation = ctypes.CDLL(ctypes.util.find_library("Foundation"))
+    except (OSError, TypeError):
+        return None
+
+    objc.objc_getClass.restype = ctypes.c_void_p
+    objc.objc_getClass.argtypes = [ctypes.c_char_p]
+    objc.sel_registerName.restype = ctypes.c_void_p
+    objc.sel_registerName.argtypes = [ctypes.c_char_p]
+
+    def msg(restype: Any, receiver: Any, selector: bytes, argtypes: Sequence = (), args: Sequence = ()) -> Any:
+        send = objc.objc_msgSend
+        send.restype = restype
+        send.argtypes = [ctypes.c_void_p, ctypes.c_void_p, *argtypes]
+        return send(receiver, objc.sel_registerName(selector), *args)
+
+    try:
+        key = ctypes.c_void_p.in_dll(foundation, "NSURLVolumeAvailableCapacityForImportantUsageKey")
+
+        ns_string = objc.objc_getClass(b"NSString")
+        ns_path = msg(ctypes.c_void_p, ns_string, b"stringWithUTF8String:", [ctypes.c_char_p], [str(path).encode()])
+        ns_url = objc.objc_getClass(b"NSURL")
+        url = msg(ctypes.c_void_p, ns_url, b"fileURLWithPath:", [ctypes.c_void_p], [ns_path])
+        if not url:
+            return None
+
+        value = ctypes.c_void_p(0)
+        error = ctypes.c_void_p(0)
+        ok = msg(
+            ctypes.c_bool,
+            url,
+            b"getResourceValue:forKey:error:",
+            [ctypes.POINTER(ctypes.c_void_p), ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)],
+            [ctypes.byref(value), key, ctypes.byref(error)],
+        )
+        if not ok or not value.value:
+            return None
+        return int(msg(ctypes.c_longlong, value, b"longLongValue"))
+    except (ValueError, OSError):
+        return None
 
 
 class DeviceLink:
@@ -212,6 +267,13 @@ class DeviceLink:
 
     async def get_free_disk_space(self, _message: DLMessage) -> None:
         freespace = shutil.disk_usage(self.root_path).free
+        if sys.platform == "darwin":
+            # statvfs excludes APFS purgeable space; report the capacity macOS will
+            # actually satisfy (matches Finder), so the device doesn't refuse a
+            # backup that fits. See https://github.com/doronz88/pymobiledevice3/issues/1769
+            important = _darwin_important_available_capacity(self.root_path)
+            if important is not None:
+                freespace = max(freespace, important)
         await self.status_response(0, status_dict=freespace)
 
     async def move_items(self, message: DLMessage) -> None:


### PR DESCRIPTION
## Problem

`backup2 backup` can fail with `Not enough disk space` on macOS even when the backup would fit, while Finder/iTunes backups of the same device to the same disk succeed.

The device gates the backup by asking the host how much space is free (`DLMessageGetFreeDiskSpace`), and `DeviceLink.get_free_disk_space` answers with `shutil.disk_usage().free` (statvfs). On APFS that number **excludes purgeable space** — local Time Machine snapshots and evictable iCloud/cache files that macOS reclaims automatically as writes land. The gap is routinely tens of GB. When statvfs under-reports below the estimated backup size, the device sends `DLMessagePurgeDiskSpace` and the backup aborts with `NotEnoughDiskSpaceError`.

Fixes #1769.

## Fix

On macOS, additionally query NSURL's `NSURLVolumeAvailableCapacityForImportantUsageKey` — the purgeable-aware capacity Apple's own tooling (Finder/iTunes) uses for the same decision — via the Objective-C runtime through `ctypes`, and report `max(statvfs_free, important_usage)`.

- **No new dependency** — stdlib `ctypes` only (PyObjC is not a project dependency).
- **Graceful fallback** — any failure in the ObjC bridge returns `None` and we fall back to the original statvfs value.
- **macOS-only** — non-macOS hosts are completely unaffected.
- **Strictly safe** — `max(statvfs, important)` means we never report *less* than the hard-guaranteed statvfs number, so this can only fix the false refusal, never regress.

## Why the reported number is trustworthy

APFS purgeable content occupies allocated blocks now but is reclaimed just-in-time when a write needs the space. `ForImportantUsage` = current free + purgeable the OS will reclaim for user-initiated work − a small reserve. It's the exact number Finder sizes backups against, so this makes pmd3 match Apple rather than invent a heuristic. It's a point-in-time estimate (a write mid-backup could still hit `ENOSPC` if space is consumed concurrently), but that is the identical risk Finder carries and strictly better than refusing a backup that would fit.

Example (APFS volume, no local snapshots):

| Key | Value |
|---|---|
| `VolumeAvailableCapacity` / statvfs | 241.8 GB |
| `ForImportantUsage` (reported) | 255.3 GB |
| `ForOpportunisticUsage` | 237.6 GB |

## Testing

Verified on macOS 26 (Python 3.14): the helper returns the purgeable-aware value, a non-existent path falls back to `None`, and `ruff check` passes.