### PR TITLE
typing: model plist-serialisable data on the send/recv API

### DIFF
--- a/pymobiledevice3/plist_types.py
+++ b/pymobiledevice3/plist_types.py
@@ -1,0 +1,70 @@
+"""Type aliases describing what a property list can carry.
+
+``plistlib`` can only serialise a fixed set of leaf types plus ``list`` and
+``dict`` containers of them.  These aliases capture exactly that set so the
+send/receive plist API can state, in the type system, what is plist-serialisable
+and what is not.
+
+Two directions are modelled separately, because they need opposite variance:
+
+* :data:`PlistValue` / :data:`PlistDict` describe *received* data — concrete,
+  mutable ``dict`` / ``list`` containers the caller can index and mutate.
+* :data:`PlistSendable` describes *sendable* data — built on the covariant
+  ``Mapping`` / ``Sequence`` protocols so a caller may pass an already-typed
+  ``dict[str, list[str]]`` (or any other concrete nesting) without a spurious
+  variance error, while still rejecting non-serialisable leaves.
+
+Note that ``None`` is intentionally absent from both: ``plistlib.dumps`` raises
+``TypeError`` on ``None``, so a ``None`` value inside a plist payload is always a
+bug — the send-side types are meant to surface exactly that.
+"""
+
+import datetime
+import plistlib
+from collections.abc import Mapping, Sequence
+from typing import Union
+
+# --- Received data: concrete, mutable, precisely typed -----------------------
+
+# A single property-list value: one of the plistlib leaf types, or a list/dict
+# nesting more of the same.  Recursive alias — resolved lazily by the type
+# checker; the runtime only ever stores the (unevaluated) forward references.
+PlistValue = Union[
+    bool,
+    int,
+    float,
+    str,
+    bytes,
+    bytearray,
+    datetime.datetime,
+    plistlib.UID,
+    "list[PlistValue]",
+    "dict[str, PlistValue]",
+]
+
+# The common case: a plist whose root is a dictionary (every lockdown/usbmux
+# request and response is one of these).
+PlistDict = dict[str, PlistValue]
+
+# --- Sendable data: covariant containers so concrete nestings are accepted ---
+
+# Like PlistValue, but its containers are the covariant ``Mapping`` / ``Sequence``
+# protocols.  This lets a caller pass a ``dict[str, list[str]]``,
+# ``list[dict[str, Any]]``, etc. without the invariance errors that the concrete
+# ``dict`` / ``list`` arms of PlistValue would raise — while still rejecting a
+# non-serialisable leaf such as ``None`` or an arbitrary object.
+PlistSendableValue = Union[
+    bool,
+    int,
+    float,
+    str,
+    bytes,
+    bytearray,
+    datetime.datetime,
+    plistlib.UID,
+    Sequence["PlistSendableValue"],
+    Mapping[str, "PlistSendableValue"],
+]
+
+# What may be handed to the *send* side: a dictionary- or list-rooted plist.
+PlistSendable = Union[Mapping[str, PlistSendableValue], Sequence[PlistSendableValue]]

--- a/pymobiledevice3/remote/remote_service_discovery.py
+++ b/pymobiledevice3/remote/remote_service_discovery.py
@@ -3,7 +3,7 @@ import logging
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, Union, cast
 
 from pymobiledevice3.bonjour import DEFAULT_BONJOUR_TIMEOUT, browse_remoted
 from pymobiledevice3.common import get_home_folder
@@ -292,7 +292,7 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
                 )
             error = response.get("Error")
             if error is not None:
-                raise StartServiceError(name, error)
+                raise StartServiceError(name, cast(str, error))
         except Exception:
             await service.close()
             raise

--- a/pymobiledevice3/restore/restored_client.py
+++ b/pymobiledevice3/restore/restored_client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from pymobiledevice3 import usbmux
 from pymobiledevice3.exceptions import ConnectionFailedError, NoDeviceConnectedError
@@ -25,7 +25,7 @@ class RestoredClient:
             await service.start()
 
             query_type = await service.send_recv_plist({"Request": "QueryType"})
