### PR TITLE
userspace_tunnel: dynamic send-MSS via PLPMTUD — discover each device's real packet limit

### DIFF
--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -213,6 +213,12 @@ class RemotePairingTunnel(ABC):
                 # packet — the userspace counterpart of _tun_read_loop_via_reader's batch-drain
                 # below. The loop this task runs on also runs the whole pytcp stack, so at
                 # MSS-sized packets a per-packet reschedule caps uploads at a few MB/s.
+                # NOTE: each packet MUST go out as its own send_packet_to_device call — do NOT
+                # coalesce the burst into one transport write. The CoreDeviceProxy forwarding
+                # path is read-boundary-sensitive: it expects each inner IPv6 packet to arrive
+                # as (roughly) its own read unit, and a concatenated burst destroys the
+                # boundaries — measured on iOS 26.5/USB: upload collapses to ~1 MB/s and the
+                # tunnel connection eventually dies outright.
                 while True:
                     for packet in await self.tun.async_read_batch():
                         if packet and (packet[0] >> 4) == 6:

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -47,7 +47,6 @@ from pmd_pytcp.lib.interface_layer import InterfaceLayer
 from pmd_pytcp.lib.io_backend import register_interface_fd, unregister_interface_fd
 from pmd_pytcp.socket import AF_INET6, SHUT_RDWR, SHUT_WR, SOCK_DGRAM, SOCK_STREAM
 from pmd_pytcp.socket import socket as pytcp_socket
-from pmd_pytcp.stack import sysctl
 
 import pymobiledevice3.remote.tunnel_service as tunnel_service
 from pymobiledevice3.exceptions import InvalidServiceError, PyMobileDevice3Exception
@@ -70,8 +69,8 @@ _PEER_MAC = "02:00:00:00:00:02"
 
 #: Ceiling on the PyTCP interface MTU. The tunnel negotiates 16000; a large interface MTU
 #: makes downloads fast (the device sends big segments to us). Host->device segments are
-#: bounded separately by the tcp.snd_mss_max sysctl (:data:`MAX_SEND_MSS`), so a large
-#: value is safe here.
+#: governed separately by PLPMTUD (seeded at :data:`BASE_MSS_SEED`, raised only through
+#: device-ACKed sizes), so a large value is safe here.
 INTERFACE_MTU = 16000
 
 #: Receive-window ceiling (PyTCP 'tcp.rcv_wnd_max'; default 65535). A download is bounded by
@@ -80,11 +79,30 @@ INTERFACE_MTU = 16000
 #: fetch: 64 KB window -> 8 MB/s, 4 MiB window -> 40 MB/s (kernel-tunnel parity).
 MAX_RECV_WINDOW = 4 * 1024 * 1024
 
