### PR TITLE
skills: unify agent skill discovery across Claude Code and Codex

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+    "name": "pymobiledevice3",
+    "description": "Agent skills for operating iOS and iPadOS devices with pymobiledevice3.",
+    "owner": {
+        "name": "doronz88",
+        "url": "https://github.com/doronz88"
+    },
+    "plugins": [
+        {
+            "name": "pymobiledevice3",
+            "source": "./misc/claude-plugin",
+            "description": "Operate iOS and iPadOS devices from Claude Code with pymobiledevice3: screenshots, syslog search, crash reports, file and app operations, developer services (DVT, tunnels, WebInspector, WDA) — works from a fresh workstation via uvx/PyPI or a local checkout."
+        }
+    ]
+}

--- a/.claude/skills/pymobiledevice3-device-operator
+++ b/.claude/skills/pymobiledevice3-device-operator
@@ -1,0 +1,1 @@
+../../.codex/skills/pymobiledevice3-device-operator

--- a/.claude/skills/tss-batch-prefetch
+++ b/.claude/skills/tss-batch-prefetch
@@ -1,0 +1,1 @@
+../../.codex/skills/tss-batch-prefetch

--- a/.codex/skills/pymobiledevice3-device-operator/SKILL.md
+++ b/.codex/skills/pymobiledevice3-device-operator/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: pymobiledevice3-device-operator
-description: Operate iOS and iPadOS devices through the local pymobiledevice3 checkout. Use when an agent needs to inspect a connected device, collect logs or crash data, browse or copy files, manage apps, profiles, or backups, use developer services such as DDI/DVT/tunnels/sysmon/screenshots/simulated location, automate Safari or WebViews through WebInspector or WDA, or add a thin repo-native device command on top of existing services. Prefer existing CLI and service modules, choose USB vs --rsd/--tunnel correctly, and require explicit user intent before state-changing or destructive actions.
+description: Operate iOS and iPadOS devices with pymobiledevice3, from a local checkout or straight from PyPI via uvx on a fresh workstation. Use when an agent needs to inspect a connected device, collect logs or crash data, browse or copy files, manage apps, profiles, or backups, use developer services such as DDI/DVT/tunnels/sysmon/screenshots/simulated location, automate Safari or WebViews through WebInspector or WDA, or add a thin repo-native device command on top of existing services. Prefer existing CLI and service modules, choose USB vs --rsd/--tunnel correctly, and require explicit user intent before state-changing or destructive actions.
 ---
 
 # PyMobileDevice3 Device Operator
 
 ## Overview
 
-Use this skill to translate a user goal into the smallest correct `pymobiledevice3` action, then execute it from the local repo or extend the repo with a thin CLI wrapper when the capability already exists in services.
+Use this skill to translate a user goal into the smallest correct `pymobiledevice3` action, then execute it — from a local checkout when one is present, or via the PyPI release (`uvx pymobiledevice3`) on a fresh workstation — or extend the repo with a thin CLI wrapper when the capability already exists in services.
 
 ## Default Operating Pattern
 
-Run commands from the repository root with `uvx --from . pymobiledevice3 ...` so the local checkout is used. Fall back to `python3 -m pymobiledevice3 ...` only if `uvx` is unavailable or the user explicitly wants the current interpreter environment.
+Inside a pymobiledevice3 checkout, run commands from the repository root with `uvx --from . pymobiledevice3 ...` so the local checkout is used. On a workstation **without** a checkout, run `uvx pymobiledevice3 ...` instead — `uvx` fetches the released package from PyPI on first use, so nothing needs to be installed beforehand except `uv` itself (`uv tool install pymobiledevice3` gives a persistent install). Everywhere this skill's references show `uvx --from . pymobiledevice3 ...`, drop the `--from .` when there is no checkout. Fall back to `python3 -m pymobiledevice3 ...` only if `uvx` is unavailable or the user explicitly wants the current interpreter environment.
 
 Start with the least invasive command that proves connectivity or surfaces missing prerequisites:
 
@@ -26,7 +26,7 @@ Prefer existing CLI commands first. Prefer reading local docs and CLI source ove
 
 1. Classify the request as one of: inspect, collect, modify, automate, developer-instrument, or extend-the-repo.
 2. Confirm transport before doing anything expensive. USB is the default. For iOS 17+ developer services, read `references/transport-and-safety.md`.
