### PR TITLE
typing: parametrize bare dict/list generics (slice 1 of reportMissingTypeArgument)

### DIFF
--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 import asyncio
 import datetime
 import logging
@@ -106,7 +107,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
         identifier: Optional[str] = None,
         label: str = DEFAULT_LABEL,
         system_buid: str = SYSTEM_BUID,
-        pair_record: Optional[dict] = None,
+        pair_record: Optional[dict[str, Any]] = None,
         pairing_records_cache_folder: Optional[Path] = None,
         port: int = SERVICE_PORT,
     ):
@@ -156,7 +157,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
         autopair: bool = True,
         pair_timeout: Optional[float] = None,
         local_hostname: Optional[str] = None,
-        pair_record: Optional[dict] = None,
+        pair_record: Optional[dict[str, Any]] = None,
         pairing_records_cache_folder: Optional[Path] = None,
         port: int = SERVICE_PORT,
         private_key: Optional[RSAPrivateKey] = None,
@@ -291,7 +292,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
         return self.all_values.get("WiFiAddress")
 
     @property
-    def short_info(self) -> dict:
+    def short_info(self) -> dict[str, Any]:
         """A compact subset of the device's values, suitable for listing devices.
 
         :returns: A dict containing ``Identifier`` plus ``DeviceClass``, ``DeviceName``, ``BuildVersion``,
@@ -315,7 +316,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
         return self.all_values["UniqueChipID"]
 
     @property
-    def preflight_info(self) -> Optional[dict]:
+    def preflight_info(self) -> Optional[dict[str, Any]]:
         """The device's ``PreflightInfo`` value.
 
         :returns: The preflight info dict, or ``None`` when the device did not report one.
@@ -323,7 +324,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
         return self.all_values.get("PreflightInfo")
 
     @property
-    def firmware_preflight_info(self) -> Optional[dict]:
+    def firmware_preflight_info(self) -> Optional[dict[str, Any]]:
         """The device's ``FirmwarePreflightInfo`` value.
 
         :returns: The firmware preflight info dict, or ``None`` when the device did not report one.
@@ -540,7 +541,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
         """
         return await self._request("EnterRecovery")
 
-    async def stop_session(self) -> dict:
+    async def stop_session(self) -> dict[str, Any]:
         """Stop the current lockdownd session.
 
         Sends a ``StopSession`` request for the active session and clears the local session id.
@@ -800,7 +801,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
             self.all_values = r
         return r
 
-    async def remove_value(self, domain: Optional[str] = None, key: Optional[str] = None) -> dict:
+    async def remove_value(self, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
         """Remove a value on the device via a ``RemoveValue`` request.
 
         :param domain: Domain to remove from, or ``None`` for the default domain.
@@ -814,7 +815,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
             options["Key"] = key
         return await self._request("RemoveValue", options)
 
-    async def set_value(self, value, domain: Optional[str] = None, key: Optional[str] = None) -> dict:
+    async def set_value(self, value, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
         """Write a value to the device via a ``SetValue`` request.
 
         :param value: The value to write.
@@ -830,7 +831,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
         options["Value"] = value
         return await self._request("SetValue", options)
 
-    async def get_service_connection_attributes(self, name: str, include_escrow_bag: bool = False) -> dict:
+    async def get_service_connection_attributes(self, name: str, include_escrow_bag: bool = False) -> dict[str, Any]:
         """Ask lockdownd to start a named service and return its connection attributes.
 
         Sends a ``StartService`` request for the given service. The returned dict includes the ``Port`` to
@@ -966,7 +967,9 @@ class LockdownClient(ABC, LockdownServiceProvider):
         """
         return await self.create_service_connection(port)
 
-    async def _request(self, request: str, options: Optional[dict] = None, verify_request: bool = True) -> dict:
+    async def _request(
+        self, request: str, options: Optional[dict[str, Any]] = None, verify_request: bool = True
+    ) -> dict[str, Any]:
         """
         Sends a request to the associated service, processes the response, and verifies
         the result. Reconnects and retries the request if a connection-related error
@@ -1014,7 +1017,9 @@ class LockdownClient(ABC, LockdownServiceProvider):
             await self.service.close()
             raise
 
-    def _verify_request_response(self, request: str, response: dict, *, verify_request: bool = True) -> dict:
+    def _verify_request_response(
+        self, request: str, response: dict[str, Any], *, verify_request: bool = True
+    ) -> dict[str, Any]:
         """Internal helper for verify request response.
 
         :param request: Request.
@@ -1052,7 +1057,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
 
         return response
 
-    async def _request_pair(self, pair_options: dict, timeout: Optional[float] = None) -> dict:
+    async def _request_pair(self, pair_options: dict[str, Any], timeout: Optional[float] = None) -> dict[str, Any]:
         """
         Asynchronously requests pairing using the provided pair options. This method handles
         pairing dialog responses and waits for user input within the given timeout period.
@@ -1140,7 +1145,7 @@ class UsbmuxLockdownClient(LockdownClient):
         identifier: Optional[str] = None,
         label: str = DEFAULT_LABEL,
         system_buid: str = SYSTEM_BUID,
-        pair_record: Optional[dict] = None,
+        pair_record: Optional[dict[str, Any]] = None,
         pairing_records_cache_folder: Optional[Path] = None,
         port: int = SERVICE_PORT,
         usbmux_address: Optional[str] = None,
@@ -1165,7 +1170,7 @@ class UsbmuxLockdownClient(LockdownClient):
         )
 
     @property
