### PR TITLE
cli: require -vv for DTX message traffic logs

### DIFF
--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -84,6 +84,8 @@ def print_hex(data, colored=True) -> None:
 
 def set_verbosity(level: int) -> None:
     coloredlogs.set_level(logging.INFO - (level * 10))
+    # DTX message traffic is very chatty -- require -vv to see it
+    logging.getLogger("pymobiledevice3.dtx").setLevel(logging.DEBUG if level >= 2 else logging.INFO)
 
 
 def set_color_flag(value: bool) -> None:


### PR DESCRIPTION
The `DTXConnection` sent/received DEBUG lines flood the output of every `developer dvt` command at plain `-v`. Pin the `pymobiledevice3.dtx` logger namespace to INFO unless verbosity is 2 or higher (`-vv`).