### PR TITLE
cli: default developer-command fallback to the no-root userspace tunnel

### DIFF
--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -1,9 +1,18 @@
 # iOS 17+ Developer Services via Tunnel
 
-Starting with iOS 17.0, Apple moved developer service access to CoreDevice/RemoteXPC flows.
-To use many `developer dvt` commands, establish a trusted tunnel first — with root via `tunneld`
-(Option 1) or a manual tunnel (Option 2), or with **no root at all** via the in-process
-`--userspace` tunnel (Option 3).
+Starting with iOS 17.0, Apple moved developer service access to CoreDevice/RemoteXPC flows, so
+`developer` commands (and a few others) need an RSD tunnel to the device.
+
+**By default pymobiledevice3 establishes this tunnel for you — in-process, with no root/admin.**
+Just run the command; there is nothing to start beforehand:
+
+```shell
+python3 -m pymobiledevice3 developer dvt ls /
+```
+
+A privileged `tunneld` is only needed for specific cases (external tools such as `lldb`, a
+shared/persistent tunnel, or iOS 17.0-17.3.1 — see
+[When you still need `tunneld`](#when-you-still-need-a-privileged-tunneld)).
 
 !!! tip "Working from Python?"
     See [Choosing a connection](python-api.md#1-connect-to-a-device) in the Python API guide for
@@ -12,15 +21,52 @@ To use many `developer dvt` commands, establish a trusted tunnel first — with 
 Reference protocol details:
 [RemoteXPC](../internals/remotexpc.md)
 
+## The default: a no-root tunnel, automatically
+
+When a developer command needs an RSD tunnel and you passed none of `--rsd` / `--tunnel` /
+`--userspace`, pymobiledevice3 brings up an **in-process userspace tunnel** using a pure-Python
+network stack (PyTCP) — no kernel interface, so **no root/admin**. The tunnel is built when the
+command starts and torn down when it exits.
+
+This covers iOS 17.4+ over USB on macOS, Linux and Windows with no privileges (it uses the
+CoreDeviceProxy lockdown service). iOS 17.0-17.3.1 is handled differently — see the note below.
+
+!!! warning "iOS 17.0-17.3.1 uses `tunneld` by default"
+    These versions predate the CoreDeviceProxy service, so the userspace tunnel can only reach them
+    over the RemotePairing path — which is Wi-Fi-only and, on macOS, races `remoted` (the no-root
+    path can't suspend it without root). Rather than depend on that fragile path, pymobiledevice3
+    **routes iOS 17.0-17.3.1 to `tunneld` on every platform**, so keep one running:
+
+    ```shell
+    sudo python3 -m pymobiledevice3 remote tunneld
+    ```
+
+    You can still force the no-root path with `--userspace` where it applies (a device on Wi-Fi;
+    unreliable on macOS).
+
 ## Support Notes
 
 | Host OS | iOS 17.0-17.3.1 | iOS 17.4+ |
 | --- | --- | --- |
-| macOS | Supported | Supported |
-| Windows | Supported (requires additional drivers) | Supported |
-| Linux | Limited | Supported (lockdown tunnel) |
+| macOS | Uses `tunneld` (root) | Supported (no-root) |
+| Windows | Uses `tunneld` (root) + additional drivers | Supported (no-root) |
+| Linux | Uses `tunneld` (root) | Supported (no-root) |
 
-## Option 1: Run `tunneld` (automatic)
+## When you still need a privileged `tunneld`
+
+The in-process tunnel's device address lives **only inside the pymobiledevice3 process**, so it is
+not reachable from any other process on your machine. Use a kernel-routable tunnel (the sections
+below) when:
+
+- **An external tool must reach the device** — `developer debugserver lldb`, or `developer
+  debugserver start-server` without `--local-port`, drive an external `lldb` and therefore refuse
+  over the userspace tunnel. Pass `--tunnel` (or `--local-port` for `start-server`, which forwards
+  to a local port and *does* work over the userspace tunnel).
+- **You want one shared/persistent tunnel** reused across many invocations instead of rebuilding it
+  per command.
+- **iOS 17.0-17.3.1** (any host OS) — routed to `tunneld` automatically; see the warning above.
+
+## Running `tunneld`
 
 ```shell
 # If the device supports remote pairing (for example, Corellium/Apple TV), pair first.
@@ -31,9 +77,23 @@ python3 -m pymobiledevice3 remote pair
 sudo python3 -m pymobiledevice3 remote tunneld
 ```
 
-With `tunneld` running, many developer commands can auto-connect via `--tunnel`.
+With `tunneld` running, point a command at it with `--tunnel` (empty value = pick automatically, or
+pass a UDID):
 
-## Option 2: Start a tunnel manually
+```shell
+python3 -m pymobiledevice3 developer dvt ls / --tunnel ''
+```
+
+To make `tunneld` the **default** fallback again — so commands route to it automatically without
+passing `--tunnel`, restoring the pre-userspace-default behavior — set the
+`PYMOBILEDEVICE3_PREFER_TUNNELD` environment variable (any non-empty value):
+
+```shell
+export PYMOBILEDEVICE3_PREFER_TUNNELD=1
+python3 -m pymobiledevice3 developer dvt ls /
+```
+
+## Starting a tunnel manually
 
 ```shell
 # Optional for remote-pairing devices.
@@ -77,28 +137,24 @@ The tunnel creation command must run with elevated privileges because it creates
     (add `--raw` to keep the `deviceKVSData` blob base64-encoded). This control channel does not create
     tunnels itself.
 
-## Option 3: No-root userspace tunnel (`--userspace`)
+## Forcing the userspace tunnel (`--userspace`)
 
-Options 1 and 2 need root/admin because they create a kernel TUN/TAP interface. `--userspace`
-instead establishes the iOS 17+ tunnel **in-process** using a pure-Python network stack (PyTCP),
-so it needs **no root/admin at all**. Just add the flag to a developer command:
+The userspace tunnel is already the default, so you rarely need the flag. Pass `--userspace`
+explicitly to **force** the no-root in-process tunnel and skip the automatic `tunneld` fallback
+(iOS 17.0-17.3.1) — any establishment failure is then surfaced as an error rather than masked:
 
 ```shell
 python3 -m pymobiledevice3 developer dvt ls / --userspace
 ```
 
-There is no separate tunnel process to start — the flag builds the tunnel inside the command and
-tears it down when it exits.
-
 Requirements:
 
 - **Python >= 3.9** — the `pmd-pytcp` dependency that powers the userspace stack is installed on
-  every supported interpreter, so `--userspace` is always available. It does not fall back to
-  `tunneld`; if the in-process tunnel cannot be established, the error is surfaced.
+  every supported interpreter, so the userspace tunnel is always available.
 - **iOS 17.0+** over USB (uses the CoreDeviceProxy lockdown service on 17.4+, or RemotePairing over
-  bonjour/Wi-Fi on 17.0–17.3.1).
+  bonjour/Wi-Fi on 17.0-17.3.1).
 
-What works over `--userspace`: the host-initiated developer services (`dvt`, `fetch-symbols`,
+What works over the userspace tunnel: the host-initiated developer services (`dvt`, `fetch-symbols`,
 `core-device …`), and the device-initiated AV/HID paths — `display serve-web`, `display serve-vnc`,
 `display start-video-stream` / `start-audio-stream`, and the HID gesture commands.
 
@@ -106,12 +162,8 @@ What works over `--userspace`: the host-initiated developer services (`dvt`, `fe
 
 The device's tunnel address lives only inside the pymobiledevice3 process, so it is **not reachable
 from any other process** on your machine. Commands that hand the device address to an external tool
-therefore cannot use the userspace tunnel:
-
-- `developer debugserver lldb` and `developer debugserver start-server` (without `--local-port`)
-  **refuse** over `--userspace`, since they drive an external `lldb` that cannot reach the in-process
-  address. Use a kernel-routable tunnel (Option 1/2) for these — or, for `start-server`, pass
-  `--local-port`, which forwards debugserver to a local port and *does* work over `--userspace`.
+therefore cannot use the userspace tunnel — see
+[When you still need `tunneld`](#when-you-still-need-a-privileged-tunneld).
 
 Because the tunnel is rebuilt per invocation (no persistent daemon), expect a little extra startup
 latency compared with attaching to an already-running `tunneld`.
@@ -126,25 +178,29 @@ limitation above applies equally to the Python API.
 ## Use tunnel details in commands
 
 ```shell
-# DVT with automatic tunnel selection
-python3 -m pymobiledevice3 developer dvt ls / --tunnel ''
-
-# If tunneld is already running, this may work without --tunnel
+# Default: no flag, no root — an in-process userspace tunnel is established automatically
 python3 -m pymobiledevice3 developer dvt ls /
 
-# No-root in-process tunnel; no tunneld/root required
+# Force the no-root tunnel (skip the automatic tunneld fallback)
 python3 -m pymobiledevice3 developer dvt ls / --userspace
 
-# Use manual RSD connection details
+# Use a running tunneld ('' = pick automatically, or pass a UDID)
+python3 -m pymobiledevice3 developer dvt ls / --tunnel ''
+
+# Use manual RSD connection details (from `start-tunnel`)
 python3 -m pymobiledevice3 developer dvt ls / --rsd fd7b:e5b:6f53::1 64337
 
-# Non-developer command over tunnel
+# Non-developer command over a running tunneld
 python3 -m pymobiledevice3 syslog live --tunnel ''
 ```
 
 ## Troubleshooting
 
-- If a developer command fails with service availability errors, retry with `--tunnel ''` (uses a
-  running `tunneld`) or `--userspace` (no-root in-process tunnel).
+- Most developer commands need no flag — the no-root tunnel is established for you. If one fails to
+  establish a tunnel, the two explicit routes are `--tunnel ''` (uses a running `tunneld`) or
+  `--userspace` (forces the no-root in-process tunnel and surfaces the real error).
+- iOS 17.0-17.3.1 is routed to `tunneld` on every platform (the no-root path only reaches those
+  over the fragile Wi-Fi RemotePairing route), so start one. `--userspace` can still force that
+  no-root path over Wi-Fi if you prefer.
 - Verify the tunnel process is running and the device is trusted/paired.
 - On Windows for iOS 17.0-17.3.1, ensure required additional drivers are installed.

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -23,8 +23,12 @@ except ImportError:  # pragma: no cover
     shellingham = None
 
 from pymobiledevice3.cli.cli_common import (
+    PREFER_TUNNELD_ENV_VAR,
     TUNNEL_ENV_VAR,
+    UDID_ENV_VAR,
+    USERSPACE_ENV_VAR,
     isatty,
+    requires_kernel_tunnel,
     set_color_flag,
     set_verbosity,
 )
@@ -59,8 +63,9 @@ from pymobiledevice3.exceptions import (
     StartServiceError,
     TunneldConnectionError,
     UserDeniedPairingError,
+    UserspaceTunnelUnavailableError,
 )
-from pymobiledevice3.lockdown import create_using_usbmux, retry_create_using_usbmux
+from pymobiledevice3.lockdown import retry_create_using_usbmux
 from pymobiledevice3.osu.os_utils import get_os_utils
 
 coloredlogs.install(level=logging.INFO)
@@ -290,25 +295,9 @@ def _root(
     set_color_flag(color)
 
 
-def device_might_need_tunneld(identifier: str) -> bool:
-    """
-    Determines if the device might require tunneling based on its product version.
-
-    This function uses the `create_using_usbmux` context manager to establish a lockdown
-    session with the specified identifier. It retrieves the device's product version,
-    and checks if it is greater than or equal to version "17.0". If so, the function
-    returns True, indicating that the device might require tunneling. Otherwise, it
-    returns False.
-
-    :param identifier: A string representing the device identifier.
-    :return: A boolean indicating whether the device might require tunneling.
-    """
-
-    async def _device_might_need_tunneld() -> bool:
-        async with await create_using_usbmux(serial=identifier) as lockdown:
-            return Version(lockdown.product_version) >= Version("17.0")
-
-    return asyncio.run(_device_might_need_tunneld())
+def product_version_needs_tunnel(product_version: str) -> bool:
+    """True when the device's iOS version (>= 17.0) means a developer command needs an RSD tunnel."""
+    return Version(product_version) >= Version("17.0")
 
 
 def invoke_cli_with_error_handling() -> bool:
@@ -356,8 +345,12 @@ def invoke_cli_with_error_handling() -> bool:
         )
     except RoutableTunnelRequiredError as e:
         logger.error(str(e))
+    except UserspaceTunnelUnavailableError as e:
+        logger.error(str(e))
     except (InvalidServiceError, RSDRequiredError) as e:
         reason = ""
+        # Both exceptions carry the device's product version (no extra device round-trip needed).
+        product_version = e.product_version
         if isinstance(e, RSDRequiredError):
             reason = "RSD is required for this command"
         elif (
@@ -365,16 +358,34 @@ def invoke_cli_with_error_handling() -> bool:
             and ("developer" in sys.argv)
             and ("--tunnel" not in sys.argv)
             and ("--userspace" not in sys.argv)
-            and device_might_need_tunneld(e.identifier)
+            and product_version_needs_tunnel(product_version)
         ):
             reason = "it is a developer command on an iOS 17+ device"
-        # Retry once over tunneld (its env var doubles as the one-shot guard: already set
-        # means we are the retry failing again — don't loop). For a no-root tunnel instead,
-        # pass --userspace (slower; see its help).
-        if reason and not os.getenv(TUNNEL_ENV_VAR):
-            logger.warning(f"Trying again over tunneld since {reason} (pass --userspace for a no-root tunnel)")
-            # use a single space because Typer/Click will ignore envvars of empty strings
-            os.environ[TUNNEL_ENV_VAR] = e.identifier or " "
+        # Retry once. Default to the no-root in-process userspace tunnel; iOS 17.0-17.3 falls back
+        # to tunneld — the userspace tunnel can only reach those over the fragile RemotePairing path
+        # (see requires_kernel_tunnel) — as does PYMOBILEDEVICE3_PREFER_TUNNELD (explicit opt-out of
+        # the userspace default). Either env var doubles as the one-shot guard: already set means we
+        # are the retry failing again — don't loop.
+        if reason and not os.getenv(USERSPACE_ENV_VAR) and not os.getenv(TUNNEL_ENV_VAR):
+            if requires_kernel_tunnel(product_version):
+                logger.warning(
+                    f"Trying again over tunneld since {reason} "
+                    "(iOS 17.0-17.3 has no reliable no-root tunnel; needs a privileged `remote tunneld`)"
+                )
+                # use a single space because Typer/Click will ignore envvars of empty strings
+                os.environ[TUNNEL_ENV_VAR] = e.identifier or " "
+            elif os.getenv(PREFER_TUNNELD_ENV_VAR):
+                logger.warning(f"Trying again over tunneld since {reason} ({PREFER_TUNNELD_ENV_VAR} is set)")
+                # use a single space because Typer/Click will ignore envvars of empty strings
+                os.environ[TUNNEL_ENV_VAR] = e.identifier or " "
+            else:
+                logger.warning(
+                    f"Trying again over a no-root userspace tunnel since {reason} (pass --tunnel to use tunneld)"
+                )
+                os.environ[USERSPACE_ENV_VAR] = "1"
+                # Target the same device the userspace tunnel would otherwise resolve by default.
+                if e.identifier and not os.getenv(UDID_ENV_VAR):
+                    os.environ[UDID_ENV_VAR] = e.identifier
             main()
             return False
         logger.error(INVALID_SERVICE_MESSAGE)

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -18,12 +18,18 @@ import inquirer3
 import typer
 from click import UsageError
 from inquirer3.themes import GreenPassion
+from packaging.version import Version
 from pygments import formatters, highlight, lexers
 from typer_injector import Depends
 from typing_extensions import ParamSpec
 
 from pymobiledevice3 import usbmux as usbmuxd
-from pymobiledevice3.exceptions import AccessDeniedError, DeviceNotFoundError, NoDeviceConnectedError
+from pymobiledevice3.exceptions import (
+    AccessDeniedError,
+    DeviceNotFoundError,
+    NoDeviceConnectedError,
+    UserspaceTunnelUnavailableError,
+)
 from pymobiledevice3.lockdown import LockdownClient, TcpLockdownClient, create_using_usbmux, get_mobdev2_lockdowns
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.osu.os_utils import get_os_utils
@@ -34,6 +40,9 @@ from pymobiledevice3.utils import get_asyncio_loop
 UDID_ENV_VAR = "PYMOBILEDEVICE3_UDID"
 TUNNEL_ENV_VAR = "PYMOBILEDEVICE3_TUNNEL"
 USERSPACE_ENV_VAR = "PYMOBILEDEVICE3_USERSPACE"
+# When set (non-empty), the automatic tunnel fallback uses tunneld instead of the
+# no-root userspace tunnel — restoring the pre-userspace-default behavior.
+PREFER_TUNNELD_ENV_VAR = "PYMOBILEDEVICE3_PREFER_TUNNELD"
 USBMUX_ENV_VAR = "PYMOBILEDEVICE3_USBMUX"
 USBMUXD_SOCKET_ADDRESS_ENV_VAR = "USBMUXD_SOCKET_ADDRESS"
 USBMUX_ENV_VARS = [USBMUX_ENV_VAR, USBMUXD_SOCKET_ADDRESS_ENV_VAR]
@@ -201,7 +210,76 @@ def _cli_udid() -> Optional[str]:
     return os.getenv(UDID_ENV_VAR)
 
 
+def _resolve_target_serial(serial: Optional[str]) -> Optional[str]:
+    """Resolve the device the default (required) RSD tunnel should target.
+
+    When the user passed an explicit UDID (--udid / env) use it. Otherwise, if more than one USB
+    device is attached, prompt for one — mirroring the interactive selection the composing
+    service-provider dependencies do — so the default tunnel does not silently pick the first
+    device. Returns the chosen serial, or ``None`` when a single/zero device leaves the choice to
+    the usbmux layer.
+
+    usbmux exposes neither the device name nor the iOS version, so the chooser connects to each
+    device via lockdown to show ID/VERSION/TYPE, then closes those connections — only the chosen
+    serial is kept. These connections use ``autopair=False``: this is a display-only listing, so
+    browsing must not pair every attached device. Only the chosen device is paired later, when the
+    tunnel is established (``establish_userspace_rsd`` / ``tunneld`` use ``autopair=True``); the cost
+    is that the ``PAIRED`` field reads ``False`` for all here (it is simply unchecked).
+    """
+    if serial is not None:
+        return serial
+    devices = cli_loop.run_until_complete(usbmuxd.select_devices_by_connection_type(connection_type="USB"))
+    if len(devices) <= 1:
+        return None
+    lockdownds = [
+        cli_loop.run_until_complete(create_using_usbmux(serial=device.serial, autopair=False)) for device in devices
+    ]
+    try:
+        return prompt_device_list(lockdownds).identifier
+    finally:
+        for lockdown in lockdownds:
+            cli_loop.run_until_complete(lockdown.close())
+
+
+def requires_kernel_tunnel(product_version: str) -> bool:
+    """True when a device needs the privileged kernel tunnel (``tunneld``) rather than the
+    no-root in-process userspace tunnel.
+
+    iOS 17.0-17.3 always qualifies: those versions predate the CoreDeviceProxy lockdown service
+    (17.4+), so the userspace tunnel can only reach them over the RemotePairing/bonjour path — which
+    is Wi-Fi-only and, on macOS, races ``remoted`` (the no-root path cannot ``stop_remoted()``
+    without root). Rather than make the default depend on that fragile path, 17.0-17.3 routes to
+    ``tunneld`` on every platform. iOS 17.4+ uses CoreDeviceProxy over USB and works root-free, so
+    it stays on the userspace default. (``--userspace`` can still force the RemotePairing path on
+    17.0-17.3 where it applies.)
+
+    Used by the ``__main__`` exception-retry path, which already carries the product version from the
+    raised exception. The required-RSD default path (:func:`make_rsd_dependency`) instead reuses the
+    tunnel's own lockdown connection and routes via ``UserspaceTunnelUnavailableError``, so it needs
+    no separate version query.
+    """
+    return Version("17.0") <= Version(product_version) < Version("17.4")
+
+
 def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteServiceDiscoveryService]]:
+    """Build the Typer dependency that resolves an RSD from --rsd/--tunnel/--userspace.
+
+    ``allow_none`` decides what happens when the user passes none of those options:
+
+    * ``allow_none=True`` — return ``None`` so the composing dependency
+      (:func:`any_service_provider_dependency`, :func:`no_autopair_service_provider_dependency`)
+      can fall back to a plain usbmux lockdown. Used by commands that work over either a
+      lockdown or an RSD tunnel; on iOS 17+ the lockdown attempt raises InvalidServiceError /
+      RSDRequiredError and ``__main__`` re-runs the command forcing a tunnel.
+    * ``allow_none=False`` — the command requires an RSD (no lockdown equivalent, e.g.
+      ``core-device`` / ``remote rsd-info``), so a default tunnel is established here rather than
+      returning ``None``: the no-root userspace tunnel by default; a pre-17.4 device (iOS 17.0-17.3)
+      raises :class:`~pymobiledevice3.exceptions.UserspaceTunnelUnavailableError` during
+      establishment (RemotePairing fallback disabled), which is caught here and routed to tunneld
+      (with the resolved UDID). Setting ``PYMOBILEDEVICE3_PREFER_TUNNELD`` skips the userspace
+      attempt and goes straight to tunneld.
+    """
+
     def rsd_dependency(
         rsd: Annotated[
             Optional[tuple[str, int]],
@@ -264,16 +342,41 @@ def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteSer
         # (pmd-pytcp) is a regular dependency on Python 3.9+, so any failure here is a real
         # establishment error and is surfaced rather than masked by a tunneld fallback.
         if userspace:
-            # Target the same device the rest of the CLI would (see _cli_udid).
-            serial = _cli_udid()
+            # Resolve (and, with multiple devices, prompt for) the target, like the other device
+            # dependencies — otherwise --userspace would silently pick the first device.
+            serial = _resolve_target_serial(_cli_udid())
+            # Imported lazily: userspace_tunnel pulls in the pure-Python PyTCP network stack
+            # (pmd-pytcp), whose import is expensive — keep it off the hot path of every CLI
+            # command that never establishes a userspace tunnel.
             from pymobiledevice3.remote import userspace_tunnel
 
             return cli_loop.run_until_complete(userspace_tunnel.establish_userspace_rsd(serial=serial))
 
-        # Default: a required RSD uses the kernel tunnel via tunneld (needs a privileged
-        # `remote tunneld`). Pass --userspace for a no-root tunnel instead.
+        # Default for a required RSD: prefer the no-root in-process userspace tunnel. A pre-17.4
+        # device (no CoreDeviceProxy — i.e. iOS 17.0-17.3, reachable no-root only over the fragile
+        # RemotePairing path) is served by tunneld instead: establishment is asked NOT to attempt
+        # RemotePairing (remotepairing_fallback=False), so it raises UserspaceTunnelUnavailableError,
+        # which we catch and route to tunneld. This reuses the single lockdown connection
+        # establishment already opens — no separate version probe.
         if not allow_none:
-            return cli_loop.run_until_complete(_tunneld(""))
+            # Resolve (and, with multiple devices, prompt for) the target so both the userspace
+            # attempt and the tunneld fallback act on the same user-chosen device.
+            serial = _resolve_target_serial(_cli_udid())
+            # PYMOBILEDEVICE3_PREFER_TUNNELD opts out of the userspace default entirely,
+            # restoring the pre-userspace-default behavior (straight to tunneld).
+            if os.getenv(PREFER_TUNNELD_ENV_VAR):
+                return cli_loop.run_until_complete(_tunneld(serial or ""))
+            # Imported lazily: see the --userspace branch above — the PyTCP stack import is
+            # expensive and must stay off the hot path of commands that never need it.
+            from pymobiledevice3.remote import userspace_tunnel
+
+            try:
+                return cli_loop.run_until_complete(
+                    userspace_tunnel.establish_userspace_rsd(serial=serial, remotepairing_fallback=False)
+                )
+            except UserspaceTunnelUnavailableError:
+                # Propagate the resolved UDID so tunneld targets the same device (empty => auto/prompt).
+                return cli_loop.run_until_complete(_tunneld(serial or ""))
 
     return rsd_dependency
 

--- a/pymobiledevice3/cli/developer/debugserver.py
+++ b/pymobiledevice3/cli/developer/debugserver.py
@@ -84,7 +84,7 @@ async def debugserver_start_server(
     elif Version(service_provider.product_version) >= Version("17.0"):
         if not isinstance(service_provider, RemoteServiceDiscoveryService):
             assert isinstance(service_provider, LockdownClient)  # non-RSD providers are lockdown clients
-            raise RSDRequiredError(service_provider.identifier or "")
+            raise RSDRequiredError(service_provider.identifier, service_provider.product_version)
         if service_provider.is_in_process_tunnel:
             raise RoutableTunnelRequiredError(
                 "Cannot print a remote LLDB connect address over a userspace tunnel: the device "

--- a/pymobiledevice3/cli/developer/fetch_symbols.py
+++ b/pymobiledevice3/cli/developer/fetch_symbols.py
@@ -31,7 +31,7 @@ async def fetch_symbols_list_task(service_provider: LockdownServiceProvider) -> 
     else:
         if not isinstance(service_provider, RemoteServiceDiscoveryService):
             assert isinstance(service_provider, LockdownClient)  # non-RSD providers are lockdown clients
-            raise RSDRequiredError(service_provider.identifier or "")
+            raise RSDRequiredError(service_provider.identifier, service_provider.product_version)
 
         async with RemoteFetchSymbolsService(service_provider) as fetch_symbols:
             print_json([f.file_path for f in await fetch_symbols.get_dsc_file_list()])
@@ -86,7 +86,7 @@ async def fetch_symbols_download_task(service_provider: LockdownServiceProvider,
     else:
         if not isinstance(service_provider, RemoteServiceDiscoveryService):
             assert isinstance(service_provider, LockdownClient)  # non-RSD providers are lockdown clients
-            raise RSDRequiredError(service_provider.identifier or "")
+            raise RSDRequiredError(service_provider.identifier, service_provider.product_version)
         async with RemoteFetchSymbolsService(service_provider) as fetch_symbols:
             await fetch_symbols.download(symbols_out)
 

--- a/pymobiledevice3/cli/diagnostics/battery.py
+++ b/pymobiledevice3/cli/diagnostics/battery.py
@@ -32,7 +32,11 @@ async def diagnostics_battery_monitor(service_provider: ServiceProviderDep) -> N
     while True:
         raw_info = await diagnostics.get_battery()
         if raw_info is None:
-            raise MissingValueError("device did not expose an IOPMPowerSource entry")
+            raise MissingValueError(
+                "device did not expose an IOPMPowerSource entry",
+                service_provider.udid,
+                service_provider.product_version,
+            )
         info = {
             "InstantAmperage": raw_info.get("InstantAmperage"),
             "Temperature": raw_info.get("Temperature"),

--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -70,6 +70,7 @@ __all__ = [
     "UnrecognizedSelectorError",
     "UnsupportedCommandError",
     "UserDeniedPairingError",
+    "UserspaceTunnelUnavailableError",
     "WdaError",
     "WebInspectorNotEnabledError",
     "WirError",
@@ -324,9 +325,13 @@ class DeveloperModeError(PyMobileDevice3Exception):
 class LockdownError(PyMobileDevice3Exception):
     """lockdown general error"""
 
-    def __init__(self, message: str, identifier: Optional[str] = None) -> None:
+    def __init__(self, message: str, identifier: Optional[str], product_version: str) -> None:
         super().__init__(message)
+        # identifier is Optional only to match the base LockdownClient contract (its constructor
+        # permits an unknown identifier); every factory-built client (usbmux/TCP/RemoteXPC)
+        # populates it. product_version is always set (the lockdown/RSD property never returns None).
         self.identifier = identifier
+        self.product_version = product_version
 
 
 class GetProhibitedError(LockdownError):
@@ -471,8 +476,9 @@ class DeprecationError(PyMobileDevice3Exception):
 class RSDRequiredError(PyMobileDevice3Exception):
     """The requested action requires an RSD object"""
 
-    def __init__(self, identifier: str) -> None:
+    def __init__(self, identifier: Optional[str], product_version: str) -> None:
         self.identifier = identifier
+        self.product_version = product_version
         super().__init__()
 
 
@@ -480,6 +486,13 @@ class RoutableTunnelRequiredError(PyMobileDevice3Exception):
     """The action exposes the device's tunnel address to an external process (e.g. lldb), which
     needs a kernel-routable tunnel. The active tunnel is an in-process userspace tunnel whose
     address is only reachable from this process."""
+
+
+class UserspaceTunnelUnavailableError(PyMobileDevice3Exception):
+    """The no-root in-process userspace tunnel cannot serve this device — e.g. iOS 17.0-17.3 (no
+    CoreDeviceProxy service) with the RemotePairing fallback disabled or no RemotePairing service
+    reachable. Callers that require an RSD (e.g. the CLI) can catch this and route to a privileged
+    kernel tunnel (``tunneld``) instead."""
 
 
 class SysdiagnoseTimeoutError(PyMobileDevice3Exception, TimeoutError):

--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -1026,7 +1026,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
         if verify_request and response.get("Request") != request:
             if response.get("Type") == RESTORED_SERVICE_TYPE:
                 raise IncorrectModeError(f"Incorrect mode returned. Got: {response}")
-            raise LockdownError(f"Incorrect response returned. Got: {response}")
+            raise LockdownError(f"Incorrect response returned. Got: {response}", self.identifier, self.product_version)
 
         error = response.get("Error")
         if error is not None:
@@ -1044,11 +1044,11 @@ class LockdownClient(ABC, LockdownServiceProvider):
                 "InvalidService": InvalidServiceError,
                 "InvalidConnection": InvalidConnectionError,
             }
-            raise exception_errors.get(error, LockdownError)(error, self.identifier)
+            raise exception_errors.get(error, LockdownError)(error, self.identifier, self.product_version)
 
         # iOS < 5: 'Error' is not present, so we need to check the 'Result' instead
         if response.get("Result") == "Failure":
-            raise LockdownError("", self.identifier)
+            raise LockdownError("", self.identifier, self.product_version)
 
         return response
 

--- a/pymobiledevice3/remote/remote_service_discovery.py
+++ b/pymobiledevice3/remote/remote_service_discovery.py
@@ -95,8 +95,12 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
 
     @property
     def product_version(self) -> str:
-        """Device OS version, taken from the RSD handshake ``peer_info``."""
-        return self._require_peer_info()["Properties"]["OSVersion"]
+        """Device OS version, taken from the RSD handshake ``peer_info`` (``"1.0"`` if absent).
+
+        Tolerates a missing ``OSVersion`` (mirrors ``LockdownClient.product_version``) so building an
+        ``InvalidServiceError`` never raises ``KeyError`` on the ``suppress(InvalidServiceError)``
+        checkin path (e.g. a device that offers no lockdown service, such as a VirtualMac)."""
+        return self._require_peer_info()["Properties"].get("OSVersion") or "1.0"
 
     @property
     def product_build_version(self) -> str:
@@ -112,7 +116,7 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
     def _lockdown(self) -> LockdownClient:
         """Return the remote lockdown client, raising if the device offers no lockdown service."""
         if self.lockdown is None:
-            raise InvalidServiceError("device does not offer a lockdown service")
+            raise InvalidServiceError("device does not offer a lockdown service", self.udid, self.product_version)
         return self.lockdown
 
     async def get_developer_mode_status(self) -> bool:
@@ -187,14 +191,16 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
 
             with suppress(InvalidServiceError):
                 self.lockdown = await create_using_remote(
-                    await self.start_lockdown_service("com.apple.mobile.lockdown.remote.trusted")
+                    await self.start_lockdown_service("com.apple.mobile.lockdown.remote.trusted"),
+                    identifier=self.udid,
                 )
 
             if self.lockdown is None:
                 # Reattempt with the untrusted service variant
                 with suppress(InvalidServiceError):
                     self.lockdown = await create_using_remote(
-                        await self.start_lockdown_service("com.apple.mobile.lockdown.remote.untrusted")
+                        await self.start_lockdown_service("com.apple.mobile.lockdown.remote.untrusted"),
+                        identifier=self.udid,
                     )
 
             self.all_values = self.lockdown.all_values if self.lockdown is not None else {}
@@ -352,7 +358,7 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         """
         service = self._require_peer_info()["Services"].get(name)
         if service is None:
-            raise InvalidServiceError(f"No such service: {name}")
+            raise InvalidServiceError(f"No such service: {name}", self.udid, self.product_version)
         return int(service["Port"])
 
     async def close(self) -> None:

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -49,7 +49,7 @@ from pmd_pytcp.socket import AF_INET6, SHUT_RDWR, SHUT_WR, SOCK_DGRAM, SOCK_STRE
 from pmd_pytcp.socket import socket as pytcp_socket
 
 import pymobiledevice3.remote.tunnel_service as tunnel_service
-from pymobiledevice3.exceptions import InvalidServiceError, PyMobileDevice3Exception
+from pymobiledevice3.exceptions import InvalidServiceError, PyMobileDevice3Exception, UserspaceTunnelUnavailableError
 from pymobiledevice3.lockdown import create_using_usbmux
 from pymobiledevice3.osu.os_utils import get_os_utils
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
@@ -549,7 +549,7 @@ class UserspaceUdp:
             self._sock.close()
 
 
-async def _create_no_root_tunnel_provider(serial: Optional[str], autopair: bool):
+async def _create_no_root_tunnel_provider(serial: Optional[str], autopair: bool, remotepairing_fallback: bool = True):
     """Pick a tunnel provider that needs no root, mirroring ``remote start-tunnel``'s family:
 
     * iOS 17.4+ over USB: :class:`~pymobiledevice3.remote.tunnel_service.CoreDeviceTunnelProxy`
@@ -561,21 +561,32 @@ async def _create_no_root_tunnel_provider(serial: Optional[str], autopair: bool)
     suspends remoted via :func:`stop_remoted`, which needs root on macOS — defeating the no-root
     purpose. Returns ``(provider, lockdown_or_None)``; the lockdown is kept alive for the
     CoreDeviceProxy provider and is ``None`` for the RemotePairing one.
+
+    ``remotepairing_fallback`` controls the pre-17.4 path: when ``True`` (default) a device with no
+    CoreDeviceProxy service falls back to RemotePairing over bonjour; when ``False`` it raises
+    :class:`UserspaceTunnelUnavailableError` immediately (used when the caller prefers to route such
+    devices elsewhere, e.g. a kernel tunnel). Either way, a device that cannot be served no-root
+    raises :class:`UserspaceTunnelUnavailableError`.
     """
     lockdown = await create_using_usbmux(serial=serial, autopair=autopair)
     try:
         return await tunnel_service.CoreDeviceTunnelProxy.create(lockdown), lockdown
     except InvalidServiceError:
-        # iOS < 17.4 has no CoreDeviceProxy lockdown service; fall back to the no-root WiFi path.
-        logger.info("CoreDeviceProxy unavailable (iOS < 17.4); falling back to RemotePairing over bonjour")
+        # iOS < 17.4 has no CoreDeviceProxy lockdown service.
         await lockdown.close()
+        if not remotepairing_fallback:
+            raise UserspaceTunnelUnavailableError(
+                "no-root userspace tunnel unavailable: the device has no CoreDeviceProxy service "
+                "(needs iOS 17.4+) and the RemotePairing fallback was disabled."
+            ) from None
+        logger.info("CoreDeviceProxy unavailable (iOS < 17.4); falling back to RemotePairing over bonjour")
     except BaseException:
         await lockdown.close()
         raise
 
     services = await tunnel_service.get_remote_pairing_tunnel_services(udid=serial)
     if not services:
-        raise PyMobileDevice3Exception(
+        raise UserspaceTunnelUnavailableError(
             "no-root userspace tunnel unavailable: the device exposes no CoreDeviceProxy lockdown "
             "service (needs iOS 17.4+) and no RemotePairing service was found over bonjour. Enable "
             "Wi-Fi for the device and host on the same network, or run a privileged kernel tunnel via "
@@ -627,9 +638,12 @@ class UserspaceRsdTunnel:
     iOS 17.4+, falling back to RemotePairing over bonjour on iOS 17.0-17.3 / Wi-Fi.
     """
 
-    def __init__(self, serial: Optional[str] = None, autopair: bool = True) -> None:
+    def __init__(
+        self, serial: Optional[str] = None, autopair: bool = True, remotepairing_fallback: bool = True
+    ) -> None:
         self.serial = serial
         self.autopair = autopair
+        self.remotepairing_fallback = remotepairing_fallback
         self.rsd: Optional[RemoteServiceDiscoveryService] = None
         self.tun: Optional[UserspaceTun] = None
         self._exit_stack: Optional[AsyncExitStack] = None
@@ -654,7 +668,9 @@ class UserspaceRsdTunnel:
         # order; a failure mid-setup unwinds whatever was already acquired.
         stack = AsyncExitStack()
         try:
-            provider, lockdown = await _create_no_root_tunnel_provider(self.serial, self.autopair)
+            provider, lockdown = await _create_no_root_tunnel_provider(
+                self.serial, self.autopair, self.remotepairing_fallback
+            )
             stack.push_async_callback(provider.close)
             if lockdown is not None:
                 stack.push_async_callback(lockdown.close)
@@ -718,16 +734,22 @@ class UserspaceRsdTunnel:
 _cli_tunnel: Optional[UserspaceRsdTunnel] = None
 
 
-async def establish_userspace_rsd(serial: Optional[str] = None, autopair: bool = True) -> RemoteServiceDiscoveryService:
+async def establish_userspace_rsd(
+    serial: Optional[str] = None, autopair: bool = True, remotepairing_fallback: bool = True
+) -> RemoteServiceDiscoveryService:
     """CLI convenience: establish a userspace tunnel, keep it alive, and return its connected RSD.
 
     Embedders should use :class:`UserspaceRsdTunnel` directly — it is a closeable handle / async
     context manager. This wrapper exists for the CLI, which has no teardown hook: it stashes the
     tunnel for the process lifetime and registers :func:`force_exit` at exit so the CLI exits
     promptly without awaiting teardown.
+
+    ``remotepairing_fallback=False`` makes a pre-17.4 device (no CoreDeviceProxy) raise
+    :class:`UserspaceTunnelUnavailableError` instead of attempting RemotePairing, so the caller can
+    route such devices elsewhere (the CLI uses this to fall back to ``tunneld``).
     """
     global _cli_tunnel
-    tunnel = UserspaceRsdTunnel(serial=serial, autopair=autopair)
+    tunnel = UserspaceRsdTunnel(serial=serial, autopair=autopair, remotepairing_fallback=remotepairing_fallback)
     rsd = await tunnel.aopen()
     _cli_tunnel = tunnel
     # The pure-asyncio stack has no threads to park, so process exit cannot hang anymore. The


### PR DESCRIPTION
## Summary

When a developer command targeting an iOS 17+ device fails with `InvalidServiceError` / `RSDRequiredError` (i.e. it needs an RSD tunnel), the CLI auto-retries once. Until now that retry always went over **tunneld** (`--tunnel`), which requires a privileged `sudo pymobiledevice3 remote tunneld` running in the background.

This changes the automatic fallback to prefer the **in-process userspace tunnel** (`--userspace`, no root/admin), which is the right default for the common iOS 17.4+ case where it works root-free over USB.

## The one exception: iOS 17.0-17.3 over USB

The userspace tunnel cannot serve an iOS 17.0-17.3 device over USB:

- It has no `CoreDeviceProxy` lockdown service (that's iOS 17.4+).
- It isn't discoverable over the Wi-Fi RemotePairing bonjour path the userspace tunnel falls back to (`get_remote_pairing_tunnel_services` only finds Wi-Fi devices).

The only transport that can serve it is the RSD/USB path, which SIGSTOPs `remoted` (needs root) and is therefore reachable only via `tunneld`. So that specific case (macOS + iOS 17.0-17.3 + USB) is routed back to the tunneld fallback via `device_needs_kernel_tunnel_fallback()`. iOS 17.4+ keeps the no-root userspace tunnel as the default.

## Changes

- `pymobiledevice3/__main__.py`:
  - Auto-retry now defaults to `PYMOBILEDEVICE3_USERSPACE`; the device identifier is propagated via `PYMOBILEDEVICE3_UDID` so userspace targets the same device.
  - New `device_needs_kernel_tunnel_fallback()` helper routes only the macOS iOS 17.0-17.3-over-USB case back to `PYMOBILEDEVICE3_TUNNEL` (tunneld).
  - Either env var doubles as the one-shot retry guard, so no retry loop.
  - Warning messages point users at the right knob for their case.

## Notes

- Explicitly passing `--tunnel` or `--userspace` still short-circuits the auto-fallback (unchanged).
- Commands that genuinely cannot run over a userspace tunnel (e.g. `developer debugserver` driving external lldb) already raise their own explicit guidance pointing at `--tunnel` / `remote tunneld`.
