### PR TITLE
deps: support construct-typing 0.8.0 (fix CI)

### DIFF
--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -29,7 +29,7 @@ from typing import Any, Callable, Optional, TextIO, Union
 
 import hexdump
 from click.exceptions import Exit
-from construct import Const, CString, GreedyRange, Int64ul, Tell
+from construct import Bytes, Const, CString, GreedyRange, Int64ul, Tell
 from construct_typed import DataclassMixin, EnumBase, TEnum, TStruct, csfield
 from parameter_decorators import path_to_str
 from pygments import formatters, highlight, lexers
@@ -46,6 +46,13 @@ from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.services.lockdown_service import LockdownService
 from pymobiledevice3.utils import get_asyncio_loop, try_decode
+
+try:
+    # construct-typing >= 0.8.0 rejects csfield(Const(...)) and requires csfield_const() for const
+    # fields. Older versions (0.7.x, the Python 3.9 floor) have no csfield_const.
+    from construct_typed import csfield_const
+except ImportError:  # construct-typing < 0.8.0
+    csfield_const = None
 
 MAXIMUM_READ_SIZE = 4 * 1024**2  # 4 MB
 MODE_MASK = 0o0000777
@@ -170,10 +177,16 @@ MAXIMUM_WRITE_SIZE = 1 << 30
 
 AFCMAGIC = b"CFA6LPAA"
 
+# construct-typing >= 0.8.0 requires csfield_const() for const fields; 0.7.x (the Python 3.9 floor)
+# only has csfield(Const(...)). Pick the form the installed version supports.
+_afc_magic_field = (
+    csfield_const(Bytes(len(AFCMAGIC)), AFCMAGIC) if csfield_const is not None else csfield(Const(AFCMAGIC))
+)
+
 
 @dataclass
 class AfcHeader(DataclassMixin):
-    magic: bytes = csfield(Const(AFCMAGIC))
+    magic: bytes = _afc_magic_field
     entire_length: int = csfield(Int64ul)
     this_length: int = csfield(Int64ul)
     packet_num: int = csfield(Int64ul)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 construct>=2.9.29
-construct-typing>=0.7.0
+# construct-typing 0.8.0 requires Python >= 3.10 and replaces csfield(Const(...)) with
+# csfield_const() (see afc.py). Keep the 3.9 floor on the last 0.7.x release.
+construct-typing>=0.8.0 ; python_version >= '3.10'
+construct-typing>=0.7.0,<0.8.0 ; python_version < '3.10'
 asn1
 coloredlogs
 IPython


### PR DESCRIPTION
## Summary

`construct-typing 0.8.0` (released 2026-07-20) broke CI on every branch: it now rejects
`csfield(Const(...))` at import time (raising `DataclassFieldError`, directing to `csfield_const()`),
which `AfcHeader.magic` in `pymobiledevice3/services/afc.py` used. Because `requirements.txt` pinned
`construct-typing>=0.7.0` with no upper bound, CI picked up 0.8.0 and failed at collection time
(`conftest.py` → … → `afc.py`).

This adds support for 0.8.0 while keeping the project's Python 3.9 floor (0.8.0 requires 3.10+).

## Changes

- **`afc.py`**: `AfcHeader.magic` uses `csfield_const(Bytes(len(AFCMAGIC)), AFCMAGIC)` when
  `csfield_const` is available (construct-typing ≥ 0.8.0), falling back to `csfield(Const(AFCMAGIC))`
  on 0.7.x. Wire format is unchanged (verified build/parse roundtrip on both versions).
- **`requirements.txt`**: version markers —
  `construct-typing>=0.8.0` on Python ≥ 3.10, `>=0.7.0,<0.8.0` on 3.9 (mirrors the existing
  marker pattern used for typer / pmd-pytcp / sslpsk).

## Testing

- Python 3.9 floor path (0.7.x): `csfield(Const(...))` — build/parse roundtrip OK.
- Python 3.10+ path (0.8.0): `csfield_const(...)` — build/parse roundtrip OK.
- `AfcHeader(...)` is never constructed with `magic`, so 0.8.0's `init=False` on `csfield_const`
  matches existing usage.