-#: Cap on the host->device send MSS (PyTCP 'tcp.snd_mss_max'; 0 = uncapped). 1340 (= a 1400-byte
-#: IPv6 packet minus 40+20 headers) is the proven-safe send size across devices; a larger
-#: interface MTU keeps downloads fast (big device->host segments) while uploads avoid RTO stalls
-#: on the forwarding path. The advertised receive MSS is untouched, so downloads stay fast.
-MAX_SEND_MSS = 1340
+#: PLPMTUD cold-start seed (PyTCP 'tcp.base_mss'): host->device segments START at
+#: ``1400 - 60 = 1340`` payload — the proven-safe size across devices (= the static
+#: ``tcp.snd_mss_max`` = 1340 cap this replaced) — and only grow through packet sizes the
+#: device has actually ACKed, as
+#: RFC 4821/8899 probing (PyTCP 'tcp.mtu_probing') walks the ladder upward. A failed probe
+#: costs one RACK-repaired segment and narrows the search; it never stalls the transfer. So the
+#: worst case on any device/transport equals the old fixed-1340 behaviour, while paths that
+#: forward bigger packets (measured: USB CoreDeviceProxy drops host->device IPv6 packets over
+#: 8192 bytes total but passes everything below) converge to their real limit and upload several
+#: times faster. No per-device packet size is hardcoded anywhere.
+BASE_MSS_SEED = 1400
+
+#: RFC 8899 PROBE_TIMER (PyTCP 'tcp.plpmtud.probe_timer_ms'; RFC default 30000). The backstop
+#: loss-declaration for an MTU probe that dies without triggering loss recovery. The tunnel RTT
+#: is a few ms, so 30 s would park the search for a whole transfer; in-band signals
+#: (fast-retransmit/RACK/TLP recovery entry) normally beat this timer by orders of magnitude.
+PROBE_TIMER_MS = 1500
+
+#: RTO floor (PyTCP 'tcp.rto.min_ms'; RFC 6298 default 1000). The tunnel RTT is single-digit
+#: milliseconds, so the RFC's 1 s floor makes every genuine stall — including a PLPMTUD
+#: black-hole revert, which fires exactly once per over-large probe rung — cost ~200x the RTT.
+#: 200 ms matches Linux's floor and keeps MSS-search convergence under a second while staying
+#: ~40x above the observed RTT (no spurious-RTO risk; RACK/TLP handle tail losses first).
+MIN_RTO_MS = 200
 
 #: Delayed-ACK timer (PyTCP 'tcp.delayed_ack.delay_ms'; RFC default 100). The device Nagle-holds
 #: the tail segment of every multi-segment response until our ACK arrives, so each DTX/RemoteXPC
@@ -99,31 +117,26 @@ def throughput_sysctls() -> dict[str, int]:
     """The ``stack.init(sysctls=...)`` entries that tune the tunnel for bulk transfer and latency.
 
     These ride pmd-pytcp's public sysctls: ``tcp.rcv_wnd_max`` raises the advertised receive
-    window for fast downloads; ``tcp.snd_mss_max`` caps host->device segments so a large
-    interface MTU does not stall uploads; ``tcp.delayed_ack.delay_ms`` drops the delayed-ACK
-    timer so interactive request/response services are not stalled by it (:data:`ACK_DELAY_MS`).
-    Any knob the installed pmd-pytcp does not register is omitted (with a warning) so the tunnel
-    runs untuned rather than failing.
+    window for fast downloads; ``tcp.delayed_ack.delay_ms`` drops the delayed-ACK timer so
+    interactive request/response services are not stalled by it (:data:`ACK_DELAY_MS`).
+
+    Host->device segment sizing is dynamic: RFC 4821/8899 PLPMTUD (``tcp.mtu_probing`` = 2)
+    starts every connection at the proven-safe 1340-byte send MSS (``tcp.base_mss`` =
+    :data:`BASE_MSS_SEED`) and raises it only through packet sizes the device has actually
+    ACKed, so each device/transport converges to its own real forwarding limit with no
+    hardcoded per-device size and a worst case equal to the old static 1340 cap.
+
+    Every knob here is guaranteed by the pmd-pytcp version floor in requirements.txt — no
+    capability probing.
     """
