### PR TITLE
skills: vendor the plugin skill as real files with a sync guard

### DIFF
--- a/.github/workflows/plugin-skill-sync.yml
+++ b/.github/workflows/plugin-skill-sync.yml
@@ -1,0 +1,22 @@
+name: Plugin skill sync
+
+on:
+  pull_request:
+    branches: [ "master" ]
+    paths:
+      - '.codex/skills/pymobiledevice3-device-operator/**'
+      - 'misc/claude-plugin/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    if: '! github.event.pull_request.draft'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify the vendored plugin skill matches the canonical source
+        run: python3 misc/claude-plugin/sync_skill.py --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,14 @@ repos:
     - id: ruff-format
 - repo: local
   hooks:
+    # The Claude Code plugin ships real copies of the device-operator skill (symlinks get
+    # flattened by ZIP-based consumers); keep them mirroring the canonical .codex files.
+    - id: sync-claude-plugin-skill
+      name: sync claude plugin skill
+      entry: python3 misc/claude-plugin/sync_skill.py
+      language: system
+      files: ^(\.codex/skills/pymobiledevice3-device-operator/|misc/claude-plugin/)
+      pass_filenames: false
     # Pinned so local hooks and CI agree; bump deliberately together with fixing any new findings.
     # Resolves the project's dependencies from .venv (venvPath/venv in pyproject.toml); CI's test
     # matrix skips this hook (SKIP=pyright) since deps aren't installed there — the dedicated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,8 +83,11 @@ device-operator skill guidance needs updating.
 
 The device-operator skill is also published as a Claude Code plugin: the repo is a
 plugin marketplace (`.claude-plugin/marketplace.json`) whose plugin package at
