### PR TITLE
typing: parametrize bare dict/list generics (slice 3 of reportMissingTypeArgument)

### DIFF
--- a/pymobiledevice3/bonjour.py
+++ b/pymobiledevice3/bonjour.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 # Async, dependency-light mDNS browser returning dataclasses with per-address interface names.
 # Works for any DNS-SD type, e.g. "_remoted._tcp.local."
 # - Uses ifaddr (optional) to map IPs -> local interfaces; otherwise iface will be None.
@@ -10,7 +11,7 @@ import struct
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Callable, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 import ifaddr  # pip install ifaddr
 from typing_extensions import dataclass_transform
@@ -226,7 +227,7 @@ class _Adapters:
 
 
 class _DatagramProtocol(asyncio.DatagramProtocol):
-    def __init__(self, queue: asyncio.Queue):
+    def __init__(self, queue: asyncio.Queue[tuple[bytes, Any]]):
         self.queue = queue
 
     def datagram_received(self, data, addr):
@@ -234,7 +235,7 @@ class _DatagramProtocol(asyncio.DatagramProtocol):
         self.queue.put_nowait((data, addr))
 
 
-async def _bind_ipv4(queue: asyncio.Queue):
+async def _bind_ipv4(queue: asyncio.Queue[tuple[bytes, Any]]):
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     if hasattr(socket, "SO_REUSEPORT"):
@@ -250,7 +251,7 @@ async def _bind_ipv4(queue: asyncio.Queue):
     return transport, s
 
 
-async def _bind_ipv6_all_ifaces(queue: asyncio.Queue):
+async def _bind_ipv6_all_ifaces(queue: asyncio.Queue[tuple[bytes, Any]]):
     s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     if hasattr(socket, "SO_REUSEPORT"):