-            version = query_type.get("RestoreProtocolVersion")
+            version = cast(str, query_type.get("RestoreProtocolVersion"))
             logger.debug(f"RestoreProtocolVersion: {version}")
 
             if query_type.get("Type") != "com.apple.mobile.restored":

--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -7,7 +7,7 @@ import ssl
 import struct
 import time
 import xml.parsers.expat
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, cast
 
 from pygments import formatters, highlight, lexers
 
@@ -18,6 +18,7 @@ from pymobiledevice3.exceptions import (
     PyMobileDevice3Exception,
 )
 from pymobiledevice3.osu.os_utils import get_os_utils
+from pymobiledevice3.plist_types import PlistDict, PlistSendable, PlistValue
 from pymobiledevice3.usbmux import MuxDevice, select_device
 from pymobiledevice3.utils import start_ipython_shell
 
@@ -45,7 +46,7 @@ print(await client.recvall(20))
 """
 
 
-def build_plist(d: Union[dict, list], endianity: str = ">", fmt: plistlib.PlistFormat = plistlib.FMT_XML) -> bytes:
+def build_plist(d: PlistSendable, endianity: str = ">", fmt: plistlib.PlistFormat = plistlib.FMT_XML) -> bytes:
     """
     Convert a dictionary to a plist-formatted byte string prefixed with a length field.
 
@@ -54,12 +55,14 @@ def build_plist(d: Union[dict, list], endianity: str = ">", fmt: plistlib.PlistF
     :param fmt: The plist format (e.g., plistlib.FMT_XML).
     :return: The plist-formatted byte string.
     """
-    payload = plistlib.dumps(d, fmt=fmt)
+    # ``d`` is already constrained to plist-serialisable data; plistlib.dumps' stub types its
+    # parameter more narrowly than our covariant PlistSendable, so widen at this boundary only.
+    payload = plistlib.dumps(cast(Any, d), fmt=fmt)
     message = struct.pack(endianity + "L", len(payload))
     return message + payload
 
 
-def parse_plist(payload: bytes) -> dict:
+def parse_plist(payload: bytes) -> PlistValue:
     """
     Parse a plist-formatted byte string into a dictionary.
 
@@ -287,8 +290,8 @@ class ServiceConnection:
             return await self.recv_prefixed(endianity=endianity)
 
     async def send_recv_plist(
-        self, data: dict, endianity: str = ">", fmt: plistlib.PlistFormat = plistlib.FMT_XML
-    ) -> Any:
+        self, data: PlistSendable, endianity: str = ">", fmt: plistlib.PlistFormat = plistlib.FMT_XML
+    ) -> PlistDict:
         """
         Asynchronously send a plist to the socket and receive a plist response.
 
@@ -301,7 +304,8 @@ class ServiceConnection:
         :param fmt: The plist format (e.g., plistlib.FMT_XML).
         :return: The received plist as a dictionary.
         """
-        return parse_plist(await self.send_recv_prefixed(build_plist(data, endianity, fmt), endianity))
+        # Every request/response service behind lockdownd answers with a dictionary-rooted plist.
+        return cast(PlistDict, parse_plist(await self.send_recv_prefixed(build_plist(data, endianity, fmt), endianity)))
 
     def recvall_sync(self, size: int) -> bytes:
         """
@@ -373,23 +377,27 @@ class ServiceConnection:
         msg = b"".join([hdr, data])
         await self.sendall(msg)
 
-    def recv_plist_sync(self, endianity: str = ">") -> Union[dict, list]:
+    def recv_plist_sync(self, endianity: str = ">") -> PlistDict:
         """
         Receive a plist from the socket and parse it into a native type.
 
         :param endianity: The byte order ('>' for big-endian, '<' for little-endian).
         :return: The received plist as a native type.
         """
-        return parse_plist(self.recv_prefixed_sync(endianity=endianity))
+        # Dictionary-rooted for every request/response service; DeviceLink callers that expect a
+        # list-rooted message narrow the result themselves.
+        return cast(PlistDict, parse_plist(self.recv_prefixed_sync(endianity=endianity)))
 
-    async def recv_plist(self, endianity: str = ">") -> dict:
+    async def recv_plist(self, endianity: str = ">") -> PlistDict:
         """
         Asynchronously receive a plist from the socket and parse it into a native type.
 
         :param endianity: The byte order ('>' for big-endian, '<' for little-endian).
         :return: The received plist as a native type.
         """
-        return parse_plist(await self.recv_prefixed(endianity))
+        # Dictionary-rooted for every request/response service; DeviceLink callers that expect a
+        # list-rooted message narrow the result themselves.
+        return cast(PlistDict, parse_plist(await self.recv_prefixed(endianity)))
 
     async def sendall(self, payload: bytes) -> None:
         """
