### PR TITLE
construct: typed DTX wire structs + shared construct-typing compat helper

### DIFF
--- a/pymobiledevice3/construct_compat.py
+++ b/pymobiledevice3/construct_compat.py
@@ -1,0 +1,32 @@
+"""Bridge between construct-typing 0.7.x (the Python 3.9 floor) and >= 0.8.0.
+
+construct-typing 0.8.0 (Python >= 3.10) replaced ``csfield(Const(...))`` with
+``csfield_const(subcon, value)`` for constant struct fields; the 0.7.x release pinned on Python 3.9
+has no ``csfield_const``. :func:`const_field` picks the form the installed version supports so struct
+definitions stay version-agnostic instead of repeating the ``try/except`` shim in every module.
+"""
+
+from typing import Any
+
+from construct import Const, Construct
+from construct_typed import csfield
+
+try:
+    from construct_typed import csfield_const  # pyright: ignore[reportAttributeAccessIssue]
+except ImportError:  # construct-typing < 0.8.0
+    csfield_const = None
+
+
+def const_field(subcon: "Construct[Any, Any]", value: Any) -> Any:
+    """Declare a constant :mod:`construct_typed` dataclass field portably across construct-typing
+    versions.
+
+    On construct-typing >= 0.8.0 this delegates to ``csfield_const``; on 0.7.x it falls back to
+    ``csfield(Const(...))``. Both make the field ``init=False`` at runtime (the constant is not a
+    constructor argument), but the return is typed ``Any`` because the two backends' stubs disagree —
+    callers annotate the field with its real value type and pyright cannot see the ``init=False``, so
+    the non-default fields that follow need a ``# pyright: ignore[reportGeneralTypeIssues]``.
+    """
+    if csfield_const is not None:
+        return csfield_const(subcon, value)
+    return csfield(Const(value, subcon))

--- a/pymobiledevice3/dtx/fragment.py
+++ b/pymobiledevice3/dtx/fragment.py
@@ -15,10 +15,10 @@ from dataclasses import dataclass
 
 from .exceptions import DTXProtocolError
 from .structs import (
-    DTX_FRAGMENT_MAGIC,
     FRAGMENT_HEADER_MIN_SIZE,
     FRAGMENT_PAYLOAD_HEADER_SIZE,
     MAX_MESSAGE_SIZE,
+    DtxFragmentHeader,
     DTXTransportFlags,
     dtx_fragment_header,
 )
@@ -87,17 +87,18 @@ class DTXFragment:
         """Return a list of memoryview chunks that make up this fragment for sending."""
         return [
             memoryview(
-                dtx_fragment_header.build({
-                    "magic": DTX_FRAGMENT_MAGIC,
-                    "header_size": FRAGMENT_HEADER_MIN_SIZE,
-                    "index": self.index,
-                    "count": self.count,
-                    "data_size": self.data_size,
-                    "identifier": self.identifier,
-                    "conversation_index": self.conversation_index,
-                    "channel_code": self.channel_code,
-                    "flags": int(self.flags),
-                })
+                dtx_fragment_header.build(
+                    DtxFragmentHeader(
+                        header_size=FRAGMENT_HEADER_MIN_SIZE,
+                        index=self.index,
+                        count=self.count,
+                        data_size=self.data_size,
+                        identifier=self.identifier,
+                        conversation_index=self.conversation_index,
+                        channel_code=self.channel_code,
+                        flags=int(self.flags),
+                    )
+                )
             ),
             self.payload,
         ]

--- a/pymobiledevice3/dtx/message.py
+++ b/pymobiledevice3/dtx/message.py
@@ -27,7 +27,13 @@ from . import ns_types as _ns_types  # noqa: F401 - registers common NSKeyedArch
 from .exceptions import DTXNSCodingError, DTXProtocolError
 from .fragment import DTXFragment, DTXTransportFlags
 from .message_aux import MessageAux
