### PR TITLE
skills: publish the plugin as ios-device-operator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,15 +1,15 @@
 {
     "name": "pymobiledevice3",
-    "description": "Agent skills for operating iOS and iPadOS devices with pymobiledevice3.",
+    "description": "Agent skills for operating iPhone and iPad (iOS/iPadOS) devices with pymobiledevice3.",
     "owner": {
         "name": "doronz88",
         "url": "https://github.com/doronz88"
     },
     "plugins": [
         {
-            "name": "pymobiledevice3",
+            "name": "ios-device-operator",
             "source": "./misc/claude-plugin",
-            "description": "Operate iOS and iPadOS devices from Claude Code with pymobiledevice3: screenshots, syslog search, crash reports, file and app operations, developer services (DVT, tunnels, WebInspector, WDA) — works from a fresh workstation via uvx/PyPI or a local checkout."
+            "description": "Operate iPhone and iPad (iOS/iPadOS) devices from Claude Code with pymobiledevice3: screenshots, syslog search, crash reports, file and app operations, developer services (DVT, tunnels, WebInspector, WDA) — works from a fresh workstation via uvx/PyPI or a local checkout."
         }
     ]
 }

--- a/.codex/skills/pymobiledevice3-device-operator/SKILL.md
+++ b/.codex/skills/pymobiledevice3-device-operator/SKILL.md
@@ -30,7 +30,7 @@ Prefer existing CLI commands first. Prefer reading local docs and CLI source ove
 4. Use `uvx --from . pymobiledevice3 <group> --help` only as a fallback when code and docs are ambiguous, or as a final verification step before suggesting an exact command to the user.
 5. Execute a reversible or read-only step first, then escalate to state-changing actions only if the user asked for them.
 6. For long-lived streams or interactive shells, keep the process attached instead of replacing it with one-shot polling.
-7. If the CLI is missing a path that clearly exists in services, add a thin command using `ServiceProviderDep`, `@async_command`, and a service class under `pymobiledevice3/services/`. Read `docs/guides/writing-commands-with-service-provider.md`.
+7. If the CLI is missing a path that clearly exists in services, add a thin command using `ServiceProviderDep`, `@async_command`, and a service class under `pymobiledevice3/services/` — commands live on an `InjectingTyper` app (from `typer_injector`). Read `docs/guides/writing-commands-with-service-provider.md`.
 
 ## Safety Rules
 

