### PR TITLE
typing: parametrize bare dict/list generics (slice 2 of reportMissingTypeArgument)

### DIFF
--- a/pymobiledevice3/cli/developer/dvt/sysmon/process.py
+++ b/pymobiledevice3/cli/developer/dvt/sysmon/process.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 import asyncio
 import contextlib
 import json
@@ -6,7 +7,7 @@ import sys
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Optional, TextIO
+from typing import Annotated, Any, Optional, TextIO
 
 import typer
 from typer_injector import InjectingTyper
@@ -115,7 +116,7 @@ def _parse_process_filters(filter_expressions: Optional[list[str]]) -> dict[str,
     return parsed_filters
 
 
-def _validate_process_keys(process: dict, keys: list[str]) -> None:
+def _validate_process_keys(process: dict[str, Any], keys: list[str]) -> None:
     unknown_keys = [key for key in keys if key not in process]
     if unknown_keys:
         raise typer.BadParameter(
@@ -123,13 +124,13 @@ def _validate_process_keys(process: dict, keys: list[str]) -> None:
         )
 
 
-def _matches_filters(proc: dict, parsed_filters: dict[str, list[str]]) -> bool:
+def _matches_filters(proc: dict[str, Any], parsed_filters: dict[str, list[str]]) -> bool:
     if len(parsed_filters) == 0:
         return True
     return all(str(proc.get(key)) in values for key, values in parsed_filters.items())
 
 
-def _select_process_output_keys(process: dict, output_keys: Optional[list[str]]) -> dict:
+def _select_process_output_keys(process: dict[str, Any], output_keys: Optional[list[str]]) -> dict[str, Any]:
     if not output_keys:
         return process
 
@@ -149,7 +150,7 @@ def _format_byte_count(value: int) -> str:
     return f"{size:.1f}{suffixes[suffix_index]}" if size < 10 else f"{size:.0f}{suffixes[suffix_index]}"
 
 
-def _humanize_process_values(process: dict) -> dict:
+def _humanize_process_values(process: dict[str, Any]) -> dict[str, Any]:
     humanized = dict(process)
     for key, value in humanized.items():
         if key in _BYTE_FIELDS and isinstance(value, int):
@@ -157,7 +158,9 @@ def _humanize_process_values(process: dict) -> dict:
     return humanized
 
 
-def _serialize_process(process: dict, keys: Optional[list[str]] = None, human: bool = False) -> dict:
+def _serialize_process(
+    process: dict[str, Any], keys: Optional[list[str]] = None, human: bool = False
+) -> dict[str, Any]:
     selected = dict(_select_process_output_keys(process, keys))
     if human:
         selected = _humanize_process_values(selected)
@@ -165,7 +168,7 @@ def _serialize_process(process: dict, keys: Optional[list[str]] = None, human: b
     return selected
 
 
-def _write_process(out: Optional[TextIO], process: dict) -> None:
+def _write_process(out: Optional[TextIO], process: dict[str, Any]) -> None:
     if out is None:
         print_json(process)
         return
@@ -188,14 +191,14 @@ def _write_status(line: str) -> None:
     print(line, flush=True)
 
 
-def _describe_process(process: dict) -> str:
+def _describe_process(process: dict[str, Any]) -> str:
     name = process.get("name") or process.get("comm") or "<unknown>"
     pid = process.get("pid")
     ppid = process.get("ppid")
     return f"pid={pid}, ppid={ppid}, name={name}"
 
 
-def _describe_processes(processes: list[dict]) -> str:
+def _describe_processes(processes: list[dict[str, Any]]) -> str:
     return "; ".join(_describe_process(process) for process in processes)
 
 
@@ -219,7 +222,7 @@ async def iter_processes(sysmon: Sysmontap, skip_first_snapshot: bool = False):
         yield process_snapshot
 
 
-def _process_sort_key(process: dict) -> tuple:
+def _process_sort_key(process: dict[str, Any]) -> tuple[int, int, str]:
     # Sort from oldest to newest process. "first" picks the oldest match and "last" picks the newest match.
     start_abs_time = process.get("startAbsTime")
     if not isinstance(start_abs_time, int):
@@ -231,7 +234,9 @@ def _process_sort_key(process: dict) -> tuple:
     return start_abs_time, pid, str(name)
 
 
-def _select_process_from_candidates(processes: list[dict], selection_mode: ProcessSelectionMode) -> dict:
+def _select_process_from_candidates(
+    processes: list[dict[str, Any]], selection_mode: ProcessSelectionMode
+) -> dict[str, Any]:
     if len(processes) == 1:
         return processes[0]
 
@@ -256,7 +261,7 @@ def _select_process_from_candidates(processes: list[dict], selection_mode: Proce
     return sorted_processes[selection_index]
 
 
-def _get_process_identifier(process: dict) -> tuple[str, object]:
+def _get_process_identifier(process: dict[str, Any]) -> tuple[str, object]:
     if process.get("uniqueID") is not None:
         return "uniqueID", process["uniqueID"]
     if process.get("startAbsTime") is not None:
@@ -264,16 +269,16 @@ def _get_process_identifier(process: dict) -> tuple[str, object]:
     return "pid", process["pid"]
 
 
-def _matches_selected_process(process: dict, selected_process_identifier: tuple[str, object]) -> bool:
+def _matches_selected_process(process: dict[str, Any], selected_process_identifier: tuple[str, object]) -> bool:
     identifier_key, identifier_value = selected_process_identifier
     return process.get(identifier_key) == identifier_value
 
 
 def _select_process_from_snapshot(
-    process_snapshot: list[dict],
+    process_snapshot: list[dict[str, Any]],
     parsed_filters: dict[str, list[str]],
     selection_mode: ProcessSelectionMode,
-) -> dict:
+) -> dict[str, Any]:
     if process_snapshot:
         # All process entries in a sysmon sample share the same schema, so validating one entry is sufficient.
         _validate_process_keys(process_snapshot[0], list(parsed_filters))
@@ -287,7 +292,7 @@ def _select_process_from_snapshot(
 
 async def _select_process_from_sysmon(
     dvt, parsed_filters: dict[str, list[str]], keys: Optional[list[str]], selection_mode: ProcessSelectionMode
-) -> dict:
+) -> dict[str, Any]:
     async with await Sysmontap.create(dvt) as selection_sysmon:
         async for process_snapshot in iter_processes(
             selection_sysmon, skip_first_snapshot=_should_skip_first_snapshot(keys)

--- a/pymobiledevice3/remote/core_device/app_service.py
+++ b/pymobiledevice3/remote/core_device/app_service.py
@@ -1,5 +1,6 @@
+# pyright: reportMissingTypeArgument=error
 import plistlib
-from typing import Optional
+from typing import Any, Optional
 
 from pymobiledevice3.remote.core_device.core_device_service import CoreDeviceService
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
@@ -23,7 +24,7 @@ class AppServiceService(CoreDeviceService):
         include_hidden_apps: bool = True,
         include_internal_apps: bool = True,
         include_default_apps: bool = True,
-    ) -> list[dict]:
+    ) -> list[dict[str, Any]]:
         """List applications"""
         return await self.invoke(
             "com.apple.coredevice.feature.listapps",
@@ -42,9 +43,9 @@ class AppServiceService(CoreDeviceService):
         arguments: Optional[list[str]] = None,
         kill_existing: bool = True,
         start_suspended: bool = False,
-        environment: Optional[dict] = None,
-        extra_options: Optional[dict] = None,
-    ) -> list[dict]:
+        environment: Optional[dict[str, str]] = None,
+        extra_options: Optional[dict[str, Any]] = None,
+    ) -> list[dict[str, Any]]:
         """launch application"""
         return await self.invoke(
             "com.apple.coredevice.feature.launchapplication",
@@ -65,11 +66,11 @@ class AppServiceService(CoreDeviceService):
             },
         )
 