-    def short_info(self) -> dict:
+    def short_info(self) -> dict[str, Any]:
         """A compact subset of the device's values, plus the usbmux connection type.
 
         :returns: The base `short_info` dict with an added ``ConnectionType`` key
@@ -1237,7 +1242,7 @@ class TcpLockdownClient(LockdownClient):
         identifier: Optional[str] = None,
         label: str = DEFAULT_LABEL,
         system_buid: str = SYSTEM_BUID,
-        pair_record: Optional[dict] = None,
+        pair_record: Optional[dict[str, Any]] = None,
         pairing_records_cache_folder: Optional[Path] = None,
         port: int = SERVICE_PORT,
         keep_alive: bool = True,
@@ -1325,7 +1330,7 @@ class RemoteLockdownClient(LockdownClient):
         identifier: Optional[str] = None,
         label: str = DEFAULT_LABEL,
         system_buid: str = SYSTEM_BUID,
-        pair_record: Optional[dict] = None,
+        pair_record: Optional[dict[str, Any]] = None,
         pairing_records_cache_folder: Optional[Path] = None,
         port: int = SERVICE_PORT,
     ):
@@ -1355,7 +1360,7 @@ async def create_using_usbmux(
     connection_type: Optional[str] = None,
     pair_timeout: Optional[float] = None,
     local_hostname: Optional[str] = None,
-    pair_record: Optional[dict] = None,
+    pair_record: Optional[dict[str, Any]] = None,
     pairing_records_cache_folder: Optional[Path] = None,
     port: int = SERVICE_PORT,
     usbmux_address: Optional[str] = None,
@@ -1465,7 +1470,7 @@ async def create_using_tcp(
     autopair: bool = True,
     pair_timeout: Optional[float] = None,
     local_hostname: Optional[str] = None,
-    pair_record: Optional[dict] = None,
+    pair_record: Optional[dict[str, Any]] = None,
     pairing_records_cache_folder: Optional[Path] = None,
     port: int = SERVICE_PORT,
     keep_alive: bool = False,
@@ -1515,7 +1520,7 @@ async def create_using_remote(
     autopair: bool = True,
     pair_timeout: Optional[float] = None,
     local_hostname: Optional[str] = None,
-    pair_record: Optional[dict] = None,
+    pair_record: Optional[dict[str, Any]] = None,
     pairing_records_cache_folder: Optional[Path] = None,
     port: int = SERVICE_PORT,
 ) -> RemoteLockdownClient:

--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 import asyncio
 import base64
 import binascii
@@ -194,7 +195,7 @@ def create_tun_device(interface_name: str = DEFAULT_INTERFACE_NAME):
 class RemotePairingTunnel(ABC):
     def __init__(self):
         self._queue = asyncio.Queue()
-        self._tun_read_task: Optional[asyncio.Task] = None
+        self._tun_read_task: Optional[asyncio.Task[None]] = None
         self._logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         # The tunnel link device is one of two duck-typed backends (kernel ``TunTapDevice`` or the
         # userspace ``UserspaceTun``) selected at runtime by ``create_tun_device`` and dispatched by
@@ -207,7 +208,7 @@ class RemotePairingTunnel(ABC):
         pass
 
     @abstractmethod
-    async def request_tunnel_establish(self) -> dict:
+    async def request_tunnel_establish(self) -> dict[str, Any]:
         pass
 
     @abstractmethod
@@ -269,7 +270,7 @@ class RemotePairingTunnel(ABC):
     async def _tun_read_loop_via_reader(self, read_size: int) -> None:
         loop = asyncio.get_running_loop()
         fd = self.tun.fileno()
-        queue: asyncio.Queue = asyncio.Queue()
+        queue: asyncio.Queue[Optional[bytes]] = asyncio.Queue()
 
         def on_readable() -> None:
             # Drain every packet currently buffered on the fd in this one callback rather than
@@ -340,7 +341,7 @@ class RemotePairingTunnel(ABC):
         self.tun = None
 
     @staticmethod
-    def _encode_cdtunnel_packet(data: dict) -> bytes:
+    def _encode_cdtunnel_packet(data: dict[str, Any]) -> bytes:
         return CDTunnelPacket.build({"body": json.dumps(data).encode()})
 
 
@@ -352,7 +353,7 @@ class RemotePairingQuicTunnel(RemotePairingTunnel, QuicConnectionProtocol):
     def __init__(self, quic: QuicConnection, stream_handler: Optional[QuicStreamHandler] = None):
         RemotePairingTunnel.__init__(self)
         QuicConnectionProtocol.__init__(self, quic, stream_handler)
-        self._keep_alive_task: Optional[asyncio.Task] = None
+        self._keep_alive_task: Optional[asyncio.Task[None]] = None
 
     async def wait_closed(self) -> None:
         with suppress(asyncio.CancelledError):
@@ -365,7 +366,7 @@ class RemotePairingQuicTunnel(RemotePairingTunnel, QuicConnectionProtocol):
         # Allow other tasks to run
         await asyncio.sleep(0)
 
-    async def request_tunnel_establish(self) -> dict:
+    async def request_tunnel_establish(self) -> dict[str, Any]:
         stream_id = self._quic.get_next_available_stream_id()
         # pad the data with random data to force the MTU size correctly
         self._quic.send_datagram_frame(b"x" * 1024)
@@ -401,7 +402,7 @@ class RemotePairingQuicTunnel(RemotePairingTunnel, QuicConnectionProtocol):
             self.tun.write(LOOPBACK_HEADER + event.data)
 
     @staticmethod
-    def _encode_cdtunnel_packet(data: dict) -> bytes:
+    def _encode_cdtunnel_packet(data: dict[str, Any]) -> bytes:
         return CDTunnelPacket.build({"body": json.dumps(data).encode()})
 
 
@@ -471,7 +472,7 @@ class RemotePairingTcpTunnel(RemotePairingTunnel):
         payload_length = struct.unpack(">H", header[8:10])[0]
         return header + await self._service.recvall(payload_length)
 
-    async def request_tunnel_establish(self) -> dict:
+    async def request_tunnel_establish(self) -> dict[str, Any]:
         payload = self._encode_cdtunnel_packet({"type": "clientHandshakeRequest", "mtu": self.REQUESTED_MTU})
         if self._writer is not None and self._reader is not None:
             self._writer.write(payload)
@@ -547,14 +548,14 @@ class RemotePairingProtocol(StartTcpTunnel):
         pass
 
     @abstractmethod
-    async def receive_response(self) -> dict:
+    async def receive_response(self) -> dict[str, Any]:
         pass
 
     @abstractmethod
-    async def send_request(self, data: dict) -> None:
+    async def send_request(self, data: dict[str, Any]) -> None:
         pass
 
-    async def send_receive_request(self, data: dict) -> dict:
+    async def send_receive_request(self, data: dict[str, Any]) -> dict[str, Any]:
         await self.send_request(data)
         return await self.receive_response()
 
@@ -573,7 +574,7 @@ class RemotePairingProtocol(StartTcpTunnel):
             # Once pairing is completed, the remote endpoint closes the connection, so it must be re-established
             raise RemotePairingCompletedError()
 
-    async def create_quic_listener(self, private_key: RSAPrivateKey) -> dict:
+    async def create_quic_listener(self, private_key: RSAPrivateKey) -> dict[str, Any]:
         request = {
             "request": {
                 "_0": {
@@ -591,7 +592,7 @@ class RemotePairingProtocol(StartTcpTunnel):
         response = await self._send_receive_encrypted_request(request)
         return response["createListener"]
 
-    async def create_tcp_listener(self) -> dict:
+    async def create_tcp_listener(self) -> dict[str, Any]:
         assert self.encryption_key is not None
         request = {
             "request": {
@@ -743,7 +744,7 @@ class RemotePairingProtocol(StartTcpTunnel):
         OSUTIL.chown_to_non_sudo_if_needed(self.pair_record_path)
 
     @property
-    def pair_record(self) -> Optional[dict]:
+    def pair_record(self) -> Optional[dict[str, Any]]:
         if self.pair_record_path.exists():
             return plistlib.loads(self.pair_record_path.read_bytes())
         return None
@@ -843,7 +844,7 @@ class RemotePairingProtocol(StartTcpTunnel):
         data = self.decode_tlv(PairingDataComponentTLVBuf.parse(response))
         assert self.srp_context.verify_proof(data[PairingDataComponentType.PROOF].hex().encode())
 
-    async def _save_pair_record_on_peer(self) -> list:
+    async def _save_pair_record_on_peer(self) -> list[Any]:
         assert self.encryption_key is not None
         # HKDF with above computed key (SRP_compute_key) + Pair-Setup-Encrypt-Salt + Pair-Setup-Encrypt-Info
         # result used as key for chacha20-poly1305
@@ -1031,7 +1032,7 @@ class RemotePairingProtocol(StartTcpTunnel):
     async def _send_pair_verify_failed(self) -> None:
         await self._send_plain_request({"event": {"_0": {"pairVerifyFailed": {}}}})
 
-    async def _send_receive_encrypted_request(self, request: dict) -> dict:
+    async def _send_receive_encrypted_request(self, request: dict[str, Any]) -> dict[str, Any]:
         nonce = Int64ul.build(self._encrypted_sequence_number) + b"\x00" * 4
         encrypted_data = self.client_cip.encrypt(nonce, json.dumps(request).encode(), b"")
 
@@ -1051,15 +1052,15 @@ class RemotePairingProtocol(StartTcpTunnel):
 
         return response
 
-    async def _send_receive_handshake(self, handshake_data: dict) -> dict:
+    async def _send_receive_handshake(self, handshake_data: dict[str, Any]) -> dict[str, Any]:
         response = await self._send_receive_plain_request({"request": {"_0": {"handshake": {"_0": handshake_data}}}})
         return response["response"]["_1"]["handshake"]["_0"]
 
-    async def _send_receive_pairing_data(self, pairing_data: dict) -> bytes:
+    async def _send_receive_pairing_data(self, pairing_data: dict[str, Any]) -> bytes:
         await self._send_pairing_data(pairing_data)
         return await self._receive_pairing_data()
 
-    async def _send_pairing_data(self, pairing_data: dict) -> None:
+    async def _send_pairing_data(self, pairing_data: dict[str, Any]) -> None:
         await self._send_plain_request({"event": {"_0": {"pairingData": {"_0": pairing_data}}}})
 
     async def _receive_pairing_data(self) -> bytes:
@@ -1076,11 +1077,11 @@ class RemotePairingProtocol(StartTcpTunnel):
             )
         raise PyMobileDevice3Exception(f"Got an unknown state message: {response}")
 
-    async def _send_receive_plain_request(self, plain_request: dict):
+    async def _send_receive_plain_request(self, plain_request: dict[str, Any]):
         await self._send_plain_request(plain_request)
         return await self._receive_plain_response()
 
-    async def _send_plain_request(self, plain_request: dict) -> None:
+    async def _send_plain_request(self, plain_request: dict[str, Any]) -> None:
         await self.send_request({
             "message": {"plain": {"_0": plain_request}},
             "originatedBy": "host",
@@ -1088,12 +1089,12 @@ class RemotePairingProtocol(StartTcpTunnel):
         })
         self._sequence_number += 1
 
-    async def _receive_plain_response(self) -> dict:
+    async def _receive_plain_response(self) -> dict[str, Any]:
         response = await self.receive_response()
         return response["message"]["plain"]["_0"]
 
     @staticmethod
-    def decode_tlv(tlv_list: list[Container]) -> dict:
+    def decode_tlv(tlv_list: list[Container[Any]]) -> dict[str, Any]:
         result = {}
         for tlv in tlv_list:
             if tlv.type in result:
@@ -1136,11 +1137,11 @@ class CoreDeviceTunnelService(RemotePairingProtocol, RemoteService):
         if self._service is not None:
             await self._service.close()
 
-    async def receive_response(self) -> dict:
+    async def receive_response(self) -> dict[str, Any]:
         response = await self.service.receive_response()
         return response["value"]
 
-    async def send_request(self, data: dict) -> None:
+    async def send_request(self, data: dict[str, Any]) -> None:
         return await self.service.send_request({
             "mangledTypeName": "RemotePairing.ControlChannelMessageEnvelope",
             "value": data,
@@ -1210,13 +1211,13 @@ class RemotePairingTunnelService(RemotePairingProtocol):
         self._writer = None
         self._reader = None
 
-    async def receive_response(self) -> dict:
+    async def receive_response(self) -> dict[str, Any]:
         reader = self.reader
         await reader.readexactly(len(REPAIRING_PACKET_MAGIC))
         size = struct.unpack(">H", await reader.readexactly(2))[0]
         return json.loads(await reader.readexactly(size))
 
-    async def send_request(self, data: dict) -> None:
+    async def send_request(self, data: dict[str, Any]) -> None:
         writer = self.writer
         writer.write(RPPairingPacket.build({"body": json.dumps(data, default=self._default_json_encoder).encode()}))
         await writer.drain()
@@ -1541,7 +1542,7 @@ class PeerDeviceInfo:
     udid: str
 
     @classmethod
-    def from_info_dict(cls, info: dict) -> "PeerDeviceInfo":
+    def from_info_dict(cls, info: dict[str, Any]) -> "PeerDeviceInfo":
         alt_irk = info.get("altIRK")
         if not isinstance(alt_irk, bytes) or len(alt_irk) != 16:
             raise PairingError(f"invalid altIRK in peer device info: {alt_irk!r}")
@@ -1697,7 +1698,7 @@ class PairableHost:
 
         await self._display_pin(pin, pin_callback)
 
-        tlv: list = [
+        tlv: list[Optional[dict[str, Any]]] = [
             {"type": PairingDataComponentType.STATE, "data": b"\x02"},
             {"type": PairingDataComponentType.SALT, "data": salt},
         ]
@@ -1754,7 +1755,9 @@ class PairableHost:
         self._expect_state(m5, 5)
         plaintext = cip.decrypt(b"\x00\x00\x00\x00PS-Msg05", m5[PairingDataComponentType.ENCRYPTED_DATA], b"")
         device_tlv = self.decode_tlv(PairingDataComponentTLVBuf.parse(plaintext))
-        peer_device = PeerDeviceInfo.from_info_dict(cast(dict, opack_loads(device_tlv[PairingDataComponentType.INFO])))
+        peer_device = PeerDeviceInfo.from_info_dict(
+            cast(dict[str, Any], opack_loads(device_tlv[PairingDataComponentType.INFO]))
+        )
 
         # M6: send our (accessory) encrypted identity
         self.logger.debug("Sending pair-setup M6 (our identity)")
@@ -1839,25 +1842,25 @@ class PairableHost:
             await result
 
     @staticmethod
-    def _chunk_component(component_type: int, data: bytes) -> list[dict]:
+    def _chunk_component(component_type: int, data: bytes) -> list[Optional[dict[str, Any]]]:
         return [
             {"type": component_type, "data": data[i : i + TLV_MAX_FRAGMENT_SIZE]}
             for i in range(0, len(data), TLV_MAX_FRAGMENT_SIZE)
         ]
 
     @staticmethod
-    def _expect_state(tlv: dict, expected: int) -> None:
+    def _expect_state(tlv: dict[str, Any], expected: int) -> None:
         state = tlv.get(PairingDataComponentType.STATE)
         if not state or state[0] != expected:
             raise PairingError(f"unexpected pair-setup state: expected {expected}, got {state!r}")
 
     @staticmethod
-    def _ensure_no_error(tlv: dict) -> None:
+    def _ensure_no_error(tlv: dict[str, Any]) -> None:
         if PairingDataComponentType.ERROR in tlv:
             raise PairingError(f"device returned pairing error: {tlv[PairingDataComponentType.ERROR]!r}")
 
     @staticmethod
-    def decode_tlv(tlv_list: list[Container]) -> dict:
+    def decode_tlv(tlv_list: list[Container[Any]]) -> dict[str, Any]:
         result = {}
         for tlv in tlv_list:
             if tlv.type in result:
@@ -1895,7 +1898,7 @@ class PairableHost:
             )
         raise PyMobileDevice3Exception(f"Got an unknown state message: {response}")
 
-    async def _send_plain(self, value: dict) -> None:
+    async def _send_plain(self, value: dict[str, Any]) -> None:
         envelope = {
             "message": {"plain": {"_0": value}},
             "originatedBy": "device",
@@ -1905,7 +1908,7 @@ class PairableHost:
         await self._writer.drain()
         self._sequence_number += 1
 
-    async def _receive_plain(self) -> dict:
+    async def _receive_plain(self) -> dict[str, Any]:
         await self._reader.readexactly(len(REPAIRING_PACKET_MAGIC))
         size = struct.unpack(">H", await self._reader.readexactly(2))[0]
         envelope = json.loads(await self._reader.readexactly(size))
@@ -1948,7 +1951,7 @@ async def serve_pairable_host(
     recognizes ``host_info.identifier`` and reconnects silently), so a timeout
     firing usually means either no device tried or the device already knows us.
     """