-    wanted = {
+    return {
         "tcp.rcv_wnd_max": MAX_RECV_WINDOW,
-        "tcp.default.snd_mss_max": MAX_SEND_MSS,
         "tcp.delayed_ack.delay_ms": ACK_DELAY_MS,
+        "tcp.rto.min_ms": MIN_RTO_MS,
+        "tcp.default.mtu_probing": 2,
+        "tcp.default.base_mss": BASE_MSS_SEED,
+        "tcp.plpmtud.default.probe_timer_ms": PROBE_TIMER_MS,
     }
-    # The registry lists base keys, so an interface-scope knob is checked by its base name.
-    base_key = {
-        "tcp.rcv_wnd_max": "tcp.rcv_wnd_max",
-        "tcp.default.snd_mss_max": "tcp.snd_mss_max",
-        "tcp.delayed_ack.delay_ms": "tcp.delayed_ack.delay_ms",
-    }
-    registered = sysctl.list_keys()
-    out: dict[str, int] = {}
-    for key, value in wanted.items():
-        if base_key[key] in registered:
-            out[key] = value
-        else:
-            logger.warning("userspace tunnel: installed pmd-pytcp lacks the %r sysctl; running untuned", base_key[key])
-    return out
 
 
 #: Datagram socketpair buffer, sized to hold a burst of a full receive window of packets.

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,8 +51,9 @@ av>=14.0.0 ; platform_system != "Darwin"
 # (https://github.com/doronz88/pmd-pytcp). Pulls its pmd-net-addr / pmd-net-proto siblings in
 # transitively. Supported on Python 3.9+ (the whole pymobiledevice3 range); if the import or
 # stack init fails the tunnel transparently falls back to the kernel path (see cli_common).
-# 0.1.0 floor: the pure-asyncio stack — the socket API is awaited (async
-# connect/accept/recv/send), stack.start()/stop() are coroutines and no worker threads exist;
-# userspace_tunnel.py is written against that API and cannot drive the older threaded stack.
-# (Supersedes the temporary >=0.0.6,<0.1.0 cap that guarded master against the 0.1.0 break.)
-pmd-pytcp>=0.1.0 ; python_version >= "3.9"
+# 0.2.0 floor: dynamic send-MSS via working RFC 4821/8899 PLPMTUD (probing sysctls
+# tcp.mtu_probing / tcp.base_mss / tcp.plpmtud.probe_timer_ms, the tcp.rto.min_ms floor, and
+# the runtime 'log.enabled' hot-path gate). userspace_tunnel.py sets these knobs
+# unconditionally — no capability probing — so the floor IS the compatibility contract.
+# (0.1.0 introduced the pure-asyncio stack the module is written against.)
+pmd-pytcp>=0.2.0 ; python_version >= "3.9"


### PR DESCRIPTION
## What

Replaces the userspace tunnel's static 1340-byte send-MSS cap with RFC 4821/8899 path probing, riding pmd-pytcp 0.2.0's fixed PLPMTUD engine. Every connection starts at the same proven-safe 1340-byte seed (`tcp.base_mss = 1400`) and raises its send MSS **only through packet sizes the device has actually ACKed** — so each device/transport converges to its own real forwarding limit with nothing hardcoded, and the worst case on any device equals the old static-cap behaviour.

## Why dynamic (and not a bigger static cap)

Measured on an iPhone 17,3 (iOS 26.5, USB CoreDeviceProxy): host→device IPv6 packets pass below ~8.2 KB and collapse above it — but the limit is device/transport-specific, and worse, this forwarder passes oversized packets *in isolation* while dropping them under sustained load (usbmuxd/USB boundary preservation is load-dependent). Any hardcoded bump would break some devices; probing with pmd-pytcp 0.2.0's multi-ACK validation + RTO-driven black-hole revert trusts a size only while the stream itself stays healthy.

## Measured (100 MB afc, payload-only)

| | master | this PR |
|---|---|---|
| push (host→device) | 9.1 MB/s (CLI 16.1 s) | **~25 MB/s (CLI 4.8 s)** |
| pull (device→host) | ~65 MB/s | **~85 MB/s** |
| DSC `fetch-symbols` | 63 MB/s | **79 MB/s** |

Pull/DSC gains come from pmd-pytcp 0.2.0's runtime log gate (the stack no longer formats debug strings per packet when logging is off). Verified with byte-exact `cmp` round-trips over repeated runs; interactive latency (`afc ls`) unaffected.

## Config

`throughput_sysctls()` now sets `tcp.mtu_probing=2`, `tcp.base_mss=1400`, `tcp.plpmtud.probe_timer_ms=1500` and `tcp.rto.min_ms=200` (loss-declaration and revert stalls proportional to the tunnel's ~5 ms RTT, Linux-style floor) unconditionally — requirements.txt floors pmd-pytcp at 0.2.0, so the version floor is the compatibility contract, no capability probing.

Also documents in `tun_read_task` why egress packets must never be coalesced into one transport write: the CoreDeviceProxy forwarding path is read-boundary-sensitive, and a concatenated burst collapses upload to ~1 MB/s and then kills the tunnel (measured).