-    async def list_processes(self) -> list[dict]:
+    async def list_processes(self) -> list[dict[str, Any]]:
         """List processes"""
         return (await self.invoke("com.apple.coredevice.feature.listprocesses"))["processTokens"]
 
-    async def list_roots(self) -> dict:
+    async def list_roots(self) -> dict[str, Any]:
         """
         List roots.
 
@@ -77,7 +78,7 @@ class AppServiceService(CoreDeviceService):
         """
         return await self.invoke("com.apple.coredevice.feature.listroots", {"rootPoint": {"relative": "/"}})
 
-    async def spawn_executable(self, executable: str, arguments: list[str]) -> dict:
+    async def spawn_executable(self, executable: str, arguments: list[str]) -> dict[str, Any]:
         """
         Spawn given executable.
 
@@ -107,7 +108,7 @@ class AppServiceService(CoreDeviceService):
             },
         )
 
-    async def monitor_process_termination(self, pid: int) -> dict:
+    async def monitor_process_termination(self, pid: int) -> dict[str, Any]:
         """
         Monitor process termination.
 
@@ -124,7 +125,7 @@ class AppServiceService(CoreDeviceService):
         """
         await self.invoke("com.apple.coredevice.feature.uninstallapp", {"bundleIdentifier": bundle_identifier})
 
-    async def send_signal_to_process(self, pid: int, signal: int) -> dict:
+    async def send_signal_to_process(self, pid: int, signal: int) -> dict[str, Any]:
         """
         Send signal to given process by its pid
         """
@@ -138,7 +139,7 @@ class AppServiceService(CoreDeviceService):
 
     async def fetch_icons(
         self, bundle_identifier: str, width: float, height: float, scale: float, allow_placeholder: bool
-    ) -> dict:
+    ) -> dict[str, Any]:
         """
         Fetch given application's icons
         """

--- a/pymobiledevice3/remote/core_device/pasteboard_service.py
+++ b/pymobiledevice3/remote/core_device/pasteboard_service.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 """
 Read/write the device pasteboard via the ``com.apple.coredevice.pasteboardservice``
 RemoteXPC service (feature ``com.apple.coredevice.feature.pasteboard``).
