### PR TITLE
userspace_tunnel: fix tun-up address race; fix stale sysctl test

### DIFF
--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -242,6 +242,19 @@ class UserspaceTun:
             ip4_support=False,
         )
         await stack.start()
+        # The interface address is installed by the stack's own tasks shortly AFTER start()
+        # returns; until it lands, source-address selection finds no local host and a stack
+        # connect fails with gaierror. Today the dial plane's localhost-relay hop happens to
+        # add enough event-loop round trips to win that race, but nothing guarantees it — and
+        # an embedder calling connect_tcp() right after aopen() has no such slack. The tun is
+        # not "up" until its address is actually usable, so wait for it (yielding, not
+        # sleeping: the install normally lands within a loop tick or two).
+        target = Ip6Address(self._addr)
+        deadline = asyncio.get_running_loop().time() + 5
+        while not any(host.address == target for host in stack.local_ip6_hosts()):
+            if asyncio.get_running_loop().time() > deadline:
+                raise PyMobileDevice3Exception(f"userspace stack address {self._addr} was not assigned within 5s")
+            await asyncio.sleep(0)
         logger.debug("userspace tunnel up: pytcp L2 iface=%s addr=%s/64 mtu=%s", self._ifidx, self._addr, self._mtu)
 
     def set_peer(self, device_addr: str) -> None:

--- a/tests/test_userspace_tunnel.py
+++ b/tests/test_userspace_tunnel.py
@@ -197,3 +197,26 @@ async def test_relaying_spawns_no_threads():
         assert set(threading.enumerate()) == baseline
     for writer in writers:
         writer.close()
+
+
+async def test_tun_address_usable_when_up_returns():
+    # The stack installs the interface address from its own tasks shortly AFTER stack.start()
+    # returns, so up() must not return before the address is usable: a connect issued right
+    # after tunnel-up would find no local source address and fail with gaierror. The relay
+    # dial path happens to add enough event-loop round trips to win that race today, but an
+    # embedder calling connect_tcp() straight after aopen() has no such slack.
+    from pmd_net_addr import Ip6Address
+    from pmd_pytcp import stack
+
+    from pymobiledevice3.remote.userspace_tunnel import UserspaceTun
+
+    tun = UserspaceTun()
+    tun.addr = "fd57:6e64:6572:7761::1"
+    try:
+        await tun.up()
+        target = Ip6Address(tun.addr)
+        assert any(host.address == target for host in stack.local_ip6_hosts()), (
+            "up() returned before the stack address was usable for source-address selection"
+        )
+    finally:
+        await tun.close()

--- a/tests/test_userspace_tunnel.py
+++ b/tests/test_userspace_tunnel.py
@@ -40,7 +40,8 @@ def test_throughput_sysctls_values_when_supported():
     if "tcp.rcv_wnd_max" not in sysctl.list_keys():
         pytest.skip("installed pmd-pytcp predates the throughput sysctls")
     assert knobs["tcp.rcv_wnd_max"] == userspace_tunnel.MAX_RECV_WINDOW
-    assert knobs["tcp.default.snd_mss_max"] == userspace_tunnel.MAX_SEND_MSS
+    assert knobs["tcp.default.base_mss"] == userspace_tunnel.BASE_MSS_SEED
+    assert knobs["tcp.default.mtu_probing"] == 2
     if "tcp.delayed_ack.delay_ms" in sysctl.list_keys():
         assert knobs["tcp.delayed_ack.delay_ms"] == userspace_tunnel.ACK_DELAY_MS
 


### PR DESCRIPTION
## What

Two stability fixes for the userspace tunnel, both currently masked or failing on master:

### 1. `UserspaceTun.up()` returns before the stack address is usable

The pytcp stack installs the interface address from its own tasks shortly **after** `stack.start()` returns. Until it lands, source-address selection finds no local host and any connect on the stack fails with `gaierror("Malformed remote IP address")`.

Today the dial plane's localhost-relay hop happens to add enough event-loop round trips to win this race, but nothing guarantees it — and an embedder calling `connect_tcp()` right after `aopen()` has no such slack (reproduced deterministically while experimenting with a direct, relay-free dial path).

`up()` now waits (yielding to the loop, bounded at 5s) until the address appears in `stack.local_ip6_hosts()`, so "tun up" means "address usable". Includes a regression test that fails without the fix.

### 2. Stale throughput-sysctl test failing on master

`test_throughput_sysctls_values_when_supported` still asserted the removed `MAX_SEND_MSS` / `tcp.default.snd_mss_max` knob (replaced by dynamic PLPMTUD in the pmd-pytcp 0.2.0 migration) and has been failing since. It now asserts the current knobs (`tcp.default.base_mss`, `tcp.default.mtu_probing`).

## Testing

- `tests/test_userspace_tunnel.py`: 8/8 pass; the new regression test verified to fail with the fix reverted
- Full suite: 379 passed; the only 3 failures (2× sysmon, 1× encrypted backup) fail identically on unmodified master
- Real device (iPhone17,3 / iOS 26.5, USB): `developer dvt ls / --userspace` and `developer dvt screenshot --userspace` pass; `dvt ls` wall time unchanged (0.48s median, 5 runs each)