-from .structs import MAX_MESSAGE_SIZE, MESSAGE_PAYLOAD_HEADER_SIZE, DTXMessageType, dtx_fragment_payload_header
+from .structs import (
+    MAX_MESSAGE_SIZE,
+    MESSAGE_PAYLOAD_HEADER_SIZE,
+    DtxFragmentPayloadHeader,
+    DTXMessageType,
+    dtx_fragment_payload_header,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -196,15 +202,17 @@ class DTXMessage:
 
         return [
             memoryview(
-                dtx_fragment_payload_header.build({
-                    "msg_type": int(self.type),
-                    "flags_a": 0,
-                    "flags_b": 0,
-                    "reserved": 0,
-                    "aux_size": len(self.aux_data),
-                    "total_size": len(self.aux_data) + len(self.payload_data),
-                    "flags": int(self.flags),
-                })
+                dtx_fragment_payload_header.build(
+                    DtxFragmentPayloadHeader(
+                        msg_type=int(self.type),
+                        flags_a=0,
+                        flags_b=0,
+                        reserved=0,
+                        aux_size=len(self.aux_data),
+                        total_size=len(self.aux_data) + len(self.payload_data),
+                        flags=int(self.flags),
+                    )
+                )
             ),
             self.aux_data,
             self.payload_data,

--- a/pymobiledevice3/dtx/structs.py
+++ b/pymobiledevice3/dtx/structs.py
@@ -1,6 +1,15 @@
+from dataclasses import dataclass
 from enum import IntEnum, IntFlag
 
-from construct import Const, Int8ul, Int16ul, Int32sl, Int32ul, Struct
+from construct import Const, Int8ul, Int16ul, Int32sl, Int32ul
+from construct_typed import DataclassMixin, DataclassStruct, csfield
+
+try:
+    # construct-typing >= 0.8.0 rejects csfield(Const(...)) and requires csfield_const() for const
+    # fields. Older versions (0.7.x, the Python 3.9 floor) have no csfield_const (see afc.py).
+    from construct_typed import csfield_const  # pyright: ignore[reportAttributeAccessIssue]
+except ImportError:  # construct-typing < 0.8.0
+    csfield_const = None
 
 # ---------------------------------------------------------------------------
 # Protocol constants
@@ -49,19 +58,37 @@ class DTXMessageType(IntEnum):
 # ---------------------------------------------------------------------------
 
 # Fragment (wire) header - minimum 32 bytes; ``header_size`` may indicate more.
-dtx_fragment_header = Struct(
-    "magic" / Const(DTX_FRAGMENT_MAGIC, Int32ul),
-    "header_size" / Int32ul,  # total header size; skip (header_size - 32) extra bytes after parsing
-    "index" / Int16ul,  # 0-based fragment index within this message
-    "count" / Int16ul,  # total number of fragments for this message
-    "data_size" / Int32ul,  # byte length of this fragment's body
-    "identifier" / Int32ul,  # message identifier (matches request to response)
-    "conversation_index" / Int32ul,  # 0 = initiator, 1 = reply, higher = subsequent
-    "channel_code" / Int32sl,
-    "flags" / Int32ul,  # DTXTransportFlags
-    # with asynchronous reads we can read the fixed-size part first, then skip any extra header bytes before reading the body
-    # "extra" / Bytes(lambda ctx: ctx.header_size - FRAGMENT_HEADER_MIN_SIZE),  # optional extra header bytes
+# construct-typing >= 0.8.0 requires csfield_const() for const fields; 0.7.x (the Python 3.9 floor)
+# only has csfield(Const(...)). Pick the form the installed version supports (see afc.py).
+_dtx_magic_field = (
+    csfield_const(Int32ul, DTX_FRAGMENT_MAGIC)
+    if csfield_const is not None
+    else csfield(Const(DTX_FRAGMENT_MAGIC, Int32ul))
 )
+
+
+@dataclass
+class DtxFragmentHeader(DataclassMixin):
+    """Typed DTX fragment (wire) header. ``parse()`` yields typed field access instead of a
+    dynamically-typed construct ``Container``.
+
+    csfield_const() returns a ``dataclasses.Field(init=False)`` at runtime, but its 0.8 stub types it
+    as the plain value, so pyright can't see the init=False and flags the non-default fields that
+    follow — hence the per-field ignores. Field order is the DTX wire format."""
+
+    magic: int = _dtx_magic_field
+    header_size: int = csfield(Int32ul)  # pyright: ignore[reportGeneralTypeIssues]  # total header size
+    index: int = csfield(Int16ul)  # pyright: ignore[reportGeneralTypeIssues]  # 0-based fragment index
+    count: int = csfield(Int16ul)  # pyright: ignore[reportGeneralTypeIssues]  # total fragment count
+    data_size: int = csfield(Int32ul)  # pyright: ignore[reportGeneralTypeIssues]  # this fragment's body length
+    identifier: int = csfield(Int32ul)  # pyright: ignore[reportGeneralTypeIssues]  # request/response id
+    conversation_index: int = csfield(Int32ul)  # pyright: ignore[reportGeneralTypeIssues]  # 0=initiator, 1=reply
+    channel_code: int = csfield(Int32sl)  # pyright: ignore[reportGeneralTypeIssues]
+    flags: int = csfield(Int32ul)  # pyright: ignore[reportGeneralTypeIssues]  # DTXTransportFlags
+
+
+dtx_fragment_header = DataclassStruct(DtxFragmentHeader)
+
 
 # Per-message payload header prepended to aux + payload bytes.
 # Layout (16 bytes, all little-endian):
@@ -70,15 +97,20 @@ dtx_fragment_header = Struct(
 #   offset 4-7: aux_size  (uint32)
 #   offset 8-11: total_size (uint32) = aux_size + payload_size
 #   offset 12-15: flags (uint32) - currently unused
-dtx_fragment_payload_header = Struct(
-    "msg_type" / Int8ul,
-    "flags_a" / Int8ul,
-    "flags_b" / Int8ul,
-    "reserved" / Int8ul,
-    "aux_size" / Int32ul,
-    "total_size" / Int32ul,
-    "flags" / Int32ul,
-)
+@dataclass
+class DtxFragmentPayloadHeader(DataclassMixin):
+    """Typed DTX per-message payload header (16 bytes)."""
+
+    msg_type: int = csfield(Int8ul)
+    flags_a: int = csfield(Int8ul)
+    flags_b: int = csfield(Int8ul)
+    reserved: int = csfield(Int8ul)
+    aux_size: int = csfield(Int32ul)
+    total_size: int = csfield(Int32ul)
+    flags: int = csfield(Int32ul)
+
+
+dtx_fragment_payload_header = DataclassStruct(DtxFragmentPayloadHeader)
 
 
 FRAGMENT_HEADER_MIN_SIZE: int = dtx_fragment_header.sizeof()  # 32

--- a/pymobiledevice3/dtx/structs.py
+++ b/pymobiledevice3/dtx/structs.py
@@ -1,15 +1,10 @@
 from dataclasses import dataclass
 from enum import IntEnum, IntFlag
 
-from construct import Const, Int8ul, Int16ul, Int32sl, Int32ul
+from construct import Int8ul, Int16ul, Int32sl, Int32ul
 from construct_typed import DataclassMixin, DataclassStruct, csfield
 
-try:
-    # construct-typing >= 0.8.0 rejects csfield(Const(...)) and requires csfield_const() for const
-    # fields. Older versions (0.7.x, the Python 3.9 floor) have no csfield_const (see afc.py).
-    from construct_typed import csfield_const  # pyright: ignore[reportAttributeAccessIssue]
-except ImportError:  # construct-typing < 0.8.0
-    csfield_const = None
+from pymobiledevice3.construct_compat import const_field
 
 # ---------------------------------------------------------------------------
 # Protocol constants
@@ -57,26 +52,18 @@ class DTXMessageType(IntEnum):
 # Construct structs
 # ---------------------------------------------------------------------------
 
+
 # Fragment (wire) header - minimum 32 bytes; ``header_size`` may indicate more.
-# construct-typing >= 0.8.0 requires csfield_const() for const fields; 0.7.x (the Python 3.9 floor)
-# only has csfield(Const(...)). Pick the form the installed version supports (see afc.py).
-_dtx_magic_field = (
-    csfield_const(Int32ul, DTX_FRAGMENT_MAGIC)
-    if csfield_const is not None
-    else csfield(Const(DTX_FRAGMENT_MAGIC, Int32ul))
-)
-
-
 @dataclass
 class DtxFragmentHeader(DataclassMixin):
     """Typed DTX fragment (wire) header. ``parse()`` yields typed field access instead of a
     dynamically-typed construct ``Container``.
 
-    csfield_const() returns a ``dataclasses.Field(init=False)`` at runtime, but its 0.8 stub types it
-    as the plain value, so pyright can't see the init=False and flags the non-default fields that
-    follow — hence the per-field ignores. Field order is the DTX wire format."""
+    ``const_field`` makes ``magic`` ``init=False`` at runtime, but pyright can't see that through the
+    construct-typing stubs and flags the non-default fields that follow — hence the per-field ignores.
+    Field order is the DTX wire format."""
 
-    magic: int = _dtx_magic_field
+    magic: int = const_field(Int32ul, DTX_FRAGMENT_MAGIC)
     header_size: int = csfield(Int32ul)  # pyright: ignore[reportGeneralTypeIssues]  # total header size
     index: int = csfield(Int16ul)  # pyright: ignore[reportGeneralTypeIssues]  # 0-based fragment index
     count: int = csfield(Int16ul)  # pyright: ignore[reportGeneralTypeIssues]  # total fragment count

--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -29,7 +29,7 @@ from typing import Any, Callable, NamedTuple, Optional, TextIO, Union, cast
 
 import hexdump
 from click.exceptions import Exit
-from construct import Bytes, Const, CString, GreedyRange, Int64ul, Tell
+from construct import Bytes, CString, GreedyRange, Int64ul, Tell
 from construct_typed import DataclassMixin, EnumBase, TEnum, TStruct, csfield
 from parameter_decorators import path_to_str
 from pygments import formatters, highlight, lexers
@@ -41,18 +41,12 @@ from xonsh.cli_utils import Annotated, Arg, ArgParserAlias
 from xonsh.main import main as xonsh_main
 from xonsh.tools import print_color
 
+from pymobiledevice3.construct_compat import const_field
 from pymobiledevice3.exceptions import AfcException, AfcFileNotFoundError, ArgumentError, ConnectionTerminatedError
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.services.lockdown_service import LockdownService
 from pymobiledevice3.utils import get_asyncio_loop, try_decode
-
-try:
-    # construct-typing >= 0.8.0 rejects csfield(Const(...)) and requires csfield_const() for const
-    # fields. Older versions (0.7.x, the Python 3.9 floor) have no csfield_const.
-    from construct_typed import csfield_const  # pyright: ignore[reportAttributeAccessIssue]
-except ImportError:  # construct-typing < 0.8.0
-    csfield_const = None
 
 MAXIMUM_READ_SIZE = 4 * 1024**2  # 4 MB
 MODE_MASK = 0o0000777
@@ -174,19 +168,13 @@ MAXIMUM_WRITE_SIZE = 1 << 30
 
 AFCMAGIC = b"CFA6LPAA"
 
-# construct-typing >= 0.8.0 requires csfield_const() for const fields; 0.7.x (the Python 3.9 floor)
-# only has csfield(Const(...)). Pick the form the installed version supports.
-_afc_magic_field = (
-    csfield_const(Bytes(len(AFCMAGIC)), AFCMAGIC) if csfield_const is not None else csfield(Const(AFCMAGIC))
-)
-
 
 @dataclass
 class AfcHeader(DataclassMixin):
-    # construct-typing 0.8's csfield_const() actually returns a dataclasses.Field(init=False), so this
-    # ordering is legal at runtime, but its stub returns the plain value type — pyright can't see the
-    # init=False and flags the non-default fields that follow. Field order is the AFC wire format.
-    magic: bytes = _afc_magic_field
+    # const_field() makes ``magic`` init=False at runtime, but pyright can't see that through the
+    # construct-typing stubs and flags the non-default fields that follow. Field order is the AFC wire
+    # format.
+    magic: bytes = const_field(Bytes(len(AFCMAGIC)), AFCMAGIC)
     entire_length: int = csfield(Int64ul)  # pyright: ignore[reportGeneralTypeIssues]
     this_length: int = csfield(Int64ul)  # pyright: ignore[reportGeneralTypeIssues]
     packet_num: int = csfield(Int64ul)  # pyright: ignore[reportGeneralTypeIssues]


### PR DESCRIPTION
## What

First step of migrating plain construct `Struct(...)` usages to the **typed** `construct_typed.DataclassStruct` API, to eliminate construct-sourced `Any`. A plain `Struct(...).parse()` returns a dynamically-typed `Container` (every `container.field` is `Any`); a typed `DataclassStruct` returns a dataclass with precise field types.

**Commit 1 — DTX structs:** converts `dtx_fragment_header` → `DtxFragmentHeader` and `dtx_fragment_payload_header` → `DtxFragmentPayloadHeader`. Parse results at the fragment/message hot paths are now typed `int` instead of `Any`; build sites pass a dataclass instance.

**Commit 2 — shared compat helper:** the construct-typing 0.7.x (Python 3.9 floor) vs >= 0.8.0 shim for `Const` fields (`csfield_const()` vs `csfield(Const(...))`) was about to be copy-pasted into every Const-bearing struct module. Extracted into `pymobiledevice3/construct_compat.const_field()`, and `afc.py`'s local `try/except` copy now uses it too.

## Safety — verified on BOTH toolchains

Set up a Python 3.9 venv with construct-typing 0.7.0 (the actual 3.9 pin) alongside the 3.14/0.8.0 dev env, and confirmed for both the DTX and AFC headers:
- **byte-identical `build()` output** and clean `build(parse(x)) == x` round-trips
- the `const_field` fallback path (`csfield_const is None`) constructs without the const arg on 0.7.0

Plus: pyright 0, ruff clean, 99 dtx+afc tests, `pytest -m cli` 117 passed.

## Compat trap (documented)

construct-typing **0.8.0 replaced `csfield(Const(...))` with `csfield_const()`**; 3.9 pins 0.7.x (no `csfield_const`). A bare `csfield_const` import passes locally (venv is 0.8.0) but ImportErrors on 3.9 — hence `const_field()`. The stubs also can't see `csfield_const`'s runtime `init=False`, so non-default fields after a const field need `# pyright: ignore[reportGeneralTypeIssues]` (confirmed required, not cosmetic).

## Follow-ups

Convert the remaining **flat** parsed-and-accessed structs. Note: many (usbmux `Switch`, xpc_message recursive `LazyBound`) are structurally harder and will be assessed separately.