@@ -306,8 +307,8 @@ async def browse_service(service_type: str, timeout: float = 4.0) -> list[Servic
     adapters = _Adapters()
 
     ptr_targets: set[str] = set()
-    srv_map: dict[str, list[dict]] = defaultdict(list)  # instance_name -> list of {"target", "port"}
-    txt_map: dict[str, dict] = {}
+    srv_map: dict[str, list[dict[str, Any]]] = defaultdict(list)  # instance_name -> list of {"target", "port"}
+    txt_map: dict[str, dict[str, Any]] = {}
     host_addrs: dict[str, list[Address]] = defaultdict(list)  # host -> list[(ip, iface)]
 
     def _record_addr(rr_name: str, ip_str: str, pkt_addr):
@@ -494,8 +495,8 @@ class MDNSResponder:
         # Every local IPv4 interface to steer multicast egress through (see _send_to_all)
         self._ipv4_send_addresses = [ip for family, ip in self.addresses if family == socket.AF_INET]
         self._transports: list[tuple[asyncio.DatagramTransport, socket.socket]] = []
-        self._queue: Optional[asyncio.Queue] = None
-        self._serve_task: Optional[asyncio.Task] = None
+        self._queue: Optional[asyncio.Queue[tuple[bytes, Any]]] = None
+        self._serve_task: Optional[asyncio.Task[None]] = None
 
     def _address_records(self) -> list[bytes]:
         records = []

--- a/pymobiledevice3/dtx/connection.py
+++ b/pymobiledevice3/dtx/connection.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 """DTX protocol connection — lifecycle, channel management and capability handshake.
 
 :class:`DTXConnection` is the top-level object for a DTX session.  It owns:
@@ -58,7 +59,7 @@ class DTXConnection(_DTXSenderMixin, _DTXReaderMixin):
     pair (useful when the caller already owns the streams).
     """
 
-    DEFAULT_CAPABILITIES: ClassVar[dict] = {
+    DEFAULT_CAPABILITIES: ClassVar[dict[str, Any]] = {
         "com.apple.private.DTXBlockCompression": 0,
         "com.apple.private.DTXConnection": 1,
     }
@@ -88,7 +89,7 @@ class DTXConnection(_DTXSenderMixin, _DTXReaderMixin):
         self._next_msg_id: int = 1
         self._send_lock = asyncio.Lock()
         self._pending_replies: dict[int, asyncio.Future[DTXMessage]] = {}
-        self._pending_outgoing_replies: list[asyncio.Future] = []
+        self._pending_outgoing_replies: list[asyncio.Future[Any]] = []
 
         # Channel registry
         self._channels: dict[int, DTXChannel] = {}
@@ -97,7 +98,7 @@ class DTXConnection(_DTXSenderMixin, _DTXReaderMixin):
         self._services: dict[int, DTXService] = {}
 
         # Background reader task
-        self._reader_task: Optional[asyncio.Task] = None
+        self._reader_task: Optional[asyncio.Task[None]] = None
         self._closed: bool = False
 
         self.ctx: DTXContext = DTXContext(parent=DTX_GLOBAL_CTX, connection=self)
@@ -125,14 +126,14 @@ class DTXConnection(_DTXSenderMixin, _DTXReaderMixin):
         self._service_condition: asyncio.Condition = asyncio.Condition()
 
         # Resolved with the peer's capabilities dict on successful handshake.
-        self._handshake_done: asyncio.Future[Optional[dict]] = asyncio.get_event_loop().create_future()
-        self.sent_capabilities: Optional[dict] = DTXConnection.DEFAULT_CAPABILITIES.copy()
+        self._handshake_done: asyncio.Future[Optional[dict[str, Any]]] = asyncio.get_event_loop().create_future()
+        self.sent_capabilities: Optional[dict[str, Any]] = DTXConnection.DEFAULT_CAPABILITIES.copy()
         """
         Supported service identifiers published by the peer during handshake.
 
         Set to None to skip the handshake exchange.
         """
-        self.supported_identifiers: Optional[dict] = None
+        self.supported_identifiers: Optional[dict[str, Any]] = None
         """
         Capabilities received from the peer during handshake.
 
@@ -181,7 +182,7 @@ class DTXConnection(_DTXSenderMixin, _DTXReaderMixin):
         if self._closed:
             return
         self._closed = True
-        current_task: Optional[asyncio.Task] = None
+        current_task: Optional[asyncio.Task[Any]] = None
         with suppress(RuntimeError):
             current_task = asyncio.current_task()
         if self._reader_task is not None and current_task is not self._reader_task:
@@ -479,7 +480,7 @@ class DTXConnection(_DTXSenderMixin, _DTXReaderMixin):
                 self.logger.error("Received cancellation for unknown channel %d", channel_code)
                 raise DTXProtocolError(f"Received channel cancellation for unknown channel {channel_code}")
 
-    async def _on_capabilities_received(self, capabilities: dict) -> None:
+    async def _on_capabilities_received(self, capabilities: dict[str, Any]) -> None:
         self.logger.debug("Received capabilities from remote: %r", capabilities)
         self.supported_identifiers = capabilities
         if not self._handshake_done.done():

--- a/pymobiledevice3/dtx/service.py
+++ b/pymobiledevice3/dtx/service.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 """DTX service base classes and decorator machinery.
 
 This module provides the building blocks for implementing DTX-based services:
@@ -151,7 +152,7 @@ def _python_name_to_objc_selector(name: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _apply_primitive_coercions(args: tuple, coercions: tuple) -> tuple:
+def _apply_primitive_coercions(args: tuple[Any, ...], coercions: tuple[Any, ...]) -> tuple[Any, ...]:
     """Coerce *args* to :class:`_PrimitiveBase` types driven by annotation hints.
 
     For each position *i*, if ``coercions[i]`` is a :class:`_PrimitiveBase`
@@ -316,7 +317,7 @@ class DTXService:
                 # Build per-parameter coercion table from type annotations.
                 # With 'from __future__ import annotations' all annotations are
                 # strings; get_type_hints() evaluates them in the module's namespace.
-                _coercions: tuple = ()
+                _coercions: tuple[Any, ...] = ()
                 try:
                     module_globals = vars(sys.modules.get(cls.__module__, None) or {})
                     hints = get_type_hints(val, globalns=module_globals)
@@ -329,8 +330,8 @@ class DTXService:
                     self,
                     *args: Any,
                     __sel: str = _sel,
-                    __kw: dict = _kw,
-                    __coercions: tuple = _coercions,
+                    __kw: dict[str, Any] = _kw,
+                    __coercions: tuple[Any, ...] = _coercions,
                     **extra: Any,
                 ) -> Any:
                     if __coercions:
@@ -513,7 +514,7 @@ class DTXControlService(DTXService):
     # ------------------------------------------------------------------
 
     @dtx_method("_notifyOfPublishedCapabilities:", expects_reply=False)
-    async def notify_capabilities(self, capabilities: dict) -> None:
+    async def notify_capabilities(self, capabilities: dict[str, Any]) -> None:
         """Announce our capability dictionary to the peer."""
 
     @dtx_method("_requestChannelWithCode:identifier:")
@@ -529,7 +530,7 @@ class DTXControlService(DTXService):
     # ------------------------------------------------------------------
 
     @dtx_on_invoke("_notifyOfPublishedCapabilities:")
-    async def _recv_capabilities(self, capabilities: dict) -> None:
+    async def _recv_capabilities(self, capabilities: dict[str, Any]) -> None:
         await self._ctx["connection"]._on_capabilities_received(capabilities)
 
     @dtx_on_invoke("_requestChannelWithCode:identifier:")

--- a/pymobiledevice3/remote/remote_service_discovery.py
+++ b/pymobiledevice3/remote/remote_service_discovery.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 import base64
 import logging
 from contextlib import suppress
@@ -57,7 +58,7 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
     """
 
     def __init__(
-        self, address: tuple[str, int], name: Optional[str] = None, open_connection: Optional[Callable] = None
+        self, address: tuple[str, int], name: Optional[str] = None, open_connection: Optional[Callable[..., Any]] = None
     ) -> None:
         """
         :param address: ``(host, port)`` of the RSD endpoint to connect to.
@@ -75,7 +76,7 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         # so device-bound connections route through its in-process stack without a global monkeypatch.
         self.open_connection = open_connection
         self.service = RemoteXPCConnection(address, open_connection=open_connection)
-        self.peer_info: Optional[dict] = None
+        self.peer_info: Optional[dict[str, Any]] = None
         self.lockdown: Optional[LockdownClient] = None
         self.all_values: dict[str, Any] = {}
 
@@ -87,7 +88,7 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         lldb as a connect endpoint."""
         return self.open_connection is not None
 
-    def _require_peer_info(self) -> dict:
+    def _require_peer_info(self) -> dict[str, Any]:
         """Return the handshake ``peer_info``, raising if the RSD has not been connected yet."""
         if self.peer_info is None:
             raise NotConnectedError("RSD is not connected; call connect() first")
@@ -211,10 +212,10 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
     async def get_value(self, domain: Optional[str] = None, key: Optional[str] = None) -> Any:
         return await self._lockdown.get_value(domain, key)
 
-    async def set_value(self, value, domain: Optional[str] = None, key: Optional[str] = None) -> dict:
+    async def set_value(self, value, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
         return await self._lockdown.set_value(value, domain=domain, key=key)
 
-    async def remove_value(self, domain: Optional[str] = None, key: Optional[str] = None) -> dict:
+    async def remove_value(self, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
         return await self._lockdown.remove_value(domain=domain, key=key)
 
     async def start_lockdown_service_without_checkin(self, name: str) -> ServiceConnection:
@@ -227,7 +228,7 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         """
         return await self.create_service_connection(self.get_service_port(name))
 
-    async def get_service_connection_attributes(self, name: str, include_escrow_bag: bool = False) -> dict:
+    async def get_service_connection_attributes(self, name: str, include_escrow_bag: bool = False) -> dict[str, Any]:
         """
         Return the connection attributes for a service.
 
@@ -272,7 +273,7 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         service = await self.start_lockdown_service_without_checkin(name)
         await service.start()
         try:
-            checkin: dict = {"Label": "pymobiledevice3", "ProtocolVersion": "2", "Request": "RSDCheckin"}
+            checkin: dict[str, Any] = {"Label": "pymobiledevice3", "ProtocolVersion": "2", "Request": "RSDCheckin"}
             if include_escrow_bag:
                 if self.udid is None:
                     raise NotConnectedError("RSD is not connected; call connect() first")

--- a/pymobiledevice3/restore/device.py
+++ b/pymobiledevice3/restore/device.py
@@ -1,5 +1,6 @@
+# pyright: reportMissingTypeArgument=error
 from contextlib import suppress
-from typing import Optional, overload
+from typing import Any, Optional, overload
 
 from pymobiledevice3.exceptions import MissingValueError
 from pymobiledevice3.irecv import IRecv
@@ -19,16 +20,16 @@ class Device:
         self._ecid: Optional[int] = None
         self._hardware_model: Optional[str] = None
         self._is_image4_supported: Optional[bool] = None
-        self._ap_parameters: Optional[dict] = None
+        self._ap_parameters: Optional[dict[str, Any]] = None
         self._ap_nonce = None
         self._ap_nonce_loaded = False
         self._sep_nonce = None
         self._sep_nonce_loaded = False
-        self._preflight_info: Optional[dict] = None
+        self._preflight_info: Optional[dict[str, Any]] = None
         self._preflight_info_loaded = False
-        self._firmware_preflight_info: Optional[dict] = None
+        self._firmware_preflight_info: Optional[dict[str, Any]] = None
         self._firmware_preflight_info_loaded = False
-        self._preflight_device_info: Optional[dict] = None
+        self._preflight_device_info: Optional[dict[str, Any]] = None
         self._preflight_device_info_loaded = False
         self._product_type: Optional[str] = None
 
@@ -85,7 +86,7 @@ class Device:
 
         return self._is_image4_supported
 
-    async def get_ap_parameters(self) -> dict:
+    async def get_ap_parameters(self) -> dict[str, Any]:
         if self._ap_parameters is not None:
             return self._ap_parameters
 
@@ -132,7 +133,7 @@ class Device:
         self._sep_nonce_loaded = True
         return self._sep_nonce
 
-    async def get_preflight_info(self) -> Optional[dict]:
+    async def get_preflight_info(self) -> Optional[dict[str, Any]]:
         if self._preflight_info_loaded:
             return self._preflight_info
 
@@ -149,7 +150,7 @@ class Device:
         self._preflight_info_loaded = True
         return self._preflight_info
 
-    async def get_firmware_preflight_info(self) -> Optional[dict]:
+    async def get_firmware_preflight_info(self) -> Optional[dict[str, Any]]:
         if self._firmware_preflight_info_loaded:
             return self._firmware_preflight_info
 
@@ -162,7 +163,7 @@ class Device:
         self._firmware_preflight_info_loaded = True
         return self._firmware_preflight_info
 
-    async def get_preflight_device_info(self) -> Optional[dict]:
+    async def get_preflight_device_info(self) -> Optional[dict[str, Any]]:
         """Return PreflightInfo.DeviceInfo (per-peripheral state: nonces, chip IDs, etc.).
 
         Present on iOS 18+. Contains entries like Rose/SE/Savage/T200, each carrying the

--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 #!/usr/bin/env python3
 """
 AFC (Apple File Connection) Service Module
@@ -323,9 +324,9 @@ class AfcService(LockdownService):
         super().__init__(lockdown, service_name)
         self.packet_num = 0
         # Demux state — populated in __aenter__, torn down in __aexit__
-        self._afc_pending: dict[int, asyncio.Future] = {}
+        self._afc_pending: dict[int, asyncio.Future[Any]] = {}
         self._afc_write_lock = asyncio.Lock()
-        self._afc_reader_task: Optional[asyncio.Task] = None
+        self._afc_reader_task: Optional[asyncio.Task[None]] = None
 
     async def __aenter__(self):
         await super().__aenter__()
@@ -385,8 +386,8 @@ class AfcService(LockdownService):
         self,
         relative_src: str,
         dst: str,
-        match: Optional[Pattern] = None,
-        callback: Optional[Callable] = None,
+        match: Optional[Pattern[str]] = None,
+        callback: Optional[Callable[..., Any]] = None,
         src_dir: str = "",
         ignore_errors: bool = False,
         progress_bar: bool = True,
@@ -637,7 +638,7 @@ class AfcService(LockdownService):
         return True
 
     @path_to_str()
-    async def rm(self, filename: str, match: Optional[Pattern] = None, force: bool = False) -> list[str]:
+    async def rm(self, filename: str, match: Optional[Pattern[str]] = None, force: bool = False) -> list[str]:
         """
         Recursively remove a file or directory tree on the device.
 
@@ -1151,7 +1152,7 @@ class AfcService(LockdownService):
             self._afc_reader_task = asyncio.create_task(self._afc_reader_loop(), name="afc-reader")
         loop = asyncio.get_event_loop()
         async with self._afc_write_lock:
-            fut: asyncio.Future = loop.create_future()
+            fut: asyncio.Future[Any] = loop.create_future()
             # Register *before* sending so the reader never misses the response
             pkt_num = self.packet_num
             self._afc_pending[pkt_num] = fut
@@ -1568,7 +1569,7 @@ class AfcShell:
 
         threading.Thread(target=_refresh, daemon=True).start()
 
-    def _register_arg_parse_alias(self, name: str, handler: Union[Callable, str]):
+    def _register_arg_parse_alias(self, name: str, handler: Union[Callable[..., Any], str]):
         """
         Register a command with argument parsing support.
 
@@ -1608,7 +1609,7 @@ class AfcShell:
         env = XSH.env
         assert env is not None
         # Env.__getitem__ is untyped; $PATH is an EnvPath (mutable sequence) at runtime
-        cast(MutableSequence, env["PATH"]).clear()
+        cast(MutableSequence[str], env["PATH"]).clear()
         # adding "file" just to fix xonsh errors
         for cmd in ["wc", "grep", "egrep", "sed", "awk", "print", "yes", "cat"]:
             executable = shutil.which(cmd)

--- a/pymobiledevice3/services/diagnostics.py
+++ b/pymobiledevice3/services/diagnostics.py
@@ -1,4 +1,5 @@
-from typing import Optional
+# pyright: reportMissingTypeArgument=error
+from typing import Any, Optional
 
 from pymobiledevice3.exceptions import DeprecationError, PyMobileDevice3Exception
 from pymobiledevice3.lockdown import LockdownClient
@@ -970,10 +971,10 @@ class DiagnosticsService(LockdownService):
         service_name = self.SERVICE_NAME if isinstance(lockdown, LockdownClient) else self.RSD_SERVICE_NAME
         super().__init__(lockdown, service_name, service=None)
 
-    async def _send_recv(self, request: dict) -> dict:
+    async def _send_recv(self, request: dict[str, Any]) -> dict[str, Any]:
         return await self.service.send_recv_plist(request)
 
-    async def mobilegestalt(self, keys: Optional[list[str]] = None) -> dict:
+    async def mobilegestalt(self, keys: Optional[list[str]] = None) -> dict[str, Any]:
         """
         Query MobileGestalt values from the device.
 
@@ -1001,7 +1002,7 @@ class DiagnosticsService(LockdownService):
 
         return response["Diagnostics"]["MobileGestalt"]
 
-    async def action(self, action: str) -> Optional[dict]:
+    async def action(self, action: str) -> Optional[dict[str, Any]]:
         """
         Send a single diagnostics relay request and return its ``Diagnostics`` payload.
 
@@ -1041,7 +1042,7 @@ class DiagnosticsService(LockdownService):
         """
         await self.action("Sleep")
 
-    async def info(self, diag_type: str = "All") -> Optional[dict]:
+    async def info(self, diag_type: str = "All") -> Optional[dict[str, Any]]:
         """
         Fetch a diagnostics information report from the device.
 
@@ -1087,7 +1088,7 @@ class DiagnosticsService(LockdownService):
             return dd.get("IORegistry")
         return None
 
-    async def get_battery(self) -> Optional[dict]:
+    async def get_battery(self) -> Optional[dict[str, Any]]:
         """
         Fetch battery/power-source information from the IORegistry.
 
@@ -1098,7 +1099,7 @@ class DiagnosticsService(LockdownService):
         """
         return await self.ioregistry(ioclass="IOPMPowerSource")
 
-    async def get_wifi(self) -> Optional[dict]:
+    async def get_wifi(self) -> Optional[dict[str, Any]]:
         """
         Fetch the Wi-Fi interface information from the IORegistry.
 

--- a/pymobiledevice3/services/dvt/instruments/core_profile_session_tap.py
+++ b/pymobiledevice3/services/dvt/instruments/core_profile_session_tap.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 import asyncio
 import queue
 import time
@@ -585,7 +586,9 @@ def clean(d):
         return d
 
 
-def jsonify_parsed_stackshot(stackshot, root: typing.Optional[dict] = None, index: int = 0) -> typing.Optional[int]:
+def jsonify_parsed_stackshot(
+    stackshot, root: typing.Optional[dict[str, typing.Any]] = None, index: int = 0
+) -> typing.Optional[int]:
     assert root is not None
     current_index = index
     while True:
@@ -621,7 +624,7 @@ STACKSHOT_HEADER = Int32ul.build(int(kcdata_types_enum.KCDATA_BUFFER_BEGIN_STACK
 
 
 class KdBufStream:
-    def __init__(self, chunk_queue: queue.Queue):
+    def __init__(self, chunk_queue: queue.Queue[typing.Any]):
         self.chunk_queue = chunk_queue
         self.current_chunk = BytesIO()
 
@@ -660,7 +663,7 @@ class CoreProfileSessionTapService(DTXService):
         super().on_closed(reason)
 
     @dtx_method("setConfig:", expects_reply=False)
-    async def set_config_(self, config: dict) -> None: ...
+    async def set_config_(self, config: dict[str, typing.Any]) -> None: ...
 
     @dtx_method("start", expects_reply=False)
     async def start(self) -> None: ...
@@ -715,7 +718,9 @@ class CoreProfileSessionTap:
 
     IDENTIFIER = CoreProfileSessionTapService.IDENTIFIER
 
-    def __init__(self, dvt: DtxServiceProvider, time_config: dict, filters: typing.Optional[set] = None):
+    def __init__(
+        self, dvt: DtxServiceProvider, time_config: dict[str, typing.Any], filters: typing.Optional[set[int]] = None
+    ):
         """
         :param dvt: Instruments service proxy.
         :param time_config: Timing information - numer, denom, mach_absolute_time and matching usecs_since_epoch,
@@ -793,7 +798,7 @@ class CoreProfileSessionTap:
         if isinstance(status, int) and status != 0:
             raise DvtException(str(notice))
 
-    async def get_stackshot(self, timeout: typing.Optional[float] = 10.0) -> dict:
+    async def get_stackshot(self, timeout: typing.Optional[float] = 10.0) -> dict[str, typing.Any]:
         """
         Wait for and parse the stackshot the device emits once per tap creation.
 
@@ -859,7 +864,7 @@ class CoreProfileSessionTap:
             out.write(data)
             out.flush()
 
-    async def pump_kdbuf_chunks(self, chunk_queue: queue.Queue) -> None:
+    async def pump_kdbuf_chunks(self, chunk_queue: queue.Queue[typing.Any]) -> None:
         """
         Continuously forward received messages into a queue for consumption by a `KdBufStream`.
 
@@ -882,7 +887,7 @@ class CoreProfileSessionTap:
         finally:
             chunk_queue.put(None)
 
-    def get_kdbuf_stream(self, chunk_queue: queue.Queue):
+    def get_kdbuf_stream(self, chunk_queue: queue.Queue[typing.Any]):
         """
         Wrap a chunk queue in a file-like `KdBufStream` for reading the kd_buf trace.
 

--- a/pymobiledevice3/services/dvt/instruments/device_info.py
+++ b/pymobiledevice3/services/dvt/instruments/device_info.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 import plistlib
 import typing
 from datetime import datetime
@@ -18,7 +19,7 @@ class DeviceInfoService(DTXService):
     async def execname_for_pid_(self, pid: int) -> str: ...
 
     @dtx_method("runningProcesses")
-    async def running_processes(self) -> list[dict]: ...
+    async def running_processes(self) -> list[dict[str, typing.Any]]: ...
 
     @dtx_method("isRunningPid:")
     async def is_running_pid_(self, pid: int) -> bool: ...
@@ -30,16 +31,16 @@ class DeviceInfoService(DTXService):
     async def name_for_gid_(self, gid: int) -> str: ...
 
     @dtx_method("systemInformation")
-    async def system_information(self) -> dict: ...
+    async def system_information(self) -> dict[str, typing.Any]: ...
 
     @dtx_method("hardwareInformation")
-    async def hardware_information(self) -> dict: ...
+    async def hardware_information(self) -> dict[str, typing.Any]: ...
 
     @dtx_method("networkInformation")
-    async def network_information(self) -> dict: ...
+    async def network_information(self) -> dict[str, typing.Any]: ...
 
     @dtx_method("machTimeInfo")
-    async def mach_time_info(self) -> dict: ...
+    async def mach_time_info(self) -> dict[int, typing.Any]: ...
 
     @dtx_method("machKernelName")
     async def mach_kernel_name(self) -> str: ...
@@ -71,7 +72,7 @@ class DeviceInfo(DtxService[DeviceInfoService]):
     and used as an async context manager to open the channel.
     """
 
-    async def ls(self, path: str) -> list:
+    async def ls(self, path: str) -> list[str]:
         """
         List the contents of a directory on the device.
 
@@ -100,7 +101,7 @@ class DeviceInfo(DtxService[DeviceInfoService]):
         """
         return await self.service.execname_for_pid_(pid)
 
-    async def proclist(self) -> list[dict]:
+    async def proclist(self) -> list[dict[str, typing.Any]]:
         """
         Get the list of running processes from the device.
 
@@ -178,7 +179,7 @@ class DeviceInfo(DtxService[DeviceInfoService]):
         """
         return await self.service.mach_kernel_name()
 
-    async def kpep_database(self) -> typing.Optional[dict]:
+    async def kpep_database(self) -> typing.Optional[dict[str, typing.Any]]:
         """
         Get the KPEP (kernel performance event) database.
 

--- a/pymobiledevice3/services/mobile_config.py
+++ b/pymobiledevice3/services/mobile_config.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 import contextlib
 import plistlib
 from enum import Enum
@@ -85,7 +86,7 @@ class MobileConfigService(LockdownService):
         await self._send_recv({"RequestType": "EscalateResponse", "SignedRequest": signed_challenge})
         await self._send_recv({"RequestType": "ProceedWithKeybagMigration"})
 
-    async def get_stored_profile(self, purpose: Purpose = Purpose.PostSetupInstallation) -> dict:
+    async def get_stored_profile(self, purpose: Purpose = Purpose.PostSetupInstallation) -> dict[str, Any]:
         """
         Retrieve a profile stored on the device for a given purpose.
 
@@ -103,7 +104,7 @@ class MobileConfigService(LockdownService):
         """
         await self._send_recv({"RequestType": "StoreProfile", "ProfileData": profile_data, "Purpose": purpose.value})
 
-    async def get_cloud_configuration(self) -> Optional[dict]:
+    async def get_cloud_configuration(self) -> Optional[dict[str, Any]]:
         """
         Retrieve the device's cloud (supervision) configuration.
 
@@ -111,7 +112,7 @@ class MobileConfigService(LockdownService):
         """
         return (await self._send_recv({"RequestType": "GetCloudConfiguration"})).get("CloudConfiguration")
 
-    async def set_cloud_configuration(self, cloud_configuration: dict) -> None:
+    async def set_cloud_configuration(self, cloud_configuration: dict[str, Any]) -> None:
         """
         Set the device's cloud (supervision) configuration.
 
@@ -152,7 +153,7 @@ class MobileConfigService(LockdownService):
                 "DisallowProximitySetup": disallow_proximity_setup,
             })
 
-    async def get_profile_list(self) -> dict:
+    async def get_profile_list(self) -> dict[str, Any]:
         """
         List the configuration profiles installed on the device.
 
@@ -208,12 +209,12 @@ class MobileConfigService(LockdownService):
         })
         await self._send_recv({"RequestType": "RemoveProfile", "ProfileIdentifier": data})
 
-    async def _send_recv(self, request: dict) -> dict:
+    async def _send_recv(self, request: dict[str, Any]) -> dict[str, Any]:
         response = await self.service.send_recv_plist(request)
         if response.get("Status", None) != "Acknowledged":
             error_chain = response.get("ErrorChain")
             if error_chain is not None:
-                error_code = cast("list[dict]", error_chain)[0]["ErrorCode"]
+                error_code = cast("list[dict[str, Any]]", error_chain)[0]["ErrorCode"]
                 if error_code == ERROR_CLOUD_CONFIGURATION_ALREADY_PRESENT:
                     raise CloudConfigurationAlreadyPresentError()
             raise ProfileError(f"invalid response {response}")

--- a/pymobiledevice3/services/mobile_image_mounter.py
+++ b/pymobiledevice3/services/mobile_image_mounter.py
@@ -1,8 +1,9 @@
+# pyright: reportMissingTypeArgument=error
 import hashlib
 import logging
 import plistlib
 from pathlib import Path
-from typing import ClassVar, Optional
+from typing import Any, ClassVar, Optional
 
 from developer_disk_image.repo import DeveloperDiskImageRepository
 from packaging.version import Version
@@ -54,7 +55,7 @@ class MobileImageMounterService(LockdownService):
         else:
             super().__init__(lockdown, self.RSD_SERVICE_NAME)
 
-    async def _send_recv(self, request: dict) -> dict:
+    async def _send_recv(self, request: dict[str, Any]) -> dict[str, Any]:
         return await self.service.send_recv_plist(request)
 
     async def raise_if_cannot_mount(self) -> None:
@@ -70,7 +71,7 @@ class MobileImageMounterService(LockdownService):
         if Version(self.lockdown.product_version).major >= 16 and not await self.lockdown.get_developer_mode_status():
             raise DeveloperModeIsNotEnabledError()
 
-    async def copy_devices(self) -> list[dict]:
+    async def copy_devices(self) -> list[dict[str, Any]]:
         """
         List the images currently mounted on the device.
 
@@ -140,7 +141,7 @@ class MobileImageMounterService(LockdownService):
             else:
                 raise PyMobileDevice3Exception(response)
 
-    async def mount_image(self, image_type: str, signature: bytes, extras: Optional[dict] = None) -> None:
+    async def mount_image(self, image_type: str, signature: bytes, extras: Optional[dict[str, Any]] = None) -> None:
         """
         Mount an image that has already been uploaded to the device.
 
@@ -235,7 +236,7 @@ class MobileImageMounterService(LockdownService):
         except KeyError as e:
             raise MessageNotSupportedError from e
 
-    async def query_personalization_identifiers(self, image_type: Optional[str] = None) -> dict:
+    async def query_personalization_identifiers(self, image_type: Optional[str] = None) -> dict[str, Any]:
         """
         Query the device identifiers required to personalize an image (board ID, chip ID, etc.).
 
@@ -337,7 +338,7 @@ class PersonalizedImageMounter(MobileImageMounterService):
     IMAGE_TYPE: ClassVar[str] = "Personalized"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     async def mount(
-        self, image: Path, build_manifest: Path, trust_cache: Path, info_plist: Optional[dict] = None
+        self, image: Path, build_manifest: Path, trust_cache: Path, info_plist: Optional[dict[str, Any]] = None
     ) -> None:
         """
         Upload and mount a personalized Developer Disk Image.
@@ -380,7 +381,7 @@ class PersonalizedImageMounter(MobileImageMounterService):
         """Unmount the Personalized Developer Disk Image (mounted at ``/System/Developer``)."""
         await self.unmount_image("/System/Developer")
 
-    async def get_manifest_from_tss(self, build_manifest: dict) -> bytes:
+    async def get_manifest_from_tss(self, build_manifest: dict[str, Any]) -> bytes:
         """
         Request an IM4M personalization manifest from Apple's TSS server.
 

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -1,10 +1,11 @@
+# pyright: reportMissingTypeArgument=error
 import asyncio
 import contextlib
 import json
 import uuid
 from dataclasses import dataclass, fields
 from enum import Enum
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from pymobiledevice3.exceptions import (
     ConnectionTerminatedError,
@@ -60,7 +61,7 @@ class Page:
     automation_connection_id: str = ""
 
     @classmethod
-    def from_page_dictionary(cls, page_dict: dict) -> "Page":
+    def from_page_dictionary(cls, page_dict: dict[str, Any]) -> "Page":
         p = cls(page_dict["WIRPageIdentifierKey"], WirTypes(page_dict["WIRTypeKey"]))
         if p.type_ in (WirTypes.WEB, WirTypes.WEB_PAGE):
             p.web_title = page_dict["WIRTitleKey"]
@@ -74,7 +75,7 @@ class Page:
                 p.automation_connection_id = page_dict["WIRConnectionIdentifierKey"]
         return p
 
-    def update(self, page_dict: dict):
+    def update(self, page_dict: dict[str, Any]):
         new_p = self.from_page_dictionary(page_dict)
         for field in fields(self):
             setattr(self, field.name, getattr(new_p, field.name))
@@ -154,7 +155,7 @@ class WebinspectorService(LockdownService):
             "_rpc_applicationSentData:": self._handle_application_sent_data,
             "_rpc_applicationDisconnected:": self._handle_application_disconnected,
         }
-        self._recv_task: Optional[asyncio.Task] = None
+        self._recv_task: Optional[asyncio.Task[None]] = None
 
     async def connect(self) -> None:
         """Establish the WebInspector session and start the background receive task.
@@ -208,7 +209,7 @@ class WebinspectorService(LockdownService):
                 with contextlib.suppress(asyncio.CancelledError):
                     await disabled_task
 
-    async def _await_or_raise_disabled(self, coro, disabled_task: asyncio.Task):
+    async def _await_or_raise_disabled(self, coro, disabled_task: asyncio.Task[None]):
         task = asyncio.create_task(coro)
         done, _ = await asyncio.wait(
             {task, disabled_task},
@@ -264,7 +265,7 @@ class WebinspectorService(LockdownService):
             wait_target=page.type_ != WirTypes.JAVASCRIPT,
         )
 
-    async def get_open_pages(self) -> dict:
+    async def get_open_pages(self) -> dict[str, Any]:
         """Request and return the currently open pages of all connected applications.
 
         :returns: A mapping of application name to the collection of its `Page` objects, including
@@ -314,7 +315,7 @@ class WebinspectorService(LockdownService):
         except TimeoutError as e:
             raise LaunchingApplicationError() from e
 
-    async def send_socket_data(self, session_id: str, app_id: str, page_id: int, data: dict):
+    async def send_socket_data(self, session_id: str, app_id: str, page_id: int, data: dict[str, Any]):
         """Forward an inspector/automation protocol message to a page's socket.
 
         :param session_id: The session identifier owning the socket.
@@ -442,7 +443,7 @@ class WebinspectorService(LockdownService):
             message["WIRAutomaticallyPause"] = False
         await self._send_message("_rpc_forwardSocketSetup:", message)
 
-    async def _forward_socket_data(self, session_id: str, app_id: str, page_id: int, data: dict):
+    async def _forward_socket_data(self, session_id: str, app_id: str, page_id: int, data: dict[str, Any]):
         await self._send_message(
             "_rpc_forwardSocketData:",
             {

--- a/pymobiledevice3/tunneld/server.py
+++ b/pymobiledevice3/tunneld/server.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingTypeArgument=error
 import asyncio
 import dataclasses
 import json
@@ -8,7 +9,7 @@ import traceback
 import warnings
 from contextlib import asynccontextmanager, suppress
 from ssl import SSLEOFError
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import pydantic
 import requests
@@ -77,7 +78,7 @@ OSUTILS = get_os_utils()
 _UPSTREAM_FETCH_TIMEOUT = 2.0
 
 
-def _fetch_upstream(url: str) -> dict:
+def _fetch_upstream(url: str) -> dict[str, Any]:
     """Fetch a tunneld listing from an upstream URL. Called in a worker thread
     via asyncio.to_thread; raises on any error so the caller can skip the
     upstream silently."""
@@ -88,7 +89,7 @@ def _fetch_upstream(url: str) -> dict:
 
 @dataclasses.dataclass
 class TunnelTask:
-    task: asyncio.Task
+    task: asyncio.Task[None]
     udid: Optional[str] = None
     tunnel: Optional[TunnelResult] = None
 
@@ -104,7 +105,7 @@ class TunneldCore:
         mobdev2_monitor: bool = True,
     ) -> None:
         self.protocol = protocol
-        self.tasks: list[asyncio.Task] = []
+        self.tasks: list[asyncio.Task[None]] = []
         self.tunnel_tasks: dict[str, TunnelTask] = {}
         self.usb_monitor = usb_monitor
         self.wifi_monitor = wifi_monitor
@@ -339,7 +340,7 @@ class TunneldCore:
         self,
         task_identifier: str,
         protocol_handler: Union[RemotePairingProtocol, CoreDeviceTunnelProxy],
-        queue: Optional[asyncio.Queue] = None,
+        queue: Optional[asyncio.Queue[Optional[TunnelResult]]] = None,
         protocol: Optional[TunnelProtocol] = None,
     ) -> None:
         if protocol is None:
@@ -468,7 +469,7 @@ class TunneldCore:
             with suppress(asyncio.CancelledError):
                 await task
 
-    def get_tunnels_ips(self) -> dict:
+    def get_tunnels_ips(self) -> dict[str, list[str]]:
         """Retrieve the available tunnel tasks and format them as {UDID: [IP]}"""
         tunnels_ips = {}
         for ip, active_tunnel in self.tunnel_tasks.items():
@@ -552,11 +553,11 @@ class TunneldRunner:
         )
 
         @self._app.get("/")
-        async def list_tunnels() -> dict[str, list[dict]]:
+        async def list_tunnels() -> dict[str, list[dict[str, Any]]]:
             """Retrieve the available tunnels and format them as {UUID: TUNNEL_ADDRESS}.
             Listings from any registered upstream tunnelds (see POST /upstream) are
             fetched in parallel and merged into the response."""
-            tunnels: dict[str, list[dict]] = {}
+            tunnels: dict[str, list[dict[str, Any]]] = {}
             for ip, active_tunnel in self._tunneld_core.tunnel_tasks.items():
                 if (active_tunnel.udid is None) or (active_tunnel.tunnel is None):
                     continue
@@ -631,7 +632,7 @@ class TunneldRunner:
             return generate_http_response(data)
 
         def generate_http_response(
-            data: dict, status_code: int = 200, media_type: str = "application/json"
+            data: dict[str, Any], status_code: int = 200, media_type: str = "application/json"
         ) -> fastapi.Response:
             return fastapi.Response(status_code=status_code, media_type=media_type, content=json.dumps(data))
 


### PR DESCRIPTION
## What

Third slice of the `reportMissingTypeArgument` campaign (after #1791, #1792). Parametrizes **~98** bare generics across the next **13 files**, dropping the package-wide count **256 → 158**.

Files: `tunneld/server.py`, `dvt/instruments/{device_info, core_profile_session_tap}.py`, `services/{afc, webinspector, mobile_image_mounter, mobile_config, diagnostics}.py`, `restore/device.py`, `dtx/{service, connection}.py`, `remote/remote_service_discovery.py`, `bonjour.py`.

## Policy (same as slices 1–2)

Heterogeneous plist/DTX/XPC/RSD payloads → `dict[str, Any]`; **precise types where evident**:
- **async:** `Task[None]` (afc/dtx/tunneld/webinspector reader loops), `Future[Any]`, `Queue[Optional[TunnelResult]]` (tunneld), `Queue[tuple[bytes, Any]]` (bonjour datagrams)
- **containers:** `Pattern[str]` (afc path globs), `MutableSequence[str]` (`$PATH`), `set[int]` (core-profile filters), `list[str]` (dir listings), `dict[str, list[str]]` (tunneld UDID→IPs), `dict[int, Any]` (`mach_time_info`, which is int-indexed — an agent self-corrected this after `dict[str, Any]` produced new errors)

## Enforcement & safety

Each cleaned file carries a `# pyright: reportMissingTypeArgument=error` header (regression-proof; headers removed + rule flipped globally at campaign end). **Annotation-only** — diff scan confirms no runtime-logic changes.

## Verification

- `pyright`: 0 errors (13 files now enforce the rule; 0 new errors elsewhere incl. tests).
- `ruff check` / `ruff format`: clean.
- `pytest -m cli`: 117 passed.
- All 13 modules import cleanly.