@@ -24,7 +25,7 @@ frameworks on macOS:
   carries data inline and we don't need to chase promises.
 """
 
-from typing import Optional
+from typing import Any, Optional
 
 from pymobiledevice3.remote.remote_service import RemoteService
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
@@ -53,12 +54,12 @@ POLICY_MATCH_SOURCE = {"matchSource": {}}
 POLICY_PROMISE_SECONDARY = {"promiseSecondary": {}}
 
 
-def policy_threshold(threshold_bytes: int) -> dict:
+def policy_threshold(threshold_bytes: int) -> dict[str, Any]:
     """Inclusion policy: include item data inline if smaller than ``threshold_bytes``, otherwise promise it."""
     return {"thresholdData": {"_0": XpcInt64Type(threshold_bytes)}}
 
 
-def text_item(text: str, utis: Optional[list[str]] = None) -> dict:
+def text_item(text: str, utis: Optional[list[str]] = None) -> dict[str, Any]:
     """Build a single ``PasteboardItem`` carrying ``text`` under the standard text UTIs."""
     if utis is None:
         utis = [UTI_UTF8_PLAIN_TEXT, UTI_PLAIN_TEXT, UTI_TEXT]
@@ -69,7 +70,7 @@ def text_item(text: str, utis: Optional[list[str]] = None) -> dict:
     }
 
 
-def data_item(uti: str, data: bytes) -> dict:
+def data_item(uti: str, data: bytes) -> dict[str, Any]:
     """Build a single ``PasteboardItem`` carrying raw ``data`` under one ``uti``."""
     return {
         "types": [uti],
@@ -77,7 +78,7 @@ def data_item(uti: str, data: bytes) -> dict:
     }
 
 
-def snapshot_text(snapshot: dict) -> Optional[str]:
+def snapshot_text(snapshot: dict[str, Any]) -> Optional[str]:
     """Best-effort extraction of UTF-8 text from a ``PasteboardSnapshot`` dict.
 
     Returns ``None`` if the snapshot has no items or no decodable text. Walks
@@ -115,8 +116,8 @@ class PasteboardService(RemoteService):
     async def get(
         self,
         pasteboard_name: str = GENERAL_PASTEBOARD,
-        data_policy: Optional[dict] = None,
-    ) -> dict:
+        data_policy: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
         """Pull the current pasteboard contents from the device.
 
         Returns the raw reply dict (``{command: "PULL_REPLY", pasteboard:
@@ -137,10 +138,10 @@ class PasteboardService(RemoteService):
 
     async def set(
         self,
-        items: list[dict],
+        items: list[dict[str, Any]],
         pasteboard_name: str = GENERAL_PASTEBOARD,
-        source_metadata: Optional[dict] = None,
-    ) -> dict:
+        source_metadata: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
         """Replace the device pasteboard contents with ``items``.
 
         Each item is a ``PasteboardItem`` dict (use :func:`text_item` or
@@ -153,6 +154,6 @@ class PasteboardService(RemoteService):
             "sourceMetadata": source_metadata,
         })
 