-    paired: asyncio.Future = asyncio.get_running_loop().create_future()
+    paired: asyncio.Future[PairableHostResult] = asyncio.get_running_loop().create_future()
 
     async def handle(reader: StreamReader, writer: StreamWriter) -> None:
         if paired.done():

--- a/pymobiledevice3/restore/restore.py
+++ b/pymobiledevice3/restore/restore.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 import asyncio
 import binascii
 import hashlib
@@ -9,7 +10,7 @@ import time
 import typing
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 from zipfile import ZipFile, ZipInfo
 
 import requests
@@ -55,12 +56,12 @@ class TrackedPrefetch:
     updater_name: str
     ticket_name: str
     nonce: bytes
-    add_tags: Callable
-    chip_params: dict
+    add_tags: Callable[..., Any]
+    chip_params: dict[str, Any]
     # how to find this chip's nonce in the restore-time DeviceGeneratedRequest
     # (one of these is set, mirroring PrefetchVariant).
     devgen_nonce: Optional[str] = None
-    devgen_nonce_path: Optional[list] = None
+    devgen_nonce_path: Optional[list[Any]] = None
 
 
 @dataclass
@@ -71,7 +72,7 @@ class PrefetchedTicket:
     response: TSSResponse
     ticket_name: str
     devgen_nonce: Optional[str] = None
-    devgen_nonce_path: Optional[list] = None
+    devgen_nonce_path: Optional[list[Any]] = None
 
 
 class Restore(BaseRestore):
@@ -178,7 +179,7 @@ class Restore(BaseRestore):
             "DeviceTree": self.send_component,
         }
 