-`misc/claude-plugin/` mounts the skill via symlink — the canonical files remain the
-single source of truth.
+`misc/claude-plugin/` ships a **vendored real copy** of the skill (symlinks get
+flattened by ZIP-based consumers such as plugin review pipelines). The canonical files
+remain the single source of truth: after editing them, the `sync-claude-plugin-skill`
+pre-commit hook refreshes the copy (`misc/claude-plugin/sync_skill.py`), and CI blocks
+out-of-sync merges.
 
 ## Documentation Expectations
 

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator
@@ -1,1 +1,0 @@
-../../../.codex/skills/pymobiledevice3-device-operator

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/SKILL.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: pymobiledevice3-device-operator
+description: Operate iOS and iPadOS devices with pymobiledevice3, from a local checkout or straight from PyPI via uvx on a fresh workstation. Use when an agent needs to inspect a connected device, collect logs or crash data, browse or copy files, manage apps, profiles, or backups, use developer services such as DDI/DVT/tunnels/sysmon/screenshots/simulated location, automate Safari or WebViews through WebInspector or WDA, write Python scripts against the pymobiledevice3 library, or add a thin repo-native device command on top of existing services. Prefer existing CLI and service modules, choose USB vs --rsd/--tunnel correctly, and require explicit user intent before state-changing or destructive actions.
+---
+
+# PyMobileDevice3 Device Operator
+
+## Overview
+
+Use this skill to translate a user goal into the smallest correct `pymobiledevice3` action, then execute it — from a local checkout when one is present, or via the PyPI release (`uvx pymobiledevice3`) on a fresh workstation — or extend the repo with a thin CLI wrapper when the capability already exists in services.
+
+## Default Operating Pattern
+
+Inside a pymobiledevice3 checkout, run commands from the repository root with `uvx --from . pymobiledevice3 ...` so the local checkout is used. On a workstation **without** a checkout, run `uvx pymobiledevice3 ...` instead — `uvx` fetches the released package from PyPI on first use, so nothing needs to be installed beforehand except `uv` itself (`uv tool install pymobiledevice3` gives a persistent install). Everywhere this skill's references show `uvx --from . pymobiledevice3 ...`, drop the `--from .` when there is no checkout. Fall back to `python3 -m pymobiledevice3 ...` only if `uvx` is unavailable or the user explicitly wants the current interpreter environment.
+
+If `uv` itself is missing, bootstrap one of the two paths first (neither needs root):
+
+- Install uv: `curl -LsSf https://astral.sh/uv/install.sh | sh` (macOS/Linux) or
+  `powershell -c "irm https://astral.sh/uv/install.ps1 | iex"` (Windows), then use `uvx` as above.
+- Or skip uv entirely: `python3 -m pip install -U pymobiledevice3`, then run
+  `python3 -m pymobiledevice3 ...` everywhere the references show `uvx ... pymobiledevice3 ...`.
+  If pip refuses with `externally-managed-environment` (PEP 668 — Debian/Ubuntu, Homebrew
+  Python, Fedora), create a venv instead of forcing it:
+  `python3 -m venv ~/.pmd3-venv && ~/.pmd3-venv/bin/pip install -U pymobiledevice3`, then use
+  `~/.pmd3-venv/bin/pymobiledevice3 ...`. Never use `--break-system-packages`.
+
+Start with the least invasive command that proves connectivity or surfaces missing prerequisites:
+
+```shell
+uvx --from . pymobiledevice3 usbmux list
+uvx --from . pymobiledevice3 lockdown info
+```
+
+Prefer existing CLI commands first. Prefer reading local docs and CLI source over invoking `--help`. Only write code when the library already exposes the underlying service but lacks the exact CLI/API path needed.
+
+## Workflow
+
+1. Classify the request as one of: inspect, collect, modify, automate, developer-instrument, or extend-the-repo.
+2. Confirm transport before doing anything expensive. USB is the default. For iOS 17+ developer services, read `references/transport-and-safety.md`.
+3. Discover the narrowest command by checking `docs/guides/cli-recipes.md`, `pymobiledevice3/__main__.py`, and the relevant CLI module under `pymobiledevice3/cli/`. Use `rg` to locate command names, options, and transport flags quickly. Without a checkout, use `--help` discovery and the published docs (<https://doronz88.github.io/pymobiledevice3/>) instead.
+4. Use `uvx --from . pymobiledevice3 <group> --help` only as a fallback when code and docs are ambiguous, or as a final verification step before suggesting an exact command to the user.
+5. Execute a reversible or read-only step first, then escalate to state-changing actions only if the user asked for them.
+6. For long-lived streams or interactive shells, keep the process attached instead of replacing it with one-shot polling.
+7. If the CLI is missing a path that clearly exists in services, add a thin command using `ServiceProviderDep`, `@async_command`, and a service class under `pymobiledevice3/services/` — commands live on an `InjectingTyper` app (from `typer_injector`). Read `docs/guides/writing-commands-with-service-provider.md`.
+
+## Safety Rules
+
+Require explicit user intent before any command that changes device state, including:
+
+- restore, erase, recovery, reboot, restart, unpair, pair-supervised
+- app install or uninstall
+- file push, rm, or app container mutation
+- profile or provisioning changes
+- developer mode toggles, mounting, simulated location, signals, kill/pkill, or automation that taps/types/swipes
+
+Do not invent prerequisites. If a developer service fails, inspect developer-mode, DDI, and tunnel requirements before changing code.
+
+Do not expose or commit pair records, crash artifacts, backups, or other device-identifying material.
+
+## Task Routing
+
+Read `references/quick-recipes.md` for the exact invocation of the most common tasks
+(screenshot, syslog search, crash pull, file copy, app listing) and for the
+syslog-first troubleshooting technique.
+
+Read `references/python-scripting.md` before writing Python code against the library —
+the API went async incrementally over many releases, so memorized/older API shapes are
+usually stale.
+
+Read `references/task-map.md` when you need to map a user goal to a command group or service module.
+
+Read `references/transport-and-safety.md` when the task touches iOS 17+ developer services, tunnels, `--rsd`, `--tunnel`, or destructive operations.
+
+## Source Files To Prefer
+
+These paths are relative to a pymobiledevice3 checkout; without one, use the published
+docs site (<https://doronz88.github.io/pymobiledevice3/>) and `--help` output instead.
+
+- `docs/guides/cli-recipes.md` for common end-user commands
+- `docs/guides/ios17-tunnels.md` for tunnel setup and `--rsd` usage
+- `docs/guides/writing-commands-with-service-provider.md` for repo-native command additions
+- `pymobiledevice3/__main__.py` for top-level CLI groups
+- `pymobiledevice3/cli/cli_common.py` for transport resolution and dependency injection
+
+## Typical Triggers
+
+- "Pull crash logs from the connected iPhone."
+- "List installed apps and copy an app container file."
+- "Take a screenshot with developer services."
+- "Start a tunnel and run DVT sysmon on an iOS 17 device."
+- "Open Safari automation and inspect tabs."
+- "Add a new CLI command for an existing service."

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/agents/openai.yaml
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PyMobileDevice3 Device Operator"
+  short_description: "Operate iOS devices via pymobiledevice3"
+  default_prompt: "Use $pymobiledevice3-device-operator to inspect or control a connected iPhone or iPad with pymobiledevice3."

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/python-scripting.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/python-scripting.md
@@ -1,0 +1,80 @@
+# Writing Python Scripts Against The Library
+
+## Use This File
+
+Read this file before writing Python code that drives a device through
+`pymobiledevice3` as a library rather than through the CLI.
+
+## Do Not Trust Memorized API Shapes
+
+The library migrated to asyncio **incrementally over many releases**, converting more of
+the API surface each version — so code written from memory or from older examples on the
+web very often uses a stale synchronous shape of an API that is a coroutine today. It
+will look plausible and fail at runtime. Verify every entry point against the current
+source or docs before using it:
+
+- In a checkout: `docs/guides/python-api.md`, then the service module itself.
+- Without a checkout: <https://doronz88.github.io/pymobiledevice3/guides/python-api/>
+  (the site also serves `llms.txt` for bulk ingestion).
+
+Everything is asyncio-based: connection helpers and service methods are coroutines, run
+inside `asyncio.run(...)`.
+
+## Connect (pick by iOS version and service)
+
+- Classic services (AFC, apps, syslog, diagnostics, backup, profiles) — lockdown, all
+  iOS versions, no root:
+
+  ```python
+  import asyncio
+  from pymobiledevice3.lockdown import create_using_usbmux
+
+  async def main():
+      async with await create_using_usbmux() as lockdown:  # serial=... to target
+          print(lockdown.all_values)
+
+  asyncio.run(main())
+  ```
+
+- Developer/DVT services on iOS 17+ — no-root in-process userspace tunnel:
+
+  ```python
+  from pymobiledevice3.remote.userspace_tunnel import UserspaceRsdTunnel
+
+  async with UserspaceRsdTunnel(serial=None, autopair=True) as rsd:
+      ...  # rsd is a connected RemoteServiceDiscoveryService
+  ```
+
+  `establish_userspace_rsd()` is the keep-alive convenience wrapper for scripts. One
+  tunnel per process; the address is unreachable from other processes (use `tunneld` +
+  `get_tunneld_devices()` from `pymobiledevice3.tunneld.api` when an external tool such
+  as `lldb` must reach the device).
+
+## The Service Pattern
+
+Nearly every service subclasses `LockdownService`, takes a service provider, and is an
+async context manager:
+
+```python
+from pymobiledevice3.services.os_trace import OsTraceService
+
+async for entry in OsTraceService(lockdown=lockdown).syslog():
+    print(entry.pid, entry.image_name, entry.message)
+```
+
+DVT services go through a `DvtProvider` over a tunnel-backed provider:
+
+```python
+from pymobiledevice3.services.dvt.instruments.dvt_provider import DvtProvider
+from pymobiledevice3.services.dvt.instruments.process_control import ProcessControl
+
+async with DvtProvider(rsd) as dvt:
+    pid = await ProcessControl(dvt).launch("com.apple.mobilesafari")
+```
+
+## Finding The Right Service
+
+~30 services live under `pymobiledevice3/services/`; the task→class table is in
+`docs/guides/python-api.md` section 4. When the CLI already does what the script needs,
+read the matching module under `pymobiledevice3/cli/` — it shows the exact service calls
+to reuse.

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/quick-recipes.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/quick-recipes.md
@@ -1,0 +1,84 @@
+# Quick Recipes
+
+## Use This File
+
+Read this file for the exact invocation of the most common device tasks. Commands are
+shown for a repository checkout (`uvx --from . pymobiledevice3`); on a workstation
+without one, drop the `--from .` so `uvx` fetches the PyPI release. On iOS 17.4+ the
+`developer` commands establish a no-root userspace tunnel automatically, so run them
+as-is — no `sudo`, no tunnel setup.
+
+## Screenshot
+
+```shell
+uvx --from . pymobiledevice3 developer dvt screenshot ./screen.png
+```
+
+Requires Developer Mode and a mounted DDI (`amfi enable-developer-mode`,
+`mounter auto-mount`). WDA-based UI automation has its own screenshot:
+`developer wda screenshot`.
+
+## Search The Device Syslog
+
+```shell
+# Live syslog filtered to lines containing a term (repeatable, case-sensitive)
+uvx --from . pymobiledevice3 syslog live -m <term>
+
+# Case-insensitive match / filter by process
+uvx --from . pymobiledevice3 syslog live --match-insensitive <term>
+uvx --from . pymobiledevice3 syslog live --process-name <name>
+uvx --from . pymobiledevice3 syslog live --pid <pid>
+```
+
+Structured os_log (with subsystem/category metadata) via developer services:
+
+```shell
+uvx --from . pymobiledevice3 developer dvt oslog
+```
+
+## Troubleshoot With The Syslog First
+
+When something on-device misbehaves — a service refuses to start, an app dies on launch,
+a developer command fails opaquely — the device usually logs the real reason in its
+syslog. Before changing code or guessing at prerequisites, reproduce the failure while
+watching:
+
+```shell
+uvx --from . pymobiledevice3 syslog live -m <bundle-id-or-daemon-or-error-term>
+```
+
+Filter by the daemon that owns the failing service (`--process-name`) when you know it.
+The device-side error message is frequently more specific than the host-side exception.
+
+## Crash Reports
+
+```shell
+uvx --from . pymobiledevice3 crash ls
+uvx --from . pymobiledevice3 crash pull <target-dir>
+uvx --from . pymobiledevice3 crash watch
+```
+
+## Apps
+
+```shell
+uvx --from . pymobiledevice3 apps list
+uvx --from . pymobiledevice3 apps query <bundle-id>
+```
+
+## Files (media domain via AFC)
+
+```shell
+uvx --from . pymobiledevice3 afc ls /
+uvx --from . pymobiledevice3 afc pull <device-path> <local-path>
+uvx --from . pymobiledevice3 afc push <local-path> <device-path>
+```
+
+App containers go through the `apps` group / `house_arrest` service instead of plain AFC.
+
+## Device Info And Processes
+
+```shell
+uvx --from . pymobiledevice3 lockdown info
+uvx --from . pymobiledevice3 developer dvt sysmon process single
+uvx --from . pymobiledevice3 developer dvt sysmon process monitor process --filter name=<name> --key name --key cpuUsage
+```

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/task-map.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/task-map.md
@@ -1,0 +1,93 @@
+# Task Map
+
+## Use This File
+
+Read this file when the user asks to do something on-device and you need to map intent to the correct `pymobiledevice3` command group or code entry point.
+
+## Connectivity And Discovery
+
+- `usbmux`: list devices, forward ports, inspect basic connectivity.
+- `bonjour`: discover RemoteXPC and related network-visible services.
+- `lockdown`: inspect values, pair or unpair, start tunnels, toggle Wi-Fi connections, basic device settings.
+- `remote`: remote pairing and tunnel helpers for CoreDevice flows.
+- `companion`: reach services on a paired companion device (e.g. Apple Watch) through the phone.
+
+Start here when the task is blocked on "find the device", "connect to the device", "`--rsd` details", or "start a tunnel".
+
+Explicit tunnel setup is rarely needed: on iOS 17.4+, commands that require an RSD tunnel establish a no-root in-process userspace tunnel automatically — just run the command. Reach for `tunneld` or `start-tunnel` (see `references/transport-and-safety.md`) only for iOS 17.0-17.3 devices or when the userspace path is not viable.
+
+## Files, Containers, And App Data
+
+- `afc`: media-domain shell, pull, push, ls, rm.
+- `apps`: list/query/install/uninstall apps and work with app AFC/container helpers.
+- `crash`: browse, pull, clear, watch crash reports and sysdiagnose artifacts.
+- Services to inspect when extending: `services/afc.py`, `services/house_arrest.py`, `services/installation_proxy.py`, `services/crash_reports.py`.
+
+Use these for browsing files, copying artifacts, or handling app containers.
+
+## Device State, Logs, And Diagnostics
+
+- `syslog`: live logs and collection.
+- `diagnostics`: restart, shutdown, info, battery-related flows under `pymobiledevice3/cli/diagnostics/`.
+- `notification`: observe or post Darwin notifications.
+- `pcap`: capture network traffic.
+- `btlogger`: capture Bluetooth HCI packet logs (pcap/pcapng).
+- `power-assertion`: keep the device awake for a task.
+- `processes`: process inspection helpers outside full DVT flows.
+
+Use these for observability, troubleshooting, and health checks.
+
+## Apps, Profiles, Provisioning, And Activation
+
+- `apps`: install, uninstall, query.
+- `profile`: configuration profile management.
+- `provision`: provisioning profile helpers.
+- `activation`: activation-related actions.
+- `amfi`: Developer Mode enablement.
+- `idam`: account/device-association flows when relevant.
+
+Treat most of these as state-changing. Do not run them unless the user clearly asked.
+
+## Backup, Restore, Recovery
+
+- `backup2`: backup, restore, list, encryption and password flows.
+- `restore`: recovery, ramdisk, TSS, update, erase, reboot, shell.
+- Supporting code: `pymobiledevice3/restore/` and `pymobiledevice3/cli/restore.py`.
+
+These are the highest-risk areas. Ask before destructive actions and prefer inspection first.
+
+## SpringBoard, UI, And Browser Automation
+
+- `springboard`: icon state, orientation, wallpapers, shell.
+- `webinspector`: opened tabs, JS shell, launch, automation shell, CDP server.
+- `developer wda`: launch/tap/press/unlock/list-items/screenshot/type/swipe/window-size/status.
+- Services to inspect: `services/webinspector.py`, `services/web_protocol/*`, `services/wda.py`, `services/springboard.py`.
+
+Use WebInspector for Safari/WebView automation and WDA for device UI automation.
+
+## Developer Services And Instrumentation
+
+- `mounter`: mount developer images.
+- `developer dvt`: screenshot, sysmon, process control, oslog, device info, netstat, HAR, energy, location simulation, xcuitest, profiling.
+- `developer core-device`: file/process/app/device-info operations through CoreDevice flows.
+- `developer debugserver`: debugserver launch and LLDB bridging.
+- `developer fetch-symbols`: symbol acquisition.
+- `developer accessibility`: audits, settings, notifications, item listing.
+- `developer simulate-location`: DVT-based location simulation.
+- `developer arbitration`: device arbitration (check-in/check-out for exclusive use).
+- `developer shell`: IPython shell connected to a named developer service (exploration/R&D).
+- Supporting code: `pymobiledevice3/cli/developer/` and `pymobiledevice3/services/dvt/`.
+
+The authoritative list of top-level groups is `CLI_GROUPS` in `pymobiledevice3/__main__.py`;
+if a goal maps to nothing above, scan it and the matching module under `pymobiledevice3/cli/`.
+
+Read `references/transport-and-safety.md` before using these on iOS 17+.
+
+## When The CLI Is Close But Not Exact
+
+If the user needs a variation that the CLI does not expose:
+
+1. Search the matching service under `pymobiledevice3/services/`.
+2. Keep transport logic in `ServiceProviderDep`.
+3. Add a thin async CLI wrapper instead of embedding protocol logic in the command handler.
+4. Reuse existing patterns from `docs/guides/writing-commands-with-service-provider.md`.

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -1,0 +1,79 @@
+# Transport And Safety
+
+## Use This File
+
+Read this file when the request touches transport selection, iOS 17+ developer services, or actions that can mutate device state.
+
+## Transport Selection
+
+- USB lockdown is the default path for most commands.
+- `ServiceProviderDep` already resolves USB, `--rsd`, `--tunnel`, and `--userspace` flows for repo-native CLI commands.
+- When a command requires an RSD tunnel and no transport flag is given, a **no-root
+  in-process userspace tunnel** is established automatically on iOS 17.4+ — no `sudo`,
+  no `start-tunnel`, no `tunneld`. This is the preferred path for agents.
+- `--userspace` forces the userspace tunnel explicitly (`PYMOBILEDEVICE3_USERSPACE=1` is
+  equivalent); it is mutually exclusive with `--rsd`/`--tunnel`.
+- `--rsd HOST PORT` is for a specific RemoteServiceDiscovery endpoint.
+- `--tunnel ''` or `--tunnel <UDID>` targets a device already exposed by `tunneld`.
+
+Use `uvx --from . pymobiledevice3 usbmux list` first for direct USB discovery.
+
+## iOS 17+ Developer Service Checklist
+
+Many `developer dvt` and related developer commands need all of the following:
+
+1. Developer Mode enabled:
+   `uvx --from . pymobiledevice3 amfi enable-developer-mode`
+2. Developer image mounted:
+   `uvx --from . pymobiledevice3 mounter auto-mount`
+3. A CoreDevice transport path. On iOS 17.4+ this needs **no setup**: the no-root
+   userspace tunnel is established automatically when the command runs. Only iOS
+   17.0-17.3 devices (which predate CoreDeviceProxy) route to `tunneld` and need a
+   privileged daemon: `sudo uvx --from . pymobiledevice3 remote tunneld` in the
+   background, then pass `--tunnel ''` or `--tunnel <UDID>`.
+
+If a developer command fails with service-availability errors, verify Developer Mode and
+the mounted image before assuming the code is broken.
+
+## Tunnel Notes
+
+- The userspace tunnel is the default; prefer it. Fall back to a privileged tunnel only
+  when userspace is not viable: sustained host->device throughput (DDI mounts and large
+  file pushes are deliberately slower over userspace), `debugserver start-server`
+  without `--local-port`, or iOS 17.0-17.3.
+- Privileged options: an already-running `tunneld`, or a one-off
+  `lockdown start-tunnel` (iOS 17.4+) / `remote start-tunnel` (iOS 17.0-17.3.1).
+- Privileged tunnel creation can require `sudo` because it creates a TUN/TAP interface.
+- For agent-driven `start-tunnel`, use `--script-mode`, read the RSD host and port from
+  stdout, and reuse those exact values in later commands via `--rsd HOST PORT`.
+- `PYMOBILEDEVICE3_PREFER_TUNNELD=1` opts out of the userspace default entirely.
+
+See `docs/guides/ios17-tunnels.md` for the repo’s detailed guidance.
+
+## Safety Gates
+
+Ask before running commands that can:
+
+- erase, restore, reboot, or move the device into or out of recovery
+- install or remove apps, profiles, provisioning data, or activation state
+- write or delete files on AFC or app containers
+- toggle Developer Mode, mount developer images, simulate location, or signal/kill processes
+- drive the UI through WDA or automation sessions in ways that change app/device state
+
+If the user only asked to inspect or debug, stay read-only unless the task cannot progress without a change and the user approves it.
+
+## Troubleshooting Order
+
+The device often logs the real reason for a failure in its own syslog. When an error is
+opaque, reproduce it while watching `syslog live -m <term>` (or
+`--process-name <daemon>`) — see `references/quick-recipes.md` — and read the
+device-side message before guessing.
+
+When a command fails, check in this order:
+
+1. Device presence and pairing: `usbmux list`, `lockdown info`
+2. Correct transport: USB vs `--rsd` vs `--tunnel`
+3. Developer prerequisites: Developer Mode, mounted image, and — only on iOS 17.0-17.3 or when a privileged tunnel is explicitly used — a running `tunneld` / sufficient privileges for `start-tunnel` such as `sudo`
+4. Capability location: existing CLI command vs service method vs unsupported feature
+
+Only after those checks should you consider implementing new code.

--- a/misc/claude-plugin/sync_skill.py
+++ b/misc/claude-plugin/sync_skill.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Mirror the canonical device-operator skill into the Claude Code plugin package.
+
+The plugin at ``misc/claude-plugin/`` ships REAL copies of the skill files rather than a
+git symlink: consumers that flatten symlinks (GitHub ZIP archives, plugin review
+pipelines) would otherwise see a one-line text file instead of the skill content. The
+canonical files stay in ``.codex/skills/pymobiledevice3-device-operator/`` — edit those
+only; the pre-commit hook runs this script to refresh the vendored copy, and CI runs it
+with ``--check`` to block out-of-sync merges.
+"""
+
+import argparse
+import filecmp
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL = REPO_ROOT / ".codex" / "skills" / "pymobiledevice3-device-operator"
+VENDORED = REPO_ROOT / "misc" / "claude-plugin" / "skills" / "pymobiledevice3-device-operator"
+
+
+def relative_files(root: Path) -> set[Path]:
+    return {path.relative_to(root) for path in root.rglob("*") if path.is_file()}
+
+
+def find_drift() -> list[Path]:
+    canonical_files = relative_files(CANONICAL)
+    vendored_files = relative_files(VENDORED) if VENDORED.exists() else set()
+    drifted = canonical_files ^ vendored_files
+    for rel in canonical_files & vendored_files:
+        if not filecmp.cmp(CANONICAL / rel, VENDORED / rel, shallow=False):
+            drifted.add(rel)
+    return sorted(drifted)
+
+
+def sync() -> None:
+    if VENDORED.exists():
+        shutil.rmtree(VENDORED)
+    shutil.copytree(CANONICAL, VENDORED)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="verify the vendored copy matches without writing")
+    args = parser.parse_args()
+
+    drifted = find_drift()
+    if not drifted:
+        return 0
+    for rel in drifted:
+        print(f"out of sync: {rel}", file=sys.stderr)
+    if args.check:
+        print("run misc/claude-plugin/sync_skill.py to refresh the vendored copy", file=sys.stderr)
+        return 1
+    sync()
+    print(f"synced {CANONICAL} -> {VENDORED}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The Claude Code plugin package mounted the device-operator skill via a git symlink. Git clones preserve that, but ZIP-based consumers — GitHub archives, and possibly Anthropic's plugin review pipeline (the plugin is currently under review) — flatten symlinks into one-line text files, which would make the plugin appear empty.

- Replace the symlink with a **vendored real copy** of the skill.
- Canonical files under `.codex/skills/` stay the single source of truth: a new `sync-claude-plugin-skill` pre-commit hook refreshes the copy via `misc/claude-plugin/sync_skill.py`, and a new `plugin-skill-sync` workflow runs `--check` on PRs touching either side to block out-of-sync merges.
- Script is ruff/pyright clean; `claude plugin validate` passes; `uv build` verified (the vendored files stay out of the package via the existing `prune misc/claude-plugin`).