-    async def set_text(self, text: str, pasteboard_name: str = GENERAL_PASTEBOARD) -> dict:
+    async def set_text(self, text: str, pasteboard_name: str = GENERAL_PASTEBOARD) -> dict[str, Any]:
         """Convenience wrapper: set the pasteboard to a single UTF-8 ``text`` value."""
         return await self.set([text_item(text)], pasteboard_name)

--- a/pymobiledevice3/remote/core_device/screen_stream.py
+++ b/pymobiledevice3/remote/core_device/screen_stream.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 """
 Live screen-stream server and helpers, sitting on top of :class:`DisplayService`.
 
@@ -29,7 +30,7 @@ import time
 import uuid
 from collections import deque
 from pathlib import Path
-from typing import Optional, Protocol, cast
+from typing import Any, Optional, Protocol, cast
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -711,8 +712,8 @@ class ScreenStreamServer:
         self._active_service: Optional[DisplayService] = None
         self._active_session_id: Optional[uuid.UUID] = None
         self._active_sock: Optional[UdpMediaTransport] = None
-        self._active_recv_task: Optional[asyncio.Task] = None
-        self._active_rtcp_task: Optional[asyncio.Task] = None
+        self._active_recv_task: Optional[asyncio.Task[None]] = None
+        self._active_rtcp_task: Optional[asyncio.Task[None]] = None
         self._stream_lock = asyncio.Lock()
         self._stream_dirty = True  # True → next request must restart the stream
 
@@ -722,7 +723,7 @@ class ScreenStreamServer:
         self._audio_service: Optional[DisplayService] = None
         self._audio_session_id: Optional[uuid.UUID] = None
         self._audio_sock: Optional[UdpMediaTransport] = None
-        self._audio_recv_task: Optional[asyncio.Task] = None
+        self._audio_recv_task: Optional[asyncio.Task[None]] = None
         self._audio_subscribers: dict[asyncio.Queue[bytes], None] = {}
         self._audio_lock = asyncio.Lock()
         # Audio RTCP bookkeeping -- parallel to the video fields below.
@@ -735,7 +736,7 @@ class ScreenStreamServer:
         self._audio_remote_ssrc: int = 0
         self._audio_rtp_highest_seq: int = 0
         self._audio_rtp_packets_received: int = 0
-        self._audio_rtcp_task: Optional[asyncio.Task] = None
+        self._audio_rtcp_task: Optional[asyncio.Task[None]] = None
         # Xcode's Mirror uses ONE client_session_id for both the audio
         # and video mediastreamstart calls (confirmed verbatim in the
         # remotexpc-sniff4 capture: same UUID in both 'CoreDevice.input'
@@ -765,10 +766,10 @@ class ScreenStreamServer:
         self._rtp_last_frame_pkts: int = 0
         self._rtp_jitter: float = 0.0
         self._rtp_prev_transit: Optional[float] = None
-        self._rctl_task: Optional[asyncio.Task] = None
+        self._rctl_task: Optional[asyncio.Task[None]] = None
         # PLI tasks in flight -- keep a reference so the GC doesn't drop
         # them while awaiting the sendto (and ruff is happy with create_task).
-        self._pli_tasks: set[asyncio.Task] = set()
+        self._pli_tasks: set[asyncio.Task[None]] = set()
         # Timestamp of the last PLI we sent. The refresh loop paces its
         # triggers on it, and the recovery paths rate-limit on it so a
         # loss burst / slow subscriber / stuck client can't turn into a
@@ -777,7 +778,7 @@ class ScreenStreamServer:
         # (timestamp, AU bytes) entries pruned to the last 1 s -- the
         # refresh loop's motion detector, also logged with every PLI so
         # post-mortems can tell a quiet-screen PLI from a mid-motion one.
-        self._au_byte_window: deque = deque()
+        self._au_byte_window: deque[tuple[float, int]] = deque()
 
         # Lazy-opened HID services for browser-driven touch / buttons. The
         # auth gate is already held open by the active media stream above,
@@ -795,7 +796,7 @@ class ScreenStreamServer:
         # handling latency from device-write latency so a touch flood
         # can't starve the stream-broadcast loop.
         self._hid_queue: asyncio.Queue[tuple[str, bytes]] = asyncio.Queue()
-        self._hid_worker_task: Optional[asyncio.Task] = None
+        self._hid_worker_task: Optional[asyncio.Task[None]] = None
 
         # Stall-detection bookkeeping. Updated whenever an AU is forwarded;
         # the watchdog restarts the stream (forcing a fresh IDR) if no AU
@@ -820,7 +821,7 @@ class ScreenStreamServer:
         # 30 s -- 2 min) and the encoder stops emitting AUs; restarts
         # also can't recover because a locked device won't start a
         # fresh DisplayService session cleanly.
-        self._keep_awake_task: Optional[asyncio.Task] = None
+        self._keep_awake_task: Optional[asyncio.Task[None]] = None
 
         # Disconnect-recovery state. The stall watchdog sets
         # ``_reconnect_signal`` when it detects "tunnel is dead" errors
@@ -831,7 +832,7 @@ class ScreenStreamServer:
         # keep running through the gap -- the browser's offline overlay
         # masks the freeze, and AUs resume after rebind.
         self._reconnect_signal = asyncio.Event()
-        self._reconnect_task: Optional[asyncio.Task] = None
+        self._reconnect_task: Optional[asyncio.Task[None]] = None
         self._reconnect_poll_interval = 2.0
 
     # ----- per-session UDP receiver -----------------------------------------
@@ -1700,7 +1701,7 @@ class ScreenStreamServer:
         "accessibilityExtraExtraExtraLarge",
     )
 
-    async def _accessibility_list(self) -> list[dict]:
+    async def _accessibility_list(self) -> list[dict[str, Any]]:
         """Read every supported knob and return a viewer-friendly list.
 
         Each entry is ``{key, value, type, options?}`` where ``type`` is
