### PR TITLE
tests: make the suite deterministic on hosts without a device

### DIFF
--- a/tests/cli/test_backup_cli.py
+++ b/tests/cli/test_backup_cli.py
@@ -37,7 +37,9 @@ def test_backup_full_help_describes_conditional_default():
     result = runner.invoke(__main__.app, ["backup2", "backup", "--help"])
 
     assert result.exit_code == 0
-    normalized_output = " ".join(result.output.split())
+    # Rich wraps the help text inside panel borders, so strip the box-drawing
+    # characters before joining lines back into a single string
+    normalized_output = " ".join(result.output.replace("│", " ").split())
     assert "incremental" in normalized_output
     assert "valid local metadata exists" in normalized_output
     assert "full for an" in normalized_output

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -11,14 +11,13 @@ pytestmark = [pytest.mark.cli]
 ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
-@pytest.mark.xfail(reason="Looks like click broke something")
 def test_cli_main_interface():
+    # No-argument behavior is covered by test_cli_from_python_m_without_args, which
+    # exercises the real entry point; invoking the Typer app directly without
+    # arguments behaves inconsistently across click versions
     runner = CliRunner()
-    r1 = runner.invoke(__main__.app, ["--help"])
-    assert r1.exit_code == 0
-
-    r2 = runner.invoke(__main__.app)
-    assert r2.exit_code == 0
+    result = runner.invoke(__main__.app, ["--help"])
+    assert result.exit_code == 0
 
 
 def test_cli_from_python_m_without_args():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,12 @@ from typing import Any, Union
 import pytest
 import pytest_asyncio
 
-from pymobiledevice3.exceptions import DeviceNotFoundError, InvalidServiceError
+from pymobiledevice3.exceptions import (
+    ConnectionFailedToUsbmuxdError,
+    DeviceNotFoundError,
+    InvalidServiceError,
+    NoDeviceConnectedError,
+)
 from pymobiledevice3.lockdown import UsbmuxLockdownClient, create_using_usbmux
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
 from pymobiledevice3.services.dvt.instruments.dvt_provider import DvtProvider
@@ -29,6 +34,16 @@ def pytest_addoption(parser):
         metavar="PATH",
         help="Path to xcuitest JSON config file",
     )
+
+
+NO_DEVICE_SKIP_REASON = "No test device is available through usbmuxd"
+
+
+async def _create_usbmux_client() -> UsbmuxLockdownClient:
+    try:
+        return await create_using_usbmux()
+    except (ConnectionFailedToUsbmuxdError, DeviceNotFoundError, NoDeviceConnectedError):
+        pytest.skip(NO_DEVICE_SKIP_REASON)
 
 
 @pytest.fixture(scope="function")
@@ -75,7 +90,7 @@ async def service_provider(
             for rsd in rsds:
                 await rsd.close()
     else:
-        async with await create_using_usbmux() as client:
+        async with await _create_usbmux_client() as client:
             yield client
 
 
@@ -96,7 +111,7 @@ async def lockdown() -> AsyncGenerator[UsbmuxLockdownClient, Any]:
     """
     Creates a new lockdown client for each test.
     """
-    async with await create_using_usbmux() as client:
+    async with await _create_usbmux_client() as client:
         yield client
 
 


### PR DESCRIPTION
Running `pytest` on a clean host without an attached device produced `1 failed, 144 errors` instead of skips. Three independent test-only fixes:

- **conftest**: the `service_provider` and `lockdown` fixtures now catch `ConnectionFailedToUsbmuxdError` / `DeviceNotFoundError` / `NoDeviceConnectedError` from `create_using_usbmux()` and `pytest.skip` — device-dependent tests skip cleanly instead of erroring at fixture setup. Pairing/protocol failures still surface as real errors.
- **test_backup_cli**: `test_backup_full_help_describes_conditional_default` joined whitespace and asserted multi-word phrases, but Rich's panel border `│` lands between wrapped words, so the assertion depended on where lines happen to wrap. Box-drawing borders are now stripped before normalizing.
- **test_cli**: `test_cli_main_interface` carried an unconditional non-strict xfail (XPASS on 3.9, XFAIL on newer Pythons), so it verified nothing. The xfail is dropped, the test keeps the `--help` assertion, and no-argument behavior stays covered by the existing `test_cli_from_python_m_without_args` subprocess test.

Verified on a no-device host (Python 3.14): full suite goes from `1 failed, 270 passed, 8 skipped, 1 xfailed, 144 errors` to `272 passed, 152 skipped`.

Fixes #1772