### PR TITLE
tunnel: type CDTunnelPacket / RPPairingPacket with construct_typed

### DIFF
--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -23,8 +23,9 @@ from socket import create_connection
 from ssl import VerifyMode
 from typing import Any, Callable, NamedTuple, Optional, TextIO, Union, cast
 
-from construct import Const, Container, GreedyBytes, GreedyRange, Int8ul, Int16ub, Int64ul, Prefixed, Struct
+from construct import Bytes, Container, GreedyBytes, GreedyRange, Int8ul, Int16ub, Int64ul, Prefixed, Struct
 from construct import Enum as ConstructEnum
+from construct_typed import DataclassMixin, DataclassStruct, csfield
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives._serialization import Encoding, NoEncryption, PrivateFormat, PublicFormat
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -47,6 +48,7 @@ from srptools import SRPClientSession, SRPContext, SRPServerSession
 from srptools.constants import PRIME_3072, PRIME_3072_GEN
 from srptools.utils import hex_from
 
+from pymobiledevice3.construct_compat import const_field
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.osu.os_utils import get_os_utils
 
@@ -155,17 +157,34 @@ class PairConsentResult(NamedTuple):
     pin: Optional[str]
 
 
-CDTunnelPacket = Struct(
-    "magic" / Const(b"CDTunnel"),
-    "body" / Prefixed(Int16ub, GreedyBytes),
-)
+CDTUNNEL_MAGIC = b"CDTunnel"
+
+
+@dataclasses.dataclass
+class CDTunnelPacketData(DataclassMixin):
+    """Typed CoreDevice tunnel packet: ``CDTunnel`` magic + a length-prefixed body.
+
+    const_field() makes ``magic`` init=False at runtime; pyright can't see that through the
+    construct-typing stubs, hence the ignore on the following field."""
+
+    magic: bytes = const_field(Bytes(len(CDTUNNEL_MAGIC)), CDTUNNEL_MAGIC)
+    body: bytes = csfield(Prefixed(Int16ub, GreedyBytes))  # pyright: ignore[reportGeneralTypeIssues]
+
+
+CDTunnelPacket = DataclassStruct(CDTunnelPacketData)
 
 REPAIRING_PACKET_MAGIC = b"RPPairing"
 
-RPPairingPacket = Struct(
-    "magic" / Const(REPAIRING_PACKET_MAGIC),
-    "body" / Prefixed(Int16ub, GreedyBytes),
-)
+
+@dataclasses.dataclass
+class RPPairingPacketData(DataclassMixin):
+    """Typed remote-pairing packet: ``RPPairing`` magic + a length-prefixed body."""
+
+    magic: bytes = const_field(Bytes(len(REPAIRING_PACKET_MAGIC)), REPAIRING_PACKET_MAGIC)
+    body: bytes = csfield(Prefixed(Int16ub, GreedyBytes))  # pyright: ignore[reportGeneralTypeIssues]
+
+
+RPPairingPacket = DataclassStruct(RPPairingPacketData)
 
 #: When True, :func:`create_tun_device` builds the tunnel's interface as a pure-Python
 #: userspace stack (``UserspaceTun``, no root) instead of a kernel ``utun`` (needs root/admin).
@@ -341,7 +360,7 @@ class RemotePairingTunnel(ABC):
 
     @staticmethod
     def _encode_cdtunnel_packet(data: dict[str, Any]) -> bytes:
-        return CDTunnelPacket.build({"body": json.dumps(data).encode()})
+        return CDTunnelPacket.build(CDTunnelPacketData(body=json.dumps(data).encode()))
 
 
 class RemotePairingQuicTunnel(RemotePairingTunnel, QuicConnectionProtocol):
@@ -402,7 +421,7 @@ class RemotePairingQuicTunnel(RemotePairingTunnel, QuicConnectionProtocol):
 
     @staticmethod
     def _encode_cdtunnel_packet(data: dict[str, Any]) -> bytes:
-        return CDTunnelPacket.build({"body": json.dumps(data).encode()})
+        return CDTunnelPacket.build(CDTunnelPacketData(body=json.dumps(data).encode()))
 
 
 class RemotePairingTcpTunnel(RemotePairingTunnel):
@@ -1218,7 +1237,11 @@ class RemotePairingTunnelService(RemotePairingProtocol):
 
     async def send_request(self, data: dict[str, Any]) -> None:
         writer = self.writer
-        writer.write(RPPairingPacket.build({"body": json.dumps(data, default=self._default_json_encoder).encode()}))
+        writer.write(
+            RPPairingPacket.build(
+                RPPairingPacketData(body=json.dumps(data, default=self._default_json_encoder).encode())
+            )
+        )
         await writer.drain()
 
     @staticmethod
@@ -1903,7 +1926,9 @@ class PairableHost:
             "originatedBy": "device",
             "sequenceNumber": XpcUInt64Type(self._sequence_number),
         }
-        self._writer.write(RPPairingPacket.build({"body": json.dumps(envelope, default=self._json_default).encode()}))
+        self._writer.write(
+            RPPairingPacket.build(RPPairingPacketData(body=json.dumps(envelope, default=self._json_default).encode()))
+        )
         await self._writer.drain()
         self._sequence_number += 1
 

--- a/tests/test_remote_pairing_host.py
+++ b/tests/test_remote_pairing_host.py
@@ -27,6 +27,7 @@ from pymobiledevice3.remote.tunnel_service import (
     PairingDataComponentTLVBuf,
     PairingDataComponentType,
     RPPairingPacket,
+    RPPairingPacketData,
 )
 
 T = PairingDataComponentType
@@ -86,7 +87,7 @@ class _DeviceSimulator:
 
     async def _send_plain(self, value: dict[str, Any]) -> None:
         env = {"message": {"plain": {"_0": value}}, "originatedBy": "host", "sequenceNumber": self.seq}
-        self.writer.write(RPPairingPacket.build({"body": json.dumps(env).encode()}))
+        self.writer.write(RPPairingPacket.build(RPPairingPacketData(body=json.dumps(env).encode())))
         await self.writer.drain()
         self.seq += 1
 


### PR DESCRIPTION
## What

Continues the construct-typed migration (after #1795) to the CoreDevice tunnel wire packets. Converts `CDTunnelPacket` and `RPPairingPacket` from plain construct `Struct` to `construct_typed.DataclassStruct` backed by `CDTunnelPacketData` / `RPPairingPacketData`.

`CDTunnelPacket.parse(...).body` is now typed `bytes` instead of `Container`/`Any` at the three CDTunnel receive sites. The const `magic` fields use the shared `construct_compat.const_field()` helper from #1795.

## Safety — verified on BOTH toolchains (protocol-critical)

Byte-identical build and clean parse round-trips confirmed under **Python 3.14 / construct-typing 0.8.0** *and* **Python 3.9 / construct-typing 0.7.0**:
- `CDTunnel\x00\x07{"k":1}`, `RPPairing\x00\x07{"k":1}` — identical to the original plain-`Struct` output.

Plus: pyright 0, ruff clean, 13 pairing/tunnel tests + `pytest -m cli` 117 passed.

## Breaking-change note

`DataclassStruct.build()` takes a **dataclass instance**, not a dict — so `CDTunnelPacket.build({"body": ...})` becomes `CDTunnelPacket.build(CDTunnelPacketData(body=...))`. All in-repo build sites (and the pairing-host test simulator) are updated. External code that builds these packets by dict would need the same one-line change.