### PR TITLE
dvt: fix silently-dropped process kill over the userspace tunnel

### DIFF
--- a/pymobiledevice3/services/dvt/instruments/process_control.py
+++ b/pymobiledevice3/services/dvt/instruments/process_control.py
@@ -11,6 +11,11 @@ from pymobiledevice3.osu.os_utils import get_os_utils
 
 OSUTIL = get_os_utils()
 
+# SIGKILL on Darwin and every Apple platform pymobiledevice3 targets. Hardcoded rather than
+# signal.SIGKILL because that constant does not exist on Windows hosts, which can still drive a
+# connected device.
+SIGKILL = 9
+
 
 @dataclasses.dataclass
 class OutputReceivedEvent:
@@ -117,11 +122,17 @@ class ProcessControl(DtxService[ProcessControlService]):
 
     async def kill(self, pid: int):
         """
-        Kill a process. The request is fire-and-forget (no reply is awaited).
+        Kill a process by sending it SIGKILL.
+
+        Implemented via ``sendSignal:toPid:`` (which awaits a reply) rather than the
+        fire-and-forget ``killPid:``: the round-trip guarantees the device has acted on the
+        request before the DTX channel — and, on iOS 17+, the tunnel — is torn down. A bare
+        ``killPid:`` is silently dropped when the channel closes immediately after sending it
+        (observed over the default userspace tunnel), leaving the target process alive.
 
         :param pid: PID of the process to kill.
         """
-        await self.service.kill_pid_(pid)
+        await self.signal(pid, SIGKILL)
 
     async def process_identifier_for_bundle_identifier(self, app_bundle_identifier: str) -> int:
         """

--- a/tests/services/instruments/test_dvt_provider.py
+++ b/tests/services/instruments/test_dvt_provider.py
@@ -82,6 +82,9 @@ async def test_kill(dvt, service_provider) -> None:
     await asyncio.sleep(3)
     async with type(dvt)(service_provider) as second_dvt, DeviceInfo(second_dvt) as device_info:
         aggregated_after_kill = await get_process_data(device_info, "SpringBoard")
+    # the kill must have taken effect: SpringBoard respawns under a fresh pid. Asserting this
+    # unconditionally guards against a silently-dropped kill (the process would keep its pid).
+    assert aggregated["pid"] != aggregated_after_kill["pid"]
     if "startDate" in aggregated:
         assert aggregated["startDate"] < aggregated_after_kill["startDate"]
 


### PR DESCRIPTION
## Symptom

`pymobiledevice3 developer dvt kill <pid>` silently no-ops on iOS 17+ over the default userspace tunnel — the process keeps running — while `developer dvt signal <pid> -s KILL` kills it. Found during live device testing on iOS 27.

## Root cause

`ProcessControl.kill()` invoked the fire-and-forget `killPid:` selector (`expects_reply=False`). The frame is written and drained, but with no reply there is no round-trip barrier, so the CLI's `async with DvtProvider(...) as dvt, ProcessControl(dvt) ...` block tears down the DTX channel — and the tunnel — immediately after sending, before the device acts on the message. `sendSignal:toPid:` works precisely because it awaits a reply, keeping the channel alive until the device has processed the request.

This was latent under the privileged kernel tunnel (`tunneld`) and surfaced once the no-root userspace tunnel became the default in v10.0.0, since its teardown races in-flight data more tightly.

## Fix

Implement `kill()` via `sendSignal:toPid:` with SIGKILL — a reply-bearing round-trip that guarantees delivery before teardown. This also fixes `pkill`, which shares the same code path. SIGKILL is hardcoded as `9` (not `signal.SIGKILL`, which is absent on Windows hosts). The raw fire-and-forget `kill_pid_` primitive is left in place for direct DTX users.

## Verification

Live on an iOS 27 device: SpringBoard is reliably killed and respawns under a fresh pid (5789 → 5872) — the scenario that no-oped before. The device-only `test_kill` now asserts the pid changed, so a dropped kill can no longer pass vacuously.