@@ -1708,7 +1709,7 @@ class ScreenStreamServer:
         as checkboxes, floats as 0..1 sliders, and enums as dropdowns.
         """
         async with self._accessibility_lock:
-            results: list[dict] = []
+            results: list[dict[str, Any]] = []
 
             async def _read(meth):
                 async with ConfigurationService(self._rsd) as cfg:

--- a/pymobiledevice3/remote/xpc_message.py
+++ b/pymobiledevice3/remote/xpc_message.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 import dataclasses
 import uuid
 from datetime import datetime
@@ -154,7 +155,7 @@ class FileTransferType:
     transfer_size: int
 
 
-def _decode_xpc_dictionary(xpc_object) -> dict:
+def _decode_xpc_dictionary(xpc_object) -> dict[str, Any]:
     if xpc_object.data.count == 0:
         return {}
     result = {}
@@ -163,7 +164,7 @@ def _decode_xpc_dictionary(xpc_object) -> dict:
     return result
 
 
-def _decode_xpc_array(xpc_object) -> list:
+def _decode_xpc_array(xpc_object) -> list[Any]:
     result = []
     for entry in xpc_object.data.entries:
         result.append(decode_xpc_object(entry))
@@ -232,7 +233,7 @@ def decode_xpc_object(xpc_object) -> Any:
     return decoder(xpc_object)
 
 
-def _build_xpc_array(payload: list) -> dict:
+def _build_xpc_array(payload: list[Any]) -> dict[str, Any]:
     entries = []
     for entry in payload:
         entry = _build_xpc_object(entry)
@@ -240,7 +241,7 @@ def _build_xpc_array(payload: list) -> dict:
     return {"type": XpcMessageType.ARRAY, "data": {"count": len(entries), "entries": entries}}
 
 
-def _build_xpc_dictionary(payload: dict) -> dict:
+def _build_xpc_dictionary(payload: dict[str, Any]) -> dict[str, Any]:
     entries = []
     for key, value in payload.items():
         entry = {"key": key, "value": _build_xpc_object(value)}
@@ -254,63 +255,63 @@ def _build_xpc_dictionary(payload: dict) -> dict:
     }
 
 
-def _build_xpc_bool(payload: bool) -> dict:
+def _build_xpc_bool(payload: bool) -> dict[str, Any]:
     return {
         "type": XpcMessageType.BOOL,
         "data": payload,
     }
 
 
-def _build_xpc_string(payload: str) -> dict:
+def _build_xpc_string(payload: str) -> dict[str, Any]:
     return {
         "type": XpcMessageType.STRING,
         "data": payload,
     }
 
 
-def _build_xpc_data(payload: bool) -> dict:
+def _build_xpc_data(payload: bool) -> dict[str, Any]:
     return {
         "type": XpcMessageType.DATA,
         "data": payload,
     }
 
 
-def _build_xpc_double(payload: float) -> dict:
+def _build_xpc_double(payload: float) -> dict[str, Any]:
     return {
         "type": XpcMessageType.DOUBLE,
         "data": payload,
     }
 
 
-def _build_xpc_uuid(payload: uuid.UUID) -> dict:
+def _build_xpc_uuid(payload: uuid.UUID) -> dict[str, Any]:
     return {
         "type": XpcMessageType.UUID,
         "data": payload.bytes,
     }
 
 
-def _build_xpc_null(payload: None) -> dict:
+def _build_xpc_null(payload: None) -> dict[str, Any]:
     return {
         "type": XpcMessageType.NULL,
         "data": None,
     }
 
 
-def _build_xpc_uint64(payload: XpcUInt64Type) -> dict:
+def _build_xpc_uint64(payload: XpcUInt64Type) -> dict[str, Any]:
     return {
         "type": XpcMessageType.UINT64,
         "data": payload,
     }
 
 
-def _build_xpc_int64(payload: XpcInt64Type) -> dict:
+def _build_xpc_int64(payload: XpcInt64Type) -> dict[str, Any]:
     return {
         "type": XpcMessageType.INT64,
         "data": payload,
     }
 
 
-def _build_xpc_object(payload: Any) -> dict:
+def _build_xpc_object(payload: Any) -> dict[str, Any]:
     if payload is None:
         return _build_xpc_null(payload)
     payload_builders = {
@@ -331,7 +332,7 @@ def _build_xpc_object(payload: Any) -> dict:
     return builder(payload)
 
 
-def create_xpc_wrapper(d: dict, message_id: int = 0, wanting_reply: bool = False) -> bytes:
+def create_xpc_wrapper(d: dict[str, Any], message_id: int = 0, wanting_reply: bool = False) -> bytes:
     flags = XpcFlags.ALWAYS_SET
     if len(d.keys()) > 0:
         flags |= XpcFlags.DATA_PRESENT

--- a/pymobiledevice3/services/dvt/testmanaged/xcuitest.py
+++ b/pymobiledevice3/services/dvt/testmanaged/xcuitest.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 """XCUITest execution via the new DTX protocol implementation.
 
 Typical usage::