--- a/.codex/skills/pymobiledevice3-device-operator/SKILL.md
+++ b/.codex/skills/pymobiledevice3-device-operator/SKILL.md
@@ -13,6 +13,13 @@ Use this skill to translate a user goal into the smallest correct `pymobiledevic
 
 Inside a pymobiledevice3 checkout, run commands from the repository root with `uvx --from . pymobiledevice3 ...` so the local checkout is used. On a workstation **without** a checkout, run `uvx pymobiledevice3 ...` instead — `uvx` fetches the released package from PyPI on first use, so nothing needs to be installed beforehand except `uv` itself (`uv tool install pymobiledevice3` gives a persistent install). Everywhere this skill's references show `uvx --from . pymobiledevice3 ...`, drop the `--from .` when there is no checkout. Fall back to `python3 -m pymobiledevice3 ...` only if `uvx` is unavailable or the user explicitly wants the current interpreter environment.
 
+If `uv` itself is missing, bootstrap one of the two paths first (neither needs root):
+
+- Install uv: `curl -LsSf https://astral.sh/uv/install.sh | sh` (macOS/Linux) or
+  `powershell -c "irm https://astral.sh/uv/install.ps1 | iex"` (Windows), then use `uvx` as above.
+- Or skip uv entirely: `python3 -m pip install -U pymobiledevice3`, then run
+  `python3 -m pymobiledevice3 ...` everywhere the references show `uvx ... pymobiledevice3 ...`.
+
 Start with the least invasive command that proves connectivity or surfaces missing prerequisites:
 
 ```shell

--- a/.codex/skills/pymobiledevice3-device-operator/SKILL.md
+++ b/.codex/skills/pymobiledevice3-device-operator/SKILL.md
@@ -19,6 +19,10 @@ If `uv` itself is missing, bootstrap one of the two paths first (neither needs r
   `powershell -c "irm https://astral.sh/uv/install.ps1 | iex"` (Windows), then use `uvx` as above.
 - Or skip uv entirely: `python3 -m pip install -U pymobiledevice3`, then run
   `python3 -m pymobiledevice3 ...` everywhere the references show `uvx ... pymobiledevice3 ...`.
+  If pip refuses with `externally-managed-environment` (PEP 668 — Debian/Ubuntu, Homebrew
+  Python, Fedora), create a venv instead of forcing it:
+  `python3 -m venv ~/.pmd3-venv && ~/.pmd3-venv/bin/pip install -U pymobiledevice3`, then use
+  `~/.pmd3-venv/bin/pymobiledevice3 ...`. Never use `--break-system-packages`.
 
 Start with the least invasive command that proves connectivity or surfaces missing prerequisites:
 

--- a/.codex/skills/pymobiledevice3-device-operator/SKILL.md
+++ b/.codex/skills/pymobiledevice3-device-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pymobiledevice3-device-operator
-description: Operate iOS and iPadOS devices with pymobiledevice3, from a local checkout or straight from PyPI via uvx on a fresh workstation. Use when an agent needs to inspect a connected device, collect logs or crash data, browse or copy files, manage apps, profiles, or backups, use developer services such as DDI/DVT/tunnels/sysmon/screenshots/simulated location, automate Safari or WebViews through WebInspector or WDA, or add a thin repo-native device command on top of existing services. Prefer existing CLI and service modules, choose USB vs --rsd/--tunnel correctly, and require explicit user intent before state-changing or destructive actions.
+description: Operate iOS and iPadOS devices with pymobiledevice3, from a local checkout or straight from PyPI via uvx on a fresh workstation. Use when an agent needs to inspect a connected device, collect logs or crash data, browse or copy files, manage apps, profiles, or backups, use developer services such as DDI/DVT/tunnels/sysmon/screenshots/simulated location, automate Safari or WebViews through WebInspector or WDA, write Python scripts against the pymobiledevice3 library, or add a thin repo-native device command on top of existing services. Prefer existing CLI and service modules, choose USB vs --rsd/--tunnel correctly, and require explicit user intent before state-changing or destructive actions.
 ---
 
 # PyMobileDevice3 Device Operator
@@ -51,6 +51,10 @@ Do not expose or commit pair records, crash artifacts, backups, or other device-
 Read `references/quick-recipes.md` for the exact invocation of the most common tasks
 (screenshot, syslog search, crash pull, file copy, app listing) and for the
 syslog-first troubleshooting technique.
+
+Read `references/python-scripting.md` before writing Python code against the library —
+the API went async incrementally over many releases, so memorized/older API shapes are
+usually stale.
 
 Read `references/task-map.md` when you need to map a user goal to a command group or service module.
 

--- a/.codex/skills/pymobiledevice3-device-operator/references/python-scripting.md
+++ b/.codex/skills/pymobiledevice3-device-operator/references/python-scripting.md
@@ -1,0 +1,80 @@
+# Writing Python Scripts Against The Library
+
+## Use This File
+
+Read this file before writing Python code that drives a device through
+`pymobiledevice3` as a library rather than through the CLI.
+
+## Do Not Trust Memorized API Shapes
+
+The library migrated to asyncio **incrementally over many releases**, converting more of
+the API surface each version — so code written from memory or from older examples on the
+web very often uses a stale synchronous shape of an API that is a coroutine today. It
+will look plausible and fail at runtime. Verify every entry point against the current
+source or docs before using it:
+
+- In a checkout: `docs/guides/python-api.md`, then the service module itself.
+- Without a checkout: <https://doronz88.github.io/pymobiledevice3/guides/python-api/>
+  (the site also serves `llms.txt` for bulk ingestion).
+
+Everything is asyncio-based: connection helpers and service methods are coroutines, run
+inside `asyncio.run(...)`.
+
+## Connect (pick by iOS version and service)
+
+- Classic services (AFC, apps, syslog, diagnostics, backup, profiles) — lockdown, all
+  iOS versions, no root:
+
+  ```python
+  import asyncio
+  from pymobiledevice3.lockdown import create_using_usbmux
+
+  async def main():
+      async with await create_using_usbmux() as lockdown:  # serial=... to target
+          print(lockdown.all_values)
+
+  asyncio.run(main())
+  ```
+
+- Developer/DVT services on iOS 17+ — no-root in-process userspace tunnel:
+
+  ```python
+  from pymobiledevice3.remote.userspace_tunnel import UserspaceRsdTunnel
+
+  async with UserspaceRsdTunnel(serial=None, autopair=True) as rsd:
+      ...  # rsd is a connected RemoteServiceDiscoveryService
+  ```
+
+  `establish_userspace_rsd()` is the keep-alive convenience wrapper for scripts. One
+  tunnel per process; the address is unreachable from other processes (use `tunneld` +
+  `get_tunneld_devices()` from `pymobiledevice3.tunneld.api` when an external tool such
+  as `lldb` must reach the device).
+
+## The Service Pattern
+
+Nearly every service subclasses `LockdownService`, takes a service provider, and is an
+async context manager:
+
+```python
+from pymobiledevice3.services.os_trace import OsTraceService
+
+async for entry in OsTraceService(lockdown=lockdown).syslog():
+    print(entry.pid, entry.image_name, entry.message)
+```
+
+DVT services go through a `DvtProvider` over a tunnel-backed provider:
+
+```python
+from pymobiledevice3.services.dvt.instruments.dvt_provider import DvtProvider
+from pymobiledevice3.services.dvt.instruments.process_control import ProcessControl
+
+async with DvtProvider(rsd) as dvt:
+    pid = await ProcessControl(dvt).launch("com.apple.mobilesafari")
+```
+
+## Finding The Right Service
+
+~30 services live under `pymobiledevice3/services/`; the task→class table is in
+`docs/guides/python-api.md` section 4. When the CLI already does what the script needs,
+read the matching module under `pymobiledevice3/cli/` — it shows the exact service calls
+to reuse.

--- a/docs/guides/codex-device-operator-skill.md
+++ b/docs/guides/codex-device-operator-skill.md
@@ -19,6 +19,8 @@ the full inventory and the edit-the-canonical-copy convention.
 You do not need to work inside this repository to use the skill. The commands it
 teaches run against the PyPI release via `uvx pymobiledevice3 ...`, so a fresh
 workstation only needs [uv](https://docs.astral.sh/uv/) and a USB-connected device.
+No uv? The skill also knows the plain-pip path
+(`python3 -m pip install -U pymobiledevice3`) and how to bootstrap uv without root.
 
 **As a plugin (recommended).** This repository doubles as a Claude Code plugin
 marketplace. Inside Claude Code run:

--- a/docs/guides/codex-device-operator-skill.md
+++ b/docs/guides/codex-device-operator-skill.md
@@ -24,7 +24,7 @@ marketplace. Inside Claude Code run:
 
 ```text
 /plugin marketplace add doronz88/pymobiledevice3
