### PR TITLE
power_assertion: use asyncio.sleep instead of blocking time.sleep

### DIFF
--- a/pymobiledevice3/cli/power_assertion.py
+++ b/pymobiledevice3/cli/power_assertion.py
@@ -1,4 +1,4 @@
-import time
+import asyncio
 from typing import Literal, Optional
 
 from typer_injector import InjectingTyper
@@ -24,4 +24,4 @@ async def power_assertion(
     """Create a power assertion"""
     async with PowerAssertionService(service_provider).create_power_assertion(assertion_type, name, timeout, details):
         print("> Hit Ctrl+C to exit")
-        time.sleep(timeout)
+        await asyncio.sleep(timeout)


### PR DESCRIPTION
The async `power-assertion` CLI handler called synchronous `time.sleep(timeout)` inside the async context manager, blocking the event loop for the entire assertion duration and preventing transport/background tasks and cooperative cancellation from running.

Replace it with `await asyncio.sleep(timeout)` so the loop stays responsive while the device assertion remains active.

Fixes #1773