@@ -13,7 +14,7 @@ import asyncio
 import logging
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Optional, cast
+from typing import Any, Optional, cast
 
 from packaging.version import Version
 
@@ -235,24 +236,25 @@ class XCUITestService:
 
 @dataclass
 class TestConfig:
-    runner_app_info: dict
+    runner_app_info: dict[str, Any]
 
-    runner_app_env: Optional[dict] = None
-    runner_app_args: Optional[list] = None
+    runner_app_env: Optional[dict[str, str]] = None
+    runner_app_args: Optional[list[str]] = None
 
-    target_app_info: Optional[dict] = None
-    target_app_env: Optional[dict] = None
-    target_app_args: Optional[list] = None
-    tests_to_run: Optional[list] = None
-    tests_to_skip: Optional[list] = None
+    target_app_info: Optional[dict[str, Any]] = None
+    target_app_env: Optional[dict[str, str]] = None
+    target_app_args: Optional[list[str]] = None
+    # elements may be plain str specs or XCTTestIdentifier objects; _to_filter_pair str()-s each
+    tests_to_run: Optional[list[Any]] = None
+    tests_to_skip: Optional[list[Any]] = None
 
     @staticmethod
     async def create_for(
         service_provider: LockdownServiceProvider, runner_bundle_id: str, target_bundle_id: Optional[str] = None
     ) -> TestConfig:
         """Helper to create a TestConfig with the required runner_app_info and optional target_app_info."""
-        runner_app_info: dict
-        target_app_info: Optional[dict] = None
+        runner_app_info: dict[str, Any]
+        target_app_info: Optional[dict[str, Any]] = None
 
         async with InstallationProxyService(lockdown=service_provider) as install_service:
             apps = await install_service.get_apps(
@@ -305,8 +307,8 @@ class TestConfig:
         # objects).  The legacy testsToRun / testsToSkip NSSet<NSString> fields
         # are also populated for compatibility with older runners.
         def _to_filter_pair(
-            specs: Optional[list],
-        ) -> tuple[Optional[set], Optional[XCTTestIdentifierSet]]:
+            specs: Optional[list[Any]],
+        ) -> tuple[Optional[set[str]], Optional[XCTTestIdentifierSet]]:
             if not specs:
                 return None, None
             strings = [str(s) for s in specs]