-/plugin install pymobiledevice3@pymobiledevice3
+/plugin install ios-device-operator@pymobiledevice3
 ```
 
 After installing, Claude can take screenshots, search the device syslog, pull crash

--- a/docs/guides/codex-device-operator-skill.md
+++ b/docs/guides/codex-device-operator-skill.md
@@ -4,6 +4,7 @@ This repository includes a repo-local agent skill for device-facing work:
 
 - Skill file: `.codex/skills/pymobiledevice3-device-operator/SKILL.md`
 - Reference file: `.codex/skills/pymobiledevice3-device-operator/references/quick-recipes.md`
+- Reference file: `.codex/skills/pymobiledevice3-device-operator/references/python-scripting.md`
 - Reference file: `.codex/skills/pymobiledevice3-device-operator/references/task-map.md`
 - Reference file:
   `.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md`
@@ -47,6 +48,8 @@ If someone is using Codex against the GitHub repository and wants a copy-pasteab
   `https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/SKILL.md`
 - Quick recipes URL:
   `https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/references/quick-recipes.md`
+- Python scripting URL:
+  `https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/references/python-scripting.md`
 - Task map URL:
   `https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/references/task-map.md`
 - Transport and safety URL:
@@ -59,6 +62,7 @@ Use the pymobiledevice3 device-operator skill:
 https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/SKILL.md
 Also use its references:
 https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/references/quick-recipes.md
+https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/references/python-scripting.md
 https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/references/task-map.md
 https://github.com/doronz88/pymobiledevice3/blob/master/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
 ```
@@ -70,6 +74,7 @@ Use this skill when an agent needs to operate a connected iPhone or iPad through
 - app/container operations
 - DVT and other developer services
 - WebInspector and WDA automation
+- Python scripting against the library
 - thin CLI additions on top of existing services
 
 ## What The Skill Enforces

--- a/misc/claude-plugin/.claude-plugin/plugin.json
+++ b/misc/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
-    "name": "pymobiledevice3",
-    "description": "Operate iOS and iPadOS devices from Claude Code with pymobiledevice3: screenshots, syslog search, crash reports, file and app operations, developer services (DVT, tunnels, WebInspector, WDA) — works from a fresh workstation via uvx/PyPI or a local checkout.",
+    "name": "ios-device-operator",
+    "description": "Operate iPhone and iPad (iOS/iPadOS) devices from Claude Code with pymobiledevice3: screenshots, syslog search, crash reports, file and app operations, developer services (DVT, tunnels, WebInspector, WDA) — works from a fresh workstation via uvx/PyPI or a local checkout.",
     "version": "1.0.0",
     "author": {
         "name": "doronz88",


### PR DESCRIPTION
Rename the public Claude Code plugin from `pymobiledevice3` to `ios-device-operator` and make the directory-facing descriptions iPhone/iPad-explicit, ahead of submitting it to the Claude plugin directory. Install line becomes:

```text
/plugin install ios-device-operator@pymobiledevice3
```

Both manifests pass `claude plugin validate`.