### PR TITLE
userspace tunnel: 13x faster interactive round-trips (delayed-ACK + egress batching)

### DIFF
--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -207,7 +207,17 @@ class RemotePairingTunnel(ABC):
     async def tun_read_task(self) -> None:
         read_size = self.tun.mtu + len(LOOPBACK_HEADER)
         try:
-            if sys.platform == "win32":
+            if hasattr(self.tun, "async_read_batch"):
+                # Userspace tun (pure-asyncio pmd-pytcp), any platform: drain the stack's whole
+                # egress burst per event-loop wakeup instead of paying one loop reschedule per
+                # packet — the userspace counterpart of _tun_read_loop_via_reader's batch-drain
+                # below. The loop this task runs on also runs the whole pytcp stack, so at
+                # MSS-sized packets a per-packet reschedule caps uploads at a few MB/s.
+                while True:
+                    for packet in await self.tun.async_read_batch():
+                        if packet and (packet[0] >> 4) == 6:
+                            await self.send_packet_to_device(packet)
+            elif sys.platform == "win32":
                 while True:
                     packet = await self.tun.async_read()
                     if packet:
@@ -228,8 +238,8 @@ class RemotePairingTunnel(ABC):
                 # the fd) keeps its blocking semantics.
                 await self._tun_read_loop_via_reader(read_size)
             else:
-                # Userspace tun (pure-asyncio pmd-pytcp): await raw IPv6 packets directly off
-                # the stack's egress — same surface as the Windows branch above.
+                # Any other async tun (no batch surface): await raw IPv6 packets one at a time —
+                # same surface as the Windows branch above.
                 while True:
                     packet = await self.tun.async_read()
                     if packet and (packet[0] >> 4) == 6:

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -86,18 +86,36 @@ MAX_RECV_WINDOW = 4 * 1024 * 1024
 #: path. The advertised receive MSS is untouched, so downloads stay fast.
 MAX_SEND_MSS = 1340
 
+#: Delayed-ACK timer (PyTCP 'tcp.delayed_ack.delay_ms'; RFC default 100). The device Nagle-holds
+#: the tail segment of every multi-segment response until our ACK arrives, so each DTX/RemoteXPC
+#: round-trip stalls one full timer: measured `dvt ls /` latency is delay + ~7 ms link RTT,
+#: linear across 1..100 ms (110 ms at the default, 8 ms at 1 ms). 1 ms effectively ACKs
+#: immediately; bulk transfers are unaffected either way (streams are governed by the
+#: ACK-every-other-segment rule, not the timer — measured 38-39 MB/s at 1/10/100 ms alike).
+ACK_DELAY_MS = 1
+
 
 def throughput_sysctls() -> dict[str, int]:
-    """The ``stack.init(sysctls=...)`` entries that tune the tunnel for bulk transfer.
+    """The ``stack.init(sysctls=...)`` entries that tune the tunnel for bulk transfer and latency.
 
     These ride pmd-pytcp's public sysctls: ``tcp.rcv_wnd_max`` raises the advertised receive
     window for fast downloads; ``tcp.snd_mss_max`` caps host->device segments so a large