-    def handle_async_data_request_msg(self, message: dict) -> typing.Coroutine:
+    def handle_async_data_request_msg(self, message: dict[str, Any]) -> typing.Coroutine[Any, Any, None]:
         self._tasks.append(
             asyncio.create_task(
                 self.handle_data_request_msg(message), name=f"AsyncDataRequestMsg-{message['DataType']}"
@@ -186,7 +187,7 @@ class Restore(BaseRestore):
         )
         return asyncio.sleep(0)
 
-    async def send_filesystem(self, message: dict) -> None:
+    async def send_filesystem(self, message: dict[str, Any]) -> None:
         self.logger.info("about to send filesystem...")
 
         asr_port = message.get("DataPort", DEFAULT_ASR_SYNC_PORT)
@@ -220,7 +221,7 @@ class Restore(BaseRestore):
     async def get_build_identity_from_request(self, msg):
         return await self.get_build_identity(msg["Arguments"].get("IsRecoveryOS", False))
 
-    async def send_buildidentity(self, message: dict) -> None:
+    async def send_buildidentity(self, message: dict[str, Any]) -> None:
         self.logger.info("About to send BuildIdentity Dict...")
         service = await self._get_service_for_data_request(message)
         req = {"BuildIdentityDict": dict(await self.get_build_identity_from_request(message))}
@@ -246,7 +247,7 @@ class Restore(BaseRestore):
         # The path of the global manifest is hardcoded. There's no pointer to in the build manifest.
         return self.ipsw.get_global_manifest(macos_variant, device_class)
 
-    async def send_personalized_boot_object_v3(self, message: dict) -> None:
+    async def send_personalized_boot_object_v3(self, message: dict[str, Any]) -> None:
         self.logger.debug("send_personalized_boot_object_v3")
         service = await self._get_service_for_data_request(message)
         image_name = message["Arguments"]["ImageName"]
@@ -272,7 +273,7 @@ class Restore(BaseRestore):
 
         self.logger.info(f"Done sending {component_name}")
 
-    async def send_source_boot_object_v4(self, message: dict) -> None:
+    async def send_source_boot_object_v4(self, message: dict[str, Any]) -> None:
         self.logger.debug("send_source_boot_object_v4")
         service = await self._get_service_for_data_request(message)
         image_name = message["Arguments"]["ImageName"]
@@ -362,7 +363,7 @@ class Restore(BaseRestore):
 
         return self.ipsw.build_manifest.get_build_identity(await self.device.get_hardware_model(), variant=variant)
 
-    async def send_restore_local_policy(self, message: dict) -> None:
+    async def send_restore_local_policy(self, message: dict[str, Any]) -> None:
         component = "Ap,LocalPolicy"
         service = await self._get_service_for_data_request(message)
 
@@ -376,7 +377,7 @@ class Restore(BaseRestore):
             "Ap,LocalPolicy": await self.get_personalized_data(component, data=lpol_file, tss=tss_localpolicy)
         })
 
-    async def send_recovery_os_root_ticket(self, message: dict) -> None:
+    async def send_recovery_os_root_ticket(self, message: dict[str, Any]) -> None:
         self.logger.info("About to send RecoveryOSRootTicket...")
         service = await self._get_service_for_data_request(message)
 
@@ -398,7 +399,7 @@ class Restore(BaseRestore):
         self.logger.info("Sending RecoveryOSRootTicket now...")
         await service.send_plist(req)
 
-    async def send_root_ticket(self, message: dict) -> None:
+    async def send_root_ticket(self, message: dict[str, Any]) -> None:
         self.logger.info("About to send RootTicket...")
         service = await self._get_service_for_data_request(message)
 
@@ -408,7 +409,7 @@ class Restore(BaseRestore):
         self.logger.info("Sending RootTicket now...")
         await service.send_plist({"RootTicketData": self.recovery.tss.ap_img4_ticket})
 
-    async def send_nor(self, message: dict):
+    async def send_nor(self, message: dict[str, Any]):
         self.logger.info("About to send NORData...")
         service = await self._get_service_for_data_request(message)
 
@@ -623,7 +624,7 @@ class Restore(BaseRestore):
                 os.remove(tmp_zip_read_name)
 
     @asyncio_print_traceback
-    async def send_baseband_data(self, message: dict):
+    async def send_baseband_data(self, message: dict[str, Any]):
         self.logger.info(f"About to send BasebandData: {message}")
         service = await self._get_service_for_data_request(message)
 
@@ -688,7 +689,7 @@ class Restore(BaseRestore):
         self.logger.info("Sending BasebandData now...")
         await service.send_plist({"BasebandData": buffer})
 
-    async def send_fdr_trust_data(self, message: dict) -> None:
+    async def send_fdr_trust_data(self, message: dict[str, Any]) -> None:
         self.logger.info("About to send FDR Trust data...")
         service = await self._get_service_for_data_request(message)
 
@@ -699,7 +700,11 @@ class Restore(BaseRestore):
         await service.send_plist({})
 
     async def send_image_data(
-        self, message: dict, image_list_k: Optional[str], image_type_k: Optional[str], image_data_k: Optional[str]
+        self,
+        message: dict[str, Any],
+        image_list_k: Optional[str],
+        image_type_k: Optional[str],
+        image_data_k: Optional[str],
     ) -> None:
         self.logger.debug(f"send_image_data: {message}")
         arguments = message["Arguments"]
@@ -763,7 +768,7 @@ class Restore(BaseRestore):
         assert self._restored is not None
         await self._restored.send(req)
 
-    async def send_bootability_bundle_data(self, message: dict) -> None:
+    async def send_bootability_bundle_data(self, message: dict[str, Any]) -> None:
         self.logger.debug(f"send_bootability_bundle_data: {message}")
         service = await self._get_service_for_data_request(message)
         await service.sendall(self.ipsw.bootability)
@@ -774,7 +779,9 @@ class Restore(BaseRestore):
         assert self._restored is not None
         await self._restored.send({"ReceiptManifest": self.build_identity.manifest})
 
-    async def get_se_firmware_data(self, updater_name: str, info: dict, arguments: dict) -> dict:
+    async def get_se_firmware_data(
+        self, updater_name: str, info: dict[str, Any], arguments: dict[str, Any]
+    ) -> dict[str, Any]:
         chip_id = info.get("SE,ChipID")
         if chip_id is None:
             chip_id = self.build_identity["Manifest"]["SE,ChipID"]
@@ -801,7 +808,7 @@ class Restore(BaseRestore):
             # Legacy non-DeviceGenerated path (pre-iOS 18). Prefetch cache lookup happens
             # only in get_device_generated_firmware_data — modern iOS never enters this branch.
             request = TSSRequest()
-            parameters: dict = {}
+            parameters: dict[str, Any] = {}
             self.populate_tss_request_from_manifest(parameters)
             parameters.update(info)
             request.add_se_tags(parameters, None)
@@ -814,7 +821,7 @@ class Restore(BaseRestore):
 
         return response
 
-    async def get_yonkers_firmware_data(self, info: dict):
+    async def get_yonkers_firmware_data(self, info: dict[str, Any]):
         # create Yonkers request
         request = TSSRequest()
         parameters = {}
@@ -852,13 +859,13 @@ class Restore(BaseRestore):
 
         return response
 
-    async def get_savage_firmware_data(self, info: dict):
+    async def get_savage_firmware_data(self, info: dict[str, Any]):
         cached = self._lookup_prefetched_tss("Savage", info.get("Savage,Nonce"))
         if cached is not None:
             response = cached
             # We still need to know which Savage,B?-*-Patch component to read; mirror
             # the comp-name selection logic from add_savage_tags.
-            parameters: dict = {}
+            parameters: dict[str, Any] = {}
             self.populate_tss_request_from_manifest(parameters)
             parameters.update(info)
             comp_name = TSSRequest().add_savage_tags(parameters, None)
@@ -893,7 +900,7 @@ class Restore(BaseRestore):
 
         return response
 