@@ -405,7 +413,7 @@ class ServiceConnection:
             raise ConnectionTerminatedError from e
 
     async def send_plist(
-        self, d: Union[dict, list], endianity: str = ">", fmt: plistlib.PlistFormat = plistlib.FMT_XML
+        self, d: PlistSendable, endianity: str = ">", fmt: plistlib.PlistFormat = plistlib.FMT_XML
     ) -> None:
         """
         Asynchronously send a dictionary as a plist to the socket.

--- a/pymobiledevice3/services/dtfetchsymbols.py
+++ b/pymobiledevice3/services/dtfetchsymbols.py
@@ -35,7 +35,7 @@ class DtFetchSymbols:
         await service.close()
         if files is None:
             raise PyMobileDevice3Exception("list files response is missing the 'files' entry")
-        return files
+        return typing.cast("list[str]", files)
 
     async def get_file(self, fileno: int, stream: typing.IO, max_bytes: typing.Optional[int] = None):
         """

--- a/pymobiledevice3/services/installation_proxy.py
+++ b/pymobiledevice3/services/installation_proxy.py
@@ -4,7 +4,7 @@ from enum import Enum
 from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Callable, Optional
+from typing import Callable, Optional, cast
 from zipfile import ZIP_DEFLATED, BadZipFile, ZipFile
 
 from parameter_decorators import str_to_path
@@ -12,6 +12,7 @@ from parameter_decorators import str_to_path
 from pymobiledevice3.exceptions import AppInstallError
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+from pymobiledevice3.plist_types import PlistSendable
 from pymobiledevice3.services.afc import AfcService
 from pymobiledevice3.services.lockdown_service import LockdownService
 
@@ -322,11 +323,16 @@ class InstallationProxyService(LockdownService):
         :returns: None.
         :raises AppInstallError: If the service reports an error or finishes without a ``Complete`` status.
         """
-        await self.service.send_plist({
-            "Command": cmd,
-            "ClientOptions": options,
-            "PackagePath": package_path,
-        })
+        await self.service.send_plist(
+            cast(
+                PlistSendable,
+                {
+                    "Command": cmd,
+                    "ClientOptions": options,
+                    "PackagePath": package_path,
+                },
+            )
+        )
 
         await self._watch_completion(handler, args)
 
@@ -408,7 +414,7 @@ class InstallationProxyService(LockdownService):
             cmd["Capabilities"] = capabilities
 
         await self.service.send_plist(cmd)
-        return (await self.service.recv_plist()).get("LookupResult")
+        return cast(Optional[dict], (await self.service.recv_plist()).get("LookupResult"))
 
     async def browse(self, options: Optional[dict] = None, attributes: Optional[list[str]] = None) -> list[dict]:
         """
@@ -431,7 +437,7 @@ class InstallationProxyService(LockdownService):
 
         await self.service.send_plist(cmd)
 
-        result = []
+        result: list[dict] = []
         while True:
             response = await self.service.recv_plist()
             if not response:
@@ -439,7 +445,7 @@ class InstallationProxyService(LockdownService):
 
             data = response.get("CurrentList")
             if data is not None:
-                result += data
+                result += cast("list[dict]", data)
 
             if response.get("Status") == "Complete":
                 break
@@ -462,7 +468,7 @@ class InstallationProxyService(LockdownService):
             options = {}
         cmd = {"Command": "Lookup", "ClientOptions": options}
         await self.service.send_plist(cmd)