-    interface MTU does not stall uploads. Any knob the installed pmd-pytcp does not register is
-    omitted (with a warning) so the tunnel runs untuned rather than failing.
+    interface MTU does not stall uploads; ``tcp.delayed_ack.delay_ms`` drops the delayed-ACK
+    timer so interactive request/response services are not stalled by it (:data:`ACK_DELAY_MS`).
+    Any knob the installed pmd-pytcp does not register is omitted (with a warning) so the tunnel
+    runs untuned rather than failing.
     """
-    wanted = {"tcp.rcv_wnd_max": MAX_RECV_WINDOW, "tcp.default.snd_mss_max": MAX_SEND_MSS}
+    wanted = {
+        "tcp.rcv_wnd_max": MAX_RECV_WINDOW,
+        "tcp.default.snd_mss_max": MAX_SEND_MSS,
+        "tcp.delayed_ack.delay_ms": ACK_DELAY_MS,
+    }
     # The registry lists base keys, so an interface-scope knob is checked by its base name.
-    base_key = {"tcp.rcv_wnd_max": "tcp.rcv_wnd_max", "tcp.default.snd_mss_max": "tcp.snd_mss_max"}
+    base_key = {
+        "tcp.rcv_wnd_max": "tcp.rcv_wnd_max",
+        "tcp.default.snd_mss_max": "tcp.snd_mss_max",
+        "tcp.delayed_ack.delay_ms": "tcp.delayed_ack.delay_ms",
+    }
     registered = sysctl.list_keys()
     out: dict[str, int] = {}
     for key, value in wanted.items():

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -81,9 +81,9 @@ INTERFACE_MTU = 16000
 MAX_RECV_WINDOW = 4 * 1024 * 1024
 
 #: Cap on the host->device send MSS (PyTCP 'tcp.snd_mss_max'; 0 = uncapped). 1340 (= a 1400-byte
-#: IPv6 packet minus 40+20 headers) is the proven-safe send size; a larger interface MTU keeps
-#: downloads fast (big device->host segments) while uploads avoid RTO stalls on the forwarding
-#: path. The advertised receive MSS is untouched, so downloads stay fast.
+#: IPv6 packet minus 40+20 headers) is the proven-safe send size across devices; a larger
+#: interface MTU keeps downloads fast (big device->host segments) while uploads avoid RTO stalls
+#: on the forwarding path. The advertised receive MSS is untouched, so downloads stay fast.
 MAX_SEND_MSS = 1340
 
 #: Delayed-ACK timer (PyTCP 'tcp.delayed_ack.delay_ms'; RFC default 100). The device Nagle-holds
@@ -142,6 +142,13 @@ def _mac_to_bytes(mac: str) -> bytes:
 
 def _eth_header(dst_mac: str, src_mac: str) -> bytes:
     return _mac_to_bytes(dst_mac) + _mac_to_bytes(src_mac) + struct.pack("!H", _ETH_IPV6)
+
+
+#: Hot-path constants: the (fixed) Ethernet header prepended to every inbound packet, and the
+#: EtherType bytes checked on every outbound frame — precomputed so the per-packet paths do no
+#: string parsing / struct packing.
+_ETH_HDR_TO_STACK = _eth_header(_STACK_MAC, _PEER_MAC)
+_ETH_IPV6_BYTES = struct.pack("!H", _ETH_IPV6)
 
 
 def _packet_socketpair() -> tuple[socket.socket, socket.socket]:
@@ -233,7 +240,7 @@ class UserspaceTun:
         # socket is non-blocking; a full buffer drops the packet (tunnel loss, TCP recovers).
         ipv6 = data[len(LOOPBACK_HEADER) :] if data[: len(LOOPBACK_HEADER)] == LOOPBACK_HEADER else data
         with suppress(OSError):
-            self._peer.send(_eth_header(_STACK_MAC, _PEER_MAC) + ipv6)
+            self._peer.send(_ETH_HDR_TO_STACK + ipv6)
 
     async def async_read(self) -> bytes:
         # outbound (stack -> device): await an Ethernet frame off the stack's socketpair and
@@ -241,10 +248,29 @@ class UserspaceTun:
         # nibble). Raises OSError once the socketpair is closed, which ends tun_read_task.
         while not self._closed:
             frame = await asyncio.get_running_loop().sock_recv(self._peer, 65535)
-            if len(frame) < 14 or struct.unpack("!H", frame[12:14])[0] != _ETH_IPV6:
+            if len(frame) < 14 or frame[12:14] != _ETH_IPV6_BYTES:
                 continue
             return frame[14:]
         return b""
+
+    async def async_read_batch(self) -> list[bytes]:
+        """Await at least one outbound frame, then greedily drain every further frame already
+        queued on the socketpair, returning their raw IPv6 payloads in arrival order.
+
+        One event-loop wakeup services a whole egress burst — the userspace counterpart of the
+        kernel tun's ``_tun_read_loop_via_reader`` batch-drain. Paying a loop reschedule per
+        MSS-sized packet caps uploads at a few thousand packets/s, because the same loop also
+        runs the pytcp stack. Raises OSError once the socketpair is closed, which ends
+        ``tun_read_task``."""
+        frame = await asyncio.get_running_loop().sock_recv(self._peer, 65535)
+        packets = []
+        while True:
+            if len(frame) > 14 and frame[12:14] == _ETH_IPV6_BYTES:
+                packets.append(frame[14:])
+            try:
+                frame = self._peer.recv(65535)
+            except (BlockingIOError, InterruptedError):
+                return packets
 
     async def connect_tcp(self, addr: str, port: int):
         """Open a PyTCP TCP socket connected to (addr, port) over this stack."""

--- a/tests/test_userspace_tunnel.py
+++ b/tests/test_userspace_tunnel.py
@@ -41,6 +41,8 @@ def test_throughput_sysctls_values_when_supported():
         pytest.skip("installed pmd-pytcp predates the throughput sysctls")
     assert knobs["tcp.rcv_wnd_max"] == userspace_tunnel.MAX_RECV_WINDOW
     assert knobs["tcp.default.snd_mss_max"] == userspace_tunnel.MAX_SEND_MSS
+    if "tcp.delayed_ack.delay_ms" in sysctl.list_keys():
+        assert knobs["tcp.delayed_ack.delay_ms"] == userspace_tunnel.ACK_DELAY_MS
 
 
 def test_throughput_sysctls_round_trip_through_sysctl_set():


### PR DESCRIPTION
## What

Two device-independent performance fixes for the userspace (no-root) tunnel — no behavior change beyond timing, no new configuration, safe on every device/OS/Python:

1. **Drop the pytcp delayed-ACK timer to 1 ms** (`tcp.delayed_ack.delay_ms`, RFC default 100). The device Nagle-holds the tail segment of every multi-segment response until our stack ACKs the previous one, so **every DTX/RemoteXPC round-trip stalled for one full timer**. Measured latency is exactly `delay + ~7 ms link RTT`, linear across 1..100 ms.
2. **Batch-drain the stack egress** (`async_read_batch`): the userspace branch of `tun_read_task` paid one event-loop reschedule per outbound packet, on the same loop that runs the whole pytcp stack — the exact pathology the kernel-tun path already fixes with `_tun_read_loop_via_reader`. One wakeup now services a whole burst. This also moves Windows off the per-packet `win32` branch. Per-packet constants (Ethernet header build, EtherType unpack) are hoisted out of the hot paths.

## Measurements (iPhone12,1, USB)

| metric | before | after |
|---|---|---|
| `dvt ls /` round-trip | 110 ms | **8 ms** |
| RSD connect | 400 ms | ~85 ms |
| DTX service connect | 190 ms | ~78 ms |
| full `dvt ls /` CLI | 1.45 s | **0.82 s** |
| DSC download | 39 MB/s | 39 MB/s (unchanged) |
| AFC small push | 17 ms | 15 ms |

The delayed-ACK sweep was run at 1/5/10/25/50/100 ms — latency is strictly linear in the timer and bulk throughput is completely insensitive to it (streams are paced by the ACK-every-other-segment rule, not the timer), so 1 ms is the optimum with no tradeoff.

Both knobs ride the existing registered-sysctl check, so an older pmd-pytcp logs a warning and runs untuned instead of failing.

## Not in this PR

The upload-throughput work (the device-side ~8.2 KB packet-size drop threshold, MSS probing via fixed PLPMTUD in pmd-pytcp 0.1.1) lands separately — it is device-dependent and gated behind an opt-in until pmd-pytcp grows RFC 8899 §4.3 black-hole demotion.