-    async def get_rose_firmware_data(self, updater_name: str, info: dict, arguments: dict):
+    async def get_rose_firmware_data(self, updater_name: str, info: dict[str, Any], arguments: dict[str, Any]):
         self.logger.info(f"get_rose_firmware_data: {info}")
 
         if "DeviceGeneratedTags" in arguments:
@@ -902,7 +909,7 @@ class Restore(BaseRestore):
 
         # Legacy non-DeviceGenerated path (pre-iOS 18); modern iOS never enters here.
         request = TSSRequest()
-        parameters: dict = {}
+        parameters: dict[str, Any] = {}
         self.populate_tss_request_from_manifest(parameters)
         parameters["ApProductionMode"] = True
         if await self.device.get_is_image4_supported():
@@ -936,7 +943,7 @@ class Restore(BaseRestore):
 
         return response
 
-    async def get_veridian_firmware_data(self, updater_name: str, info: dict, arguments: dict):
+    async def get_veridian_firmware_data(self, updater_name: str, info: dict[str, Any], arguments: dict[str, Any]):
         self.logger.info(f"get_veridian_firmware_data: {info}")
         comp_name = "BMU,FirmwareMap"
 
@@ -945,7 +952,7 @@ class Restore(BaseRestore):
         else:
             # Legacy non-DeviceGenerated path (pre-iOS 18); modern iOS never enters here.
             request = TSSRequest()
-            parameters: dict = {}
+            parameters: dict[str, Any] = {}
             self.populate_tss_request_from_manifest(parameters)
             parameters.update(info)
             request.add_veridian_tags(parameters, None)
@@ -963,7 +970,7 @@ class Restore(BaseRestore):
 
         return response
 
-    async def get_tcon_firmware_data(self, info: dict):
+    async def get_tcon_firmware_data(self, info: dict[str, Any]):
         self.logger.info(f"restore_get_tcon_firmware_data: {info}")
         comp_name = "Baobab,TCON"
 
@@ -991,7 +998,9 @@ class Restore(BaseRestore):
 
         return response
 
-    async def get_device_generated_firmware_data(self, updater_name: str, info: dict, arguments: dict) -> dict:
+    async def get_device_generated_firmware_data(
+        self, updater_name: str, info: dict[str, Any], arguments: dict[str, Any]
+    ) -> dict[str, Any]:
         self.logger.info(f"get_device_generated_firmware_data ({updater_name}): {arguments}")
 
         response_ticket = arguments["DeviceGeneratedTags"]["ResponseTags"][0]
@@ -1038,7 +1047,7 @@ class Restore(BaseRestore):
 
         return response
 
-    async def get_timer_firmware_data(self, info: dict):
+    async def get_timer_firmware_data(self, info: dict[str, Any]):
         self.logger.info(f"get_timer_firmware_data: {info}")
 
         ftab = None
@@ -1117,7 +1126,7 @@ class Restore(BaseRestore):
     # ---------- Tethered preflight (iOS 18+) — batched-only ----------
 
     @staticmethod
-    def _merge_device_info(parameters: dict, info: dict) -> dict:
+    def _merge_device_info(parameters: dict[str, Any], info: dict[str, Any]) -> dict[str, Any]:
         """Merge a peripheral's PreflightInfo.DeviceInfo entry into params, without clobbering
         manifest-derived int fields with the device's raw-bytes representation.
 
@@ -1141,7 +1150,7 @@ class Restore(BaseRestore):
         return merged
 
     @staticmethod
-    def _dig(container: dict, path) -> typing.Any:
+    def _dig(container: dict[str, Any], path) -> typing.Any:
         """Navigate a dict by a single key or a list-of-keys path; None if any hop misses."""
         cur = container
         for key in [path] if isinstance(path, str) else path:
@@ -1151,7 +1160,7 @@ class Restore(BaseRestore):
         return cur
 
     @classmethod
-    def _resolve_nonce(cls, container: dict, nonce_key: Optional[str], nonce_path: Optional[list]):
+    def _resolve_nonce(cls, container: dict[Any, Any], nonce_key: Optional[str], nonce_path: Optional[list[Any]]):
         """Resolve a peripheral nonce from a container (PreflightInfo entry or
         DeviceGeneratedRequest). Pass either a single ``nonce_key``, or a ``nonce_path``
         (a list of paths whose bytes are concatenated into one composite nonce, e.g.
@@ -1166,7 +1175,9 @@ class Restore(BaseRestore):
             return None
         return b"".join(bytes(part) for part in parts)
 
-    def _lookup_prefetched_tss_by_ticket(self, response_ticket: str, arguments: dict) -> Optional[TSSResponse]:
+    def _lookup_prefetched_tss_by_ticket(
+        self, response_ticket: str, arguments: dict[str, Any]
+    ) -> Optional[TSSResponse]:
         """Cache lookup for the iOS 18+ DeviceGeneratedTags path.
 
         On modern iOS, restored builds the TSS request itself and the host just forwards.
@@ -1228,7 +1239,7 @@ class Restore(BaseRestore):
         """
         # Common AP context — required by every peripheral signing request even though
         # we're NOT asking TSS to sign the AP ticket itself.
-        parameters: dict = {"ApECID": await self.device.get_ecid()}
+        parameters: dict[str, Any] = {"ApECID": await self.device.get_ecid()}
         parameters["ApProductionMode"] = True
         if await self.device.get_is_image4_supported():
             parameters["ApSecurityMode"] = True
@@ -1320,7 +1331,7 @@ class Restore(BaseRestore):
             self._store_prefetched_ticket(entry, response)
         return True
 
-    def _store_prefetched_ticket(self, entry: TrackedPrefetch, response: dict) -> bool:
+    def _store_prefetched_ticket(self, entry: TrackedPrefetch, response: dict[str, Any]) -> bool:
         """Cache a single peripheral's ticket from a TSS response if present. Returns True
         if the expected ticket was found and stored."""
         ticket_name = entry.ticket_name
@@ -1338,7 +1349,7 @@ class Restore(BaseRestore):
         self.logger.info(f"TSS batch: TSS did NOT return {ticket_name}; reactive path will handle this peripheral")
         return False
 
-    async def _prefetch_per_chip(self, parameters: dict, tracked: list[TrackedPrefetch]) -> bool:
+    async def _prefetch_per_chip(self, parameters: dict[str, Any], tracked: list[TrackedPrefetch]) -> bool:
         """Fallback when the combined POST is rejected: sign each peripheral in its own POST
         so a single rejected chip doesn't deny the others their prefetched tickets. Returns
         True if at least one ticket was cached."""
@@ -1360,7 +1371,7 @@ class Restore(BaseRestore):
 
     # ---------------------------------------------------
 
-    async def send_firmware_updater_data(self, message: dict):
+    async def send_firmware_updater_data(self, message: dict[str, Any]):
         self.logger.debug(f"got FirmwareUpdaterData request: {message}")
         service = await self._get_service_for_data_request(message)
         arguments = message["Arguments"]
@@ -1404,13 +1415,13 @@ class Restore(BaseRestore):
         self.logger.info("Sending FirmwareResponse data now...")
         await service.send_plist({"FirmwareResponseData": fwdict})
 
-    async def send_firmware_updater_preflight(self, message: dict) -> None:
+    async def send_firmware_updater_preflight(self, message: dict[str, Any]) -> None:
         self.logger.warning(f"send_firmware_updater_preflight: {message}")
         service = await self._get_service_for_data_request(message)
         await service.send_plist({})
 
     @asyncio_print_traceback
-    async def send_url_asset(self, message: dict) -> None:
+    async def send_url_asset(self, message: dict[str, Any]) -> None:
         self.logger.info(f"send_url_asset: {message}")
         service = await self._get_service_for_data_request(message)
         arguments = message["Arguments"]
@@ -1441,7 +1452,7 @@ class Restore(BaseRestore):
         )
         await service.close()
 
-    async def send_streamed_image_decryption_key(self, message: dict) -> None:
+    async def send_streamed_image_decryption_key(self, message: dict[str, Any]) -> None:
         self.logger.info(f"send_streamed_image_decryption_key: {message}")
         service = await self._get_service_for_data_request(message)
         arguments = message["Arguments"]