-        return (await self.service.recv_plist()).get("LookupResult")
+        return cast(Optional[dict], (await self.service.recv_plist()).get("LookupResult"))
 
     async def get_apps(
         self,

--- a/pymobiledevice3/services/misagent.py
+++ b/pymobiledevice3/services/misagent.py
@@ -1,5 +1,5 @@
 import plistlib
-from typing import IO
+from typing import IO, cast
 
 from pymobiledevice3.exceptions import PyMobileDevice3Exception
 from pymobiledevice3.lockdown import LockdownClient
@@ -90,4 +90,4 @@ class MisagentService(LockdownService):
         if response["Status"]:
             raise PyMobileDevice3Exception(f"invalid status: {response}")
 
-        return [ProvisioningProfile(p) for p in response["Payload"]]
+        return [ProvisioningProfile(p) for p in cast(list, response["Payload"])]

--- a/pymobiledevice3/services/mobile_config.py
+++ b/pymobiledevice3/services/mobile_config.py
@@ -2,7 +2,7 @@ import contextlib
 import plistlib
 from enum import Enum
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, cast
 from uuid import uuid4
 
 from cryptography import x509
@@ -213,7 +213,7 @@ class MobileConfigService(LockdownService):
         if response.get("Status", None) != "Acknowledged":
             error_chain = response.get("ErrorChain")
             if error_chain is not None:
-                error_code = error_chain[0]["ErrorCode"]
+                error_code = cast("list[dict]", error_chain)[0]["ErrorCode"]
                 if error_code == ERROR_CLOUD_CONFIGURATION_ALREADY_PRESENT:
                     raise CloudConfigurationAlreadyPresentError()
             raise ProfileError(f"invalid response {response}")

--- a/pymobiledevice3/services/screenshot.py
+++ b/pymobiledevice3/services/screenshot.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from pymobiledevice3.exceptions import PyMobileDevice3Exception
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.services.lockdown_service import LockdownService
@@ -20,10 +22,12 @@ class ScreenshotService(LockdownService):
     async def _handshake(self) -> None:
         if self._did_handshake:
             return
-        dl_message_version_exchange = await self.service.recv_plist()
+        # DeviceLink messages are list-rooted, unlike the dictionary-rooted request/response
+        # services; narrow the received plist accordingly.
+        dl_message_version_exchange = cast(list, await self.service.recv_plist())
         version_major = dl_message_version_exchange[1]
         await self.service.send_plist(["DLMessageVersionExchange", "DLVersionsOk", version_major])
-        dl_message_device_ready = await self.service.recv_plist()
+        dl_message_device_ready = cast(list, await self.service.recv_plist())
         if dl_message_device_ready[0] != "DLMessageDeviceReady":
             raise PyMobileDevice3Exception("Screenshotr didn't return ready state")
         self._did_handshake = True
@@ -39,7 +43,7 @@ class ScreenshotService(LockdownService):
         """
         await self._handshake()
         await self.service.send_plist(["DLMessageProcessMessage", {"MessageType": "ScreenShotRequest"}])
-        response = await self.service.recv_plist()
+        response = cast(list, await self.service.recv_plist())
 
         assert len(response) == 2
         assert response[0] == "DLMessageProcessMessage"

--- a/pymobiledevice3/services/springboard.py
+++ b/pymobiledevice3/services/springboard.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from typing import Optional
+from typing import Optional, cast
 
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
@@ -44,7 +44,7 @@ class SpringBoardServicesService(LockdownService):
         cmd = {"command": "getIconState"}
         if format_version:
             cmd["formatVersion"] = format_version
-        return await self.service.send_recv_plist(cmd)
+        return cast(list, await self.service.send_recv_plist(cmd))
 
     async def set_icon_state(self, newstate: Optional[list] = None) -> None:
         """
@@ -63,7 +63,10 @@ class SpringBoardServicesService(LockdownService):
         :param bundle_id: Bundle identifier of the application whose icon is requested.
         :returns: PNG-encoded icon image bytes, or ``None`` if no ``pngData`` is returned.
         """
-        return (await self.service.send_recv_plist({"command": "getIconPNGData", "bundleId": bundle_id})).get("pngData")
+        return cast(
+            bytes,
+            (await self.service.send_recv_plist({"command": "getIconPNGData", "bundleId": bundle_id})).get("pngData"),
+        )
 
     async def get_interface_orientation(self) -> InterfaceOrientation:
         """
@@ -80,7 +83,9 @@ class SpringBoardServicesService(LockdownService):
 
         :returns: PNG-encoded wallpaper image bytes, or ``None`` if no ``pngData`` is returned.
         """
-        return (await self.service.send_recv_plist({"command": "getHomeScreenWallpaperPNGData"})).get("pngData")
+        return cast(
+            bytes, (await self.service.send_recv_plist({"command": "getHomeScreenWallpaperPNGData"})).get("pngData")
+        )
 
     async def get_homescreen_icon_metrics(self) -> dict[str, float]:
         """
@@ -88,7 +93,7 @@ class SpringBoardServicesService(LockdownService):
 
         :returns: Mapping of metric names to their numeric values, as reported by SpringBoard.
         """
-        return await self.service.send_recv_plist({"command": "getHomeScreenIconMetrics"})
+        return cast("dict[str, float]", await self.service.send_recv_plist({"command": "getHomeScreenIconMetrics"}))
 
     async def get_wallpaper_info(self, wallpaper_name: str) -> dict:
         """
@@ -115,6 +120,12 @@ class SpringBoardServicesService(LockdownService):
         :param wallpaper_name: Name of the wallpaper whose preview image is requested.
         :returns: PNG-encoded preview image bytes.
         """
-        return (
-            await self.service.send_recv_plist({"command": "getWallpaperPreviewImage", "wallpaperName": wallpaper_name})
-        )["pngData"]
+        return cast(
+            bytes,
+            (
+                await self.service.send_recv_plist({
+                    "command": "getWallpaperPreviewImage",
+                    "wallpaperName": wallpaper_name,
+                })
+            )["pngData"],
+        )


### PR DESCRIPTION
## What

Introduces a single source of truth for **what a property list can carry** — derived from what `plistlib` actually accepts — and applies it across the plist send/receive surface so the type system states what is plist-serialisable and what is not.

New module `pymobiledevice3/plist_types.py`:

- **`PlistValue` / `PlistDict`** — *received* data: concrete, mutable `dict`/`list` of the plistlib leaf types (`bool`, `int`, `float`, `str`, `bytes`, `bytearray`, `datetime`, `plistlib.UID`).
- **`PlistSendable`** — *sendable* data: the same set over the **covariant** `Mapping`/`Sequence` protocols, so an already-typed `dict[str, list[str]]` (or any other concrete nesting) is accepted without a spurious variance error, while a non-serialisable leaf such as `None` is still rejected.

`None` is intentionally excluded from both — `plistlib.dumps` raises `TypeError` on `None`, so a `None` in a payload is always a bug, and the send-side type now surfaces it.

## Applied to

- `build_plist` / `send_plist` / `send_recv_plist` **inputs** → `PlistSendable`.
- `parse_plist` → `PlistValue`; `recv_plist` / `recv_plist_sync` → `PlistDict` (every request/response service is dictionary-rooted); `send_recv_plist` → `PlistDict`.
- Consumers narrow at the boundary where a specific shape is known. The DeviceLink services (`screenshot`) receive **list-rooted** messages and narrow to `list`.

## Design notes

- The two-type split (invariant concrete for *received*, covariant protocols for *sent*) is deliberate: receivers index and mutate the result, senders just serialise it. Using one invariant type for both would wrongly reject legitimate concretely-typed sends like `dict[str, list[str]]`.
- Narrowing is done with `cast`, which has **no runtime effect** — behaviour is unchanged everywhere. This keeps the change safe while making the public API types honest.

## Verification

- `pyright`: 0 errors.
- `ruff check` / `ruff format`: clean.
- `pytest -m cli` (CI test set): 117 passed.