@@ -333,11 +335,11 @@ class TestConfig:
 def _generate_launch_args(
     product_major_version: int,
     test_session_identifier: NSUUID,
-    app_info: dict,
+    app_info: dict[str, Any],
     xctest_path: str,
-    test_runner_env: Optional[dict] = None,
-    test_runner_args: Optional[list] = None,
-) -> tuple[list, dict, dict]:
+    test_runner_env: Optional[dict[str, str]] = None,
+    test_runner_args: Optional[list[str]] = None,
+) -> tuple[list[str], dict[str, str], dict[str, Any]]:
     """Return *(app_args, app_env, app_options)* for launching the test runner.
 
     Extracted from the old ``launch_test_app`` method so that it can be
@@ -384,7 +386,7 @@ def _generate_launch_args(
     ]
     app_args.extend(test_runner_args or [])
 
-    app_options: dict = {"StartSuspendedKey": False}
+    app_options: dict[str, Any] = {"StartSuspendedKey": False}
     if product_major_version >= 12:
         app_options["ActivateSuspended"] = True
 

--- a/pymobiledevice3/services/web_protocol/inspector_session.py
+++ b/pymobiledevice3/services/web_protocol/inspector_session.py
@@ -1,8 +1,9 @@
+# pyright: reportMissingTypeArgument=error
 import asyncio
 import json
 import logging
 from collections import UserDict
-from typing import Optional, cast
+from typing import Any, Optional, cast
 
 from pymobiledevice3.exceptions import InspectorEvaluateError
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
@@ -20,8 +21,8 @@ webinspector_logger_handlers = {
 }
 
 
-class JSObjectPreview(UserDict):
-    def __init__(self, properties: list[dict]):
+class JSObjectPreview(UserDict[str, Any]):
+    def __init__(self, properties: list[dict[str, Any]]):
         super().__init__()
         for p in properties:
             name = p["name"]
@@ -29,8 +30,8 @@ class JSObjectPreview(UserDict):
             self.data[name] = value
 
 
-class JSObjectProperties(UserDict):
-    def __init__(self, properties: list[dict]):
+class JSObjectProperties(UserDict[str, Any]):
+    def __init__(self, properties: list[dict[str, Any]]):
         super().__init__()
         for p in properties:
             name = p["name"]
@@ -105,7 +106,7 @@ class InspectorSession:
         snapshot = await self.send_command("Heap.snapshot")
         if self.target_id is not None:
             # when a target id is present, the response came from Target.dispatchMessageFromTarget (a dict)
-            snapshot = json.loads(cast(dict, snapshot)["params"]["message"])
+            snapshot = json.loads(cast(dict[str, Any], snapshot)["params"]["message"])
         snapshot = json.loads(cast(str, snapshot))["result"]["snapshotData"]
         return snapshot
 
@@ -153,7 +154,7 @@ class InspectorSession:
     async def navigate_to_url(self, url: str):
         return await self.runtime_evaluate(exp=f'window.location = "{url}"')
 
-    async def send_and_receive(self, message: dict) -> dict:
+    async def send_and_receive(self, message: dict[str, Any]) -> dict[str, Any]:
         if self.target_id is None:
             message_id = await self.protocol.send_command(message["method"], **message.get("params", {}))
             return await self.protocol.wait_for_message(message_id)
@@ -161,7 +162,7 @@ class InspectorSession:
             message_id = await self.send_message_to_target(message)
             return await self.receive_response_by_id(message_id)
 
-    async def send_message_to_target(self, message: dict) -> int:
+    async def send_message_to_target(self, message: dict[str, Any]) -> int:
         message["id"] = self.message_id
         self.message_id += 1
         await self.protocol.send_command(
@@ -181,7 +182,7 @@ class InspectorSession:
             else:
                 logger.error(f"Unknown response: {response}")
 
-    async def receive_response_by_id(self, message_id: int) -> dict:
+    async def receive_response_by_id(self, message_id: int) -> dict[str, Any]:
         while True:
             if message_id in self._dispatch_message_responses:
                 return self._dispatch_message_responses.pop(message_id)
@@ -189,7 +190,7 @@ class InspectorSession:
 
     async def get_properties(self, object_id: str) -> JSObjectProperties:
         message = cast(
-            dict,
+            dict[str, Any],
             await self.send_command(
                 "Runtime.getProperties", objectId=object_id, ownProperties=True, generatePreview=True
             ),
@@ -198,7 +199,7 @@ class InspectorSession:
             message = json.loads(message["params"]["message"])["result"]
         return JSObjectProperties(message["properties"])
 
-    async def _parse_runtime_evaluate(self, response: dict):
+    async def _parse_runtime_evaluate(self, response: dict[str, Any]):
         message = response if self.target_id is None else json.loads(response["params"]["message"])
         result = message["result"]["result"]
         if result.get("subtype", "") == "error":
@@ -235,7 +236,7 @@ class InspectorSession:
             return result["value"]
 
     # response methods
-    def _target_dispatch_message_from_target(self, response: dict):
+    def _target_dispatch_message_from_target(self, response: dict[str, Any]):
         target_message = json.loads(response["params"]["message"])
         receive_message_id = target_message.get("id")
         if receive_message_id is None:
@@ -243,30 +244,30 @@ class InspectorSession:
             return
         self._dispatch_message_responses[receive_message_id] = response
 
-    def _missing_id_in_message(self, message: dict):
+    def _missing_id_in_message(self, message: dict[str, Any]):
         handler = self.response_methods.get(message["method"])
         if handler is not None:
             handler(message)
         else:
             logger.critical(f"unhandled message: {message}")
 
-    def _console_message_added(self, message: dict):
+    def _console_message_added(self, message: dict[str, Any]):
         log_level = message["params"]["message"]["level"]
         text = message["params"]["message"]["text"]
         self._last_console_message = message
         webinspector_logger_handlers[log_level](text)
 
-    def _console_message_repeated_count_updated(self, message: dict):
+    def _console_message_repeated_count_updated(self, message: dict[str, Any]):
         self._console_message_added(self._last_console_message)
 
-    def _heap_garbage_collected(self, message: dict):
+    def _heap_garbage_collected(self, message: dict[str, Any]):
         heap_logger.debug(message["params"])
 
-    def _target_created(self, response: dict):
+    def _target_created(self, response: dict[str, Any]):
         pass
 
-    def _target_destroyed(self, response: dict):
+    def _target_destroyed(self, response: dict[str, Any]):
         pass
 
-    def _target_did_commit_provisional_target(self, response: dict):
+    def _target_did_commit_provisional_target(self, response: dict[str, Any]):
         self.set_target_id(response["params"]["newTargetId"])


### PR DESCRIPTION
## What

Second slice of the `reportMissingTypeArgument` campaign (after #1791). Parametrizes **~106** bare generics across the next 7 densest files, dropping the package-wide count **362 → 256**.

| File | sites |
|---|---|
| `cli/developer/dvt/sysmon/process.py` | 20 |
| `services/web_protocol/inspector_session.py` | 19 |
| `services/dvt/testmanaged/xcuitest.py` | 19 |
| `remote/xpc_message.py` | 16 |
| `remote/core_device/screen_stream.py` | 12 |
| `remote/core_device/pasteboard_service.py` | 10 |
| `remote/core_device/app_service.py` | 10 |

## Policy (same as slice 1)

Heterogeneous plist/XPC/CDP payloads → `dict[str, Any]`; **precise types wherever evident**:
- `screen_stream`: all 8+ `asyncio.Task` fields → `Task[None]` (each coroutine returns `None`), `deque[tuple[float, int]]`
- `xcuitest`: env dicts → `dict[str, str]`, args/tests lists → `list[str]`
- `sysmon/process`: `_process_sort_key` → `tuple[int, int, str]`
- `app_service`: `environment` → `dict[str, str]`
- `inspector_session`: `UserDict` subclasses → `UserDict[str, Any]`

## Notable correctness fix

An agent initially over-narrowed `TestConfig.tests_to_run` / `tests_to_skip` (and `_to_filter_pair`'s param) to `list[str]`, which broke `tests/services/test_xcuitest_filter.py` — the code does `str(s)` on each element and callers pass **`XCTTestIdentifier`** objects, not just strings. Corrected to `list[Any]` (the honest type for a "stringify anything" field). Caught by the full pyright run over tests.

## Enforcement & safety

Each cleaned file carries a `# pyright: reportMissingTypeArgument=error` header (regression-proof; headers removed + rule flipped globally at campaign end). **Annotation-only** — diff scan confirms no runtime-logic changes.

## Verification

- `pyright`: 0 errors (7 files now enforce the rule).
- `ruff check` / `ruff format`: clean.
- `pytest -m cli`: 117 passed.
- All 7 modules import cleanly.