@@ -1468,7 +1479,7 @@ class Restore(BaseRestore):
             f"{component_name}File": await self.get_personalized_data(component, tss=self.recovery.require_tss())
         })
 
-    async def handle_data_request_msg(self, message: dict):
+    async def handle_data_request_msg(self, message: dict[str, Any]):
         self.logger.debug(f"handle_data_request_msg: {message}")
 
         # checks and see what kind of data restored is requests and pass the request to its own handler
@@ -1502,11 +1513,11 @@ class Restore(BaseRestore):
         else:
             self.logger.error(f"unknown data request: {message}")
 
-    async def handle_previous_restore_log_msg(self, message: dict):
+    async def handle_previous_restore_log_msg(self, message: dict[str, Any]):
         restorelog = message["PreviousRestoreLog"]
         self.logger.debug(f"PreviousRestoreLog: {restorelog}")
 
-    async def handle_progress_msg(self, message: dict) -> None:
+    async def handle_progress_msg(self, message: dict[str, Any]) -> None:
         operation = message["Operation"]
         if operation in PROGRESS_BAR_OPERATIONS:
             message["Operation"] = PROGRESS_BAR_OPERATIONS[operation]
@@ -1529,7 +1540,7 @@ class Restore(BaseRestore):
 
         self.logger.debug(f"progress-bar: {message}")
 
-    async def handle_status_msg(self, message: dict):
+    async def handle_status_msg(self, message: dict[str, Any]):
         self.logger.debug(f"status message: {message}")
         status = message["Status"]
         log = message.get("Log")
@@ -1548,15 +1559,15 @@ class Restore(BaseRestore):
             else:
                 self.logger.error("unknown error")
 
-    async def handle_checkpoint_msg(self, message: dict):
+    async def handle_checkpoint_msg(self, message: dict[str, Any]):
         self.logger.debug(f"checkpoint: {message}")
 
-    async def handle_bb_update_status_msg(self, message: dict):
+    async def handle_bb_update_status_msg(self, message: dict[str, Any]):
         self.logger.debug(f"bb_update_status_msg: {message}")
         if not message["Accepted"]:
             raise PyMobileDevice3Exception(str(message))
 
-    async def handle_baseband_updater_output_data(self, message: dict) -> None:
+    async def handle_baseband_updater_output_data(self, message: dict[str, Any]) -> None:
         self.logger.debug(f"restore_handle_baseband_updater_output_data: {message}")
         data_port = message["DataPort"]
 
@@ -1590,18 +1601,18 @@ class Restore(BaseRestore):
         self.logger.debug("Closing connection of BasebandUpdaterOutputData data port")
         await client.close()
 
-    async def handle_host_system_time(self, message: dict) -> None:
+    async def handle_host_system_time(self, message: dict[str, Any]) -> None:
         assert self._restored is not None
         await self._restored.send({"SetHostTimeOnDevice": time.time()})
 
-    async def handle_restored_crash(self, message: dict) -> None:
+    async def handle_restored_crash(self, message: dict[str, Any]) -> None:
         backtrace = "\n".join(message["RestoredBacktrace"])
         self.logger.info(f"restored crashed. backtrace:\n{backtrace}")
 
-    async def handle_async_wait(self, message: dict) -> None:
+    async def handle_async_wait(self, message: dict[str, Any]) -> None:
         self.logger.debug(message)
 
-    async def handle_restore_attestation(self, message: dict) -> None:
+    async def handle_restore_attestation(self, message: dict[str, Any]) -> None:
         self.logger.debug(message)
         assert self._restored is not None
         await self._restored.send({"RestoreShouldAttest": False})
@@ -1719,7 +1730,7 @@ class Restore(BaseRestore):
         self.logger.info(f"  >> gs.apple.com POSTs saved during restore: {len(hits)}")
         self.logger.info("=" * 64)
 
-    async def _get_service_for_data_request(self, message: dict) -> ServiceConnection:
+    async def _get_service_for_data_request(self, message: dict[str, Any]) -> ServiceConnection:
         assert self._restored is not None
         data_port = message.get("DataPort")
         if data_port is None:

--- a/pymobiledevice3/restore/tss.py
+++ b/pymobiledevice3/restore/tss.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 import asyncio
 import logging
 import plistlib
@@ -27,7 +28,7 @@ TSS_CLIENT_VERSION_STRING = "libauthinstall-1104.0.9"
 logger = logging.getLogger(__name__)
 
 
-def get_with_or_without_comma(obj: dict, k: str, default=None) -> typing.Any:
+def get_with_or_without_comma(obj: dict[str, typing.Any], k: str, default=None) -> typing.Any:
     val = obj.get(k, obj.get(k.replace(",", "")))
     if val is None and default is not None:
         val = default
@@ -46,7 +47,7 @@ def is_fw_payload(info: dict[str, typing.Any]) -> bool:
     )
 
 
-class TSSResponse(dict):
+class TSSResponse(dict[str, typing.Any]):
     @property
     def ap_img4_ticket(self):
         ticket = self.get("ApImg4Ticket")
@@ -77,7 +78,9 @@ class TSSRequest:
         }
 
     @staticmethod
-    def apply_restore_request_rules(tss_entry: dict, parameters: dict, rules: list) -> dict:
+    def apply_restore_request_rules(
+        tss_entry: dict[str, typing.Any], parameters: dict[str, typing.Any], rules: list[dict[str, typing.Any]]
+    ) -> dict[str, typing.Any]:
         for rule in rules:
             conditions_fulfilled = True
             conditions = rule["Conditions"]
@@ -114,13 +117,13 @@ class TSSRequest:
                     tss_entry[key] = value
         return tss_entry
 
-    def add_tags(self, parameters: dict):
+    def add_tags(self, parameters: dict[str, typing.Any]):
         for key, value in parameters.items():
             if isinstance(value, str) and value.startswith("0x"):
                 value = int(value, 16)
             self._request[key] = value
 
-    def add_common_tags(self, parameters: dict, overrides=None):
+    def add_common_tags(self, parameters: dict[str, typing.Any], overrides=None):
         keys = ("ApECID", "UniqueBuildID", "ApChipID", "ApBoardID", "ApSecurityDomain")
         for k in keys:
             if k in parameters:
@@ -128,7 +131,7 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_ap_recovery_tags(self, parameters: dict, overrides=None):
+    def add_ap_recovery_tags(self, parameters: dict[str, typing.Any], overrides=None):
         skip_keys = (
             "BasebandFirmware",
             "SE,UpdatePayload",
@@ -202,7 +205,7 @@ class TSSRequest:
         if overrides:
             self._request.update(overrides)
 
-    def add_timer_tags(self, parameters: dict, overrides=None):
+    def add_timer_tags(self, parameters: dict[str, typing.Any], overrides=None):
         manifest = parameters["Manifest"]
 
         # add tags indicating we want to get the Timer ticket
@@ -270,7 +273,7 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_local_policy_tags(self, parameters: dict):
+    def add_local_policy_tags(self, parameters: dict[str, typing.Any]):
         self._request["@ApImg4Ticket"] = True
 
         keys_to_copy = (
@@ -295,7 +298,7 @@ class TSSRequest:
                     v = int(v, 16)
                 self._request[k] = v
 
-    def add_vinyl_prefetch_tags(self, parameters: dict, overrides=None):
+    def add_vinyl_prefetch_tags(self, parameters: dict[str, typing.Any], overrides=None):
         # Prefetch shim for Vinyl/eUICC: PreflightInfo nests the Gold/Main nonces under
         # eUICC,Gold / eUICC,Main, but add_vinyl_tags reads them from the flat
         # EUICCGoldNonce / EUICCMainNonce params (the recovery.py AP-batch path sets these).
@@ -305,7 +308,7 @@ class TSSRequest:
                 parameters.setdefault(flat, node["Nonce"])
         self.add_vinyl_tags(parameters, overrides)
 
-    def add_vinyl_tags(self, parameters: dict, overrides=None):
+    def add_vinyl_tags(self, parameters: dict[str, typing.Any], overrides=None):
         self._request["@BBTicket"] = True
         self._request["@eUICC,Ticket"] = True
 
@@ -319,12 +322,16 @@ class TSSRequest:
                 self._request[k] = parameters[k]
 
         if self._request.get("eUICC,Gold") is None:
-            n = typing.cast(typing.Optional[dict], plist_access_path(parameters, ("Manifest", "eUICC,Gold")))
+            n = typing.cast(
+                typing.Optional[dict[str, typing.Any]], plist_access_path(parameters, ("Manifest", "eUICC,Gold"))
+            )
             if n:
                 self._request["eUICC,Gold"] = {"Digest": n["Digest"]}
 
         if self._request.get("eUICC,Main") is None:
-            n = typing.cast(typing.Optional[dict], plist_access_path(parameters, ("Manifest", "eUICC,Main")))
+            n = typing.cast(
+                typing.Optional[dict[str, typing.Any]], plist_access_path(parameters, ("Manifest", "eUICC,Main"))
+            )
             if n:
                 self._request["eUICC,Main"] = {"Digest": n["Digest"]}
 
@@ -345,7 +352,7 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_ap_tags(self, parameters: dict, overrides=None):
+    def add_ap_tags(self, parameters: dict[str, typing.Any], overrides=None):
         """loop over components from build manifest"""
 
         manifest_node = parameters["Manifest"]
@@ -403,7 +410,7 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_ap_img3_tags(self, parameters: dict):
+    def add_ap_img3_tags(self, parameters: dict[str, typing.Any]):
         if "ApNonce" in parameters:
             self._request["ApNonce"] = parameters["ApNonce"]
         self._request["@APTicket"] = True
@@ -455,7 +462,7 @@ class TSSRequest:
             # Workaround: We have only seen Ap,SikaFuse together with UID_MODE
             self._request["Ap,SikaFuse"] = 0
 
-    def add_se2_tags(self, parameters: dict, overrides=None):
+    def add_se2_tags(self, parameters: dict[str, typing.Any], overrides=None):
         # Modern Secure Enclave personalization (A19 / iOS 27+). The device generates an
         # @SE2,Ticket request (response key "SE2,Ticket"), NOT the legacy @SE,Ticket of
         # add_se_tags. Confirmed by a ramrod capture on iPhone 18,4: the
@@ -488,7 +495,7 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_se_tags(self, parameters: dict, overrides=None):
+    def add_se_tags(self, parameters: dict[str, typing.Any], overrides=None):
         manifest = parameters["Manifest"]
 
         # add tags indicating we want to get the SE,Ticket
@@ -553,7 +560,7 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_savage_tags(self, parameters: dict, overrides=None, component_name=None):
+    def add_savage_tags(self, parameters: dict[str, typing.Any], overrides=None, component_name=None):
         manifest = parameters["Manifest"]
 
         # add tags indicating we want to get the Savage,Ticket
@@ -605,7 +612,7 @@ class TSSRequest:
 
         return comp_name
 
-    def add_yonkers_tags(self, parameters: dict, overrides=None):
+    def add_yonkers_tags(self, parameters: dict[str, typing.Any], overrides=None):
         manifest = parameters["Manifest"]
 
         # add tags indicating we want to get the Yonkers,Ticket
@@ -665,7 +672,7 @@ class TSSRequest:
 
         return result_comp_name
 
-    def add_baseband_tags(self, parameters: dict, overrides=None):
+    def add_baseband_tags(self, parameters: dict[str, typing.Any], overrides=None):
         self._request["@BBTicket"] = True
 
         keys_to_copy = (
@@ -707,7 +714,9 @@ class TSSRequest:
         if overrides:
             self._request.update(overrides)
 
-    def add_rose_tags(self, parameters: dict, overrides: typing.Optional[dict] = None):
+    def add_rose_tags(
+        self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None
+    ):
         manifest = parameters["Manifest"]
 
         # add tags indicating we want to get the Rap,Ticket
@@ -774,7 +783,9 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_centauri_tags(self, parameters: dict, overrides: typing.Optional[dict] = None):
+    def add_centauri_tags(
+        self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None
+    ):
         # Centauri (the converged Wi-Fi/BT/UWB coprocessor) is personalized exactly like
         # Rose/Rap: same Wireless1,* field set and the same @Wireless1,Ticket flag. Confirmed
         # by reversing libCentauriUpdater.dylib (response key "Wireless1,Ticket") and
@@ -847,7 +858,9 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_cellular_tags(self, parameters: dict, overrides: typing.Optional[dict] = None):
+    def add_cellular_tags(
+        self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None
+    ):
         # A19 baseband personalization: device-generated @Cellular1,Ticket (response key
         # "Cellular1,Ticket"), structured like Rose/Centauri over the Cellular1,* field set
         # (ramrod capture on iPhone 18,4). The Bb*ManifestKeyHash fields come from the
@@ -897,7 +910,9 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_veridian_tags(self, parameters: dict, overrides: typing.Optional[dict] = None):
+    def add_veridian_tags(
+        self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None
+    ):
         manifest = parameters["Manifest"]
 
         # add tags indicating we want to get the Rap,Ticket
@@ -940,7 +955,9 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_tcon_tags(self, parameters: dict, overrides: typing.Optional[dict] = None):
+    def add_tcon_tags(
+        self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None
+    ):
         manifest = parameters["Manifest"]
 
         # add tags indicating we want to get the Baobab,Ticket
@@ -1100,7 +1117,7 @@ class PrefetchVariant:
     ticket_name: str
     # the reactive ``TSSRequest`` helper that knows this chip's quirks; called as
     # ``add_tags(tss, parameters, None)`` on a fresh ``TSSRequest`` instance.
-    add_tags: typing.Callable
+    add_tags: typing.Callable[..., typing.Any]
     # nested key under the PreflightInfo entry holding this variant's state
     # (``None`` -> the entry itself, e.g. flat ``Savage,*``).
     preflight_subkey: typing.Optional[str] = None
@@ -1108,12 +1125,12 @@ class PrefetchVariant:
     preflight_nonce: typing.Optional[str] = None
     # list-of-paths whose bytes concatenate into one composite nonce (e.g. Vinyl's
     # ``eUICC,Gold.Nonce`` + ``eUICC,Main.Nonce``); mutually exclusive with ``preflight_nonce``.
-    nonce_path: typing.Optional[list] = None
+    nonce_path: typing.Optional[list[list[str]]] = None
     # nonce field name in ``DataRequestMsg.DeviceGeneratedRequest`` at restore time
     # (used by ``Restore._lookup_prefetched_tss_by_ticket`` for nonce-match).
     devgen_nonce: typing.Optional[str] = None
     # composite (list-of-paths) variant of ``devgen_nonce``.
-    devgen_nonce_path: typing.Optional[list] = None
+    devgen_nonce_path: typing.Optional[list[list[str]]] = None
 
 
 @dataclass(frozen=True)

--- a/pymobiledevice3/services/installation_proxy.py
+++ b/pymobiledevice3/services/installation_proxy.py
@@ -1,10 +1,11 @@
+# pyright: reportMissingTypeArgument=error
 import os
 import uuid
 from enum import Enum
 from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Callable, Optional, cast
+from typing import Any, Callable, Optional, cast
 from zipfile import ZIP_DEFLATED, BadZipFile, ZipFile
 
 from parameter_decorators import str_to_path
@@ -83,7 +84,7 @@ class InstallationProxyService(LockdownService):
         else:
             super().__init__(lockdown, self.RSD_SERVICE_NAME)
 
-    async def _watch_completion(self, handler: Optional[Callable] = None, *args) -> None:
+    async def _watch_completion(self, handler: Optional[Callable[..., Any]] = None, *args) -> None:
         while True:
             response = await self.service.recv_plist()
             if not response:
@@ -106,8 +107,8 @@ class InstallationProxyService(LockdownService):
         self,
         bundle_identifier: str,
         cmd: str = "Archive",
-        options: Optional[dict] = None,
-        handler: Optional[Callable] = None,
+        options: Optional[dict[str, Any]] = None,
+        handler: Optional[Callable[..., Any]] = None,
         *args,
     ) -> None:
         """
@@ -126,7 +127,7 @@ class InstallationProxyService(LockdownService):
         :returns: None.
         :raises AppInstallError: If the service reports an error or finishes without a ``Complete`` status.
         """
-        request: dict = {"Command": cmd, "ApplicationIdentifier": bundle_identifier}
+        request: dict[str, Any] = {"Command": cmd, "ApplicationIdentifier": bundle_identifier}
 
         if options is None:
             options = {}
@@ -136,7 +137,11 @@ class InstallationProxyService(LockdownService):
         await self._watch_completion(handler, *args)
 
     async def upgrade(
-        self, ipa_path: str, options: Optional[dict] = None, handler: Optional[Callable] = None, *args
+        self,
+        ipa_path: str,
+        options: Optional[dict[str, Any]] = None,
+        handler: Optional[Callable[..., Any]] = None,
+        *args,
     ) -> None:
         """
         Upgrade an installed app from a local package.
@@ -154,7 +159,11 @@ class InstallationProxyService(LockdownService):
         await self.install_from_local(Path(ipa_path), "Upgrade", options, handler, False, *args)
 
     async def restore(
-        self, bundle_identifier: str, options: Optional[dict] = None, handler: Optional[Callable] = None, *args
+        self,
+        bundle_identifier: str,
+        options: Optional[dict[str, Any]] = None,
+        handler: Optional[Callable[..., Any]] = None,
+        *args,
     ) -> None:
         """
         Restore a previously archived app, identified by its bundle identifier.
@@ -172,7 +181,11 @@ class InstallationProxyService(LockdownService):
         await self.send_cmd_for_bundle_identifier(bundle_identifier, "Restore", options, handler, args)
 
     async def uninstall(
-        self, bundle_identifier: str, options: Optional[dict] = None, handler: Optional[Callable] = None, *args
+        self,
+        bundle_identifier: str,
+        options: Optional[dict[str, Any]] = None,
+        handler: Optional[Callable[..., Any]] = None,
+        *args,
     ) -> None:
         """
         Uninstall an app, identified by its bundle identifier.
@@ -193,8 +206,8 @@ class InstallationProxyService(LockdownService):
         self,
         package_bytes: bytes,
         cmd: str = "Install",
-        options: Optional[dict] = None,
-        handler: Optional[Callable] = None,
+        options: Optional[dict[str, Any]] = None,
+        handler: Optional[Callable[..., Any]] = None,
         *args,
     ) -> None:
         """
@@ -243,8 +256,8 @@ class InstallationProxyService(LockdownService):
         self,
         package_path: Path,
         cmd: str = "Install",
-        options: Optional[dict] = None,
-        handler: Optional[Callable] = None,
+        options: Optional[dict[str, Any]] = None,
+        handler: Optional[Callable[..., Any]] = None,
         developer: bool = False,
         *args,
     ) -> None:
@@ -304,7 +317,12 @@ class InstallationProxyService(LockdownService):
                 await afc.rm_single(fname, force=True)
 
     async def send_package(
-        self, cmd: str, options: Optional[dict], handler: Optional[Callable], package_path: str, *args
+        self,
+        cmd: str,
+        options: Optional[dict[str, Any]],
+        handler: Optional[Callable[..., Any]],
+        package_path: str,
+        *args,
     ):
         """
         Send an install/upgrade command for a package already staged on the device, and wait for completion.
@@ -391,8 +409,8 @@ class InstallationProxyService(LockdownService):
         self.logger.info("Upload complete.")
 
     async def check_capabilities_match(
-        self, capabilities: Optional[dict] = None, options: Optional[dict] = None
-    ) -> Optional[dict]:
+        self, capabilities: Optional[dict[str, Any]] = None, options: Optional[dict[str, Any]] = None
+    ) -> Optional[dict[str, Any]]:
         """
         Ask the device whether it satisfies a set of app capabilities.
 
@@ -414,9 +432,11 @@ class InstallationProxyService(LockdownService):
             cmd["Capabilities"] = capabilities
 
         await self.service.send_plist(cmd)
-        return cast(Optional[dict], (await self.service.recv_plist()).get("LookupResult"))
+        return cast(Optional[dict[str, Any]], (await self.service.recv_plist()).get("LookupResult"))
 
-    async def browse(self, options: Optional[dict] = None, attributes: Optional[list[str]] = None) -> list[dict]:
+    async def browse(
+        self, options: Optional[dict[str, Any]] = None, attributes: Optional[list[str]] = None
+    ) -> list[dict[str, Any]]:
         """
         Enumerate installed apps via the ``"Browse"`` command.
 
@@ -437,7 +457,7 @@ class InstallationProxyService(LockdownService):
 
         await self.service.send_plist(cmd)
 
-        result: list[dict] = []
+        result: list[dict[str, Any]] = []
         while True:
             response = await self.service.recv_plist()
             if not response:
@@ -445,14 +465,14 @@ class InstallationProxyService(LockdownService):
 
             data = response.get("CurrentList")
             if data is not None:
-                result += cast("list[dict]", data)
+                result += cast("list[dict[str, Any]]", data)
 
             if response.get("Status") == "Complete":
                 break
 
         return result
 
-    async def lookup(self, options: Optional[dict] = None) -> Optional[dict]:
+    async def lookup(self, options: Optional[dict[str, Any]] = None) -> Optional[dict[str, Any]]:
         """
         Look up installed apps via the ``"Lookup"`` command.
 
@@ -468,7 +488,7 @@ class InstallationProxyService(LockdownService):
             options = {}
         cmd = {"Command": "Lookup", "ClientOptions": options}
         await self.service.send_plist(cmd)
-        return cast(Optional[dict], (await self.service.recv_plist()).get("LookupResult"))
+        return cast(Optional[dict[str, Any]], (await self.service.recv_plist()).get("LookupResult"))
 
     async def get_apps(
         self,
@@ -476,7 +496,7 @@ class InstallationProxyService(LockdownService):
         calculate_sizes: bool = False,
         bundle_identifiers: Optional[list[str]] = None,
         show_placeholders: bool = False,
-    ) -> dict[str, dict]:
+    ) -> dict[str, dict[str, Any]]:
         """
         Retrieve installed apps, keyed by bundle identifier.
 


### PR DESCRIPTION
## What

First slice of an incremental campaign to kill **bare, unparametrized generics** (`dict`, `list`, `Callable`, `Task`, …) — pyright's `reportMissingTypeArgument`, **551 package-wide**. This directly targets the "many bare `dict`/`list`" quality problem.

This slice takes the **5 highest-density files** and parametrizes **~190** annotations:

| File | sites |
|---|---|
| `restore/restore.py` | ~52 |
| `remote/tunnel_service.py` | ~42 |
| `restore/tss.py` | ~24 |
| `services/installation_proxy.py` | ~27 |
| `lockdown.py` | ~22 |

## Policy

- **Heterogeneous, dynamically-keyed plist/message payloads → `dict[str, Any]`.** Deliberately *not* `PlistDict` — that would re-trigger the value-narrowing cascade (the deferred `reportUnknown*` work). `dict[str, Any]` is strictly better than bare `dict` (`dict[Unknown, Unknown]`); tightening `Any` → precise is the *next* campaign.
- **Precise types wherever the shape is evident:** `Task[None]`, `Queue[Optional[bytes]]`, `Future[PairableHostResult]`, `list[dict[str, Any]]`, `Coroutine[Any, Any, None]`, `list[Container[Any]]`, etc.

## Enforcement

Each cleaned file carries a `# pyright: reportMissingTypeArgument=error` header, so it's **enforced now and can't regress** while the remaining ~370 sites are worked in later slices. The headers come off and the rule flips globally in `pyproject.toml` at the end of the campaign.

## Safety

**Annotation-only** — a diff scan confirms no changed line touches runtime logic (only type annotations, signature reflows, and the directive headers).

## Verification

- `pyright`: 0 errors (the 5 files now enforce the rule via their headers).
- `ruff check` / `ruff format`: clean.
- `pytest -m cli` (CI set): 117 passed.
- All five modules import cleanly.