-3. Discover the narrowest command by checking `docs/guides/cli-recipes.md`, `pymobiledevice3/__main__.py`, and the relevant CLI module under `pymobiledevice3/cli/`. Use `rg` to locate command names, options, and transport flags quickly.
+3. Discover the narrowest command by checking `docs/guides/cli-recipes.md`, `pymobiledevice3/__main__.py`, and the relevant CLI module under `pymobiledevice3/cli/`. Use `rg` to locate command names, options, and transport flags quickly. Without a checkout, use `--help` discovery and the published docs (<https://doronz88.github.io/pymobiledevice3/>) instead.
 4. Use `uvx --from . pymobiledevice3 <group> --help` only as a fallback when code and docs are ambiguous, or as a final verification step before suggesting an exact command to the user.
 5. Execute a reversible or read-only step first, then escalate to state-changing actions only if the user asked for them.
 6. For long-lived streams or interactive shells, keep the process attached instead of replacing it with one-shot polling.
@@ -57,6 +57,9 @@ Read `references/task-map.md` when you need to map a user goal to a command grou
 Read `references/transport-and-safety.md` when the task touches iOS 17+ developer services, tunnels, `--rsd`, `--tunnel`, or destructive operations.
 
 ## Source Files To Prefer
+
+These paths are relative to a pymobiledevice3 checkout; without one, use the published
+docs site (<https://doronz88.github.io/pymobiledevice3/>) and `--help` output instead.
 
 - `docs/guides/cli-recipes.md` for common end-user commands
 - `docs/guides/ios17-tunnels.md` for tunnel setup and `--rsd` usage

--- a/.codex/skills/pymobiledevice3-device-operator/SKILL.md
+++ b/.codex/skills/pymobiledevice3-device-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pymobiledevice3-device-operator
-description: Operate iOS and iPadOS devices through the local pymobiledevice3 checkout. Use when Codex needs to inspect a connected device, collect logs or crash data, browse or copy files, manage apps, profiles, or backups, use developer services such as DDI/DVT/tunnels/sysmon/screenshots/simulated location, automate Safari or WebViews through WebInspector or WDA, or add a thin repo-native device command on top of existing services. Prefer existing CLI and service modules, choose USB vs --rsd/--tunnel correctly, and require explicit user intent before state-changing or destructive actions.
+description: Operate iOS and iPadOS devices through the local pymobiledevice3 checkout. Use when an agent needs to inspect a connected device, collect logs or crash data, browse or copy files, manage apps, profiles, or backups, use developer services such as DDI/DVT/tunnels/sysmon/screenshots/simulated location, automate Safari or WebViews through WebInspector or WDA, or add a thin repo-native device command on top of existing services. Prefer existing CLI and service modules, choose USB vs --rsd/--tunnel correctly, and require explicit user intent before state-changing or destructive actions.
 ---
 
 # PyMobileDevice3 Device Operator
@@ -47,6 +47,10 @@ Do not invent prerequisites. If a developer service fails, inspect developer-mod
 Do not expose or commit pair records, crash artifacts, backups, or other device-identifying material.
 
 ## Task Routing
+
+Read `references/quick-recipes.md` for the exact invocation of the most common tasks
+(screenshot, syslog search, crash pull, file copy, app listing) and for the
+syslog-first troubleshooting technique.
 
 Read `references/task-map.md` when you need to map a user goal to a command group or service module.
 

--- a/.codex/skills/pymobiledevice3-device-operator/references/quick-recipes.md
+++ b/.codex/skills/pymobiledevice3-device-operator/references/quick-recipes.md
@@ -1,0 +1,82 @@
+# Quick Recipes
+
+## Use This File
+
+Read this file for the exact invocation of the most common device tasks. All commands run
+from the repository root; on iOS 17.4+ the `developer` commands establish a no-root
+userspace tunnel automatically, so run them as-is — no `sudo`, no tunnel setup.
+
+## Screenshot
+
+```shell
+uvx --from . pymobiledevice3 developer dvt screenshot ./screen.png
+```
+
+Requires Developer Mode and a mounted DDI (`amfi enable-developer-mode`,
+`mounter auto-mount`). WDA-based UI automation has its own screenshot:
+`developer wda screenshot`.
+
+## Search The Device Syslog
+
+```shell
+# Live syslog filtered to lines containing a term (repeatable, case-sensitive)
+uvx --from . pymobiledevice3 syslog live -m <term>
+
+# Case-insensitive match / filter by process
+uvx --from . pymobiledevice3 syslog live --match-insensitive <term>
+uvx --from . pymobiledevice3 syslog live --process-name <name>
+uvx --from . pymobiledevice3 syslog live --pid <pid>
+```
+
+Structured os_log (with subsystem/category metadata) via developer services:
+
+```shell
+uvx --from . pymobiledevice3 developer dvt oslog
+```
+
+## Troubleshoot With The Syslog First
+
+When something on-device misbehaves — a service refuses to start, an app dies on launch,
+a developer command fails opaquely — the device usually logs the real reason in its
+syslog. Before changing code or guessing at prerequisites, reproduce the failure while
+watching:
+
+```shell
+uvx --from . pymobiledevice3 syslog live -m <bundle-id-or-daemon-or-error-term>
+```
+
+Filter by the daemon that owns the failing service (`--process-name`) when you know it.
+The device-side error message is frequently more specific than the host-side exception.
+
+## Crash Reports
+
+```shell
+uvx --from . pymobiledevice3 crash ls
+uvx --from . pymobiledevice3 crash pull <target-dir>
+uvx --from . pymobiledevice3 crash watch
+```
+
+## Apps
+
+```shell
+uvx --from . pymobiledevice3 apps list
+uvx --from . pymobiledevice3 apps query <bundle-id>
+```
+
+## Files (media domain via AFC)
+
+```shell
+uvx --from . pymobiledevice3 afc ls /
+uvx --from . pymobiledevice3 afc pull <device-path> <local-path>
+uvx --from . pymobiledevice3 afc push <local-path> <device-path>
+```
+
+App containers go through the `apps` group / `house_arrest` service instead of plain AFC.
+
+## Device Info And Processes
+
+```shell
+uvx --from . pymobiledevice3 lockdown info
+uvx --from . pymobiledevice3 developer dvt sysmon process single
+uvx --from . pymobiledevice3 developer dvt sysmon process monitor process --filter name=<name> --key name --key cpuUsage
+```

--- a/.codex/skills/pymobiledevice3-device-operator/references/quick-recipes.md
+++ b/.codex/skills/pymobiledevice3-device-operator/references/quick-recipes.md
@@ -2,9 +2,11 @@
 
 ## Use This File
 
-Read this file for the exact invocation of the most common device tasks. All commands run
-from the repository root; on iOS 17.4+ the `developer` commands establish a no-root
-userspace tunnel automatically, so run them as-is — no `sudo`, no tunnel setup.
+Read this file for the exact invocation of the most common device tasks. Commands are
+shown for a repository checkout (`uvx --from . pymobiledevice3`); on a workstation
+without one, drop the `--from .` so `uvx` fetches the PyPI release. On iOS 17.4+ the
+`developer` commands establish a no-root userspace tunnel automatically, so run them
+as-is — no `sudo`, no tunnel setup.
 
 ## Screenshot
 

--- a/.codex/skills/pymobiledevice3-device-operator/references/task-map.md
+++ b/.codex/skills/pymobiledevice3-device-operator/references/task-map.md
@@ -10,10 +10,11 @@ Read this file when the user asks to do something on-device and you need to map 
 - `bonjour`: discover RemoteXPC and related network-visible services.
 - `lockdown`: inspect values, pair or unpair, start tunnels, toggle Wi-Fi connections, basic device settings.
 - `remote`: remote pairing and tunnel helpers for CoreDevice flows.
+- `companion`: reach services on a paired companion device (e.g. Apple Watch) through the phone.
 
 Start here when the task is blocked on "find the device", "connect to the device", "`--rsd` details", or "start a tunnel".
 
-For `lockdown start-tunnel` and `remote start-tunnel`, use `--script-mode`, parse the RSD host and port from stdout, and be ready to use `sudo` if tunnel interface creation fails for permission reasons.
+Explicit tunnel setup is rarely needed: on iOS 17.4+, commands that require an RSD tunnel establish a no-root in-process userspace tunnel automatically — just run the command. Reach for `tunneld` or `start-tunnel` (see `references/transport-and-safety.md`) only for iOS 17.0-17.3 devices or when the userspace path is not viable.
 
 ## Files, Containers, And App Data
 
@@ -30,6 +31,7 @@ Use these for browsing files, copying artifacts, or handling app containers.
 - `diagnostics`: restart, shutdown, info, battery-related flows under `pymobiledevice3/cli/diagnostics/`.
 - `notification`: observe or post Darwin notifications.
 - `pcap`: capture network traffic.
+- `btlogger`: capture Bluetooth HCI packet logs (pcap/pcapng).
 - `power-assertion`: keep the device awake for a task.
 - `processes`: process inspection helpers outside full DVT flows.
 
@@ -71,7 +73,13 @@ Use WebInspector for Safari/WebView automation and WDA for device UI automation.
 - `developer debugserver`: debugserver launch and LLDB bridging.
 - `developer fetch-symbols`: symbol acquisition.
 - `developer accessibility`: audits, settings, notifications, item listing.
+- `developer simulate-location`: DVT-based location simulation.
+- `developer arbitration`: device arbitration (check-in/check-out for exclusive use).
+- `developer shell`: IPython shell connected to a named developer service (exploration/R&D).
 - Supporting code: `pymobiledevice3/cli/developer/` and `pymobiledevice3/services/dvt/`.
+
+The authoritative list of top-level groups is `CLI_GROUPS` in `pymobiledevice3/__main__.py`;
+if a goal maps to nothing above, scan it and the matching module under `pymobiledevice3/cli/`.
 
 Read `references/transport-and-safety.md` before using these on iOS 17+.
 

--- a/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -7,7 +7,12 @@ Read this file when the request touches transport selection, iOS 17+ developer s
 ## Transport Selection
 
 - USB lockdown is the default path for most commands.
-- `ServiceProviderDep` already resolves USB, `--rsd`, and `--tunnel` flows for repo-native CLI commands.
+- `ServiceProviderDep` already resolves USB, `--rsd`, `--tunnel`, and `--userspace` flows for repo-native CLI commands.
+- When a command requires an RSD tunnel and no transport flag is given, a **no-root
+  in-process userspace tunnel** is established automatically on iOS 17.4+ — no `sudo`,
+  no `start-tunnel`, no `tunneld`. This is the preferred path for agents.
+- `--userspace` forces the userspace tunnel explicitly (`PYMOBILEDEVICE3_USERSPACE=1` is
+  equivalent); it is mutually exclusive with `--rsd`/`--tunnel`.
 - `--rsd HOST PORT` is for a specific RemoteServiceDiscovery endpoint.
 - `--tunnel ''` or `--tunnel <UDID>` targets a device already exposed by `tunneld`.
 
@@ -21,24 +26,27 @@ Many `developer dvt` and related developer commands need all of the following:
    `uvx --from . pymobiledevice3 amfi enable-developer-mode`
 2. Developer image mounted:
    `uvx --from . pymobiledevice3 mounter auto-mount`
-3. A CoreDevice transport path:
-   `uvx --from . pymobiledevice3 lockdown start-tunnel --script-mode`
-   or
-   `uvx --from . pymobiledevice3 remote start-tunnel --script-mode`
-   or an already-running `tunneld`
+3. A CoreDevice transport path. On iOS 17.4+ this needs **no setup**: the no-root
+   userspace tunnel is established automatically when the command runs. Only iOS
+   17.0-17.3 devices (which predate CoreDeviceProxy) route to `tunneld` and need a
+   privileged daemon: `sudo uvx --from . pymobiledevice3 remote tunneld` in the
+   background, then pass `--tunnel ''` or `--tunnel <UDID>`.
 
-`start-tunnel` commands may need to be executed as the `root` user via `sudo` so tunnel interface setup succeeds.
-
-If a developer command fails with service-availability errors, retry with `--tunnel ''` before assuming the code is broken.
+If a developer command fails with service-availability errors, verify Developer Mode and
+the mounted image before assuming the code is broken.
 
 ## Tunnel Notes
 
-- Tunnel creation can require elevated privileges because it creates a TUN/TAP interface.
-- `lockdown start-tunnel` is the preferred path on iOS 17.4+.
-- `remote start-tunnel` is the fallback for iOS 17.0 through 17.3.1.
-- For Codex-driven tunnel setup, invoke `lockdown start-tunnel` or `remote start-tunnel` with `--script-mode`.
-- If tunnel creation fails on permissions, retry `lockdown start-tunnel --script-mode` or `remote start-tunnel --script-mode` with `sudo`.
-- Read the RSD host and port from the command's stdout and reuse those exact values in later commands.
+- The userspace tunnel is the default; prefer it. Fall back to a privileged tunnel only
+  when userspace is not viable: sustained host->device throughput (DDI mounts and large
+  file pushes are deliberately slower over userspace), `debugserver start-server`
+  without `--local-port`, or iOS 17.0-17.3.
+- Privileged options: an already-running `tunneld`, or a one-off
+  `lockdown start-tunnel` (iOS 17.4+) / `remote start-tunnel` (iOS 17.0-17.3.1).
+- Privileged tunnel creation can require `sudo` because it creates a TUN/TAP interface.
+- For agent-driven `start-tunnel`, use `--script-mode`, read the RSD host and port from
+  stdout, and reuse those exact values in later commands via `--rsd HOST PORT`.
+- `PYMOBILEDEVICE3_PREFER_TUNNELD=1` opts out of the userspace default entirely.
 
 See `docs/guides/ios17-tunnels.md` for the repo’s detailed guidance.
 
@@ -56,11 +64,16 @@ If the user only asked to inspect or debug, stay read-only unless the task canno
 
 ## Troubleshooting Order
 
+The device often logs the real reason for a failure in its own syslog. When an error is
+opaque, reproduce it while watching `syslog live -m <term>` (or
+`--process-name <daemon>`) — see `references/quick-recipes.md` — and read the
+device-side message before guessing.
+
 When a command fails, check in this order:
 
 1. Device presence and pairing: `usbmux list`, `lockdown info`
 2. Correct transport: USB vs `--rsd` vs `--tunnel`
-3. Developer prerequisites: Developer Mode, mounted image, tunnel, and sufficient privileges for `start-tunnel` such as `sudo`
+3. Developer prerequisites: Developer Mode, mounted image, and — only on iOS 17.0-17.3 or when a privileged tunnel is explicitly used — a running `tunneld` / sufficient privileges for `start-tunnel` such as `sudo`
 4. Capability location: existing CLI command vs service method vs unsupported feature
 
 Only after those checks should you consider implementing new code.

--- a/.codex/skills/release
+++ b/.codex/skills/release
@@ -1,0 +1,1 @@
+../../.claude/skills/release

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,7 @@
 # Generated MkDocs build output (not source).
 site/
+
+# The Claude Code plugin package mounts agent skill files (canonical under the
+# unscanned dot-directories .codex/ and .claude/) via symlink; skill payloads
+# are not part of the linted documentation set.
+misc/claude-plugin/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ device-operator skill guidance needs updating.
 
 - Update docs for user-facing command/API changes.
 - Keep root `README.md` concise; place deep guides under `docs/guides/`.
-- Add links in `docs/README.md` for new guides.
+- Add new guides to the `nav` section of `mkdocs.yml`.
 
 ## Safety
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,11 @@ When adding a skill, create it in one tree and symlink it from the other. When c
 user-facing CLI layout, transports, or safety-relevant behavior, review whether the
 device-operator skill guidance needs updating.
 
+The device-operator skill is also published as a Claude Code plugin: the repo is a
+plugin marketplace (`.claude-plugin/marketplace.json`) whose plugin package at
+`misc/claude-plugin/` mounts the skill via symlink — the canonical files remain the
+single source of truth.
+
 ## Documentation Expectations
 
 - Update docs for user-facing command/API changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,23 @@ Guidance for AI coding agents and automation contributors working in this reposi
 - Run at least targeted tests for touched areas; run full `pytest` when practical.
 - Verify relevant linting for touched files when practical.
 
+## Skills
+
+Repo-local agent skills (`SKILL.md` + optional `references/`) are discoverable by both
+Claude Code and Codex: `.claude/skills/` and `.codex/skills/` mirror each other via
+relative symlinks. Each skill has exactly one canonical directory — the other tree holds
+a symlink to it — so edit the canonical files only:
+
+- `.codex/skills/pymobiledevice3-device-operator/` — operate a connected device through
+  the local checkout (task routing, transport selection, safety gates).
+- `.codex/skills/tss-batch-prefetch/` — maintain `PREFETCHABLE_UPDATERS` in
+  `pymobiledevice3/restore/tss.py`.
+- `.claude/skills/release/` — cut a GitHub release (which publishes to PyPI).
+
+When adding a skill, create it in one tree and symlink it from the other. When changing
+user-facing CLI layout, transports, or safety-relevant behavior, review whether the
+device-operator skill guidance needs updating.
+
 ## Documentation Expectations
 
 - Update docs for user-facing command/API changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,6 @@ the editable install above ran inside it.
 ## Recommended Reading
 
 - [Understanding iDevice protocol layers](misc/understanding_idevice_protocol_layers.md)
-- [Documentation index](docs/README.md)
+- [Documentation site](https://doronz88.github.io/pymobiledevice3/)
 - [Writing commands with service_provider](docs/guides/writing-commands-with-service-provider.md)
 - [AGENTS](AGENTS.md)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ prune docs
 prune site
 exclude mkdocs.yml
 exclude .markdownlintignore
+prune misc/claude-plugin

--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -168,10 +168,10 @@ pymobiledevice3 developer dvt sysmon process single
 pymobiledevice3 developer dvt sysmon process monitor threshold 50
 
 # Stream one process and only show the selected fields
-pymobiledevice3 developer dvt sysmon process monitor pid 123 --key name --key cpuUsage --key physFootprint
+pymobiledevice3 developer dvt sysmon process monitor process --filter pid=123 --key name --key cpuUsage --key physFootprint
 
 # Stream one process with human-readable memory sizes
-pymobiledevice3 developer dvt sysmon process monitor pid 123 --key name --key physFootprint --human
+pymobiledevice3 developer dvt sysmon process monitor process --filter name=SpringBoard --key name --key physFootprint --human
 
 # Stream oslog
 pymobiledevice3 developer dvt oslog

--- a/docs/guides/codex-device-operator-skill.md
+++ b/docs/guides/codex-device-operator-skill.md
@@ -13,6 +13,32 @@ Claude Code (via a symlink in `.claude/skills/`). The two skill trees mirror eac
 other with relative symlinks; see the Skills section of the repo's `AGENTS.md` for
 the full inventory and the edit-the-canonical-copy convention.
 
+## Install Into Your Own Claude Code
+
+You do not need to work inside this repository to use the skill. The commands it
+teaches run against the PyPI release via `uvx pymobiledevice3 ...`, so a fresh
+workstation only needs [uv](https://docs.astral.sh/uv/) and a USB-connected device.
+
+**As a plugin (recommended).** This repository doubles as a Claude Code plugin
+marketplace. Inside Claude Code run:
+
+```text
+/plugin marketplace add doronz88/pymobiledevice3
+/plugin install pymobiledevice3@pymobiledevice3
+```
+
+After installing, Claude can take screenshots, search the device syslog, pull crash
+reports, manage apps and files, and drive developer services from any directory.
+
+**As a personal skill (manual).** Clone the repository once and symlink the skill into
+your personal skills directory:
+
+```shell
+git clone https://github.com/doronz88/pymobiledevice3.git
+mkdir -p ~/.claude/skills
+ln -s "$(pwd)/pymobiledevice3/.codex/skills/pymobiledevice3-device-operator" ~/.claude/skills/
+```
+
 ## Use From GitHub
 
 If someone is using Codex against the GitHub repository and wants a copy-pasteable reference, point them at these URLs:

--- a/docs/guides/codex-device-operator-skill.md
+++ b/docs/guides/codex-device-operator-skill.md
@@ -1,11 +1,16 @@
-# Codex Device Operator Skill
+# Device Operator Skill
 
-This repository includes a repo-local Codex skill for device-facing work:
+This repository includes a repo-local agent skill for device-facing work:
 
 - Skill file: `.codex/skills/pymobiledevice3-device-operator/SKILL.md`
 - Reference file: `.codex/skills/pymobiledevice3-device-operator/references/task-map.md`
 - Reference file:
   `.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md`
+
+The skill is discovered automatically by both Codex (via `.codex/skills/`) and
+Claude Code (via a symlink in `.claude/skills/`). The two skill trees mirror each
+other with relative symlinks; see the Skills section of the repo's `AGENTS.md` for
+the full inventory and the edit-the-canonical-copy convention.
 
 ## Use From GitHub
 
@@ -28,7 +33,7 @@ https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobilede
 https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
 ```
 
-Use this skill when Codex needs to operate a connected iPhone or iPad through the local `pymobiledevice3` checkout, including:
+Use this skill when an agent needs to operate a connected iPhone or iPad through the local `pymobiledevice3` checkout, including:
 
 - connectivity and transport selection
 - crash/log/file collection
@@ -65,7 +70,7 @@ into later `--rsd HOST PORT` commands.
 ## When Updating The Project
 
 If you add, remove, or substantially change device-facing CLI behavior,
-update the skill guidance when needed so Codex keeps routing requests
+update the skill guidance when needed so agents keep routing requests
 correctly.
 
 In practice, review the skill when changes affect:

--- a/docs/guides/codex-device-operator-skill.md
+++ b/docs/guides/codex-device-operator-skill.md
@@ -3,6 +3,7 @@
 This repository includes a repo-local agent skill for device-facing work:
 
 - Skill file: `.codex/skills/pymobiledevice3-device-operator/SKILL.md`
+- Reference file: `.codex/skills/pymobiledevice3-device-operator/references/quick-recipes.md`
 - Reference file: `.codex/skills/pymobiledevice3-device-operator/references/task-map.md`
 - Reference file:
   `.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md`
@@ -18,6 +19,8 @@ If someone is using Codex against the GitHub repository and wants a copy-pasteab
 
 - Skill URL:
   `https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/SKILL.md`
+- Quick recipes URL:
+  `https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/references/quick-recipes.md`
 - Task map URL:
   `https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/references/task-map.md`
 - Transport and safety URL:
@@ -29,6 +32,7 @@ Example prompt:
 Use the pymobiledevice3 device-operator skill:
 https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/SKILL.md
 Also use its references:
+https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/references/quick-recipes.md
 https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/references/task-map.md
 https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
 ```
@@ -58,14 +62,18 @@ For iOS 17+ developer services, the skill routes users through the project tunne
 - [iOS 17+ tunnels](ios17-tunnels.md)
 - `.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md`
 
-If `lockdown start-tunnel` or `remote start-tunnel` fails because
-tunnel interface creation needs elevated privileges, the skill is expected
-to consider retrying with `sudo`.
+On iOS 17.4+ no tunnel setup is needed at all: commands that require an RSD
+tunnel establish a no-root in-process userspace tunnel automatically, so the
+skill routes agents straight to the target command. Privileged tunnels
+(`tunneld`, `start-tunnel`) remain the fallback for iOS 17.0-17.3 devices or
+when the userspace path is not viable (e.g. sustained host-to-device
+throughput).
 
-For Codex-driven tunnel startup, the skill should prefer
-`lockdown start-tunnel --script-mode` or `remote start-tunnel --script-mode`,
-then read the RSD connection details from stdout and feed those exact values
-into later `--rsd HOST PORT` commands.
+For agent-driven `start-tunnel` startup on those fallback paths, the skill
+prefers `lockdown start-tunnel --script-mode` or
+`remote start-tunnel --script-mode` (with `sudo` if tunnel interface creation
+needs elevated privileges), then reads the RSD connection details from stdout
+and feeds those exact values into later `--rsd HOST PORT` commands.
 
 ## When Updating The Project
 

--- a/docs/guides/python-api.md
+++ b/docs/guides/python-api.md
@@ -102,8 +102,9 @@ established.
 
 ## 2. The service pattern
 
-Every service subclasses `LockdownService`, takes a service provider, and is an **async context
-manager**. Once you have that pattern, all services work the same way:
+Nearly every service subclasses `LockdownService`, takes a service provider, and is an **async
+context manager** (a few, like `CrashReportsManager` and `DvtProvider`, wrap other services
+instead). Once you have that pattern, the services all work the same way:
 
 ```python
 from pymobiledevice3.lockdown import create_using_usbmux

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ pymobiledevice3 apps list
 Install shell completions:
 
 ```shell
-pymobiledevice3 install-completions
+pymobiledevice3 --install-completion
 ```
 
 ## Platform notes

--- a/misc/claude-plugin/.claude-plugin/plugin.json
+++ b/misc/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+    "name": "pymobiledevice3",
+    "description": "Operate iOS and iPadOS devices from Claude Code with pymobiledevice3: screenshots, syslog search, crash reports, file and app operations, developer services (DVT, tunnels, WebInspector, WDA) — works from a fresh workstation via uvx/PyPI or a local checkout.",
+    "version": "1.0.0",
+    "author": {
+        "name": "doronz88",
+        "url": "https://github.com/doronz88"
+    },
+    "homepage": "https://github.com/doronz88/pymobiledevice3",
+    "repository": "https://github.com/doronz88/pymobiledevice3",
+    "license": "GPL-3.0",
+    "keywords": [
+        "ios",
+        "iphone",
+        "ipad",
+        "lockdown",
+        "dvt",
+        "instruments"
+    ]
+}

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator
@@ -1,0 +1,1 @@
+../../../.codex/skills/pymobiledevice3-device-operator

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,7 +115,7 @@ nav:
       - iOS 17+ tunnels: guides/ios17-tunnels.md
       - Python API: guides/python-api.md
       - Writing CLI commands: guides/writing-commands-with-service-provider.md
-      - Codex device operator: guides/codex-device-operator-skill.md
+      - Device operator skill: guides/codex-device-operator-skill.md
   - Python API Reference:
       - Overview: api/index.md
       - Connecting to a device: api/connection.md


### PR DESCRIPTION
## What

The repo's three agent skills were split across two discovery roots, so each tool saw only a subset: Claude Code (`.claude/skills/`) saw only `release`, Codex (`.codex/skills/`) saw only `pymobiledevice3-device-operator` and `tss-batch-prefetch`.

- Cross-link the two skill trees with **relative symlinks** — each skill keeps exactly one canonical directory; the other tree holds a symlink. Verified live: after creating the symlinks, Claude Code's skill discovery picked up both `.codex`-canonical skills in-session.
- Add a one-line `CLAUDE.md` (`@AGENTS.md`) so Claude Code actually loads the shared agent guidance — previously it loaded nothing, since it does not read `AGENTS.md` on its own.
- Document the skill inventory and the edit-the-canonical-copy convention in `AGENTS.md`.

## Refresh stale device-operator transport guidance

The skill predates the userspace-tunnel default and still routed agents through `sudo start-tunnel --script-mode` for every iOS 17+ developer command — directly contradicting AGENTS.md, which prefers the no-root path. The guidance now matches reality:

- iOS 17.4+: no tunnel setup at all — commands that need an RSD establish the no-root in-process userspace tunnel automatically.
- iOS 17.0-17.3 / throughput-sensitive or `debugserver` cases: privileged `tunneld` / `start-tunnel --script-mode` remain the documented fallback.
- Skill description made agent-neutral now that both tools discover it.

## Make the skill cover the full capability surface

- New `references/quick-recipes.md`: exact invocations for the most common tasks — screenshot, syslog search, crash pull, app listing, file copy, process monitoring — plus the **syslog-first troubleshooting technique**: the device usually logs the real reason for a failure in its own syslog, so reproduce while watching `syslog live -m <term>` before guessing at causes.
- Task-map gaps closed against `CLI_GROUPS`: `companion`, `btlogger`, `developer simulate-location`/`arbitration`/`shell`, and a pointer to `CLI_GROUPS` in `__main__.py` as the authoritative group list for anything unmapped.

## Installable into anyone's Claude Code

The repo now doubles as a **Claude Code plugin marketplace** (`.claude-plugin/marketplace.json` + plugin package at `misc/claude-plugin/`, both passing `claude plugin validate`):

```text
/plugin marketplace add doronz88/pymobiledevice3
/plugin install pymobiledevice3@pymobiledevice3
```

The skill is workstation-portable to match: outside a checkout it runs `uvx pymobiledevice3` (PyPI — a fresh machine only needs `uv`), and discovers commands via `--help` and the published docs site instead of repo sources. The docs guide gained an 'Install Into Your Own Claude Code' section covering the plugin and manual-symlink paths.

## Docs accuracy fixes (from a full docs-vs-code audit)

- `installation.md`: `install-completions` subcommand does not exist — it's Typer's `--install-completion` flag.
- `cli-recipes.md`: `sysmon process monitor pid N` is not a real command form; the `process` subcommand selects targets with `--filter key=value`.
- `python-api.md`: softened the "every service subclasses `LockdownService`" overgeneralization (`CrashReportsManager`, `DvtProvider` don't).
- `CONTRIBUTING.md` / `AGENTS.md`: both pointed at a nonexistent `docs/README.md` — now the documentation site and the `mkdocs.yml` nav respectively.
- `docs/guides/codex-device-operator-skill.md` retitled/updated accordingly (filename kept to preserve URLs).

## Notes

- The pre-existing long lines flagged by a manual `markdownlint` run of the `.codex` files are untouched; CI's `**/*.md` glob does not match dot-directories, so markdown-lint stays green either way.
- Symlinks degrade gracefully on Windows checkouts without `core.symlinks` (they materialize as small text files); skills are only consumed by agent tooling on the developer's machine, so this does not affect the package or CI.