### PR TITLE
userspace tunnel: enable RX checksum offload (~+35% bulk download)

### DIFF
--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -118,7 +118,10 @@ def throughput_sysctls() -> dict[str, int]:
 
     These ride pmd-pytcp's public sysctls: ``tcp.rcv_wnd_max`` raises the advertised receive
     window for fast downloads; ``tcp.delayed_ack.delay_ms`` drops the delayed-ACK timer so
-    interactive request/response services are not stalled by it (:data:`ACK_DELAY_MS`).
+    interactive request/response services are not stalled by it (:data:`ACK_DELAY_MS`);
+    ``net.default.rx_cksum_validate`` turns off the software RX checksum pass (the tunnel is
+    AEAD-authenticated, so the RFC 1071 checksum only re-verifies bytes that cannot have been
+    corrupted) — measured ~+35% bulk-download throughput on an iOS 17+ DSC fetch.
 
     Host->device segment sizing is dynamic: RFC 4821/8899 PLPMTUD (``tcp.mtu_probing`` = 2)
     starts every connection at the proven-safe 1340-byte send MSS (``tcp.base_mss`` =
@@ -136,6 +139,10 @@ def throughput_sysctls() -> dict[str, int]:
         "tcp.default.mtu_probing": 2,
         "tcp.default.base_mss": BASE_MSS_SEED,
         "tcp.plpmtud.default.probe_timer_ms": PROBE_TIMER_MS,
+        # Software RX-checksum offload: every packet reaching the stack came through the
+        # AEAD-authenticated tunnel and an in-memory socketpair, so the RFC 1071 checksum
+        # verifies RAM. TX checksums stay on (the device kernel verifies them).
+        "net.default.rx_cksum_validate": False,
     }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,9 +51,11 @@ av>=14.0.0 ; platform_system != "Darwin"
 # (https://github.com/doronz88/pmd-pytcp). Pulls its pmd-net-addr / pmd-net-proto siblings in
 # transitively. Supported on Python 3.9+ (the whole pymobiledevice3 range); if the import or
 # stack init fails the tunnel transparently falls back to the kernel path (see cli_common).
-# 0.2.0 floor: dynamic send-MSS via working RFC 4821/8899 PLPMTUD (probing sysctls
-# tcp.mtu_probing / tcp.base_mss / tcp.plpmtud.probe_timer_ms, the tcp.rto.min_ms floor, and
-# the runtime 'log.enabled' hot-path gate). userspace_tunnel.py sets these knobs
-# unconditionally — no capability probing — so the floor IS the compatibility contract.
-# (0.1.0 introduced the pure-asyncio stack the module is written against.)
-pmd-pytcp>=0.2.0 ; python_version >= "3.9"
+# 0.3.0 floor: the 'net.rx_cksum_validate' software RX-checksum-offload sysctl (skips the
+# RFC 1071 checksum on the AEAD-authenticated tunnel; ~+35% bulk download). 0.2.0 added
+# dynamic send-MSS via working RFC 4821/8899 PLPMTUD (probing sysctls tcp.mtu_probing /
+# tcp.base_mss / tcp.plpmtud.probe_timer_ms, the tcp.rto.min_ms floor, and the runtime
+# 'log.enabled' hot-path gate). userspace_tunnel.py sets these knobs unconditionally — no
+# capability probing — so the floor IS the compatibility contract. (0.1.0 introduced the
+# pure-asyncio stack the module is written against.)
+pmd-pytcp>=0.3.0 ; python_version >= "3.9"


### PR DESCRIPTION
Sets `net.default.rx_cksum_validate = False` in the userspace tunnel's `throughput_sysctls()`, turning on the software RX-checksum-offload knob added in **pmd-pytcp 0.3.0** (doronz88/pmd-pytcp#6).

## Why it's safe

Every packet reaching the userspace stack arrived through the **AEAD-authenticated** RemotePairing/CoreDevice tunnel and an **in-memory socketpair** — so the RFC 1071 TCP/UDP checksum only re-verifies bytes that cannot have been corrupted in transit. It was the single most expensive step of per-packet parsing. The knob skips **only** the checksum arithmetic:
- every structural integrity check stays active,
- the RFC 8200 §8.1 UDP zero-checksum policy stays active,
- **all TX checksums stay on** — the device kernel still verifies everything we send.

## Measured

iPhone17,3 / iOS 26.5 over USB, DSC pull (`developer fetch-symbols`):

| | throughput |
|---|---|
| before (validation on) | 73.0 MB/s |
| after (validation off) | **98.9 MB/s** |

**+35%**, with a **byte-identical sha256** on both runs (proof the skip changes speed, not data). Interactive `dvt ls` latency is unchanged — checksum cost scales with payload, not round-trips. The tunnel is CPU-bound (one core at 0.99 during the pull), so the removed per-packet work converts almost 1:1 into throughput.

## Dependency floor

Bumps `pmd-pytcp>=0.3.0`, which registers the `net.rx_cksum_validate` sysctl. The knob is set unconditionally (no capability probing), so the floor is the compatibility contract — consistent with how the existing PLPMTUD/window/delayed-ACK knobs are floored.

https://claude.ai/code/session_01DPMTARDjwnoxYQyVg2DY9k