### PR TITLE
typing: annotate all unannotated params + enforce reportMissingParameterType globally

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -14,6 +14,8 @@ from typing import Annotated, Callable, Optional, Union
 import coloredlogs
 import typer
 from packaging.version import Version
+from typer._click.core import Command as ClickCommand
+from typer._click.core import Context as ClickContext
 from typer.core import TyperGroup
 from typer_injector import InjectingTyper
 
@@ -172,16 +174,16 @@ _patch_xonsh_completion_detection()
 
 
 class Pmd3TyperGroup(TyperGroup):
-    def list_commands(self, ctx) -> list[str]:
+    def list_commands(self, ctx: ClickContext) -> list[str]:
         # Order is preserved by dict insertion; adjust if you want alphabetical
         return list(CLI_GROUPS.keys())
 
-    def get_command(self, ctx, cmd_name: str):
+    def get_command(self, ctx: ClickContext, cmd_name: str):
         if cmd_name not in CLI_GROUPS:
             self.handle_invalid_command(ctx, cmd_name)
         return self.import_and_get_command(ctx, cmd_name)
 
-    def handle_invalid_command(self, ctx, name: str) -> None:
+    def handle_invalid_command(self, ctx: ClickContext, name: str) -> None:
         suggested_commands = self.search_commands(name)
         suggestion = self.format_suggestions(suggested_commands)
         # ctx.fail raises a ClickException underneath, which Typer displays nicely
@@ -195,7 +197,7 @@ class Pmd3TyperGroup(TyperGroup):
         return f"\nDid you mean:\n{cmds}"
 
     @staticmethod
-    def import_and_get_command(ctx, name: str):
+    def import_and_get_command(ctx: ClickContext, name: str):
         module_name = f"pymobiledevice3.cli.{CLI_GROUPS[name]}"
         mod = importlib.import_module(module_name)
         # submodules expose a Typer Group named "cli"
@@ -207,7 +209,7 @@ class Pmd3TyperGroup(TyperGroup):
         return re.sub(f"({keyword})", typer.style("\\1", bold=True), text, flags=re.IGNORECASE)
 
     @staticmethod
-    def collect_commands(command) -> Union[str, list[str]]:
+    def collect_commands(command: ClickCommand) -> Union[str, list[str]]:
         if isinstance(command, TyperGroup):  # group
             cmds = []
             for v in command.commands.values():
@@ -245,7 +247,7 @@ class Pmd3TyperGroup(TyperGroup):
                 all_commands.append(cmd)
         return all_commands
 
-    def resolve_command(self, ctx, args: list[str]):
+    def resolve_command(self, ctx: ClickContext, args: list[str]):
         return super().resolve_command(ctx, args)
 
 

--- a/pymobiledevice3/bonjour.py
+++ b/pymobiledevice3/bonjour.py
@@ -10,6 +10,7 @@ import struct
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
+from types import TracebackType
 from typing import Any, Callable, Optional, TypeVar
 
 import ifaddr  # pip install ifaddr
@@ -47,7 +48,7 @@ _T = TypeVar("_T")
 
 # --- Dataclass decorator shim (adds slots only on 3.10+)
 @dataclass_transform(field_specifiers=(field,))
-def dataclass_compat(*d_args, **d_kwargs) -> Callable[[type[_T]], type[_T]]:
+def dataclass_compat(*d_args: Any, **d_kwargs: Any) -> Callable[[type[_T]], type[_T]]:
     if sys.version_info < (3, 10):
         d_kwargs.pop("slots", None)  # ignore on 3.9
     return dataclass(*d_args, **d_kwargs)
@@ -229,7 +230,7 @@ class _DatagramProtocol(asyncio.DatagramProtocol):
     def __init__(self, queue: asyncio.Queue[tuple[bytes, Any]]):
         self.queue = queue
 
-    def datagram_received(self, data, addr):
+    def datagram_received(self, data: bytes, addr: Any) -> None:
         # addr: IPv4 -> (host, port); IPv6 -> (host, port, flowinfo, scopeid)
         self.queue.put_nowait((data, addr))
 
@@ -280,7 +281,7 @@ async def _open_mdns_sockets():
     return transports, queue
 
 
-async def _send_query_all(transports, pkt: bytes):
+async def _send_query_all(transports: list[tuple[asyncio.DatagramTransport, socket.socket]], pkt: bytes):
     for transport, sock in transports:
         if sock.family == socket.AF_INET:
             transport.sendto(pkt, (MDNS_MCAST_V4, MDNS_PORT))
@@ -310,7 +311,7 @@ async def browse_service(service_type: str, timeout: float = 4.0) -> list[Servic
     txt_map: dict[str, dict[str, Any]] = {}
     host_addrs: dict[str, list[Address]] = defaultdict(list)  # host -> list[(ip, iface)]
 
-    def _record_addr(rr_name: str, ip_str: str, pkt_addr):
+    def _record_addr(rr_name: str, ip_str: str, pkt_addr: Any) -> None:
         # Determine family and possible scopeid from the packet that delivered this RR
         family = socket.AF_INET6 if ":" in ip_str else socket.AF_INET
         scopeid = None
@@ -596,7 +597,12 @@ class MDNSResponder:
             await asyncio.sleep(0.25)
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         if self._serve_task is not None:
             self._serve_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/pymobiledevice3/cli/backup.py
+++ b/pymobiledevice3/cli/backup.py
@@ -126,7 +126,7 @@ async def backup(
 
         with tqdm(total=100, dynamic_ncols=True) as pbar:
 
-            def update_bar(percentage) -> None:
+            def update_bar(percentage: float) -> None:
                 pbar.n = percentage
                 pbar.refresh()
 
@@ -180,7 +180,7 @@ async def restore(
     async with Mobilebackup2Service(service_provider) as backup_client:
         with tqdm(total=100, dynamic_ncols=True) as pbar:
 
-            def update_bar(percentage) -> None:
+            def update_bar(percentage: float) -> None:
                 pbar.n = percentage
                 pbar.refresh()
 

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -57,7 +57,7 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def default_json_encoder(obj):
+def default_json_encoder(obj: Any) -> str:
     if isinstance(obj, bytes):
         return f"<{obj.hex()}>"
     if isinstance(obj, datetime.datetime):
@@ -67,7 +67,7 @@ def default_json_encoder(obj):
     raise TypeError()
 
 
-def print_json(buf, colored: Optional[bool] = None, default=default_json_encoder) -> str:
+def print_json(buf: Any, colored: Optional[bool] = None, default: Callable[[Any], Any] = default_json_encoder) -> str:
     if colored is None:
         colored = user_requested_colored_output()
     formatted_json = json.dumps(buf, sort_keys=True, indent=4, default=default)
@@ -82,7 +82,7 @@ def print_json(buf, colored: Optional[bool] = None, default=default_json_encoder
         return formatted_json
 
 
-def print_hex(data, colored=True) -> None:
+def print_hex(data: bytes, colored: bool = True) -> None:
     hex_dump = hexdump.hexdump(data, result="return")
     assert isinstance(hex_dump, str)  # result='return' always yields a str
     if colored:
@@ -114,9 +114,9 @@ def get_last_used_terminal_formatting(buf: str) -> str:
     return "\x1b" + buf.rsplit("\x1b", 1)[1].split("m")[0] + "m"
 
 
-def sudo_required(func):
+def sudo_required(func: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> None:
         if not OSUTILS.is_admin:
             raise AccessDeniedError()
         else:

--- a/pymobiledevice3/cli/developer/debugserver.py
+++ b/pymobiledevice3/cli/developer/debugserver.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import FrameType
 from typing import Annotated, Optional
 from zipfile import ZipFile
 
@@ -287,7 +288,7 @@ async def debugserver_lldb(
     resize_pty()
 
     # Set up signal handler for window resize
-    def handle_sigwinch(signum, frame):
+    def handle_sigwinch(signum: int, frame: Optional[FrameType]) -> None:
         resize_pty()
 
     old_sigwinch_handler = signal.signal(signal.SIGWINCH, handle_sigwinch)

--- a/pymobiledevice3/cli/developer/dvt/__init__.py
+++ b/pymobiledevice3/cli/developer/dvt/__init__.py
@@ -470,16 +470,16 @@ async def xcuitest(
 
             async def test_suite_did_finish(
                 self,
-                suite,
-                finished_at,
-                run_count,
-                failures,
-                unexpected,
-                test_duration,
-                total_duration,
-                skipped,
-                expected_failures,
-                uncaught_exceptions,
+                suite: str,
+                finished_at: str,
+                run_count: int,
+                failures: int,
+                unexpected: int,
+                test_duration: float,
+                total_duration: float,
+                skipped: int,
+                expected_failures: int,
+                uncaught_exceptions: int,
             ) -> None:
                 _write(
                     f"[suite] finish {suite}  at={finished_at}"

--- a/pymobiledevice3/cli/developer/dvt/core_profile_session.py
+++ b/pymobiledevice3/cli/developer/dvt/core_profile_session.py
@@ -346,7 +346,7 @@ async def parse_live_profile_session(
                 chunk_queue.put(None)
 
 
-def get_image_name(dsc_uuid_map, image_uuid, current_dsc_map):
+def get_image_name(dsc_uuid_map: dict[str, dict[str, str]], image_uuid: str, current_dsc_map: dict[str, str]) -> str:
     if not current_dsc_map:
         for dsc_mapping in dsc_uuid_map.values():
             if image_uuid in dsc_mapping:
@@ -355,7 +355,7 @@ def get_image_name(dsc_uuid_map, image_uuid, current_dsc_map):
     return current_dsc_map.get(image_uuid, image_uuid)
 
 
-def format_callstack(callstack: str, dsc_uuid_map, current_dsc_map) -> str:
+def format_callstack(callstack: str, dsc_uuid_map: dict[str, dict[str, str]], current_dsc_map: dict[str, str]) -> str:
     lines = callstack.splitlines()
     for i, line in enumerate(lines[1:]):
         if ":" in line:

--- a/pymobiledevice3/cli/developer/dvt/sysmon/process.py
+++ b/pymobiledevice3/cli/developer/dvt/sysmon/process.py
@@ -177,7 +177,7 @@ def _write_process(out: Optional[TextIO], process: dict[str, Any]) -> None:
     out.flush()
 
 
-def _write_json(out: Optional[TextIO], value) -> None:
+def _write_json(out: Optional[TextIO], value: Any) -> None:
     if out is None:
         print_json(value)
         return
@@ -290,7 +290,10 @@ def _select_process_from_snapshot(
 
 
 async def _select_process_from_sysmon(
-    dvt, parsed_filters: dict[str, list[str]], keys: Optional[list[str]], selection_mode: ProcessSelectionMode
+    dvt: DvtProvider,
+    parsed_filters: dict[str, list[str]],
+    keys: Optional[list[str]],
+    selection_mode: ProcessSelectionMode,
 ) -> dict[str, Any]:
     async with await Sysmontap.create(dvt) as selection_sysmon:
         async for process_snapshot in iter_processes(

--- a/pymobiledevice3/cli/mounter.py
+++ b/pymobiledevice3/cli/mounter.py
@@ -1,7 +1,7 @@
 import logging
 from functools import update_wrapper
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Any, Callable, Optional
 from urllib.error import URLError
 
 import typer
@@ -25,8 +25,8 @@ from pymobiledevice3.services.mobile_image_mounter import (
 logger = logging.getLogger(__name__)
 
 
-def catch_errors(func):
-    def catch_function(*args, **kwargs):
+def catch_errors(func: Callable[..., Any]) -> Callable[..., Any]:
+    def catch_function(*args: Any, **kwargs: Any) -> Any:
         try:
             return func(*args, **kwargs)
         except AlreadyMountedError:

--- a/pymobiledevice3/cli/pcap.py
+++ b/pymobiledevice3/cli/pcap.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
 import typer
+from construct import Container
 from pygments import formatters, highlight, lexers
 from typer_injector import InjectingTyper
 
@@ -16,7 +17,7 @@ cli = InjectingTyper(
 )
 
 
-def print_packet_header(packet, color: bool) -> None:
+def print_packet_header(packet: Container[Any], color: bool) -> None:
     date = datetime.fromtimestamp(packet.seconds + (packet.microseconds / 1000000))
     data = (
         f"{date}: "
@@ -30,7 +31,7 @@ def print_packet_header(packet, color: bool) -> None:
         print(highlight(data, lexers.HspecLexer(), formatters.Terminal256Formatter(style="native")), end="")
 
 
-def print_packet(packet, color: Optional[bool] = None):
+def print_packet(packet: Container[Any], color: Optional[bool] = None) -> Container[Any]:
     """Return the packet, so it can be chained in a generator"""
     if color is None:
         color = user_requested_colored_output()

--- a/pymobiledevice3/cli/remote.py
+++ b/pymobiledevice3/cli/remote.py
@@ -7,7 +7,7 @@ import tempfile
 from contextlib import nullcontext
 from functools import partial
 from pathlib import Path
-from typing import Annotated, Any, Optional, TextIO
+from typing import Annotated, Any, Optional, TextIO, Union
 
 import typer
 from typer_injector import InjectingTyper
@@ -30,8 +30,10 @@ from pymobiledevice3.remote.common import ConnectionType, TunnelProtocol
 from pymobiledevice3.remote.module_imports import MAX_IDLE_TIMEOUT, start_tunnel, verify_tunnel_imports
 from pymobiledevice3.remote.remote_service_discovery import RSD_PORT
 from pymobiledevice3.remote.tunnel_service import (
+    CoreDeviceTunnelProxy,
     PairableHostInfo,
     RemotePairingManualPairingService,
+    RemotePairingProtocol,
     get_core_device_tunnel_services,
     get_remote_pairing_tunnel_services,
     serve_pairable_host,
@@ -152,7 +154,7 @@ def rsd_info(service_provider: RSDServiceProviderDep) -> None:
 
 
 async def tunnel_task(
-    service,
+    service: Union[RemotePairingProtocol, CoreDeviceTunnelProxy],
     secrets: Optional[TextIO] = None,
     script_mode: bool = False,
     max_idle_timeout: float = MAX_IDLE_TIMEOUT,

--- a/pymobiledevice3/cli/syslog.py
+++ b/pymobiledevice3/cli/syslog.py
@@ -175,7 +175,7 @@ def _highlight_match_filters(styled_line: str, match: list[str], match_insensiti
 
 
 def _highlight_regex_filters(styled_line: str, match_regex: list[re.Pattern[str]]) -> str:
-    def replace(m):
+    def replace(m: re.Match[str]) -> str:
         if len(m.groups()):
             return styled_line.replace(m.group(1), typer.style(m.group(1), bold=True, underline=True))
         return ""

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 import inspect
 import logging
 import re

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 import inspect
 import logging
 import re

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -3,7 +3,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from asyncio import CancelledError
-from collections.abc import AsyncGenerator, AsyncIterator, Iterable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from functools import update_wrapper
 from string import Template
@@ -142,19 +142,19 @@ cli = InjectingTyper(
 )
 
 
-def catch_errors(func):
+def catch_errors(func: Callable[..., Any]) -> Callable[..., Any]:
     errors = {
         LaunchingApplicationError: "Unable to launch application (try to unlock device)",
         WebInspectorNotEnabledError: "Web inspector is not enabled",
         RemoteAutomationNotEnabledError: "Remote automation is not enabled",
     }
 
-    def handle_error(e):
+    def handle_error(e: Exception) -> None:
         logger.error(next(msg for exc, msg in errors.items() if isinstance(e, exc)))
 
     if inspect.iscoroutinefunction(func):
 
-        async def async_catch_function(*args, **kwargs):
+        async def async_catch_function(*args: Any, **kwargs: Any):
             try:
                 return await func(*args, **kwargs)
             except tuple(errors) as e:
@@ -163,7 +163,7 @@ def catch_errors(func):
         catch_function = async_catch_function
     else:
 
-        def sync_catch_function(*args, **kwargs):
+        def sync_catch_function(*args: Any, **kwargs: Any):
             try:
                 return func(*args, **kwargs)
             except tuple(errors) as e:
@@ -221,7 +221,7 @@ async def opened_tabs(
 
 
 @catch_errors
-async def launch_task(service_provider: LockdownServiceProvider, url, timeout) -> None:
+async def launch_task(service_provider: LockdownServiceProvider, url: str, timeout: float) -> None:
     async with webinspector_service(service_provider) as inspector:
         safari = await inspector.open_app(SAFARI)
         session = await inspector.automation_session(safari)
@@ -492,11 +492,11 @@ class JsShell(ABC):
         timeout: float,
         open_safari: bool,
         bundle_identifier: Optional[str] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> "AbstractAsyncContextManager[JsShell]": ...
 
     @abstractmethod
-    async def evaluate_expression(self, exp, return_by_value: bool = False) -> Any: ...
+    async def evaluate_expression(self, exp: str, return_by_value: bool = False) -> Any: ...
 
     @abstractmethod
     async def navigate(self, url: str) -> None: ...
@@ -545,7 +545,7 @@ class AutomationJsShell(JsShell):
         timeout: float,
         open_safari: bool,
         bundle_identifier: Optional[str] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> "AsyncIterator[AutomationJsShell]":
         if bundle_identifier is None:
             bundle_identifier = SAFARI
@@ -581,7 +581,7 @@ class InspectorJsShell(JsShell):
         bundle_identifier: Optional[str] = None,
         *,
         console_enable: bool = True,
-        **kwargs,
+        **kwargs: Any,
     ) -> "AsyncIterator[InspectorJsShell]":
         async with webinspector_service(lockdown) as inspector:
             if open_safari:

--- a/pymobiledevice3/dtx/message_aux.py
+++ b/pymobiledevice3/dtx/message_aux.py
@@ -16,7 +16,7 @@ class MessageAux(list[Any]):
     """An adapter that parse DISPTACH arguments from/to primitive dictionaries"""
 
     @classmethod
-    def parse(cls, obj: Union[bytes, bytearray, memoryview], context, path):
+    def parse(cls, obj: Union[bytes, bytearray, memoryview], context: Any, path: str):
         if len(obj) == 0:
             # interpret empty buffers as an empty list
             return []
@@ -56,7 +56,7 @@ class MessageAux(list[Any]):
         return converted_list
 
     @classmethod
-    def build(cls, obj, context, path) -> bytes:
+    def build(cls, obj: Any, context: Any, path: str) -> bytes:
         if not obj:
             # nothing is written ¯\_(ツ)_/¯
             return b""

--- a/pymobiledevice3/dtx/ns_types.py
+++ b/pymobiledevice3/dtx/ns_types.py
@@ -50,7 +50,7 @@ class DTTapMessage:
     """Proxy for all ``DTTapMessage`` subclasses from the device diagnostics tap."""
 
     @staticmethod
-    def decode_archive(archive_obj) -> Any:
+    def decode_archive(archive_obj: archiver.ArchivedObject) -> Any:
         """Decode an archived DTTapMessage by extracting its embedded plist."""
         return archive_obj.decode("DTTapMessagePlist")
 
@@ -59,7 +59,7 @@ class NSNull:
     """Proxy for Objective-C ``NSNull``."""
 
     @staticmethod
-    def decode_archive(archive_obj) -> None:
+    def decode_archive(archive_obj: archiver.ArchivedObject) -> None:
         """Decode an archived NSNull — always returns ``None``."""
         return None
 
@@ -79,7 +79,7 @@ class NSError:
         archive_obj.encode("NSUserInfo", self.user_info)
 
     @staticmethod
-    def decode_archive(archive_obj) -> NSError:
+    def decode_archive(archive_obj: archiver.ArchivedObject) -> NSError:
         """Decode an NSKeyedArchive object into an :class:`NSError` instance."""
         domain = archive_obj.decode("NSDomain")
         code = archive_obj.decode("NSCode")
@@ -127,7 +127,7 @@ class NSUUID(uuid.UUID):
 class NSURL:
     """Proxy for Objective-C ``NSURL``."""
 
-    def __init__(self, base, relative):
+    def __init__(self, base: Any, relative: Any):
         self.base = base
         self.relative = relative
 

--- a/pymobiledevice3/dtx/primitives.py
+++ b/pymobiledevice3/dtx/primitives.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 """DTX primitive value types and dictionary codec.
 
 This module provides the low-level wire representation for DTX *auxiliary
@@ -26,7 +27,7 @@ from __future__ import annotations
 
 import io
 import logging
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import IO, TYPE_CHECKING, Any, ClassVar, cast
 
 from construct import (
     Bytes,
@@ -78,7 +79,7 @@ class _PrimitiveBase:
     _type_code: ClassVar[int]
 
     @classmethod
-    def _read(cls, stream, context, path) -> Any:
+    def _read(cls, stream: IO[bytes], context: Context, path: str) -> Any:
         """Parse this value's bytes from *stream* and return a new instance.
 
         Return type is ``Any`` rather than ``_PrimitiveBase`` because
@@ -87,7 +88,7 @@ class _PrimitiveBase:
         """
         raise NotImplementedError
 
-    def _write(self, stream, context, path) -> None:
+    def _write(self, stream: IO[bytes], context: Context, path: str) -> None:
         """Write the encoded value bytes to *stream* (type tag NOT included)."""
         raise NotImplementedError
 
@@ -95,7 +96,7 @@ class _PrimitiveBase:
 class PrimitiveValue(_ConstructBase):
     """Construct for a single DTX primitive: u32 type tag followed by value bytes."""
 
-    def _parse(self, stream, context, path) -> Any:
+    def _parse(self, stream: IO[bytes], context: Context, path: str) -> Any:
         context = context or cast("Context", Container())
         raw_type_code = Int32ul._parse(stream, context, path)
         context["type_code_and_flags"] = raw_type_code
@@ -106,14 +107,14 @@ class PrimitiveValue(_ConstructBase):
             raise ConstructError(f"unknown primitive type code {raw_type_code:#x}", path)
         return cls._read(stream, context, path)
 
-    def _build(self, obj, stream, context, path):  # pyright: ignore[reportIncompatibleMethodOverride]  # construct's stub types _build -> int, but our _write returns None; matching int would change behavior
+    def _build(self, obj: Any, stream: IO[bytes], context: Context, path: str):  # pyright: ignore[reportIncompatibleMethodOverride]  # construct's stub types _build -> int, but our _write returns None; matching int would change behavior
         if not isinstance(obj, _PrimitiveBase):
             raise ConstructError(
                 f"Expected a _PrimitiveBase instance for PrimitiveValue, got {type(obj).__name__}", path
             )
         return obj._write(stream, context, path)
 
-    def _sizeof(self, context, path):
+    def _sizeof(self, context: Context, path: str):
         raise SizeofError("variable-length primitive")
 
 
@@ -130,13 +131,13 @@ class PrimitiveNull(_PrimitiveBase):
     _type_code = 10
 
     @classmethod
-    def _read(cls, stream, context, path) -> PrimitiveNull:
+    def _read(cls, stream: IO[bytes], context: Context, path: str) -> PrimitiveNull:
         return PNULL  # return the singleton instance for convenience
 
-    def _write(self, stream, context, path) -> None:
+    def _write(self, stream: IO[bytes], context: Context, path: str) -> None:
         Int32ul._build(self._type_code, stream, context, path)  # type tag only, no value bytes
 
-    def __eq__(self, value):
+    def __eq__(self, value: object):
         return type(self) is type(value)  # all instances are equal, since there is no value data
 
     def __hash__(self):
@@ -153,11 +154,11 @@ class PrimitiveString(_PrimitiveBase, str):
     _type_code = 1
 
     @classmethod
-    def _read(cls, stream, context, path) -> PrimitiveString:
+    def _read(cls, stream: IO[bytes], context: Context, path: str) -> PrimitiveString:
         length = Int32ul._parse(stream, context, path)
         return cls(stream.read(length).decode("utf-8", errors="replace"))
 
-    def _write(self, stream, context, path) -> None:
+    def _write(self, stream: IO[bytes], context: Context, path: str) -> None:
         Int32ul._build(self._type_code, stream, context, path)
         raw = str(self).encode("utf-8")
         length = len(raw)
@@ -176,10 +177,10 @@ class PrimitiveInt32(_PrimitiveBase, int):
     _type_code = 3
 
     @classmethod
-    def _read(cls, stream, context, path) -> PrimitiveInt32:
+    def _read(cls, stream: IO[bytes], context: Context, path: str) -> PrimitiveInt32:
         return cls(Int32sl._parse(stream, context, path))
 
-    def _write(self, stream, context, path) -> None:
+    def _write(self, stream: IO[bytes], context: Context, path: str) -> None:
         Int32ul._build(self._type_code, stream, context, path)
         Int32sl._build(int(self), stream, context, path)
 
@@ -190,10 +191,10 @@ class PrimitiveInt64(_PrimitiveBase, int):
     _type_code = 6
 
     @classmethod
-    def _read(cls, stream, context, path) -> PrimitiveInt64:
+    def _read(cls, stream: IO[bytes], context: Context, path: str) -> PrimitiveInt64:
         return cls(Int64sl._parse(stream, context, path))
 
-    def _write(self, stream, context, path) -> None:
+    def _write(self, stream: IO[bytes], context: Context, path: str) -> None:
         Int32ul._build(self._type_code, stream, context, path)
         Int64sl._build(int(self), stream, context, path)
 
@@ -204,11 +205,11 @@ class PrimitiveBuffer(_PrimitiveBase, bytes):
     _type_code = 2
 
     @classmethod
-    def _read(cls, stream, context, path) -> PrimitiveBuffer:
+    def _read(cls, stream: IO[bytes], context: Context, path: str) -> PrimitiveBuffer:
         length = Int32ul._parse(stream, context, path)
         return cls(stream.read(length))
 
-    def _write(self, stream, context, path) -> None:
+    def _write(self, stream: IO[bytes], context: Context, path: str) -> None:
         Int32ul._build(self._type_code, stream, context, path)
         length = len(self)
         Int32ul._build(length, stream, context, path)
@@ -221,10 +222,10 @@ class PrimitiveDouble(_PrimitiveBase, float):
     _type_code = 9
 
     @classmethod
-    def _read(cls, stream, context, path) -> PrimitiveDouble:
+    def _read(cls, stream: IO[bytes], context: Context, path: str) -> PrimitiveDouble:
         return cls(Float64l._parse(stream, context, path))
 
-    def _write(self, stream, context, path) -> None:
+    def _write(self, stream: IO[bytes], context: Context, path: str) -> None:
         Int32ul._build(self._type_code, stream, context, path)
         Float64l._build(float(self), stream, context, path)
 
@@ -244,7 +245,7 @@ class PrimitiveDictionary(_PrimitiveBase, dict[Any, list[Any]]):
     _DEFAULT_MAGIC: ClassVar[int] = 0x1F0  # 0x100 | 0xF0 — seen most often
 
     @classmethod
-    def _read(cls, stream, context, path) -> dict[Any, list[Any]]:
+    def _read(cls, stream: IO[bytes], context: Context, path: str) -> dict[Any, list[Any]]:
         unknown_flags = Int32ul._parse(stream, context, path)
         body_len = Int64ul._parse(stream, context, path)
         begin = stream_tell(stream, path)
@@ -261,7 +262,7 @@ class PrimitiveDictionary(_PrimitiveBase, dict[Any, list[Any]]):
             logger.warning(f"PrimitiveDictionary: non-zero unknown flags {unknown_flags:#x} at {path}: {result!r}")
         return result
 
-    def _write(self, stream, context, path):
+    def _write(self, stream: IO[bytes], context: Context, path: str):
 
         start = stream_tell(stream, path)
         stream_seek(stream, self._HEADER_SIZE, io.SEEK_CUR, path)  # reserve space for header

--- a/pymobiledevice3/dtx/primitives.py
+++ b/pymobiledevice3/dtx/primitives.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 """DTX primitive value types and dictionary codec.
 
 This module provides the low-level wire representation for DTX *auxiliary

--- a/pymobiledevice3/dtx/service.py
+++ b/pymobiledevice3/dtx/service.py
@@ -33,7 +33,7 @@ import re
 import sys
 from collections.abc import Awaitable, Sequence
 from functools import partial, wraps
-from typing import Any, Callable, ClassVar, Optional, Protocol, TypeVar, cast, get_type_hints
+from typing import Any, Callable, ClassVar, Optional, Protocol, TypeVar, cast, get_type_hints, overload
 
 from .channel import DTXChannel
 from .context import DTX_GLOBAL_CTX, DTXContext  # noqa: F401 — re-exported for back-compat
@@ -43,6 +43,9 @@ from .primitives import PInt32, _PrimitiveBase
 logger = logging.getLogger(__name__)
 
 _MISSING = object()  # sentinel for missing attribute values in __init_subclass__
+# Identity TypeVar for the DTX method/handler decorators: keeps the decorated
+# function's own type so `self.service.<method>(...)` stays callable/typed.
+_DtxFnT = TypeVar("_DtxFnT", bound=Callable[..., Any])
 DTX_SERVICE_T = TypeVar("DTX_SERVICE_T", bound="DTXService")
 QUEUE_ITEM_T = TypeVar("QUEUE_ITEM_T")
 
@@ -194,7 +197,11 @@ class _DtxOnInvokeFn(Protocol):
     _dtx_on_invoke: Optional[str]
 
 
-def dtx_method(selector_or_fn=None, /, **invoke_kwargs):
+@overload
+def dtx_method(selector_or_fn: _DtxFnT, /) -> _DtxFnT: ...
+@overload
+def dtx_method(selector_or_fn: Optional[str] = ..., /, **invoke_kwargs: Any) -> Callable[[_DtxFnT], _DtxFnT]: ...
+def dtx_method(selector_or_fn: Any = None, /, **invoke_kwargs: Any) -> Any:
     """Decorator for outgoing DTX calls.
 
     Replaces the decorated method body with a ``self._channel.invoke(...)``
@@ -213,14 +220,18 @@ def dtx_method(selector_or_fn=None, /, **invoke_kwargs):
         return selector_or_fn
     selector = selector_or_fn
 
-    def decorator(fn):
+    def decorator(fn: Any) -> Any:
         fn._dtx_method = (selector, invoke_kwargs)
         return fn
 
     return decorator
 
 
-def dtx_on_invoke(selector_or_fn=None, /):
+@overload
+def dtx_on_invoke(selector_or_fn: _DtxFnT, /) -> _DtxFnT: ...
+@overload
+def dtx_on_invoke(selector_or_fn: Optional[str] = ..., /) -> Callable[[_DtxFnT], _DtxFnT]: ...
+def dtx_on_invoke(selector_or_fn: Any = None, /) -> Any:
     """Register a method as the handler for a specific incoming ObjC selector.
 
     Usage::
@@ -233,29 +244,29 @@ def dtx_on_invoke(selector_or_fn=None, /):
         return selector_or_fn
     selector = selector_or_fn
 
-    def decorator(fn):
+    def decorator(fn: Any) -> Any:
         fn._dtx_on_invoke = selector
         return fn
 
     return decorator
 
 
-def dtx_on_data(fn):
+def dtx_on_data(fn: _DtxFnT) -> _DtxFnT:
     """Register a method as the handler for incoming DATA frames (raw bytes)."""
-    fn._dtx_on_data = True
+    cast(Any, fn)._dtx_on_data = True
     return fn
 
 
-def dtx_on_notification(fn):
+def dtx_on_notification(fn: _DtxFnT) -> _DtxFnT:
     """Register a method as the handler for incoming OBJECT/OK notifications."""
-    fn._dtx_on_notification = True
+    cast(Any, fn)._dtx_on_notification = True
     return fn
 
 
-def dtx_on_dispatch(fn):
+def dtx_on_dispatch(fn: _DtxFnT) -> _DtxFnT:
     """Catch-all handler for incoming DISPATCH messages not matched by
     :func:`dtx_on_invoke`.  The method receives ``(selector: str, *args)``."""
-    fn._dtx_on_dispatch = True
+    cast(Any, fn)._dtx_on_dispatch = True
     return fn
 
 
@@ -326,7 +337,7 @@ class DTXService:
                     pass
 
                 async def _wrapper(
-                    self,
+                    self: Any,
                     *args: Any,
                     __sel: str = _sel,
                     __kw: dict[str, Any] = _kw,

--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -502,7 +502,7 @@ class SysdiagnoseTimeoutError(PyMobileDevice3Exception, TimeoutError):
 
 
 class SupportError(PyMobileDevice3Exception):
-    def __init__(self, os_name):
+    def __init__(self, os_name: Optional[str]) -> None:
         self.os_name = os_name
         super().__init__()
 
@@ -516,7 +516,7 @@ class OSNotSupportedError(SupportError):
 class FeatureNotSupportedError(SupportError):
     """Feature has not been implemented for OS."""
 
-    def __init__(self, os_name, feature):
+    def __init__(self, os_name: Optional[str], feature: str) -> None:
         super().__init__(os_name)
         self.feature = feature
 

--- a/pymobiledevice3/irecv.py
+++ b/pymobiledevice3/irecv.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 import binascii
 import contextlib
 import logging
@@ -6,7 +7,8 @@ import struct
 import time
 from collections.abc import Iterable
 from enum import Enum
-from typing import Optional, cast
+from types import TracebackType
+from typing import Any, Optional, cast
 
 from tqdm import trange
 from usb.core import Device, USBError, find
@@ -29,11 +31,11 @@ class Mode(Enum):
     DFU_MODE = 0x1227
 
     @classmethod
-    def has_value(cls, value):
+    def has_value(cls, value: int):
         return any(value == m.value for m in cls)
 
     @classmethod
-    def get_mode_from_value(cls, value):
+    def get_mode_from_value(cls, value: int):
         """
         :rtype: Mode
         """
@@ -60,7 +62,7 @@ logger = logging.getLogger(__name__)
 
 
 class IRecv:
-    def __init__(self, ecid=None, timeout=0xFFFFFFFF, is_recovery=None):
+    def __init__(self, ecid: Optional[int] = None, timeout: int = 0xFFFFFFFF, is_recovery: Optional[bool] = None):
         self._mode: Optional[Mode] = None
         self._device_info = {}
         self._device: Optional[Device] = None
@@ -137,12 +139,12 @@ class IRecv:
     def status(self):
         return self.ctrl_transfer(0xA1, 3, data_or_wLength=b"\x00" * 6)[4]
 
-    def set_interface_altsetting(self, interface=None, alternate_setting=None):
+    def set_interface_altsetting(self, interface: Optional[int] = None, alternate_setting: Optional[int] = None):
         logger.debug(f"set_interface_altsetting: {interface} {alternate_setting}")
         if interface == 1:
             self.device.set_interface_altsetting(interface=interface, alternate_setting=alternate_setting)
 
-    def set_configuration(self, configuration=None):
+    def set_configuration(self, configuration: Optional[int] = None):
         logger.debug(f"set_configuration: {configuration}")
         device = self.device
         try:
@@ -153,7 +155,7 @@ class IRecv:
 
         device.set_configuration(configuration=configuration)
 
-    def ctrl_transfer(self, bmRequestType, bRequest, timeout=USB_TIMEOUT, **kwargs):
+    def ctrl_transfer(self, bmRequestType: int, bRequest: int, timeout: int = USB_TIMEOUT, **kwargs: Any):
         return self.device.ctrl_transfer(bmRequestType, bRequest, timeout=timeout, **kwargs)
 
     def send_buffer(self, buf: bytes):
@@ -240,10 +242,10 @@ class IRecv:
 
         self._reinit(ecid=self.ecid)
 
-    def send_command(self, cmd: str, timeout=USB_TIMEOUT, b_request=0):
+    def send_command(self, cmd: str, timeout: int = USB_TIMEOUT, b_request: int = 0):
         self.device.ctrl_transfer(0x40, b_request, 0, 0, cmd.encode() + b"\0", timeout=timeout)
 
-    def getenv(self, name):
+    def getenv(self, name: str):
         try:
             self.send_command(f"getenv {name}")
         except USBError:
@@ -258,7 +260,7 @@ class IRecv:
         with contextlib.suppress(USBError):
             self.send_command("reboot")
 
-    def _reinit(self, ecid=None, timeout=0xFFFFFFFF, is_recovery=None):
+    def _reinit(self, ecid: Optional[int] = None, timeout: int = 0xFFFFFFFF, is_recovery: Optional[bool] = None):
         self._device = None
         self._device_info = {}
         self._mode = None
@@ -279,7 +281,7 @@ class IRecv:
         else:
             self.set_interface_altsetting(0, 0)
 
-    def _copy_nonce_with_tag(self, tag):
+    def _copy_nonce_with_tag(self, tag: str):
         device_string = get_string(self.device, 1)
         if device_string is None:
             raise IRecvError("failed to read the device string descriptor")
@@ -288,7 +290,7 @@ class IRecv:
         else:
             return None
 
-    def _find(self, ecid=None, timeout=0xFFFFFFFF, is_recovery=None):
+    def _find(self, ecid: Optional[int] = None, timeout: int = 0xFFFFFFFF, is_recovery: Optional[bool] = None):
         start = time.time()
         end = start + timeout
         while (self._device is None) and (time.time() < end):
@@ -339,7 +341,9 @@ class IRecv:
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self, exc_type: Optional[type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
+    ):
         del self._device
 
 

--- a/pymobiledevice3/irecv.py
+++ b/pymobiledevice3/irecv.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 import binascii
 import contextlib
 import logging

--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 import asyncio
 import datetime
 import logging
@@ -13,6 +14,7 @@ from contextlib import contextmanager, suppress
 from enum import Enum
 from pathlib import Path
 from ssl import SSLZeroReturnError, TLSVersion
+from types import TracebackType
 from typing import Any, Optional, overload
 
 from construct import StreamError
@@ -160,7 +162,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
         pairing_records_cache_folder: Optional[Path] = None,
         port: int = SERVICE_PORT,
         private_key: Optional[RSAPrivateKey] = None,
-        **cls_specific_args,
+        **cls_specific_args: Any,
     ):
         """Build a client around an existing service connection, initialize it and optionally pair.
 
@@ -243,7 +245,12 @@ class LockdownClient(ABC, LockdownServiceProvider):
         """
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         """Exit the async context manager and close open resources.
 
         :param exc_type: Exc type.
@@ -814,7 +821,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
             options["Key"] = key
         return await self._request("RemoveValue", options)
 
-    async def set_value(self, value, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
+    async def set_value(self, value: Any, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
         """Write a value to the device via a ``SetValue`` request.
 
         :param value: The value to write.
@@ -1292,7 +1299,7 @@ class RemoteLockdownClient(LockdownClient):
             "RemoteXPC service connections should only be created using RemoteServiceDiscoveryService"
         )
 
-    async def _handle_autopair(self, *args, **kwargs):
+    async def _handle_autopair(self, *args: Any, **kwargs: Any):
         # The RemoteXPC version of lockdown doesn't support pairing operations
         """Internal helper for handle autopair.
 
@@ -1303,7 +1310,7 @@ class RemoteLockdownClient(LockdownClient):
         """
         return None
 
-    async def pair(self, *args, **kwargs) -> None:
+    async def pair(self, *args: Any, **kwargs: Any) -> None:
         """Pair.
 
         :param *args: Additional positional arguments.
@@ -1424,14 +1431,16 @@ async def create_using_usbmux(
 
 
 @overload
-async def retry_create_using_usbmux(retry_timeout: None = ..., **kwargs) -> UsbmuxLockdownClient: ...
+async def retry_create_using_usbmux(retry_timeout: None = ..., **kwargs: Any) -> UsbmuxLockdownClient: ...
 
 
 @overload
-async def retry_create_using_usbmux(retry_timeout: float, **kwargs) -> Optional[UsbmuxLockdownClient]: ...
+async def retry_create_using_usbmux(retry_timeout: float, **kwargs: Any) -> Optional[UsbmuxLockdownClient]: ...
 
 
-async def retry_create_using_usbmux(retry_timeout: Optional[float] = None, **kwargs) -> Optional[UsbmuxLockdownClient]:
+async def retry_create_using_usbmux(
+    retry_timeout: Optional[float] = None, **kwargs: Any
+) -> Optional[UsbmuxLockdownClient]:
     """Repeatedly call `create_using_usbmux` until it succeeds, tolerating transient errors.
 
     Useful while a device is rebooting or reconnecting: connection/device errors are swallowed and the

--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 import asyncio
 import datetime
 import logging

--- a/pymobiledevice3/lockdown_service_provider.py
+++ b/pymobiledevice3/lockdown_service_provider.py
@@ -135,7 +135,7 @@ class LockdownServiceProvider:
         pass
 
     @abstractmethod
-    async def set_value(self, value, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
+    async def set_value(self, value: Any, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
         """Write a lockdownd value (optionally scoped by domain/key)."""
         pass
 

--- a/pymobiledevice3/osu/os_utils.py
+++ b/pymobiledevice3/osu/os_utils.py
@@ -93,7 +93,7 @@ class OsUtils:
     ) -> None:
         raise FeatureNotSupportedError(self._os_name, _calling_function_name())
 
-    def parse_timestamp(self, time_stamp) -> datetime:
+    def parse_timestamp(self, time_stamp: float) -> datetime:
         raise FeatureNotSupportedError(self._os_name, _calling_function_name())
 
     def chown_to_non_sudo_if_needed(self, path: Path) -> None:

--- a/pymobiledevice3/osu/posix_util.py
+++ b/pymobiledevice3/osu/posix_util.py
@@ -50,7 +50,7 @@ class Posix(OsUtils):
         assert sudo_gid is not None
         os.chown(path, int(sudo_uid), int(sudo_gid))
 
-    def parse_timestamp(self, time_stamp) -> datetime.datetime:
+    def parse_timestamp(self, time_stamp: float) -> datetime.datetime:
         return datetime.datetime.fromtimestamp(time_stamp)
 
     def wait_return(self):

--- a/pymobiledevice3/osu/win_util.py
+++ b/pymobiledevice3/osu/win_util.py
@@ -78,7 +78,7 @@ class Win32(OsUtils):
         logging.getLogger(__name__).debug("Socket does not expose ioctl(); enabling SO_KEEPALIVE fallback")
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
 
-    def parse_timestamp(self, time_stamp) -> datetime.datetime:
+    def parse_timestamp(self, time_stamp: float) -> datetime.datetime:
         return datetime.datetime.fromtimestamp(time_stamp / 1000)
 
     def chown_to_non_sudo_if_needed(self, path: Path) -> None:

--- a/pymobiledevice3/remote/core_device/aac_eld.py
+++ b/pymobiledevice3/remote/core_device/aac_eld.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import ctypes
 import sys
-from typing import Optional
+from typing import Any, Optional
 
 # Standard AudioSpecificConfig for AAC-ELD @ 48 kHz stereo, 480 samples/frame.
 # Used as the decompression magic cookie ("dmgc") when constructing the
@@ -110,7 +110,7 @@ class AACELDDecoder:
         self._pending_buf = None
         self._pending_pd = _APD(0, 0, 0)
 
-        def _input_proc(decoder, ioN, ioData, outPD, _):
+        def _input_proc(decoder: Any, ioN: Any, ioData: Any, outPD: Any, _: Any) -> int:
             au = self._pending
             if au is None:
                 ioN[0] = 0

--- a/pymobiledevice3/remote/core_device/audio_player.py
+++ b/pymobiledevice3/remote/core_device/audio_player.py
@@ -175,7 +175,7 @@ class AudioQueuePlayer:
             latency_ms,
         )
 
-    def _on_buffer_consumed(self, user, aq, buf_ref):
+    def _on_buffer_consumed(self, user: Any, aq: Any, buf_ref: Any) -> None:
         # Called on AudioQueue's internal thread when it's done with
         # this buffer. queue.Queue is thread-safe.
         if not self._closed:

--- a/pymobiledevice3/remote/core_device/hevc_av.py
+++ b/pymobiledevice3/remote/core_device/hevc_av.py
@@ -29,7 +29,7 @@ import contextlib
 import logging
 import queue
 import threading
-from typing import Optional
+from typing import Any, Callable, Optional
 
 from pymobiledevice3.remote.core_device.hevc_rps import (
     parse_sps,
@@ -67,8 +67,8 @@ class HevcToBgraTranscoder:
         sps: bytes,
         pps: bytes,
         *,
-        on_frame,
-        on_decode_error=None,
+        on_frame: Callable[[bytes], None],
+        on_decode_error: Optional[Callable[[], None]] = None,
     ) -> None:
         # libav reports decoded-frame dimensions rounded up to the
         # codec's coding-block alignment (typically a multiple of 16);
@@ -115,7 +115,7 @@ class HevcToBgraTranscoder:
             self._codec.close()  # pyright: ignore[reportAttributeAccessIssue]
 
     # -- worker --------------------------------------------------------
-    def _emit_frame(self, frame) -> None:
+    def _emit_frame(self, frame: Any) -> None:
         # PyAV's reformat to bgra returns a tightly-packed buffer
         # (linesize = width * 4) at exactly the cropped width/height
         # we requested.

--- a/pymobiledevice3/remote/core_device/screen_stream.py
+++ b/pymobiledevice3/remote/core_device/screen_stream.py
@@ -28,6 +28,7 @@ import tempfile
 import time
 import uuid
 from collections import deque
+from collections.abc import Awaitable
 from pathlib import Path
 from typing import Any, Optional, Protocol, cast
 
@@ -1710,7 +1711,7 @@ class ScreenStreamServer:
         async with self._accessibility_lock:
             results: list[dict[str, Any]] = []
 
-            async def _read(meth):
+            async def _read(meth: str) -> Any:
                 async with ConfigurationService(self._rsd) as cfg:
                     return await getattr(cfg, meth)()
 
@@ -1751,7 +1752,7 @@ class ScreenStreamServer:
             results.append({"key": "liquid_glass_opacity", "type": "float", "value": 1.0})
             return results
 
-    async def _accessibility_set(self, key: str, value) -> None:
+    async def _accessibility_set(self, key: str, value: Any) -> None:
         """Apply one knob change. Raises ValueError for unknown keys so
         the HTTP layer can return 400 instead of swallowing typos."""
         async with self._accessibility_lock, ConfigurationService(self._rsd) as cfg:
@@ -2917,7 +2918,7 @@ class ScreenStreamServer:
 
                 loop.add_signal_handler(getattr(signal, signame), _request_stop)
 
-        async def _bounded(coro, label, timeout=3.0):
+        async def _bounded(coro: Awaitable[Any], label: str, timeout: float = 3.0) -> None:
             """Run an async cleanup step with a hard timeout so a hung
             RPC can't keep us alive at shutdown."""
             try:

--- a/pymobiledevice3/remote/core_device/vt_jpeg.py
+++ b/pymobiledevice3/remote/core_device/vt_jpeg.py
@@ -44,7 +44,7 @@ from ctypes import (
     c_void_p,
     cast,
 )
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 # Pure-Python type/constant declarations live at module top so importers
 # on non-Darwin platforms (Linux/Windows) can `import vt_jpeg` without
@@ -286,7 +286,9 @@ class HEVCDecoder:
         self.width = int(dims.width)
         self.height = int(dims.height)
 
-    def _on_output(self, refcon, src_ref, status, info_flags, image_buf, pts, dur):
+    def _on_output(
+        self, refcon: Any, src_ref: Any, status: int, info_flags: int, image_buf: Any, pts: Any, dur: Any
+    ) -> None:
         # kVTDecodeInfo_FrameDropped is set when VT concealed a frame --
         # the status may be 0 (no API-level error) yet output is corrupt.
         # Treat as an error so callers can drive a sticky keyframe-required
@@ -367,8 +369,8 @@ class HevcToBgraTranscoder:
         sps: bytes,
         pps: bytes,
         *,
-        on_frame,
-        on_decode_error=None,
+        on_frame: Callable[[bytes], None],
+        on_decode_error: Optional[Callable[[], None]] = None,
     ) -> None:
         self._dec = HEVCDecoder(vps, sps, pps, bgra_output=True)
         self._on_frame = on_frame

--- a/pymobiledevice3/remote/remote_service.py
+++ b/pymobiledevice3/remote/remote_service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from pymobiledevice3.exceptions import NotConnectedError
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
@@ -31,7 +31,7 @@ class RemoteService:
         await self.connect()
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any):
         await self.close()
 
     async def close(self) -> None:

--- a/pymobiledevice3/remote/remote_service_discovery.py
+++ b/pymobiledevice3/remote/remote_service_discovery.py
@@ -211,7 +211,7 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
     async def get_value(self, domain: Optional[str] = None, key: Optional[str] = None) -> Any:
         return await self._lockdown.get_value(domain, key)
 
-    async def set_value(self, value, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
+    async def set_value(self, value: Any, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
         return await self._lockdown.set_value(value, domain=domain, key=key)
 
     async def remove_value(self, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
@@ -298,7 +298,7 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
             raise
         return service
 
-    async def start_lockdown_developer_service(self, name, include_escrow_bag: bool = False) -> ServiceConnection:
+    async def start_lockdown_developer_service(self, name: str, include_escrow_bag: bool = False) -> ServiceConnection:
         """
         Open a connection to a developer service (without RSD check-in).
 
@@ -371,7 +371,7 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         await self.connect()
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         await self.close()
 
     def __repr__(self) -> str:

--- a/pymobiledevice3/remote/remotexpc.py
+++ b/pymobiledevice3/remote/remotexpc.py
@@ -88,7 +88,7 @@ class RemoteXPCConnection:
         await self.connect()
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         await self.close()
 
     async def connect(self) -> None:

--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -333,7 +333,7 @@ class RemotePairingTunnel(ABC):
         finally:
             loop.remove_reader(fd)
 
-    async def start_tunnel(self, address: str, mtu: int, interface_name=DEFAULT_INTERFACE_NAME) -> None:
+    async def start_tunnel(self, address: str, mtu: int, interface_name: str = DEFAULT_INTERFACE_NAME) -> None:
         self.tun = create_tun_device(interface_name)
         self.tun.addr = address
         self.tun.mtu = mtu
@@ -400,7 +400,7 @@ class RemotePairingQuicTunnel(RemotePairingTunnel, QuicConnectionProtocol):
             await self.ping()
             await asyncio.sleep(self._quic.configuration.idle_timeout / 2)
 
-    async def start_tunnel(self, address: str, mtu: int, interface_name=DEFAULT_INTERFACE_NAME) -> None:
+    async def start_tunnel(self, address: str, mtu: int, interface_name: str = DEFAULT_INTERFACE_NAME) -> None:
         await super().start_tunnel(address, mtu, interface_name=interface_name)
         self._keep_alive_task = asyncio.create_task(self.keep_alive_task())
 
@@ -501,7 +501,7 @@ class RemotePairingTcpTunnel(RemotePairingTunnel):
         await self._service.sendall(payload)
         return json.loads(CDTunnelPacket.parse(await self._recv_cdtunnel_packet_from_service()).body)
 
-    async def start_tunnel(self, address: str, mtu: int, interface_name=DEFAULT_INTERFACE_NAME) -> None:
+    async def start_tunnel(self, address: str, mtu: int, interface_name: str = DEFAULT_INTERFACE_NAME) -> None:
         await super().start_tunnel(address, mtu, interface_name=interface_name)
         self._sock_read_task = asyncio.create_task(self.sock_read_task(), name=f"sock-read-task-{address}")
 
@@ -1124,7 +1124,7 @@ class RemotePairingProtocol(StartTcpTunnel):
     async def __aenter__(self) -> "RemotePairingProtocol":
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         await self.close()
 
 
@@ -1245,7 +1245,7 @@ class RemotePairingTunnelService(RemotePairingProtocol):
         await writer.drain()
 
     @staticmethod
-    def _default_json_encoder(obj) -> str:
+    def _default_json_encoder(obj: Any) -> str:
         if isinstance(obj, bytes):
             return base64.b64encode(obj).decode()
         raise TypeError()
@@ -1939,7 +1939,7 @@ class PairableHost:
         return envelope["message"]["plain"]["_0"]
 
     @staticmethod
-    def _json_default(obj) -> str:
+    def _json_default(obj: Any) -> str:
         if isinstance(obj, bytes):
             return base64.b64encode(obj).decode()
         raise TypeError(f"Object of type {type(obj)} is not JSON serializable")

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -39,7 +39,7 @@ import socket
 import struct
 import sys
 from contextlib import AsyncExitStack, suppress
-from typing import Optional, Protocol, cast
+from typing import Any, Optional, Protocol, cast
 
 from pmd_net_addr import Ip6Address, Ip6IfAddr, MacAddress
 from pmd_pytcp import stack
@@ -376,7 +376,7 @@ class UserspaceDialPlane:
     async def __aenter__(self) -> UserspaceDialPlane:
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         for srv in self._servers:
             srv.close()
         # Cancel the in-flight relay handlers BEFORE wait_closed(): since Python 3.12.1
@@ -477,7 +477,7 @@ class UserspaceDialPlane:
         logger.debug("userspace relay %s:%s -> 127.0.0.1:%s", self._device_addr, port, lport)
         return lport
 
-    async def dial(self, host=None, port=None, **kwargs):
+    async def dial(self, host: Optional[str] = None, port: Optional[int] = None, **kwargs: Any):
         """``asyncio.open_connection``-compatible dialer passed to the RSD via ``open_connection=``.
 
         Connections to the device's tunnel address are relayed through the userspace stack;
@@ -725,7 +725,7 @@ class UserspaceRsdTunnel:
     async def __aenter__(self) -> RemoteServiceDiscoveryService:
         return await self.aopen()
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         await self.aclose()
 
 

--- a/pymobiledevice3/remote/xpc_message.py
+++ b/pymobiledevice3/remote/xpc_message.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 import dataclasses
 import uuid
 from datetime import datetime
@@ -8,6 +9,7 @@ from construct import (
     Array,
     Bytes,
     Const,
+    Container,
     CString,
     Default,
     Enum,
@@ -154,7 +156,7 @@ class FileTransferType:
     transfer_size: int
 
 
-def _decode_xpc_dictionary(xpc_object) -> dict[str, Any]:
+def _decode_xpc_dictionary(xpc_object: Container[Any]) -> dict[str, Any]:
     if xpc_object.data.count == 0:
         return {}
     result = {}
@@ -163,55 +165,55 @@ def _decode_xpc_dictionary(xpc_object) -> dict[str, Any]:
     return result
 
 
-def _decode_xpc_array(xpc_object) -> list[Any]:
+def _decode_xpc_array(xpc_object: Container[Any]) -> list[Any]:
     result = []
     for entry in xpc_object.data.entries:
         result.append(decode_xpc_object(entry))
     return result
 
 
-def _decode_xpc_bool(xpc_object) -> bool:
+def _decode_xpc_bool(xpc_object: Container[Any]) -> bool:
     return bool(xpc_object.data)
 
 
-def _decode_xpc_int64(xpc_object) -> XpcInt64Type:
+def _decode_xpc_int64(xpc_object: Container[Any]) -> XpcInt64Type:
     return XpcInt64Type(xpc_object.data)
 
 
-def _decode_xpc_uint64(xpc_object) -> XpcUInt64Type:
+def _decode_xpc_uint64(xpc_object: Container[Any]) -> XpcUInt64Type:
     return XpcUInt64Type(xpc_object.data)
 
 
-def _decode_xpc_uuid(xpc_object) -> uuid.UUID:
+def _decode_xpc_uuid(xpc_object: Container[Any]) -> uuid.UUID:
     return uuid.UUID(bytes=xpc_object.data)
 
 
-def _decode_xpc_string(xpc_object) -> str:
+def _decode_xpc_string(xpc_object: Container[Any]) -> str:
     return xpc_object.data
 
 
-def _decode_xpc_data(xpc_object) -> bytes:
+def _decode_xpc_data(xpc_object: Container[Any]) -> bytes:
     return xpc_object.data
 
 
-def _decode_xpc_date(xpc_object) -> datetime:
+def _decode_xpc_date(xpc_object: Container[Any]) -> datetime:
     # Convert from nanoseconds to seconds
     return datetime.fromtimestamp(xpc_object.data / 1000000000)
 
 
-def _decode_xpc_file_transfer(xpc_object) -> FileTransferType:
+def _decode_xpc_file_transfer(xpc_object: Container[Any]) -> FileTransferType:
     return FileTransferType(transfer_size=_decode_xpc_dictionary(xpc_object.data.data)["s"])
 
 
-def _decode_xpc_double(xpc_object) -> float:
+def _decode_xpc_double(xpc_object: Container[Any]) -> float:
     return xpc_object.data
 
 
-def _decode_xpc_null(xpc_object) -> None:
+def _decode_xpc_null(xpc_object: Container[Any]) -> None:
     return None
 
 
-def decode_xpc_object(xpc_object) -> Any:
+def decode_xpc_object(xpc_object: Container[Any]) -> Any:
     decoders = {
         XpcMessageType.DICTIONARY: _decode_xpc_dictionary,
         XpcMessageType.ARRAY: _decode_xpc_array,

--- a/pymobiledevice3/remote/xpc_message.py
+++ b/pymobiledevice3/remote/xpc_message.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 import dataclasses
 import uuid
 from datetime import datetime

--- a/pymobiledevice3/resources/dsc_uuid_map.py
+++ b/pymobiledevice3/resources/dsc_uuid_map.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os.path
+from typing import Any, Optional
 from uuid import UUID
 
 import click
@@ -16,14 +17,14 @@ UUID_SIZE = 0x10
 logger = logging.getLogger(__name__)
 
 
-def get_dsc_map(dsc_uuid):
+def get_dsc_map(dsc_uuid: str):
     with open(MAP_FILENAME) as f:
         uuid_map = json.load(f)
 
     return uuid_map.get(dsc_uuid)
 
 
-def sanitize_path(path):
+def sanitize_path(path: str) -> Optional[str]:
     for partition in PARTITIONS:
         if path.startswith(partition):
             return path
@@ -37,7 +38,7 @@ def sanitize_path(path):
 @click.argument("dyld_uuid", type=click.UUID)
 @click.argument("dsc", type=click.File("rb"))
 @click.option("-f", "--force", is_flag=True)
-def main(dsc, dyld_uuid, force):
+def main(dsc: Any, dyld_uuid: UUID, force: bool):
     """
     Simple utility to get all UUIDs used for symbolication from given DSC.
     The UUID of `/usr/lib/dyld` still needs manual insertion.

--- a/pymobiledevice3/resources/firmware_notifications.py
+++ b/pymobiledevice3/resources/firmware_notifications.py
@@ -21,7 +21,7 @@ def save_notifications(notifications: list[str]):
 
 @click.command()
 @click.argument("root_fs", type=click.Path(dir_okay=True, file_okay=False, exists=True))
-def main(root_fs):
+def main(root_fs: str):
     """
     Add notifications registered to `com.apple.notifyd.matching` from a given IPSW `root_fs` (extracted filesystem)
     into `notifications.txt`

--- a/pymobiledevice3/restore/mbn.py
+++ b/pymobiledevice3/restore/mbn.py
@@ -192,7 +192,7 @@ def _read_elf_headers(data: bytes):
     return None, None
 
 
-def _read_program_headers(data: bytes, kind: str, hdr) -> list[Any]:
+def _read_program_headers(data: bytes, kind: str, hdr: Any) -> list[Any]:
     phdrs = []
     if hdr.e_phnum == 0:
         logger.error("%s: ELF has no program sections", "_read_program_headers")
@@ -223,7 +223,7 @@ def _elf_last_segment_end(data: bytes) -> Optional[int]:
     return int(last.p_offset + last.p_filesz)
 
 
-def _mbn_v7_header_sizes_valid(h, sect_size: int) -> bool:
+def _mbn_v7_header_sizes_valid(h: Any, sect_size: int) -> bool:
     total = (
         MBN_V7.sizeof()
         + h.common_metadata_size
@@ -238,7 +238,7 @@ def _mbn_v7_header_sizes_valid(h, sect_size: int) -> bool:
     return total <= sect_size
 
 
-def _mbn_v7_header_sizes_expected(h) -> bool:
+def _mbn_v7_header_sizes_expected(h: Any) -> bool:
     return (
         (h.qti_metadata_size in (0, 0xE0))
         and (h.oem_metadata_size in (0, 0xE0))
@@ -247,7 +247,7 @@ def _mbn_v7_header_sizes_expected(h) -> bool:
     )
 
 
-def _mbn_v7_log(h, func: str, prefix: str) -> None:
+def _mbn_v7_log(h: Any, func: str, prefix: str) -> None:
     logger.debug(
         "%s: %s header {version=0x%x, common_metadata_size=0x%x, qti_metadata_size=0x%x, "
         "oem_metadata_size=0x%x, hash_table_size=0x%x, qti_signature_size=0x%x, "

--- a/pymobiledevice3/restore/recovery.py
+++ b/pymobiledevice3/restore/recovery.py
@@ -29,7 +29,7 @@ class Recovery(BaseRestore):
         self.tss_recoveryos_root_ticket = None
         self.restore_boot_args = None
 
-    async def reconnect_irecv(self, is_recovery=None):
+    async def reconnect_irecv(self, is_recovery: Optional[bool] = None):
         self.logger.debug("waiting for device to reconnect...")
         self.device.set_irecv(IRecv(ecid=await self.device.get_ecid(), is_recovery=is_recovery))
         assert self.device.irecv is not None
@@ -272,7 +272,7 @@ class Recovery(BaseRestore):
         assert self.device.irecv is not None
         self.device.irecv.send_buffer(data)
 
-    async def send_component_and_command(self, name, command):
+    async def send_component_and_command(self, name: str, command: str):
         await self.send_component(name)
         assert self.device.irecv is not None
         self.device.irecv.send_command(command)
@@ -284,7 +284,7 @@ class Recovery(BaseRestore):
         self.device.irecv.send_command("go", b_request=1)
         self.device.irecv.ctrl_transfer(0x21, 1)
 
-    async def send_applelogo(self, allow_missing=True):
+    async def send_applelogo(self, allow_missing: bool = True):
         component = "RestoreLogo"
 
         if not self.build_identity.has_component(component):

--- a/pymobiledevice3/restore/restore.py
+++ b/pymobiledevice3/restore/restore.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Optional
 from zipfile import ZipFile, ZipInfo
 
 import requests
+from ipsw_parser.build_identity import BuildIdentity
 from ipsw_parser.ipsw import IPSW
 from tqdm import tqdm, trange
 
@@ -79,9 +80,9 @@ class Restore(BaseRestore):
         self,
         ipsw: IPSW,
         device: Device,
-        tss=None,
+        tss: Optional[dict[str, Any]] = None,
         behavior: Behavior = Behavior.Update,
-        ignore_fdr=False,
+        ignore_fdr: bool = False,
         enable_tss_batch: bool = False,
     ):
         super().__init__(ipsw, device, tss, behavior)
@@ -217,7 +218,7 @@ class Restore(BaseRestore):
 
         await asr.close()
 
-    async def get_build_identity_from_request(self, msg):
+    async def get_build_identity_from_request(self, msg: dict[str, Any]):
         return await self.get_build_identity(msg["Arguments"].get("IsRecoveryOS", False))
 
     async def send_buildidentity(self, message: dict[str, Any]) -> None:
@@ -312,7 +313,9 @@ class Restore(BaseRestore):
 
         self.logger.info(f"Done sending {component_name}")
 
-    async def get_recovery_os_local_policy_tss_response(self, args, build_identity=None):
+    async def get_recovery_os_local_policy_tss_response(
+        self, args: dict[str, Any], build_identity: Optional[BuildIdentity] = None
+    ):
         if build_identity is None:
             build_identity = self.build_identity
 
@@ -522,13 +525,13 @@ class Restore(BaseRestore):
 
         return bbfw_fn_elem_mav25.get(elem) if bb_chip_id == 0x1F30E1 else bbfw_fn_elem.get(elem)
 
-    def fls_parse(self, buffer):
+    def fls_parse(self, buffer: bytes):
         raise NotImplementedError()
 
-    def fls_update_sig_blob(self, buffer, blob):
+    def fls_update_sig_blob(self, buffer: bytes, blob: bytes):
         raise NotImplementedError()
 
-    def fls_insert_ticket(self, fls, bbticket):
+    def fls_insert_ticket(self, fls: bytes, bbticket: bytes):
         raise NotImplementedError()
 
     def sign_bbfw(
@@ -1149,7 +1152,7 @@ class Restore(BaseRestore):
         return merged
 
     @staticmethod
-    def _dig(container: dict[str, Any], path) -> typing.Any:
+    def _dig(container: dict[str, Any], path: typing.Union[str, list[str]]) -> typing.Any:
         """Navigate a dict by a single key or a list-of-keys path; None if any hop misses."""
         cur = container
         for key in [path] if isinstance(path, str) else path:
@@ -1197,7 +1200,7 @@ class Restore(BaseRestore):
         runtime_nonce = self._resolve_nonce(devgen, entry.devgen_nonce, entry.devgen_nonce_path)
         return self._lookup_prefetched_tss(updater_name, runtime_nonce)
 
-    def _lookup_prefetched_tss(self, updater_name: str, runtime_nonce) -> Optional[TSSResponse]:
+    def _lookup_prefetched_tss(self, updater_name: str, runtime_nonce: Optional[bytes]) -> Optional[TSSResponse]:
         """Return the prefetched TSS response if the runtime nonce matches what we prefetched with."""
         entry = self._prefetched_updater_tss.get(updater_name)
         if entry is None or runtime_nonce is None:

--- a/pymobiledevice3/restore/restore_options.py
+++ b/pymobiledevice3/restore/restore_options.py
@@ -1,7 +1,7 @@
 # extracted from ac2
 import logging
 import uuid
-from typing import Optional
+from typing import Any, Optional
 
 from ipsw_parser.build_identity import BuildIdentity
 
@@ -102,14 +102,14 @@ SUPPORTED_MESSAGE_TYPES = {
 class RestoreOptions:
     def __init__(
         self,
-        firmware_preflight_info=None,
-        sep=None,
-        macos_variant=None,
+        firmware_preflight_info: Optional[dict[str, Any]] = None,
+        sep: Optional[dict[str, Any]] = None,
+        macos_variant: Optional[BuildIdentity] = None,
         build_identity: Optional[BuildIdentity] = None,
-        restore_boot_args=None,
-        spp=None,
+        restore_boot_args: Optional[str] = None,
+        spp: Optional[dict[str, Any]] = None,
         restore_behavior: Optional[str] = None,
-        msp=None,
+        msp: Optional[int] = None,
     ):
         self.AutoBootDelay = 0
 

--- a/pymobiledevice3/restore/tss.py
+++ b/pymobiledevice3/restore/tss.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 import asyncio
 import logging
 import plistlib
@@ -27,7 +28,7 @@ TSS_CLIENT_VERSION_STRING = "libauthinstall-1104.0.9"
 logger = logging.getLogger(__name__)
 
 
-def get_with_or_without_comma(obj: dict[str, typing.Any], k: str, default=None) -> typing.Any:
+def get_with_or_without_comma(obj: dict[str, typing.Any], k: str, default: typing.Any = None) -> typing.Any:
     val = obj.get(k, obj.get(k.replace(",", "")))
     if val is None and default is not None:
         val = default
@@ -122,7 +123,9 @@ class TSSRequest:
                 value = int(value, 16)
             self._request[key] = value
 
-    def add_common_tags(self, parameters: dict[str, typing.Any], overrides=None):
+    def add_common_tags(
+        self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None
+    ):
         keys = ("ApECID", "UniqueBuildID", "ApChipID", "ApBoardID", "ApSecurityDomain")
         for k in keys:
             if k in parameters:
@@ -130,7 +133,9 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_ap_recovery_tags(self, parameters: dict[str, typing.Any], overrides=None):
+    def add_ap_recovery_tags(
+        self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None
+    ):
         skip_keys = (
             "BasebandFirmware",
             "SE,UpdatePayload",
@@ -204,7 +209,9 @@ class TSSRequest:
         if overrides:
             self._request.update(overrides)
 
-    def add_timer_tags(self, parameters: dict[str, typing.Any], overrides=None):
+    def add_timer_tags(
+        self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None
+    ):
         manifest = parameters["Manifest"]
 
         # add tags indicating we want to get the Timer ticket
@@ -297,7 +304,9 @@ class TSSRequest:
                     v = int(v, 16)
                 self._request[k] = v
 
-    def add_vinyl_prefetch_tags(self, parameters: dict[str, typing.Any], overrides=None):
+    def add_vinyl_prefetch_tags(
+        self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None
+    ):
         # Prefetch shim for Vinyl/eUICC: PreflightInfo nests the Gold/Main nonces under
         # eUICC,Gold / eUICC,Main, but add_vinyl_tags reads them from the flat
         # EUICCGoldNonce / EUICCMainNonce params (the recovery.py AP-batch path sets these).
@@ -307,7 +316,9 @@ class TSSRequest:
                 parameters.setdefault(flat, node["Nonce"])
         self.add_vinyl_tags(parameters, overrides)
 
-    def add_vinyl_tags(self, parameters: dict[str, typing.Any], overrides=None):
+    def add_vinyl_tags(
+        self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None
+    ):
         self._request["@BBTicket"] = True
         self._request["@eUICC,Ticket"] = True
 
@@ -351,7 +362,7 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_ap_tags(self, parameters: dict[str, typing.Any], overrides=None):
+    def add_ap_tags(self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None):
         """loop over components from build manifest"""
 
         manifest_node = parameters["Manifest"]
@@ -414,7 +425,7 @@ class TSSRequest:
             self._request["ApNonce"] = parameters["ApNonce"]
         self._request["@APTicket"] = True
 
-    def add_ap_img4_tags(self, parameters):
+    def add_ap_img4_tags(self, parameters: dict[str, typing.Any]):
         keys_to_copy = (
             "ApNonce",
             "ApProductionMode",
@@ -461,7 +472,7 @@ class TSSRequest:
             # Workaround: We have only seen Ap,SikaFuse together with UID_MODE
             self._request["Ap,SikaFuse"] = 0
 
-    def add_se2_tags(self, parameters: dict[str, typing.Any], overrides=None):
+    def add_se2_tags(self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None):
         # Modern Secure Enclave personalization (A19 / iOS 27+). The device generates an
         # @SE2,Ticket request (response key "SE2,Ticket"), NOT the legacy @SE,Ticket of
         # add_se_tags. Confirmed by a ramrod capture on iPhone 18,4: the
@@ -494,7 +505,7 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_se_tags(self, parameters: dict[str, typing.Any], overrides=None):
+    def add_se_tags(self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None):
         manifest = parameters["Manifest"]
 
         # add tags indicating we want to get the SE,Ticket
@@ -559,7 +570,12 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def add_savage_tags(self, parameters: dict[str, typing.Any], overrides=None, component_name=None):
+    def add_savage_tags(
+        self,
+        parameters: dict[str, typing.Any],
+        overrides: typing.Optional[dict[str, typing.Any]] = None,
+        component_name: typing.Optional[str] = None,
+    ):
         manifest = parameters["Manifest"]
 
         # add tags indicating we want to get the Savage,Ticket
@@ -611,7 +627,9 @@ class TSSRequest:
 
         return comp_name
 
-    def add_yonkers_tags(self, parameters: dict[str, typing.Any], overrides=None):
+    def add_yonkers_tags(
+        self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None
+    ):
         manifest = parameters["Manifest"]
 
         # add tags indicating we want to get the Yonkers,Ticket
@@ -671,7 +689,9 @@ class TSSRequest:
 
         return result_comp_name
 
-    def add_baseband_tags(self, parameters: dict[str, typing.Any], overrides=None):
+    def add_baseband_tags(
+        self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None
+    ):
         self._request["@BBTicket"] = True
 
         keys_to_copy = (
@@ -1006,7 +1026,7 @@ class TSSRequest:
         if overrides is not None:
             self._request.update(overrides)
 
-    def img4_create_local_manifest(self, build_identity=None):
+    def img4_create_local_manifest(self, build_identity: typing.Optional[typing.Mapping[str, typing.Any]] = None):
         manifest = None
         if build_identity is not None:
             manifest = build_identity["Manifest"]
@@ -1068,7 +1088,7 @@ class TSSRequest:
         if key in self._request:
             self._request.pop(key)
 
-    def update(self, options) -> None:
+    def update(self, options: dict[str, typing.Any]) -> None:
         self._request.update(options)
 
     async def send_receive(self) -> TSSResponse:

--- a/pymobiledevice3/restore/tss.py
+++ b/pymobiledevice3/restore/tss.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 import asyncio
 import logging
 import plistlib

--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -525,7 +525,7 @@ class ServiceConnection:
         await self.start()
         return self
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         await self.close()
 
     def shell(self) -> None:

--- a/pymobiledevice3/services/accessibilityaudit.py
+++ b/pymobiledevice3/services/accessibilityaudit.py
@@ -4,6 +4,7 @@ import typing
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from enum import Enum, IntEnum
+from types import TracebackType
 
 from packaging.version import Version
 
@@ -18,7 +19,7 @@ class SerializedObject:
 
 
 class AXAuditInspectorFocus_v1(SerializedObject):
-    def __init__(self, fields):
+    def __init__(self, fields: dict[str, typing.Any]):
         super().__init__(fields)
 
     @property
@@ -81,7 +82,7 @@ class AXAuditInspectorFocus_v1(SerializedObject):
 
 
 class AXAuditElement_v1(SerializedObject):
-    def __init__(self, fields):
+    def __init__(self, fields: dict[str, typing.Any]):
         super().__init__(fields)
 
     @property
@@ -93,19 +94,19 @@ class AXAuditElement_v1(SerializedObject):
 
 
 class AXAuditInspectorSection_v1(SerializedObject):
-    def __init__(self, fields):
+    def __init__(self, fields: dict[str, typing.Any]):
         super().__init__(fields)
 
 
 class AXAuditElementAttribute_v1(SerializedObject):
-    def __init__(self, fields):
+    def __init__(self, fields: dict[str, typing.Any]):
         super().__init__(fields)
 
 
 class AXAuditDeviceSetting_v1(SerializedObject):
     FIELDS = ("IdentiifierValue_v1", "CurrentValueNumber_v1")
 
-    def __init__(self, fields):
+    def __init__(self, fields: dict[str, typing.Any]):
         super().__init__(fields)
         for k in self.FIELDS:
             if k not in self._fields:
@@ -159,7 +160,7 @@ class AXAuditIssue_v1(SerializedObject):
         "ForegroundColorValue_v1",
     )
 
-    def __init__(self, fields):
+    def __init__(self, fields: dict[str, typing.Any]):
         super().__init__(fields)
 
         for k in self.FIELDS:
@@ -252,7 +253,7 @@ class Direction(Enum):
     Last = 6
 
 
-def deserialize_object(d) -> typing.Any:
+def deserialize_object(d: typing.Any) -> typing.Any:
     if not isinstance(d, dict):
         if isinstance(d, list):
             return [deserialize_object(x) for x in d]
@@ -316,7 +317,12 @@ class AccessibilityAudit:
         else:
             return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(
+        self,
+        exc_type: typing.Optional[type[BaseException]],
+        exc_val: typing.Optional[BaseException],
+        exc_tb: typing.Optional[TracebackType],
+    ):
         await self.close()
 
     async def close(self) -> None:
@@ -464,7 +470,7 @@ class AccessibilityAudit:
         await self._invoke("deviceInspectorShowVisuals:", int(value), expects_reply=False)
 
     async def iter_events(
-        self, app_monitoring_enabled=True, monitored_event_type: typing.Optional[int] = None
+        self, app_monitoring_enabled: bool = True, monitored_event_type: typing.Optional[int] = None
     ) -> AsyncGenerator[Event, None]:
         """
         Stream accessibility events from the device indefinitely.

--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 #!/usr/bin/env python3
 """
 AFC (Apple File Connection) Service Module
@@ -25,6 +26,7 @@ from collections.abc import Iterator, MutableMapping, MutableSequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from re import Pattern
+from types import TracebackType
 from typing import Any, Callable, NamedTuple, Optional, TextIO, Union, cast
 
 import hexdump
@@ -332,7 +334,12 @@ class AfcService(LockdownService):
         self._afc_pending.clear()
         await super().close()
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ):
         await self.aclose()
 
     async def _afc_reader_loop(self) -> None:
@@ -478,7 +485,7 @@ class AfcService(LockdownService):
                     self.logger.warning(f"(Ignoring) Error: {afc_exception} occurred during the copy of {src_filename}")
 
     @path_to_str()
-    async def exists(self, filename):
+    async def exists(self, filename: str):
         """
         Check whether a path exists on the device.
 
@@ -495,7 +502,7 @@ class AfcService(LockdownService):
         return True
 
     @path_to_str()
-    async def wait_exists(self, filename):
+    async def wait_exists(self, filename: str):
         """
         Block until a path exists on the device.
 
@@ -508,7 +515,13 @@ class AfcService(LockdownService):
             await asyncio.sleep(0.1)
 
     @path_to_str()
-    async def _push_internal(self, local_path, remote_path, callback=None, progress_bar: bool = True):
+    async def _push_internal(
+        self,
+        local_path: str,
+        remote_path: str,
+        callback: Optional[Callable[[str, str], Any]] = None,
+        progress_bar: bool = True,
+    ):
         """
         Internal method for pushing files to the device.
 
@@ -581,7 +594,13 @@ class AfcService(LockdownService):
                 await self._push_internal(local_filename, remote_filename, callback=callback, progress_bar=progress_bar)
 
     @path_to_str()
-    async def push(self, local_path, remote_path, callback=None, progress_bar: bool = True):
+    async def push(
+        self,
+        local_path: str,
+        remote_path: str,
+        callback: Optional[Callable[[str, str], Any]] = None,
+        progress_bar: bool = True,
+    ):
         """
         Push (upload) a file or directory from the local machine to the device.
 
@@ -813,7 +832,7 @@ class AfcService(LockdownService):
         )
 
     @path_to_str()
-    async def link(self, target: str, source: str, type_=AfcLinkType.SYMLINK):
+    async def link(self, target: str, source: str, type_: AfcLinkType = AfcLinkType.SYMLINK):
         """
         Create a symbolic or hard link on the device.
 
@@ -1050,7 +1069,7 @@ class AfcService(LockdownService):
             for entry in dirs + files:
                 yield posixpath.join(folder, entry)
 
-    async def lock(self, handle, operation):
+    async def lock(self, handle: int, operation: int):
         """
         Apply or release an advisory ``flock``-style lock on an open file.
 
@@ -1196,7 +1215,7 @@ class AfcLsStub(LsStub):
     file system, translating calls to work with remote device paths.
     """
 
-    def __init__(self, afc_shell, stdout: Optional[TextIO] = sys.stdout):
+    def __init__(self, afc_shell: "AfcShell", stdout: Optional[TextIO] = sys.stdout):
         """
         Initialize the ls stub.
 
@@ -1210,49 +1229,49 @@ class AfcLsStub(LsStub):
     def sep(self):
         return posixpath.sep
 
-    def join(self, path, *paths):
+    def join(self, path: str, *paths: str):
         return posixpath.join(path, *paths)
 
-    def abspath(self, path):
+    def abspath(self, path: str):
         return posixpath.normpath(path)
 
-    def stat(self, path, dir_fd=None, follow_symlinks=True):
+    def stat(self, path: str, dir_fd: Optional[int] = None, follow_symlinks: bool = True):
         if follow_symlinks:
             path = self.afc_shell.afc.resolve_path(path)
         return self.afc_shell.afc.os_stat(path)
 
-    def readlink(self, path, dir_fd=None):
+    def readlink(self, path: str, dir_fd: Optional[int] = None):
         return self.afc_shell.afc.resolve_path(path)
 
-    def isabs(self, path):
+    def isabs(self, path: str):
         return posixpath.isabs(path)
 
-    def dirname(self, path):
+    def dirname(self, path: str):
         return posixpath.dirname(path)
 
-    def basename(self, path):
+    def basename(self, path: str):
         return posixpath.basename(path)
 
-    def getgroup(self, st_gid):
+    def getgroup(self, st_gid: int):
         return "-"
 
-    def getuser(self, st_uid):
+    def getuser(self, st_uid: int):
         return "-"
 
     def now(self):
         timestamp = self.afc_shell.lockdown.all_values.get("TimeIntervalSince1970", 0)
         return datetime.fromtimestamp(timestamp)
 
-    def listdir(self, path="."):
+    def listdir(self, path: str = "."):
         return self.afc_shell.afc.listdir(path)
 
     def system(self):
         return "Darwin"
 
-    def getenv(self, key, default=None):
+    def getenv(self, key: str, default: Optional[str] = None):
         return ""
 
-    def print(self, *objects, sep=" ", end="\n", file=sys.stdout, flush=False):
+    def print(self, *objects: Any, sep: str = " ", end: str = "\n", file: TextIO = sys.stdout, flush: bool = False):
         """
         Print ls output to the constructor-provided stream.
 
@@ -1275,7 +1294,7 @@ class _AsyncRunner:
         self._loop = get_asyncio_loop()
         self._lock = threading.Lock()
 
-    def run(self, coro):
+    def run(self, coro: Any):
         with self._lock:
             if self._loop.is_running():
                 loop_thread_id = getattr(self._loop, "_thread_id", None)
@@ -1293,7 +1312,7 @@ class _AsyncRunner:
 class _SyncAsyncGenIterator:
     """Bridge an async generator into a blocking iterator for xonsh handlers."""
 
-    def __init__(self, agen, lock: threading.Lock, runner: _AsyncRunner):
+    def __init__(self, agen: Any, lock: threading.Lock, runner: _AsyncRunner):
         self._agen = agen
         self._lock = lock
         self._runner = runner
@@ -1322,7 +1341,7 @@ class _SyncAfcProxy:
         if not callable(attr):
             return attr
 
-        def sync_call(*args, **kwargs):
+        def sync_call(*args: Any, **kwargs: Any):
             result = attr(*args, **kwargs)
             if inspect.isasyncgen(result):
                 return _SyncAsyncGenIterator(result, self._lock, self._runner)
@@ -1341,7 +1360,7 @@ class _SyncAfcProxy:
         return sync_call
 
 
-def path_completer(xsh, action, completer, alias, command) -> list[str]:
+def path_completer(xsh: Any, action: Any, completer: Any, alias: Any, command: Any) -> list[str]:
     """
     Provide path completion for xonsh shell commands.
 
@@ -1384,7 +1403,7 @@ def path_completer(xsh, action, completer, alias, command) -> list[str]:
     return result
 
 
-def dir_completer(xsh, action, completer, alias, command):
+def dir_completer(xsh: Any, action: Any, completer: Any, alias: Any, command: Any):
     """
     Provide directory-only completion for xonsh shell commands.
 
@@ -1571,7 +1590,7 @@ class AfcShell:
             self._orig_aliases[name] = aliases[name]
         aliases[name] = handler
 
-    def _register_rpc_command(self, name, handler):
+    def _register_rpc_command(self, name: str, handler: Union[Callable[..., Any], str]):
         """
         Register a simple command without argument parsing.
 
@@ -1690,7 +1709,7 @@ class AfcShell:
         else:
             print(f"[ERROR] {directory} does not exist")
 
-    def do_ls(self, args, stdin, stdout, stderr):
+    def do_ls(self, args: list[str], stdin: Optional[TextIO], stdout: Optional[TextIO], stderr: Optional[TextIO]):
         """
         List directory contents with Unix ls-like formatting.
 
@@ -1755,7 +1774,7 @@ class AfcShell:
             Show progress bar for large files (--progress_bar flag)
         """
 
-        def log(src, dst):
+        def log(src: str, dst: str):
             print(f"{src} --> {dst}")
 
         self.afc.pull(
@@ -1775,7 +1794,7 @@ class AfcShell:
         :param remote_path: Destination path on the device
         """
 
-        def log(src, dst):
+        def log(src: str, dst: str):
             print(f"{src} --> {dst}")
 
         self.afc.push(local_path, self.relative_path(remote_path), callback=log)
@@ -1848,7 +1867,7 @@ class AfcShell:
             formatters.Terminal256Formatter(style="solarized-dark"),
         ).strip()
 
-    def _complete(self, text, line, begidx, endidx):
+    def _complete(self, text: str, line: str, begidx: int, endidx: int):
         """
         Provide path completion for commands (internal method).
 
@@ -1867,7 +1886,7 @@ class AfcShell:
             if filename.startswith(prefix)
         ]
 
-    def _complete_first_arg(self, text, line, begidx, endidx):
+    def _complete_first_arg(self, text: str, line: str, begidx: int, endidx: int):
         """
         Complete only the first argument of a command.
 
@@ -1877,7 +1896,7 @@ class AfcShell:
             return []
         return self._complete(text, line, begidx, endidx)
 
-    def _complete_push_arg(self, text, line, begidx, endidx):
+    def _complete_push_arg(self, text: str, line: str, begidx: int, endidx: int):
         """
         Completion for push command (local path, then remote path).
 
@@ -1891,7 +1910,7 @@ class AfcShell:
         else:
             return []
 
-    def _complete_pull_arg(self, text, line, begidx, endidx):
+    def _complete_pull_arg(self, text: str, line: str, begidx: int, endidx: int):
         """
         Completion for pull command (remote path, then local path).
 
@@ -1918,7 +1937,7 @@ class AfcShell:
         return [str(p) for p in path_iter if str(p).startswith(text)]
 
     @staticmethod
-    def _count_completion_parts(line, begidx):
+    def _count_completion_parts(line: str, begidx: int):
         """
         Count the number of space-separated parts in a command line.
 

--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 #!/usr/bin/env python3
 """
 AFC (Apple File Connection) Service Module

--- a/pymobiledevice3/services/amfi.py
+++ b/pymobiledevice3/services/amfi.py
@@ -47,7 +47,7 @@ class AmfiService:
         if not resp.get("success"):
             raise PyMobileDevice3Exception(f"create_AMFIShowOverridePath() failed with: {resp}")
 
-    async def enable_developer_mode(self, enable_post_restart=True):
+    async def enable_developer_mode(self, enable_post_restart: bool = True):
         """
         Request that Developer Mode be enabled on the device.
 

--- a/pymobiledevice3/services/crash_reports.py
+++ b/pymobiledevice3/services/crash_reports.py
@@ -3,9 +3,10 @@ import logging
 import posixpath
 import re
 import time
-from collections.abc import AsyncGenerator, Iterator
+from collections.abc import AsyncGenerator, Awaitable, Iterator
 from json import JSONDecodeError
-from typing import Callable, ClassVar, Optional, Union, cast
+from types import TracebackType
+from typing import Any, Callable, ClassVar, Optional, Union, cast
 
 from pycrashreport.crash_report import CrashReportBase, get_crash_report_from_buf
 from xonsh.built_ins import XSH
@@ -74,10 +75,20 @@ class CrashReportsManager:
     async def __aenter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ):
         raise RuntimeError("Use async context manager: `async with ...`")
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ):
         await self.aclose()
 
     async def aclose(self) -> None:
@@ -379,7 +390,7 @@ class CrashReportsShell(AfcShell):
         self._register_arg_parse_alias("parse-latest", self._do_parse_latest)
         self._register_arg_parse_alias("clear", self._do_clear)
 
-    def _run_manager(self, awaitable):
+    def _run_manager(self, awaitable: Awaitable[Any]):
         return self.afc._runner.run(awaitable)
 
     def _do_parse(self, filename: Annotated[str, Arg(completer=_path_arg_completer)]) -> None:

--- a/pymobiledevice3/services/dvt/instruments/activity_trace_tap.py
+++ b/pymobiledevice3/services/dvt/instruments/activity_trace_tap.py
@@ -5,6 +5,7 @@ import struct
 from io import BytesIO
 from typing import Any, cast
 
+from pymobiledevice3.dtx_service_provider import DtxServiceProvider
 from pymobiledevice3.services.dvt.instruments.tap import Tap
 
 CMD_DEFINE_TABLE = 1
@@ -39,7 +40,7 @@ def ignored_null(s: bytes) -> bytes:
     return s
 
 
-def decode_message_format(message) -> str:
+def decode_message_format(message: Any) -> str:
     s = ""
     for type_, data in message:
         if data and isinstance(data, bytes):
@@ -89,7 +90,7 @@ class ActivityTraceTap(Tap):
 
     IDENTIFIER = "com.apple.instruments.server.services.activitytracetap"
 
-    def __init__(self, dvt, enable_http_archive_logging=False):
+    def __init__(self, dvt: DtxServiceProvider, enable_http_archive_logging: bool = False):
         """
         :param dvt: The `DvtProvider` used to open the Instruments channel.
         :param enable_http_archive_logging: When True, request that the device also include HTTP
@@ -134,10 +135,10 @@ class ActivityTraceTap(Tap):
         self._set_current_message(self._carry + message)
         self._carry = b""
 
-    def _set_current_message(self, message):
+    def _set_current_message(self, message: bytes):
         self._message = BytesIO(message)
 
-    def _seek_relative(self, offset):
+    def _seek_relative(self, offset: int):
         self._message.seek(offset, os.SEEK_CUR)
 
     def _peek_word(self) -> int:
@@ -153,7 +154,7 @@ class ActivityTraceTap(Tap):
         self._message.seek(2, os.SEEK_CUR)
         return word
 
-    def _handle_push(self, word):
+    def _handle_push(self, word: int):
         assert word >> 14 in (0b10, 0b11), f"invalid magic for pushed item. word: {hex(word)}"
 
         count = 0
@@ -177,17 +178,17 @@ class ActivityTraceTap(Tap):
 
         return result
 
-    def _handle_table_reset(self, word):
+    def _handle_table_reset(self, word: int):
         """start new table vector"""
         self.generation += 1
         self.background = 0
         self.stack = []
 
-    def _handle_sentinel(self, word):
+    def _handle_sentinel(self, word: int):
         """push a dummy"""
         self.stack.append(None)
 
-    def _handle_struct(self, word):
+    def _handle_struct(self, word: int):
         """replace last `distance` items with a single one which represents them as a tuple"""
         distance = word & 0xFF
 
@@ -199,7 +200,7 @@ class ActivityTraceTap(Tap):
         self.stack = self.stack[:-distance]
         self.stack.append(new_item)
 
-    def _handle_define_table(self, word):
+    def _handle_define_table(self, word: int):
         """define a table struct"""
         distance = 4
 
@@ -215,7 +216,7 @@ class ActivityTraceTap(Tap):
         self.stack = self.stack[:-distance]
         self.tables.append(table)
 
-    def _handle_debug(self, word):
+    def _handle_debug(self, word: int):
         """pop last pushed item from stack"""
         debug_id = word & 0xFF
         item = self.stack[-1]
@@ -227,7 +228,7 @@ class ActivityTraceTap(Tap):
         )
         self.stack = self.stack[:-1]
 
-    def _handle_copy(self, word):
+    def _handle_copy(self, word: int):
         """copy item at distance from stack"""
         distance = word & 0xFF
         if distance != 0xFF:
@@ -240,7 +241,7 @@ class ActivityTraceTap(Tap):
             self.stack = self.stack[:-1]
             self.stack.append(self.stack[reference])
 
-    def _handle_end_row(self, word):
+    def _handle_end_row(self, word: int):
         """flush current row"""
         generation = word & 0xFF
         columns = self.tables[generation].columns
@@ -269,13 +270,13 @@ class ActivityTraceTap(Tap):
         if hasattr(message, "message"):
             return message
 
-    def _handle_placeholder_count(self, word):
+    def _handle_placeholder_count(self, word: int):
         """remove `count` last items from stack"""
         count = word & 0xFF
         if count > 0:
             self.stack = self.stack[:-count]
 
-    def _handle_convert_mach_continuous(self, word):
+    def _handle_convert_mach_continuous(self, word: int):
         """push an item and pop it. effectively do nothing"""
         pass
 

--- a/pymobiledevice3/services/dvt/instruments/condition_inducer.py
+++ b/pymobiledevice3/services/dvt/instruments/condition_inducer.py
@@ -3,6 +3,7 @@ from typing import Any, cast
 
 from pymobiledevice3.dtx import DTXService, dtx_method
 from pymobiledevice3.dtx_service import DtxService
+from pymobiledevice3.dtx_service_provider import DtxServiceProvider
 from pymobiledevice3.exceptions import PyMobileDevice3Exception
 
 
@@ -30,7 +31,7 @@ class ConditionInducer(DtxService[ConditionInducerService]):
     replaces any previously active condition.
     """
 
-    def __init__(self, dvt):
+    def __init__(self, dvt: DtxServiceProvider):
         super().__init__(dvt)
         self.logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class ConditionInducer(DtxService[ConditionInducerService]):
         """
         return await self.service.available_condition_inducers()
 
-    async def set(self, profile_identifier):
+    async def set(self, profile_identifier: str):
         """
         Activate the condition profile with the given identifier.
 

--- a/pymobiledevice3/services/dvt/instruments/core_profile_session_tap.py
+++ b/pymobiledevice3/services/dvt/instruments/core_profile_session_tap.py
@@ -31,7 +31,7 @@ from construct import (
 )
 from pykdebugparser.kd_buf_parser import RAW_VERSION2_BYTES
 
-from pymobiledevice3.dtx import DTXQueue, DTXService, dtx_method, dtx_on_data, dtx_on_notification
+from pymobiledevice3.dtx import DTXContext, DTXQueue, DTXService, dtx_method, dtx_on_data, dtx_on_notification
 from pymobiledevice3.dtx_service import DtxService
 from pymobiledevice3.dtx_service_provider import DtxServiceProvider
 from pymobiledevice3.exceptions import ConnectionTerminatedError, DvtException, ExtractingStackshotError
@@ -576,7 +576,7 @@ kcdata_item = Struct(
 kcdata = GreedyRange(kcdata_item)
 
 
-def clean(d):
+def clean(d: typing.Any) -> typing.Any:
     if isinstance(d, dict):
         return {k: clean(v) for k, v in d.items() if not k.startswith("_")}
     elif isinstance(d, list):
@@ -586,7 +586,7 @@ def clean(d):
 
 
 def jsonify_parsed_stackshot(
-    stackshot, root: typing.Optional[dict[str, typing.Any]] = None, index: int = 0
+    stackshot: typing.Any, root: typing.Optional[dict[str, typing.Any]] = None, index: int = 0
 ) -> typing.Optional[int]:
     assert root is not None
     current_index = index
@@ -630,10 +630,10 @@ class KdBufStream:
     def tell(self):
         return self.current_chunk.tell()
 
-    def seek(self, offset, whence):
+    def seek(self, offset: int, whence: int):
         return self.current_chunk.seek(offset, whence)
 
-    def read(self, size):
+    def read(self, size: int):
         while size > len(self.current_chunk.getbuffer()) - self.current_chunk.tell():
             data = self.chunk_queue.get()
             if isinstance(data, Exception):
@@ -653,7 +653,7 @@ class KdBufStream:
 class CoreProfileSessionTapService(DTXService):
     IDENTIFIER = "com.apple.instruments.server.services.coreprofilesessiontap"
 
-    def __init__(self, ctx):
+    def __init__(self, ctx: DTXContext):
         super().__init__(ctx)
         self.messages: DTXQueue[bytes] = DTXQueue()
 
@@ -772,7 +772,7 @@ class CoreProfileSessionTap:
         await service.messages.get()
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type: typing.Any, exc_val: typing.Any, exc_tb: typing.Any):
         await (await self._service_ref()).stop()
 
     @staticmethod
@@ -896,7 +896,7 @@ class CoreProfileSessionTap:
         return KdBufStream(chunk_queue)
 
     @staticmethod
-    def parse_stackshot(data):
+    def parse_stackshot(data: bytes):
         """
         Parse raw KCDATA stackshot bytes into a nested dictionary.
 

--- a/pymobiledevice3/services/dvt/instruments/dvt_provider.py
+++ b/pymobiledevice3/services/dvt/instruments/dvt_provider.py
@@ -1,4 +1,8 @@
+from typing import Optional
+
+from pymobiledevice3.dtx import DTXConnection
 from pymobiledevice3.dtx_service_provider import DtxServiceProvider
+from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 
 
 class DvtProvider(DtxServiceProvider):
@@ -30,7 +34,12 @@ class DvtProvider(DtxServiceProvider):
     RSD_SERVICE_NAME = "com.apple.instruments.dtservicehub"
     OLD_SERVICE_NAME = "com.apple.instruments.remoteserver"
 
-    def __init__(self, lockdown, strip_ssl=None, dtx=None):
+    def __init__(
+        self,
+        lockdown: LockdownServiceProvider,
+        strip_ssl: Optional[bool] = None,
+        dtx: Optional[DTXConnection] = None,
+    ) -> None:
         """
         :param lockdown: Lockdown or RSD service provider used to reach the DVT service.
         :param strip_ssl: Override the SSL-stripping behaviour. ``None`` (default) lets

--- a/pymobiledevice3/services/dvt/instruments/energy_monitor.py
+++ b/pymobiledevice3/services/dvt/instruments/energy_monitor.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from pymobiledevice3.dtx import DTXService, dtx_method
 from pymobiledevice3.dtx_service import DtxService
+from pymobiledevice3.dtx_service_provider import DtxServiceProvider
 
 
 class EnergyMonitorService(DTXService):
@@ -27,7 +28,7 @@ class EnergyMonitor(DtxService[EnergyMonitorService]):
     async-iterable, yielding one energy-attribute sample for the monitored PIDs per iteration.
     """
 
-    def __init__(self, dvt, pid_list: list[int]) -> None:
+    def __init__(self, dvt: DtxServiceProvider, pid_list: list[int]) -> None:
         """
         :param dvt: The `DvtProvider` used to open the Instruments channel.
         :param pid_list: The process IDs to sample energy usage for.
@@ -43,7 +44,7 @@ class EnergyMonitor(DtxService[EnergyMonitorService]):
         await self.service.start_sampling_for_pids_(self._pid_list)
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any):
         await self.service.stop_sampling_for_pids_(self._pid_list)
 
     async def __aiter__(self) -> AsyncGenerator[Any, None]:

--- a/pymobiledevice3/services/dvt/instruments/graphics.py
+++ b/pymobiledevice3/services/dvt/instruments/graphics.py
@@ -1,14 +1,14 @@
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from pymobiledevice3.dtx import DTXQueue, DTXService, dtx_method, dtx_on_dispatch, dtx_on_notification
+from pymobiledevice3.dtx import DTXContext, DTXQueue, DTXService, dtx_method, dtx_on_dispatch, dtx_on_notification
 from pymobiledevice3.dtx_service import DtxService
 
 
 class GraphicsService(DTXService):
     IDENTIFIER = "com.apple.instruments.server.services.graphics.opengl"
 
-    def __init__(self, ctx):
+    def __init__(self, ctx: DTXContext):
         super().__init__(ctx)
         self.events: DTXQueue[Any] = DTXQueue()
 
@@ -45,7 +45,7 @@ class Graphics(DtxService[GraphicsService]):
         await self.service.start_sampling_at_time_interval_(0.0)
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any):
         await self.service.stop_sampling()
 
     async def __aiter__(self) -> AsyncGenerator[Any, None]:

--- a/pymobiledevice3/services/dvt/instruments/location_simulation.py
+++ b/pymobiledevice3/services/dvt/instruments/location_simulation.py
@@ -1,5 +1,6 @@
 from pymobiledevice3.dtx import DTXService, dtx_method
 from pymobiledevice3.dtx_service import DtxService
+from pymobiledevice3.dtx_service_provider import DtxServiceProvider
 from pymobiledevice3.services.dvt.instruments.location_simulation_base import LocationSimulationBase
 
 
@@ -22,7 +23,7 @@ class LocationSimulation(DtxService[LocationSimulationService], LocationSimulati
     and used as an async context manager to open the channel.
     """
 
-    def __init__(self, dvt):
+    def __init__(self, dvt: DtxServiceProvider):
         DtxService.__init__(self, dvt)
         LocationSimulationBase.__init__(self)
 

--- a/pymobiledevice3/services/dvt/instruments/network_monitor.py
+++ b/pymobiledevice3/services/dvt/instruments/network_monitor.py
@@ -7,8 +7,9 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from construct import Adapter, Bytes, Int8ul, Int16ub, Int32ul, Switch, this
 from construct_typed import DataclassMixin, TStruct, csfield
 
-from pymobiledevice3.dtx import DTXQueue, DTXService, dtx_method, dtx_on_dispatch, dtx_on_notification
+from pymobiledevice3.dtx import DTXContext, DTXQueue, DTXService, dtx_method, dtx_on_dispatch, dtx_on_notification
 from pymobiledevice3.dtx_service import DtxService
+from pymobiledevice3.dtx_service_provider import DtxServiceProvider
 
 if TYPE_CHECKING:
     # ``construct.Adapter`` is generic in its type stubs but not subscriptable at runtime.
@@ -20,7 +21,7 @@ else:
 class IpAddressAdapter(_IpAddressAdapterBase):
     """Decode raw address bytes into ipaddress objects."""
 
-    def _decode(self, obj, context, path):
+    def _decode(self, obj: bytes, context: Any, path: str):
         return ipaddress.ip_address(obj)
 
 
@@ -111,7 +112,7 @@ NetworkMonitorEvent = Union[InterfaceDetectionEvent, ConnectionDetectionEvent, C
 class NetworkMonitorService(DTXService):
     IDENTIFIER = "com.apple.instruments.server.services.networking"
 
-    def __init__(self, ctx) -> None:
+    def __init__(self, ctx: DTXContext) -> None:
         super().__init__(ctx)
         self.events: DTXQueue[Any] = DTXQueue()
 
@@ -144,7 +145,7 @@ class NetworkMonitor(DtxService[NetworkMonitorService]):
     instances as they arrive.
     """
 
-    def __init__(self, dvt):
+    def __init__(self, dvt: DtxServiceProvider):
         super().__init__(dvt)
         self.logger = logging.getLogger(__name__)
 
@@ -153,7 +154,7 @@ class NetworkMonitor(DtxService[NetworkMonitorService]):
         await self.service.start_monitoring()
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         await self.service.stop_monitoring()
 
     async def __aiter__(self) -> AsyncIterator[Optional[NetworkMonitorEvent]]:

--- a/pymobiledevice3/services/dvt/instruments/notifications.py
+++ b/pymobiledevice3/services/dvt/instruments/notifications.py
@@ -1,14 +1,14 @@
 import typing
 from typing import Any
 
-from pymobiledevice3.dtx import DTXQueue, DTXService, dtx_method, dtx_on_dispatch, dtx_on_notification
+from pymobiledevice3.dtx import DTXContext, DTXQueue, DTXService, dtx_method, dtx_on_dispatch, dtx_on_notification
 from pymobiledevice3.dtx_service import DtxService
 
 
 class NotificationsService(DTXService):
     IDENTIFIER = "com.apple.instruments.server.services.mobilenotifications"
 
-    def __init__(self, ctx):
+    def __init__(self, ctx: DTXContext):
         super().__init__(ctx)
         self.events: DTXQueue[Any] = DTXQueue()
 
@@ -49,7 +49,7 @@ class Notifications(DtxService[NotificationsService]):
         await self.service.set_memory_notifications_enabled_(True)
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any):
         await self.service.set_application_state_notifications_enabled_(False)
         await self.service.set_memory_notifications_enabled_(False)
 

--- a/pymobiledevice3/services/dvt/instruments/process_control.py
+++ b/pymobiledevice3/services/dvt/instruments/process_control.py
@@ -4,7 +4,7 @@ import typing
 from datetime import datetime
 from typing import Any, Optional
 
-from pymobiledevice3.dtx import DTXQueue, DTXService, PInt32, dtx_method, dtx_on_invoke
+from pymobiledevice3.dtx import DTXContext, DTXQueue, DTXService, PInt32, dtx_method, dtx_on_invoke
 from pymobiledevice3.dtx_service import DtxService
 from pymobiledevice3.exceptions import DisableMemoryLimitError
 from pymobiledevice3.osu.os_utils import get_os_utils
@@ -42,7 +42,7 @@ class OutputReceivedEvent:
 class ProcessControlService(DTXService):
     IDENTIFIER = "com.apple.instruments.server.services.processcontrol"
 
-    def __init__(self, ctx):
+    def __init__(self, ctx: DTXContext):
         super().__init__(ctx)
         self.output_events: DTXQueue[list[Any]] = DTXQueue()
 
@@ -151,7 +151,7 @@ class ProcessControl(DtxService[ProcessControlService]):
     async def launch(
         self,
         bundle_id: str,
-        arguments=None,
+        arguments: Optional[list[str]] = None,
         kill_existing: bool = True,
         start_suspended: bool = False,
         environment: Optional[dict[str, Any]] = None,

--- a/pymobiledevice3/services/dvt/instruments/sysmontap.py
+++ b/pymobiledevice3/services/dvt/instruments/sysmontap.py
@@ -1,5 +1,6 @@
 import dataclasses
 
+from pymobiledevice3.dtx_service_provider import DtxServiceProvider
 from pymobiledevice3.services.dvt.instruments.device_info import DeviceInfo
 from pymobiledevice3.services.dvt.instruments.tap import Tap
 
@@ -21,7 +22,7 @@ class Sysmontap(Tap):
 
     def __init__(
         self,
-        dvt,
+        dvt: DtxServiceProvider,
         process_attributes: list[str],
         system_attributes: list[str],
         interval_ms: int = DEFAULT_INTERVAL_MS,
@@ -48,7 +49,7 @@ class Sysmontap(Tap):
         super().__init__(dvt, self.IDENTIFIER, config)
 
     @classmethod
-    async def create(cls, dvt, interval: int = DEFAULT_INTERVAL_MS) -> "Sysmontap":
+    async def create(cls, dvt: DtxServiceProvider, interval: int = DEFAULT_INTERVAL_MS) -> "Sysmontap":
         """
         Build a `Sysmontap` with the device's full set of supported attributes.
 

--- a/pymobiledevice3/services/dvt/instruments/tap.py
+++ b/pymobiledevice3/services/dvt/instruments/tap.py
@@ -5,14 +5,14 @@ from typing import Any, Optional
 
 from bpylist2 import archiver
 
-from pymobiledevice3.dtx import DTXQueue, DTXService, dtx_method, dtx_on_data, dtx_on_notification
+from pymobiledevice3.dtx import DTXContext, DTXQueue, DTXService, dtx_method, dtx_on_data, dtx_on_notification
 from pymobiledevice3.dtx_service import DtxService
 from pymobiledevice3.dtx_service_provider import DtxServiceProvider
 from pymobiledevice3.exceptions import NotConnectedError
 
 
 class TapService(DTXService):
-    def __init__(self, ctx):
+    def __init__(self, ctx: DTXContext):
         super().__init__(ctx)
         self.messages: DTXQueue[tuple[str, Any]] = DTXQueue()
 
@@ -120,7 +120,7 @@ class Tap:
         await self._message_channel.receive_plist()
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any):
         await (await self._service_ref()).stop()
 
     async def __aiter__(self) -> AsyncGenerator[Any, None]:

--- a/pymobiledevice3/services/file_relay.py
+++ b/pymobiledevice3/services/file_relay.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.services.lockdown_service import LockdownService
 
@@ -47,7 +49,7 @@ class FileRelayService(LockdownService):
         self.logger.info("Disconecting...")
         await self.service.close()
 
-    async def request_sources(self, sources=None):
+    async def request_sources(self, sources: Optional[list[str]] = None):
         """
         Request one or more data sources and return the combined archive.
 

--- a/pymobiledevice3/services/installation_proxy.py
+++ b/pymobiledevice3/services/installation_proxy.py
@@ -83,7 +83,7 @@ class InstallationProxyService(LockdownService):
         else:
             super().__init__(lockdown, self.RSD_SERVICE_NAME)
 
-    async def _watch_completion(self, handler: Optional[Callable[..., Any]] = None, *args) -> None:
+    async def _watch_completion(self, handler: Optional[Callable[..., Any]] = None, *args: Any) -> None:
         while True:
             response = await self.service.recv_plist()
             if not response:
@@ -108,7 +108,7 @@ class InstallationProxyService(LockdownService):
         cmd: str = "Archive",
         options: Optional[dict[str, Any]] = None,
         handler: Optional[Callable[..., Any]] = None,
-        *args,
+        *args: Any,
     ) -> None:
         """
         Send a command that targets an installed app by its bundle identifier and wait for completion.
@@ -140,7 +140,7 @@ class InstallationProxyService(LockdownService):
         ipa_path: str,
         options: Optional[dict[str, Any]] = None,
         handler: Optional[Callable[..., Any]] = None,
-        *args,
+        *args: Any,
     ) -> None:
         """
         Upgrade an installed app from a local package.
@@ -162,7 +162,7 @@ class InstallationProxyService(LockdownService):
         bundle_identifier: str,
         options: Optional[dict[str, Any]] = None,
         handler: Optional[Callable[..., Any]] = None,
-        *args,
+        *args: Any,
     ) -> None:
         """
         Restore a previously archived app, identified by its bundle identifier.
@@ -184,7 +184,7 @@ class InstallationProxyService(LockdownService):
         bundle_identifier: str,
         options: Optional[dict[str, Any]] = None,
         handler: Optional[Callable[..., Any]] = None,
-        *args,
+        *args: Any,
     ) -> None:
         """
         Uninstall an app, identified by its bundle identifier.
@@ -207,7 +207,7 @@ class InstallationProxyService(LockdownService):
         cmd: str = "Install",
         options: Optional[dict[str, Any]] = None,
         handler: Optional[Callable[..., Any]] = None,
-        *args,
+        *args: Any,
     ) -> None:
         """
         Install an app or carrier bundle from a zipped package held in memory.
@@ -258,7 +258,7 @@ class InstallationProxyService(LockdownService):
         options: Optional[dict[str, Any]] = None,
         handler: Optional[Callable[..., Any]] = None,
         developer: bool = False,
-        *args,
+        *args: Any,
     ) -> None:
         """
         Install an app or carrier bundle from a local path.
@@ -321,7 +321,7 @@ class InstallationProxyService(LockdownService):
         options: Optional[dict[str, Any]],
         handler: Optional[Callable[..., Any]],
         package_path: str,
-        *args,
+        *args: Any,
     ):
         """
         Send an install/upgrade command for a package already staged on the device, and wait for completion.

--- a/pymobiledevice3/services/lockdown_service.py
+++ b/pymobiledevice3/services/lockdown_service.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
 from inspect import isawaitable
-from typing import Optional, Union
+from types import TracebackType
+from typing import Any, Optional, Union
 
 from typing_extensions import Self
 
@@ -20,7 +21,7 @@ class _LazyServiceConnection:
         return self._owner._service
 
     def __getattr__(self, name: str):
-        async def _call(*args, **kwargs):
+        async def _call(*args: Any, **kwargs: Any):
             conn = await self._get_conn()
             attr = getattr(conn, name)
             result = attr(*args, **kwargs)
@@ -95,7 +96,12 @@ class LockdownService:
         await self.connect()
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ):
         await self.close()
 
     async def close(self) -> None:

--- a/pymobiledevice3/services/mobile_activation.py
+++ b/pymobiledevice3/services/mobile_activation.py
@@ -30,7 +30,7 @@ NONCE_CYCLE_INTERVAL = 60 * 5
 
 
 @asynccontextmanager
-async def _aclosing(resource):
+async def _aclosing(resource: Any):
     try:
         yield resource
     finally:
@@ -262,7 +262,7 @@ class MobileActivationService:
             raise MobileActivationException(f"Mobile activation can not be done due to: {response}")
         return response["Value"]
 
-    async def create_activation_info_with_session(self, handshake_response):
+    async def create_activation_info_with_session(self, handshake_response: Any):
         """
         Build the device's activation info from a completed DRM handshake.
 
@@ -279,7 +279,7 @@ class MobileActivationService:
             raise MobileActivationException(f"Mobile activation can not be done due to: {response}")
         return response["Value"]
 
-    async def activate_with_lockdown(self, activation_record):
+    async def activate_with_lockdown(self, activation_record: bytes):
         """
         Apply an activation record to the device using the legacy lockdown flow.
 
@@ -300,7 +300,7 @@ class MobileActivationService:
         assert isinstance(self.lockdown, LockdownClient)
         await self.lockdown._request("Activate", {"ActivationRecord": node.get("activation-record")})
 
-    async def activate_with_session(self, activation_record, headers):
+    async def activate_with_session(self, activation_record: Any, headers: CaseInsensitiveDict[str]):
         """
         Apply an activation record to the device using the session-based flow.
 

--- a/pymobiledevice3/services/mobilebackup2.py
+++ b/pymobiledevice3/services/mobilebackup2.py
@@ -202,7 +202,7 @@ class Mobilebackup2Service(LockdownService):
         self,
         full: bool = True,
         backup_directory: Union[str, Path] = ".",
-        progress_callback=lambda x: None,
+        progress_callback: Callable[..., Any] = lambda x: None,
         filter_callback: Optional[BackupFilterCallback] = None,
         password: str = "",
         unback: bool = False,
@@ -321,7 +321,7 @@ class Mobilebackup2Service(LockdownService):
 
     async def restore(
         self,
-        backup_directory=".",
+        backup_directory: Union[str, Path] = ".",
         system: bool = False,
         reboot: bool = True,
         copy: bool = True,
@@ -329,7 +329,7 @@ class Mobilebackup2Service(LockdownService):
         remove: bool = False,
         password: str = "",
         source: str = "",
-        progress_callback=lambda x: None,
+        progress_callback: Callable[..., Any] = lambda x: None,
         skip_apps: bool = False,
     ):
         """
@@ -395,7 +395,7 @@ class Mobilebackup2Service(LockdownService):
 
             await dl.dl_loop(progress_callback)
 
-    async def info(self, backup_directory=".", source: str = "") -> str:
+    async def info(self, backup_directory: Union[str, Path] = ".", source: str = "") -> str:
         """
         Get information about a backup.
 
@@ -414,7 +414,7 @@ class Mobilebackup2Service(LockdownService):
             result = await dl.dl_loop()
         return result
 
-    async def list(self, backup_directory=".", source: str = "") -> str:
+    async def list(self, backup_directory: Union[str, Path] = ".", source: str = "") -> str:
         """
         List the files in the last backup.
 
@@ -434,7 +434,7 @@ class Mobilebackup2Service(LockdownService):
             result = await dl.dl_loop()
         return result
 
-    async def unback(self, backup_directory=".", password: str = "", source: str = "") -> None:
+    async def unback(self, backup_directory: Union[str, Path] = ".", password: str = "", source: str = "") -> None:
         """
         Unpack a complete backup into its original device file hierarchy.
 
@@ -474,7 +474,12 @@ class Mobilebackup2Service(LockdownService):
         return output_directory
 
     async def extract(
-        self, domain_name: str, relative_path: str, backup_directory=".", password: str = "", source: str = ""
+        self,
+        domain_name: str,
+        relative_path: str,
+        backup_directory: Union[str, Path] = ".",
+        password: str = "",
+        source: str = "",
     ) -> None:
         """
         Extract a single file from a previous backup.
@@ -502,7 +507,7 @@ class Mobilebackup2Service(LockdownService):
             await dl.send_process_message(message)
             await dl.dl_loop()
 
-    async def change_password(self, backup_directory=".", old: str = "", new: str = "") -> None:
+    async def change_password(self, backup_directory: Union[str, Path] = ".", old: str = "", new: str = "") -> None:
         """
         Change, enable, or disable the device's backup encryption password.
 
@@ -519,7 +524,7 @@ class Mobilebackup2Service(LockdownService):
             await dl.send_process_message(message)
             await dl.dl_loop()
 
-    async def erase_device(self, backup_directory=".") -> None:
+    async def erase_device(self, backup_directory: Union[str, Path] = ".") -> None:
         """
         Erase the device, restoring it to factory state.
 
@@ -530,7 +535,7 @@ class Mobilebackup2Service(LockdownService):
                 await dl.send_process_message({"MessageName": "EraseDevice", "TargetIdentifier": self.lockdown.udid})
                 await dl.dl_loop()
 
-    async def version_exchange(self, dl: DeviceLink, local_versions=None) -> None:
+    async def version_exchange(self, dl: DeviceLink, local_versions: Optional[Sequence[float]] = None) -> None:
         """
         Exchange protocol versions with the device and assert it supports one of ours.
 
@@ -630,7 +635,7 @@ class Mobilebackup2Service(LockdownService):
             return ret
 
     @asynccontextmanager
-    async def _backup_lock(self, afc, notification_proxy):
+    async def _backup_lock(self, afc: AfcService, notification_proxy: NotificationProxyService):
         await notification_proxy.notify_post(NP_SYNC_WILL_START)
         lockfile = await afc.fopen("/com.apple.itunes.lock_sync", "r+")
         if lockfile:
@@ -923,7 +928,7 @@ class Mobilebackup2Service(LockdownService):
 
     @asynccontextmanager
     async def device_link(
-        self, backup_directory, filter_callback: Optional[BackupFilterCallback] = None, password: str = ""
+        self, backup_directory: Path, filter_callback: Optional[BackupFilterCallback] = None, password: str = ""
     ):
         """
         Async context manager yielding a connected `DeviceLink` for backup operations.

--- a/pymobiledevice3/services/notification_proxy.py
+++ b/pymobiledevice3/services/notification_proxy.py
@@ -26,7 +26,9 @@ class NotificationProxyService(LockdownService):
     INSECURE_SERVICE_NAME = "com.apple.mobile.insecure_notification_proxy"
     RSD_INSECURE_SERVICE_NAME = "com.apple.mobile.insecure_notification_proxy.shim.remote"
 
-    def __init__(self, lockdown: LockdownServiceProvider, insecure=False, timeout: Optional[Union[float, int]] = None):
+    def __init__(
+        self, lockdown: LockdownServiceProvider, insecure: bool = False, timeout: Optional[Union[float, int]] = None
+    ):
         """
         :param lockdown: service provider used to start the service and reach the device.
         :param insecure: when True, use the insecure notification proxy service instead of the secure one.

--- a/pymobiledevice3/services/pcapd.py
+++ b/pymobiledevice3/services/pcapd.py
@@ -2,8 +2,8 @@
 
 import enum
 import time
-from collections.abc import AsyncGenerator
-from typing import Any, Optional, cast
+from collections.abc import AsyncGenerator, AsyncIterator
+from typing import Any, BinaryIO, Optional, cast
 
 import pcapng.blocks as blocks
 from construct import Byte, Bytes, Container, CString, Int16ub, Int32ub, Int32ul, Padded, Seek, Struct, this
@@ -393,7 +393,7 @@ class PcapdService(LockdownService):
 
             packet_index += 1
 
-    async def write_to_pcap(self, out, packet_generator) -> None:
+    async def write_to_pcap(self, out: BinaryIO, packet_generator: AsyncIterator[Container[Any]]) -> None:
         """
         Write captured packets to a pcapng stream.
 

--- a/pymobiledevice3/services/preboard.py
+++ b/pymobiledevice3/services/preboard.py
@@ -24,7 +24,7 @@ class PreboardService(LockdownService):
         else:
             super().__init__(lockdown, self.RSD_SERVICE_NAME)
 
-    async def create_stashbag(self, manifest):
+    async def create_stashbag(self, manifest: bytes):
         """
         Create a stashbag on the device.
 
@@ -35,7 +35,7 @@ class PreboardService(LockdownService):
         """
         return await self.service.send_recv_plist({"Command": "CreateStashbag", "Manifest": manifest})
 
-    async def commit(self, manifest):
+    async def commit(self, manifest: bytes):
         """
         Commit a previously created stashbag on the device.
 

--- a/pymobiledevice3/services/wda.py
+++ b/pymobiledevice3/services/wda.py
@@ -384,7 +384,7 @@ class WdaServiceClient:
 
         return data
 
-    async def _read_until(self, conn, marker: bytes) -> tuple[bytes, bytes]:
+    async def _read_until(self, conn: ServiceConnection, marker: bytes) -> tuple[bytes, bytes]:
         """Read from a connection until a marker is found."""
         buf = b""
         while marker not in buf:

--- a/pymobiledevice3/services/wda.py
+++ b/pymobiledevice3/services/wda.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 """Minimal WebDriverAgent (WDA) client.
 
 This module provides:

--- a/pymobiledevice3/services/wda.py
+++ b/pymobiledevice3/services/wda.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 """Minimal WebDriverAgent (WDA) client.
 
 This module provides:

--- a/pymobiledevice3/services/web_protocol/alert.py
+++ b/pymobiledevice3/services/web_protocol/alert.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/pymobiledevice3/services/web_protocol/alert.py
+++ b/pymobiledevice3/services/web_protocol/alert.py
@@ -1,5 +1,12 @@
+# pyright: reportMissingParameterType=error
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pymobiledevice3.services.web_protocol.automation_session import AutomationSession
+
+
 class Alert:
-    def __init__(self, session):
+    def __init__(self, session: "AutomationSession"):
         """
         :param pymobiledevice3.services.web_protocol.automation_session.AutomationSession session: Automation session.
         """

--- a/pymobiledevice3/services/web_protocol/automation_session.py
+++ b/pymobiledevice3/services/web_protocol/automation_session.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 import importlib.resources
 import json
 from collections.abc import Iterable

--- a/pymobiledevice3/services/web_protocol/automation_session.py
+++ b/pymobiledevice3/services/web_protocol/automation_session.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 import importlib.resources
 import json
 from collections.abc import Iterable

--- a/pymobiledevice3/services/web_protocol/automation_session.py
+++ b/pymobiledevice3/services/web_protocol/automation_session.py
@@ -1,9 +1,14 @@
 import importlib.resources
 import json
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import pymobiledevice3.resources
+
+if TYPE_CHECKING:
+    from pymobiledevice3.services.web_protocol.element import WebElement
 
 RESOURCES = importlib.resources.files(pymobiledevice3.resources) / "webinspector"
 FIND_NODES = (RESOURCES / "find_nodes.js").read_text()
@@ -153,7 +158,7 @@ class Rect:
 
 
 class AutomationSession:
-    def __init__(self, protocol):
+    def __init__(self, protocol: Any):
         """
         :param pymobiledevice3.services.web_protocol.session_protocol.SessionProtocol protocol: Session protocol.
         """
@@ -179,7 +184,7 @@ class AutomationSession:
         for handle in await self.get_window_handles():
             await self.protocol.closeBrowsingContext(handle=handle)
 
-    async def create_window(self, type_):
+    async def create_window(self, type_: str):
         type_ = type_.capitalize()
         params = {"presentationHint": type_} if type_ else {}
         return (await self.protocol.createBrowsingContext(**params))["handle"]
@@ -203,7 +208,13 @@ class AutomationSession:
         contexts = await self.protocol.getBrowsingContexts()
         return [c["handle"] for c in contexts["contexts"]]
 
-    async def set_window_frame(self, x=None, y=None, width=None, height=None):
+    async def set_window_frame(
+        self,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+    ):
         params = {}
         if x is not None and y is not None:
             params["origin"] = {"x": x, "y": y}
@@ -211,19 +222,19 @@ class AutomationSession:
             params["size"] = {"width": width, "height": height}
         await self.protocol.setWindowFrameOfBrowsingContext(handle=self.top_level_handle, **params)
 
-    async def add_single_cookie(self, cookie):
+    async def add_single_cookie(self, cookie: dict[str, Any]):
         await self.protocol.addSingleCookie(browsingContextHandle=self.top_level_handle, cookie=cookie)
 
     async def delete_all_cookies(self):
         await self.protocol.deleteAllCookies(browsingContextHandle=self.top_level_handle)
 
-    async def delete_single_cookie(self, name):
+    async def delete_single_cookie(self, name: str):
         await self.protocol.deleteSingleCookie(browsingContextHandle=self.top_level_handle, cookieName=name)
 
     async def get_all_cookies(self):
         return (await self.protocol.getAllCookies(browsingContextHandle=self.top_level_handle))["cookies"]
 
-    async def execute_script(self, script, args, async_=False):
+    async def execute_script(self, script: str, args: Iterable[Any], async_: bool = False):
         parameters = {
             "browsingContextHandle": self.top_level_handle,
             "function": "function(){\n" + script + "\n}",
@@ -241,7 +252,9 @@ class AutomationSession:
         else:
             return json.loads(result["result"])
 
-    async def evaluate_js_function(self, function, *args, implicit_callback=False, include_frame=True):
+    async def evaluate_js_function(
+        self, function: str, *args: Any, implicit_callback: bool = False, include_frame: bool = True
+    ):
         params = {
             "browsingContextHandle": self.top_level_handle,
             "function": function,
@@ -254,7 +267,9 @@ class AutomationSession:
         result = await self.protocol.evaluateJavaScriptFunction(**params)
         return json.loads(result["result"])
 
-    async def find_elements(self, by, value, single: bool = True, root=None):
+    async def find_elements(
+        self, by: Union[By, str], value: Optional[str], single: bool = True, root: Optional[str] = None
+    ):
         await self.wait_for_navigation_to_complete()
         by = by.value if isinstance(by, By) else by
         if by == By.ID.value:
@@ -282,7 +297,7 @@ class AutomationSession:
         result = json.loads((await self.protocol.evaluateJavaScriptFunction(**parameters))["result"])
         return result
 
-    async def screenshot_as_base64(self, scroll=False, node_id="", clip=True):
+    async def screenshot_as_base64(self, scroll: bool = False, node_id: str = "", clip: bool = True):
         params = {"handle": self.top_level_handle, "clipToViewport": clip}
         if self.current_handle:
             params["frameHandle"] = self.current_handle
@@ -292,12 +307,12 @@ class AutomationSession:
             params["nodeHandle"] = node_id
         return (await self.protocol.takeScreenshot(**params))["data"]
 
-    async def switch_to_top_level_browsing_context(self, top_level_handle):
+    async def switch_to_top_level_browsing_context(self, top_level_handle: str):
         self.top_level_handle = top_level_handle
         self.current_handle = ""
         self.current_parent_handle = ""
 
-    async def switch_to_browsing_context(self, handle):
+    async def switch_to_browsing_context(self, handle: Optional[str]):
         self.current_handle = handle
         if not self.current_handle:
             self.current_parent_handle = ""
@@ -308,10 +323,10 @@ class AutomationSession:
         )
         self.current_parent_handle = resp["result"]
 
-    async def switch_to_browsing_context_frame(self, context, frame):
+    async def switch_to_browsing_context_frame(self, context: str, frame: str):
         await self.protocol.switchToBrowsingContext(browsingContextHandle=context, frameHandle=frame)
 
-    async def navigate_broswing_context(self, url):
+    async def navigate_broswing_context(self, url: str):
         await self.protocol.navigateBrowsingContext(
             handle=self.top_level_handle, pageLoadTimeout=self.page_load_timeout, url=url
         )
@@ -329,7 +344,7 @@ class AutomationSession:
     async def reload_browsing_context(self):
         await self.protocol.reloadBrowsingContext(handle=self.top_level_handle, pageLoadTimeout=self.page_load_timeout)
 
-    async def switch_to_frame(self, frame_ordinal=None, frame_handle=None):
+    async def switch_to_frame(self, frame_ordinal: Any = None, frame_handle: Optional["WebElement"] = None):
         params = {"browsingContextHandle": self.top_level_handle}
         if self.current_handle:
             params["frameHandle"] = self.current_handle
@@ -341,17 +356,19 @@ class AutomationSession:
         await self.switch_to_browsing_context_frame(self.top_level_handle, resp)
         await self.switch_to_browsing_context(resp)
 
-    async def switch_to_window(self, handle):
+    async def switch_to_window(self, handle: str):
         await self.switch_to_browsing_context_frame(handle, "")
         await self.switch_to_top_level_browsing_context(handle)
 
-    async def perform_keyboard_interactions(self, interactions):
+    async def perform_keyboard_interactions(self, interactions: list[dict[str, Any]]):
         for interaction in interactions:
             type_ = interaction["type"]
             interaction["type"] = type_.value if isinstance(type_, KeyboardInteractionType) else type_
         await self.protocol.performKeyboardInteractions(handle=self.top_level_handle, interactions=interactions)
 
-    async def perform_mouse_interaction(self, x, y, button: MouseButton, interaction: MouseInteraction, modifiers=None):
+    async def perform_mouse_interaction(
+        self, x: int, y: int, button: MouseButton, interaction: MouseInteraction, modifiers: Optional[list[Any]] = None
+    ):
         modifiers = [] if modifiers is None else modifiers
         await self.protocol.performMouseInteraction(
             handle=self.top_level_handle,
@@ -361,7 +378,7 @@ class AutomationSession:
             modifiers=modifiers,
         )
 
-    async def perform_interaction_sequence(self, sources, steps):
+    async def perform_interaction_sequence(self, sources: list[dict[str, Any]], steps: list[dict[str, Any]]):
         params = {
             "handle": self.top_level_handle,
             "inputSources": sources,
@@ -383,7 +400,7 @@ class AutomationSession:
     async def dismiss_current_javascript_dialog(self):
         await self.protocol.dismissCurrentJavaScriptDialog(browsingContextHandle=self.top_level_handle)
 
-    async def set_user_input_for_current_javascript_prompt(self, user_input):
+    async def set_user_input_for_current_javascript_prompt(self, user_input: str):
         await self.protocol.setUserInputForCurrentJavaScriptPrompt(
             browsingContextHandle=self.top_level_handle, userInput=user_input
         )
@@ -393,7 +410,7 @@ class AutomationSession:
             "message"
         ]
 
-    async def compute_element_layout(self, node_id, scroll_if_needed, coordinate_system):
+    async def compute_element_layout(self, node_id: str, scroll_if_needed: bool, coordinate_system: str):
         return await self.protocol.computeElementLayout(
             browsingContextHandle=self.top_level_handle,
             nodeHandle=node_id,
@@ -402,7 +419,7 @@ class AutomationSession:
             frameHandle="" if self.current_handle is None else self.current_handle,
         )
 
-    async def select_option_element(self, node_id):
+    async def select_option_element(self, node_id: str):
         await self.protocol.selectOptionElement(
             browsingContextHandle=self.top_level_handle,
             nodeHandle=node_id,

--- a/pymobiledevice3/services/web_protocol/cdp_screencast.py
+++ b/pymobiledevice3/services/web_protocol/cdp_screencast.py
@@ -3,13 +3,13 @@ import contextlib
 from base64 import b64decode, b64encode
 from datetime import datetime
 from io import BytesIO
-from typing import Optional
+from typing import Any, Optional
 
 from PIL import Image
 
 
 class ScreenCast:
-    def __init__(self, target, format_: str, quality: int, max_width: int, max_height: int):
+    def __init__(self, target: Any, format_: str, quality: int, max_width: int, max_height: int):
         """
         :param pymobiledevice3.services.web_protocol.cdp_target.CdpTarget target:
         :param format_: Image compression format. Allowed values: jpeg, png.
@@ -102,7 +102,7 @@ class ScreenCast:
             return 0, 0, 0
         return tuple(map(int, frame_size.split(",")))
 
-    async def recording_loop(self, message_id):
+    async def recording_loop(self, message_id: int):
         """
         Fetch screenshots and send to devtools.
         :param message_id: Message id to use when requesting WIR data concerning the screencast.

--- a/pymobiledevice3/services/web_protocol/cdp_screencast.py
+++ b/pymobiledevice3/services/web_protocol/cdp_screencast.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 import asyncio
 import contextlib
 from base64 import b64decode, b64encode

--- a/pymobiledevice3/services/web_protocol/cdp_screencast.py
+++ b/pymobiledevice3/services/web_protocol/cdp_screencast.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 import asyncio
 import contextlib
 from base64 import b64decode, b64encode

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 import asyncio
 import uuid
 from contextlib import asynccontextmanager

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -51,13 +51,13 @@ def version():
     }
 
 
-async def from_cdp(target: CdpTarget, websocket):
+async def from_cdp(target: CdpTarget, websocket: WebSocket):
     async for message in websocket.iter_json():
         logger.debug(f"CDP INPUT:  {message}")
         await target.send(message)
 
 
-async def to_cdp(target: CdpTarget, websocket):
+async def to_cdp(target: CdpTarget, websocket: WebSocket):
     while True:
         message = await target.receive()
         logger.debug(f"CDP OUTPUT:  {message}")

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 import asyncio
 import uuid
 from contextlib import asynccontextmanager

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -1,12 +1,14 @@
+# pyright: reportMissingParameterType=error
 import asyncio
 import hashlib
 import json
 import logging
 from datetime import datetime
 from functools import partial
-from typing import Optional
+from typing import Any, Optional
 
 from pymobiledevice3.services.web_protocol.cdp_screencast import ScreenCast
+from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +85,7 @@ DEBUGGER_PAUSED_REASON = {
 
 
 class CdpTarget:
-    def __init__(self, protocol, target_id: str):
+    def __init__(self, protocol: SessionProtocol, target_id: str):
         """
         :param pymobiledevice3.services.web_protocol.session_protocol.SessionProtocol protocol: Session protocol.
         :param target_id: Target id.
@@ -176,7 +178,7 @@ class CdpTarget:
         self._default_execution_id = 0
 
     @classmethod
-    async def create(cls, protocol):
+    async def create(cls, protocol: SessionProtocol) -> "CdpTarget":
         """
         :param pymobiledevice3.services.web_protocol.session_protocol.SessionProtocol protocol: Session protocol.
         """
@@ -192,7 +194,7 @@ class CdpTarget:
         await target.output_queue.put(created)
         return target
 
-    async def send(self, message):
+    async def send(self, message: dict[str, Any]):
         """
         Send message from devtools to the target.
         """
@@ -221,7 +223,7 @@ class CdpTarget:
                 return message
             await asyncio.sleep(0)
 
-    async def send_message_with_result(self, id_, method, params):
+    async def send_message_with_result(self, id_: int, method: str, params: dict[str, Any]):
         """
         Send a message to the target and wait for response.
         """
@@ -231,7 +233,7 @@ class CdpTarget:
         self._waiting_for_id -= 1
         return result
 
-    async def evaluate_and_result(self, id_, expression):
+    async def evaluate_and_result(self, id_: int, expression: str) -> Any:
         """
         Evaluate Javascript expression.
         """
@@ -266,26 +268,26 @@ class CdpTarget:
             message = self.protocol.inspector.wir_events.pop(0)
             await self._to_output_queue(message)
 
-    async def _to_output_queue(self, message):
+    async def _to_output_queue(self, message: dict[str, Any]):
         if message["method"] in self.to_cdp_special_messages_methods:
             await self.to_cdp_special_messages_methods[message["method"]](message)
         else:
             logger.error("Error!!!!!!!!!!!!", message)
             raise RuntimeError()
 
-    async def _send_message_to_target(self, message):
+    async def _send_message_to_target(self, message: dict[str, Any]):
         await self.protocol.send_command(
             "Target.sendMessageToTarget", targetId=self.target_id, message=json.dumps(message)
         )
 
-    async def _simple_response(self, message, value):
+    async def _simple_response(self, message: dict[str, Any], value: Any):
         await self.output_queue.put({"id": message["id"], "result": {"result": value}})
 
-    async def _audits_enable(self, message):
+    async def _audits_enable(self, message: dict[str, Any]):
         message["method"] = "Audit.setup"
         await self._send_message_to_target(message)
 
-    async def _dom_get_box_model(self, message):
+    async def _dom_get_box_model(self, message: dict[str, Any]):
         message["method"] = "DOM.highlightNode"
         message["params"]["highlightConfig"] = {
             "showInfo": True,
@@ -296,11 +298,11 @@ class CdpTarget:
         }
         await self._send_message_to_target(message)
 
-    async def object_id_to_node_id(self, object_id, id_):
+    async def object_id_to_node_id(self, object_id: str, id_: int):
         node = await self.send_message_with_result(id_, "DOM.requestNode", {"objectId": object_id})
         return node["result"]["nodeId"]
 
-    async def _dom_get_node_for_location(self, message):
+    async def _dom_get_node_for_location(self, message: dict[str, Any]):
         x, y = message["params"]["x"], message["params"]["y"]
         obj = await self.evaluate_and_result(message["id"], f"document.elementFromPoint({x},{y})")
         if obj is None or "objectId" not in obj:
@@ -309,7 +311,7 @@ class CdpTarget:
         result = {"nodeId": await self.object_id_to_node_id(obj["objectId"], message["id"])}
         await self.output_queue.put({"id": message["id"], "result": result})
 
-    async def _dom_get_nodes_for_subtree_by_style(self, message):
+    async def _dom_get_nodes_for_subtree_by_style(self, message: dict[str, Any]):
         object_id = (
             await self.send_message_with_result(
                 message["id"], "DOM.resolveNode", {"nodeId": message["params"]["nodeId"]}
@@ -352,19 +354,19 @@ class CdpTarget:
         nodes = [n for n in nodes if isinstance(n, int)]
         await self.output_queue.put({"id": message["id"], "result": {"nodeIds": nodes}})
 
-    async def _log_clear(self, message):
+    async def _log_clear(self, message: dict[str, Any]):
         message["method"] = "Console.clearMessages"
         await self._send_message_to_target(message)
 
-    async def _log_disable(self, message):
+    async def _log_disable(self, message: dict[str, Any]):
         message["method"] = "Console.disable"
         await self._send_message_to_target(message)
 
-    async def _log_enable(self, message):
+    async def _log_enable(self, message: dict[str, Any]):
         message["method"] = "Console.enable"
         await self._send_message_to_target(message)
 
-    async def _page_get_navigation_history(self, message):
+    async def _page_get_navigation_history(self, message: dict[str, Any]):
         href = await self.evaluate_and_result(message["id"], "window.location.href")
         title = await self.evaluate_and_result(message["id"], "document.title")
         await self.output_queue.put({
@@ -372,33 +374,33 @@ class CdpTarget:
             "result": {"currentIndex": 0, "entries": [{"id": 0, "url": href, "title": title}]},
         })
 
-    async def _page_start_screencast(self, message):
+    async def _page_start_screencast(self, message: dict[str, Any]):
         params = message["params"]
         self.screencast = ScreenCast(self, params["format"], params["quality"], params["maxWidth"], params["maxHeight"])
         await self.screencast.start(message["id"])
         await self._simple_response(message, None)
 
-    async def _page_stop_screencast(self, message):
+    async def _page_stop_screencast(self, message: dict[str, Any]):
         if self.screencast is not None:
             await self.screencast.stop()
             self.screencast = None
         await self._simple_response(message, None)
 
-    async def _page_screencast_frame_ack(self, message):
+    async def _page_screencast_frame_ack(self, message: dict[str, Any]):
         if self.screencast is not None:
             self.screencast.ack(message["params"]["sessionId"])
         await self._simple_response(message, None)
 
-    async def _page_get_resource_tree(self, message):
+    async def _page_get_resource_tree(self, message: dict[str, Any]):
         result = await self.send_message_with_result(message["id"], message["method"], message["params"])
         self.frame = result["result"]["frameTree"]["frame"]
         await self.output_queue.put(result)
 
-    async def _emulation_set_emulated_media(self, message):
+    async def _emulation_set_emulated_media(self, message: dict[str, Any]):
         message["method"] = "Page.setEmulatedMedia"
         await self._send_message_to_target(message)
 
-    async def _emulation_set_auto_dark_mode_override(self, message):
+    async def _emulation_set_auto_dark_mode_override(self, message: dict[str, Any]):
         message["method"] = "Page.setForcedAppearance"
         params = message["params"]
         if not params:
@@ -407,20 +409,20 @@ class CdpTarget:
         message["params"] = {"appearance": "Dark" if params["enabled"] else "Light"}
         await self._send_message_to_target(message)
 
-    async def _debugger_set_blackbox_patterns(self, message):
+    async def _debugger_set_blackbox_patterns(self, message: dict[str, Any]):
         for pattern in message["params"]["patterns"]:
             await self.send_message_with_result(
                 message["id"], "Debugger.setShouldBlackboxURL", {"url": pattern, "shouldBlackbox": True}
             )
         await self._simple_response(message, None)
 
-    async def _debugger_set_breakpoint_by_url(self, message):
+    async def _debugger_set_breakpoint_by_url(self, message: dict[str, Any]):
         condition = message["params"].pop("condition", "")
         if condition:
             message["params"]["options"]["condition"] = condition
         await self._send_message_to_target(message)
 
-    async def _domdebugger_get_event_listeners(self, message):
+    async def _domdebugger_get_event_listeners(self, message: dict[str, Any]):
         node = {"nodeId": await self.object_id_to_node_id(message["params"]["objectId"], message["id"])}
         listeners = await self.send_message_with_result(message["id"], "DOM.getEventListenersForNode", node)
         if "error" in listeners:
@@ -441,23 +443,23 @@ class CdpTarget:
             listeners_out.append(data)
         await self.output_queue.put({"id": message["id"], "result": {"listeners": listeners_out}})
 
-    async def _network_set_cache_disabled(self, message):
+    async def _network_set_cache_disabled(self, message: dict[str, Any]):
         message["method"] = "Network.setResourceCachingDisabled"
         message["params"] = {"disabled": message["params"]["cacheDisabled"]}
         await self._send_message_to_target(message)
 
-    async def _network_load_network_resource(self, message):
+    async def _network_load_network_resource(self, message: dict[str, Any]):
         await self.output_queue.put({"id": message["id"], "result": {"resource": {"success": True}}})
 
-    async def _service_worker_enable(self, message):
+    async def _service_worker_enable(self, message: dict[str, Any]):
         message["method"] = "Worker.enable"
         await self._send_message_to_target(message)
 
-    async def _overlay_highlight_node(self, message):
+    async def _overlay_highlight_node(self, message: dict[str, Any]):
         message["method"] = "DOM.highlightNode"
         await self._send_message_to_target(message)
 
-    async def _runtime_compile_script(self, message):
+    async def _runtime_compile_script(self, message: dict[str, Any]):
         self._script_source_to_context_id[message["params"]["expression"]] = message["params"]["executionContextId"]
         response = await self.send_message_with_result(
             message["id"], "Runtime.parse", {"source": message["params"]["expression"]}
@@ -479,10 +481,10 @@ class CdpTarget:
             },
         })
 
-    async def _runtime_get_isolate_id(self, message):
+    async def _runtime_get_isolate_id(self, message: dict[str, Any]):
         await self.output_queue.put({"id": message["id"], "result": {"id": self._default_execution_id}})
 
-    async def _target_set_auto_attach(self, message):
+    async def _target_set_auto_attach(self, message: dict[str, Any]):
         await self._simple_response(message, None)
         await self.output_queue.put({
             "method": "Target.attachedToTarget",
@@ -493,14 +495,14 @@ class CdpTarget:
             },
         })
 
-    async def _css_take_computed_style_updates(self, message):
+    async def _css_take_computed_style_updates(self, message: dict[str, Any]):
         await self.output_queue.put({"id": message["id"], "result": {"nodeIds": []}})
 
-    async def _css_add_rule(self, message):
+    async def _css_add_rule(self, message: dict[str, Any]):
         message["params"]["selector"] = message["params"]["ruleText"].split("{")[0]
         await self._send_message_to_target(message)
 
-    async def _input_emulate_touch_from_mouse_event(self, message):
+    async def _input_emulate_touch_from_mouse_event(self, message: dict[str, Any]):
         params = message["params"]
         if params["type"] == "mouseWheel":
             assert self.screencast is not None
@@ -544,7 +546,7 @@ class CdpTarget:
 
         await self._simple_response(message, None)
 
-    async def _input_dispatch_key_event(self, message):
+    async def _input_dispatch_key_event(self, message: dict[str, Any]):
         params = message["params"]
         key = params["key"]
         if params["type"] == "keyUp" and key == "Backspace":
@@ -593,7 +595,7 @@ class CdpTarget:
         await self.evaluate_and_result(message["id"], simulate_key_event)
         await self._simple_response(message, None)
 
-    async def _target_created(self, message):
+    async def _target_created(self, message: dict[str, Any]):
         self.target_id = message["params"]["targetInfo"]["targetId"]
         message["method"] = "Target.targetInfoChanged"
         message["params"]["targetInfo"]["url"] = await self.evaluate_and_result(1, "window.location.href")
@@ -601,7 +603,7 @@ class CdpTarget:
         message["params"]["targetInfo"]["attached"] = message["params"]["targetInfo"].pop("isProvisional")
         await self.output_queue.put(message)
 
-    async def _target_destroyed(self, message):
+    async def _target_destroyed(self, message: dict[str, Any]):
         result = await self.send_message_with_result(1, "Page.getResourceTree", {})
         self.frame = result["result"]["frameTree"]["frame"]
         await self.output_queue.put({
@@ -618,7 +620,7 @@ class CdpTarget:
         })
         await self.output_queue.put({"method": "DOM.documentUpdated"})
 
-    async def _target_dispatch_message_from_target(self, message):
+    async def _target_dispatch_message_from_target(self, message: dict[str, Any]):
         message = json.loads(message["params"]["message"])
         if "error" in message:
             logger.error(message)
@@ -629,14 +631,14 @@ class CdpTarget:
                 logger.debug("DISPACHING", message["method"])
             await self.output_queue.put(message)
 
-    async def _target_did_commit_provisional_target(self, message):
+    async def _target_did_commit_provisional_target(self, message: dict[str, Any]):
         pass
 
-    async def _debugger_script_parsed(self, message):
+    async def _debugger_script_parsed(self, message: dict[str, Any]):
         if not self._waiting_for_id:
             await self.output_queue.put(message)
 
-    async def _debugger_script_failed_to_parse(self, message):
+    async def _debugger_script_failed_to_parse(self, message: dict[str, Any]):
         message["params"] = {
             "endColumn": 0,
             "endLine": message["params"]["errorLine"],
@@ -649,19 +651,19 @@ class CdpTarget:
         }
         await self.output_queue.put(message)
 
-    async def _debugger_paused(self, message):
+    async def _debugger_paused(self, message: dict[str, Any]):
         message["params"]["reason"] = DEBUGGER_PAUSED_REASON[message["params"]["reason"]]
         if "breakpointId" in message["params"].get("data", {}):
             message["params"]["hitBreakpoints"] = [message["params"]["data"]["breakpointId"]]
         await self.output_queue.put(message)
 
-    async def _debugger_global_object_cleared(self, message):
+    async def _debugger_global_object_cleared(self, message: dict[str, Any]):
         await self.output_queue.put({"method": "DOM.documentUpdated"})
 
-    async def _page_default_appearance_did_change(self, message):
+    async def _page_default_appearance_did_change(self, message: dict[str, Any]):
         pass
 
-    async def _runtime_execution_context_created(self, message):
+    async def _runtime_execution_context_created(self, message: dict[str, Any]):
         if message["params"]["context"]["type"] == "normal":
             self._default_execution_id = message["params"]["context"]["id"]
         message["params"] = {
@@ -674,7 +676,7 @@ class CdpTarget:
         }
         await self.output_queue.put(message)
 
-    async def _console_message_added(self, message):
+    async def _console_message_added(self, message: dict[str, Any]):
         log_record = {
             "source": LOG_MESSAGE_SOURCES[message["params"]["message"]["source"]],
             "level": LOG_MESSAGE_LEVELS[message["params"]["message"]["level"]],
@@ -690,7 +692,7 @@ class CdpTarget:
 
         await self.output_queue.put({"method": "Log.entryAdded", "params": {"entry": log_record}})
 
-    async def _network_response_received(self, message):
+    async def _network_response_received(self, message: dict[str, Any]):
         params = message["params"]
         message["params"] = {
             "loaderId": params["loaderId"],
@@ -712,7 +714,7 @@ class CdpTarget:
             message["params"]["frameId"] = params["frameId"]
         await self.output_queue.put(message)
 
-    async def _network_loading_finished(self, message):
+    async def _network_loading_finished(self, message: dict[str, Any]):
         params = message["params"]
         header_size = params["metrics"].get("responseHeaderBytesReceived", 0)
         body_size = params["metrics"].get("responseBodyBytesReceived", 0)

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 import asyncio
 import hashlib
 import json

--- a/pymobiledevice3/services/web_protocol/driver.py
+++ b/pymobiledevice3/services/web_protocol/driver.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 from dataclasses import asdict, dataclass
 from typing import Any, Optional, Union
 

--- a/pymobiledevice3/services/web_protocol/driver.py
+++ b/pymobiledevice3/services/web_protocol/driver.py
@@ -1,7 +1,8 @@
+# pyright: reportMissingParameterType=error
 from dataclasses import asdict, dataclass
 from typing import Any, Optional, Union
 
-from pymobiledevice3.services.web_protocol.automation_session import RESOURCES, Point, Rect, Size
+from pymobiledevice3.services.web_protocol.automation_session import RESOURCES, AutomationSession, Point, Rect, Size
 from pymobiledevice3.services.web_protocol.element import WebElement
 from pymobiledevice3.services.web_protocol.selenium_api import By, SeleniumApi
 from pymobiledevice3.services.web_protocol.switch_to import SwitchTo
@@ -22,13 +23,13 @@ class Cookie:
     sameSite: str = "None"
 
     @classmethod
-    def from_automation(cls, d):
+    def from_automation(cls, d: dict[str, Any]):
         d.pop("size")
         return cls(**d)
 
 
 class WebDriver(SeleniumApi):
-    def __init__(self, session):
+    def __init__(self, session: AutomationSession):
         """
         :param pymobiledevice3.services.web_protocol.automation_session.AutomationSession session: Automation session.
         """
@@ -68,7 +69,7 @@ class WebDriver(SeleniumApi):
         """Deletes a single cookie with the given name."""
         await self.session.delete_single_cookie(name)
 
-    async def execute_async_script(self, script: str, *args):
+    async def execute_async_script(self, script: str, *args: Any):
         """
         Asynchronously Executes JavaScript in the current window/frame.
         :param script: The JavaScript to execute.
@@ -76,7 +77,7 @@ class WebDriver(SeleniumApi):
         """
         return await self.session.execute_script(script, args, async_=True)
 
-    async def execute_script(self, script: str, *args):
+    async def execute_script(self, script: str, *args: Any):
         """
         Synchronously Executes JavaScript in the current window/frame.
         :param script: The JavaScript to execute.
@@ -84,12 +85,12 @@ class WebDriver(SeleniumApi):
         """
         return await self.session.execute_script(script, args)
 
-    async def find_element(self, by=By.ID, value=None) -> Optional[WebElement]:
+    async def find_element(self, by: By = By.ID, value: Optional[str] = None) -> Optional[WebElement]:
         """Find an element given a By strategy and locator."""
         elem = await self.session.find_elements(by, value)
         return None if elem is None else WebElement(self.session, elem)
 
-    async def find_elements(self, by=By.ID, value=None) -> list[WebElement]:
+    async def find_elements(self, by: By = By.ID, value: Optional[str] = None) -> list[WebElement]:
         """Find elements given a By strategy and locator."""
         elements = await self.session.find_elements(by, value, single=False)
         return [WebElement(self.session, elem) for elem in elements]
@@ -145,7 +146,7 @@ class WebDriver(SeleniumApi):
         rect = await self.get_window_rect()
         return Size(height=rect.height, width=rect.width)
 
-    def implicitly_wait(self, time_to_wait):
+    def implicitly_wait(self, time_to_wait: int):
         """Sets a sticky timeout to implicitly wait for an element to be found, or a command to complete."""
         self.session.implicit_wait_timeout = time_to_wait * 1000
 
@@ -167,15 +168,21 @@ class WebDriver(SeleniumApi):
         await self.session.reload_browsing_context()
         await self.session.switch_to_browsing_context("")
 
-    async def set_window_position(self, x, y):
+    async def set_window_position(self, x: str, y: str):
         """Sets the x,y position of the current window."""
         await self.set_window_rect(x=int(x, 0), y=int(y, 0))
 
-    async def set_window_rect(self, x=None, y=None, width=None, height=None):
+    async def set_window_rect(
+        self,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+    ):
         """Sets the x, y coordinates of the window as well as height and width of the current window."""
         await self.session.set_window_frame(x, y, width, height)
 
-    async def set_window_size(self, width, height):
+    async def set_window_size(self, width: str, height: str):
         """Sets the width and height of the current window."""
         await self.set_window_rect(width=int(width, 0), height=int(height, 0))
 

--- a/pymobiledevice3/services/web_protocol/element.py
+++ b/pymobiledevice3/services/web_protocol/element.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 from typing import Any, Optional
 
 from pymobiledevice3.exceptions import WirError

--- a/pymobiledevice3/services/web_protocol/element.py
+++ b/pymobiledevice3/services/web_protocol/element.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 from typing import Any, Optional
 
 from pymobiledevice3.exceptions import WirError

--- a/pymobiledevice3/services/web_protocol/element.py
+++ b/pymobiledevice3/services/web_protocol/element.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 from pymobiledevice3.exceptions import WirError
 from pymobiledevice3.services.web_protocol.automation_session import (
@@ -24,7 +24,7 @@ FOCUS = (RESOURCES / "focus.js").read_text()
 
 
 class WebElement(SeleniumApi):
-    def __init__(self, session, id_):
+    def __init__(self, session: Any, id_: dict[str, Any]):
         """
         :param pymobiledevice3.services.web_protocol.automation_session.AutomationSession session: Automation session.
         :param dict id_: Element id.
@@ -57,12 +57,12 @@ class WebElement(SeleniumApi):
                 center.x, center.y, MouseButton.LEFT, MouseInteraction.SINGLE_CLICK
             )
 
-    async def find_element(self, by=By.ID, value=None):
+    async def find_element(self, by: By = By.ID, value: Optional[str] = None):
         """Find an element given a By strategy and locator."""
         elem = await self.session.find_elements(by, value, root=self.id_)
         return None if elem is None else WebElement(self.session, elem)
 
-    async def find_elements(self, by=By.ID, value=None):
+    async def find_elements(self, by: By = By.ID, value: Optional[str] = None):
         """Find elements given a By strategy and locator."""
         elements = await self.session.find_elements(by, value, single=False, root=self.id_)
         return [WebElement(self.session, elem) for elem in elements]
@@ -114,7 +114,7 @@ class WebElement(SeleniumApi):
         """Gets the screenshot of the current element as a base64 encoded string."""
         return await self.session.screenshot_as_base64(scroll=True, node_id=self.node_id)
 
-    async def send_keys(self, value):
+    async def send_keys(self, value: str):
         """
         Simulates typing into the element.
         :param value: A string for typing, or setting form fields.
@@ -178,7 +178,7 @@ class WebElement(SeleniumApi):
             [{"states": [{"sourceId": self.session.get_id(), "location": {"x": center.x, "y": center.y}}]}],
         )
 
-    async def value_of_css_property(self, property_name) -> str:
+    async def value_of_css_property(self, property_name: str) -> str:
         """The value of a CSS property."""
         return await self._evaluate_js_function(
             "function(element) {"
@@ -190,7 +190,9 @@ class WebElement(SeleniumApi):
         """Returns whether the element is editable."""
         return await self._evaluate_js_function(IS_EDITABLE)
 
-    async def _compute_layout(self, scroll_if_needed=True, use_viewport=False) -> Optional[tuple[Rect, Point, bool]]:
+    async def _compute_layout(
+        self, scroll_if_needed: bool = True, use_viewport: bool = False
+    ) -> Optional[tuple[Rect, Point, bool]]:
         try:
             result = await self.session.compute_element_layout(
                 self.node_id, scroll_if_needed, "LayoutViewport" if use_viewport else "Page"
@@ -207,8 +209,8 @@ class WebElement(SeleniumApi):
     async def _select_option_element(self):
         await self.session.select_option_element(self.node_id)
 
-    async def _evaluate_js_function(self, function, *args):
+    async def _evaluate_js_function(self, function: str, *args: Any):
         return await self.session.evaluate_js_function(function, self.id_, *args)
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any):
         return self.id_ == other.id_

--- a/pymobiledevice3/services/web_protocol/inspector_session.py
+++ b/pymobiledevice3/services/web_protocol/inspector_session.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 import asyncio
 import json
 import logging

--- a/pymobiledevice3/services/web_protocol/inspector_session.py
+++ b/pymobiledevice3/services/web_protocol/inspector_session.py
@@ -94,7 +94,7 @@ class InspectorSession:
         target = cls(protocol, target_id)
         return target
 
-    def set_target_id(self, target_id):
+    def set_target_id(self, target_id: str):
         self.target_id = target_id
         logger.info(f"Changed to: {target_id}")
 
@@ -118,7 +118,7 @@ class InspectorSession:
     async def runtime_enable(self):
         return await self.send_command("Runtime.enable")
 
-    async def send_command(self, method: str, **kwargs):
+    async def send_command(self, method: str, **kwargs: Any):
         if self.target_id is None:
             return await self.protocol.send_receive(method, **kwargs)
         else:

--- a/pymobiledevice3/services/web_protocol/inspector_session.py
+++ b/pymobiledevice3/services/web_protocol/inspector_session.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 import asyncio
 import json
 import logging

--- a/pymobiledevice3/services/web_protocol/selenium_api.py
+++ b/pymobiledevice3/services/web_protocol/selenium_api.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 from abc import ABC, abstractmethod
 from base64 import b64decode
 from typing import TYPE_CHECKING, Optional

--- a/pymobiledevice3/services/web_protocol/selenium_api.py
+++ b/pymobiledevice3/services/web_protocol/selenium_api.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 from abc import ABC, abstractmethod
 from base64 import b64decode
 from typing import TYPE_CHECKING, Optional
@@ -10,66 +11,66 @@ if TYPE_CHECKING:
 
 class SeleniumApi(ABC):
     @abstractmethod
-    async def find_element(self, by=By.ID, value=None) -> "Optional[WebElement]":
+    async def find_element(self, by: By = By.ID, value: Optional[str] = None) -> "Optional[WebElement]":
         pass
 
     @abstractmethod
-    async def find_elements(self, by=By.ID, value=None) -> "list[WebElement]":
+    async def find_elements(self, by: By = By.ID, value: Optional[str] = None) -> "list[WebElement]":
         pass
 
     @abstractmethod
     async def _get_screenshot_as_base64(self) -> str:
         pass
 
-    async def find_element_by_class_name(self, name):
+    async def find_element_by_class_name(self, name: str):
         return await self.find_element(By.CLASS_NAME, name)
 
-    async def find_element_by_css_selector(self, css_selector):
+    async def find_element_by_css_selector(self, css_selector: str):
         return await self.find_element(By.CSS_SELECTOR, css_selector)
 
-    async def find_element_by_id(self, id_):
+    async def find_element_by_id(self, id_: str):
         return await self.find_element(value=id_)
 
-    async def find_element_by_link_text(self, link_text):
+    async def find_element_by_link_text(self, link_text: str):
         return await self.find_element(By.LINK_TEXT, link_text)
 
-    async def find_element_by_name(self, name):
+    async def find_element_by_name(self, name: str):
         return await self.find_element(By.NAME, name)
 
-    async def find_element_by_partial_link_text(self, link_text):
+    async def find_element_by_partial_link_text(self, link_text: str):
         return await self.find_element(By.PARTIAL_LINK_TEXT, link_text)
 
-    async def find_element_by_tag_name(self, name):
+    async def find_element_by_tag_name(self, name: str):
         return await self.find_element(By.TAG_NAME, name)
 
-    async def find_element_by_xpath(self, xpath):
+    async def find_element_by_xpath(self, xpath: str):
         return await self.find_element(By.XPATH, xpath)
 
-    async def find_elements_by_class_name(self, name):
+    async def find_elements_by_class_name(self, name: str):
         return await self.find_elements(By.CLASS_NAME, name)
 
-    async def find_elements_by_css_selector(self, css_selector):
+    async def find_elements_by_css_selector(self, css_selector: str):
         return await self.find_elements(By.CSS_SELECTOR, css_selector)
 
-    async def find_elements_by_id(self, id_):
+    async def find_elements_by_id(self, id_: str):
         return await self.find_elements(value=id_)
 
-    async def find_elements_by_link_text(self, link_text):
+    async def find_elements_by_link_text(self, link_text: str):
         return await self.find_elements(By.LINK_TEXT, link_text)
 
-    async def find_elements_by_name(self, name):
+    async def find_elements_by_name(self, name: str):
         return await self.find_elements(By.NAME, name)
 
-    async def find_elements_by_partial_link_text(self, link_text):
+    async def find_elements_by_partial_link_text(self, link_text: str):
         return await self.find_elements(By.PARTIAL_LINK_TEXT, link_text)
 
-    async def find_elements_by_tag_name(self, name):
+    async def find_elements_by_tag_name(self, name: str):
         return await self.find_elements(By.TAG_NAME, name)
 
-    async def find_elements_by_xpath(self, xpath):
+    async def find_elements_by_xpath(self, xpath: str):
         return await self.find_elements(By.XPATH, xpath)
 
-    async def screenshot(self, filename):
+    async def screenshot(self, filename: str):
         png = await self.screenshot_as_png()
         try:
             with open(filename, "wb") as f:
@@ -84,11 +85,11 @@ class SeleniumApi(ABC):
     async def get_screenshot_as_base64(self) -> str:
         return await self._get_screenshot_as_base64()
 
-    async def get_screenshot_as_file(self, filename):
+    async def get_screenshot_as_file(self, filename: str):
         return await self.screenshot(filename)
 
     async def get_screenshot_as_png(self):
         return await self.screenshot_as_png()
 
-    async def save_screenshot(self, filename) -> bool:
+    async def save_screenshot(self, filename: str) -> bool:
         return await self.screenshot(filename)

--- a/pymobiledevice3/services/web_protocol/session_protocol.py
+++ b/pymobiledevice3/services/web_protocol/session_protocol.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 import asyncio
 from functools import partial
 from typing import TYPE_CHECKING, Any

--- a/pymobiledevice3/services/web_protocol/session_protocol.py
+++ b/pymobiledevice3/services/web_protocol/session_protocol.py
@@ -1,11 +1,23 @@
+# pyright: reportMissingParameterType=error
 import asyncio
 from functools import partial
+from typing import TYPE_CHECKING, Any
 
 from pymobiledevice3.exceptions import WirError
 
+if TYPE_CHECKING:
+    from pymobiledevice3.services.webinspector import Application, Page, WebinspectorService
+
 
 class SessionProtocol:
-    def __init__(self, inspector, id_, app, page, method_prefix="Automation"):
+    def __init__(
+        self,
+        inspector: "WebinspectorService",
+        id_: str,
+        app: "Application",
+        page: "Page",
+        method_prefix: str = "Automation",
+    ):
         """
         :param pymobiledevice3.services.webinspector.WebinspectorService inspector:
         """
@@ -16,7 +28,7 @@ class SessionProtocol:
         self.method_prefix = method_prefix
         self._wir_messages_id = 1
 
-    async def send_command(self, method, **kwargs):
+    async def send_command(self, method: str, **kwargs: Any):
         wir_id = self._wir_messages_id
         self._wir_messages_id += 1
         await self.inspector.send_socket_data(
@@ -31,7 +43,7 @@ class SessionProtocol:
         )
         return wir_id
 
-    async def get_response(self, wir_id):
+    async def get_response(self, wir_id: int):
         response = await self.wait_for_message(wir_id)
         if "result" in response:
             return response["result"]
@@ -39,20 +51,20 @@ class SessionProtocol:
             raise WirError(response["error"]["message"])
         raise WirError(f"Unknown response: {response}")
 
-    async def send_receive(self, method, wait_for_response=True, **kwargs):
+    async def send_receive(self, method: str, wait_for_response: bool = True, **kwargs: Any):
         wir_id = await self.send_command(method, **kwargs)
         if wait_for_response:
             return await self.get_response(wir_id)
         else:
             return wir_id
 
-    async def wait_for_message(self, id_):
+    async def wait_for_message(self, id_: int):
         while id_ not in self.inspector.wir_message_results:
             await asyncio.sleep(0)
         return self.inspector.wir_message_results.pop(id_)
 
-    async def sync_send_receive(self, method, wait_for_response=True, **kwargs):
+    async def sync_send_receive(self, method: str, wait_for_response: bool = True, **kwargs: Any):
         return await self.send_receive(method, wait_for_response, **kwargs)
 
-    def __getattr__(self, item):
+    def __getattr__(self, item: str):
         return partial(self.sync_send_receive, method=item)

--- a/pymobiledevice3/services/web_protocol/switch_to.py
+++ b/pymobiledevice3/services/web_protocol/switch_to.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 from pymobiledevice3.services.web_protocol.alert import Alert
 from pymobiledevice3.services.web_protocol.automation_session import AutomationSession, By
 from pymobiledevice3.services.web_protocol.element import WebElement

--- a/pymobiledevice3/services/web_protocol/switch_to.py
+++ b/pymobiledevice3/services/web_protocol/switch_to.py
@@ -1,10 +1,11 @@
+# pyright: reportMissingParameterType=error
 from pymobiledevice3.services.web_protocol.alert import Alert
-from pymobiledevice3.services.web_protocol.automation_session import By
+from pymobiledevice3.services.web_protocol.automation_session import AutomationSession, By
 from pymobiledevice3.services.web_protocol.element import WebElement
 
 
 class SwitchTo:
-    def __init__(self, session):
+    def __init__(self, session: AutomationSession):
         """
         :param pymobiledevice3.services.web_protocol.automation_session.AutomationSession session: Automation session.
         """
@@ -26,7 +27,7 @@ class SwitchTo:
         """Switch focus to the default frame."""
         await self.session.switch_to_browsing_context("")
 
-    async def frame(self, frame_reference):
+    async def frame(self, frame_reference: object):
         """
         Switches focus to the specified frame, by index, name, or web element.
         :param frame_reference: The name of the window to switch to, an integer representing the index,
@@ -48,9 +49,9 @@ class SwitchTo:
         else:
             await self.session.switch_to_frame(frame_handle=frame)
 
-    async def new_window(self, type_=""):
+    async def new_window(self, type_: str = ""):
         """Switches to a new top-level browsing context."""
-        await self.session.switch_to_window(self.session.create_window(type_))
+        await self.session.switch_to_window(await self.session.create_window(type_))
 
     async def parent_frame(self):
         """
@@ -63,6 +64,6 @@ class SwitchTo:
         )
         await self.session.switch_to_browsing_context(self.session.current_parent_handle)
 
-    async def window(self, window_name):
+    async def window(self, window_name: str):
         """Switches focus to the specified window."""
         await self.session.switch_to_window(window_name)

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingParameterType=error
 import asyncio
 import contextlib
 import json

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingParameterType=error
 import asyncio
 import contextlib
 import json

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 import uuid
+from collections.abc import Coroutine
 from dataclasses import dataclass, fields
 from enum import Enum
 from typing import Any, Optional, Union
@@ -98,7 +99,7 @@ class Application:
     host: str = ""
 
     @classmethod
-    def from_application_dictionary(cls, app_dict) -> "Application":
+    def from_application_dictionary(cls, app_dict: dict[str, Any]) -> "Application":
         return cls(
             app_dict["WIRApplicationIdentifierKey"],
             app_dict["WIRApplicationBundleIdentifierKey"],
@@ -208,7 +209,7 @@ class WebinspectorService(LockdownService):
                 with contextlib.suppress(asyncio.CancelledError):
                     await disabled_task
 
-    async def _await_or_raise_disabled(self, coro, disabled_task: asyncio.Task[None]):
+    async def _await_or_raise_disabled(self, coro: Coroutine[Any, Any, Any], disabled_task: asyncio.Task[None]):
         task = asyncio.create_task(coro)
         done, _ = await asyncio.wait(
             {task, disabled_task},
@@ -353,13 +354,13 @@ class WebinspectorService(LockdownService):
         """
         return await asyncio.sleep(duration)
 
-    async def _handle_recv(self, plist):
+    async def _handle_recv(self, plist: dict[str, Any]):
         await self.receive_handlers[plist["__selector"]](plist["__argument"])
 
-    async def _handle_report_current_state(self, arg):
+    async def _handle_report_current_state(self, arg: dict[str, Any]):
         self.state = arg["WIRAutomationAvailabilityKey"]
 
-    async def _handle_report_connected_application_list(self, arg):
+    async def _handle_report_connected_application_list(self, arg: dict[str, Any]):
         self.connected_application = {}
         for key, application in arg["WIRApplicationDictionaryKey"].items():
             self.connected_application[key] = Application.from_application_dictionary(application)
@@ -367,10 +368,10 @@ class WebinspectorService(LockdownService):
             # Immediately also query the application pages
             await self._forward_get_listing(self.connected_application[key].id_)
 
-    async def _handle_report_connected_driver_list(self, arg):
+    async def _handle_report_connected_driver_list(self, arg: dict[str, Any]):
         pass
 
-    async def _handle_application_sent_listing(self, arg):
+    async def _handle_application_sent_listing(self, arg: dict[str, Any]):
         if arg["WIRApplicationIdentifierKey"] in self.application_pages:
             # Update existing application pages
             for id_, page in arg["WIRListingKey"].items():
@@ -385,15 +386,15 @@ class WebinspectorService(LockdownService):
                 pages[id_] = Page.from_page_dictionary(page)
             self.application_pages[arg["WIRApplicationIdentifierKey"]] = pages
 
-    async def _handle_application_updated(self, arg):
+    async def _handle_application_updated(self, arg: dict[str, Any]):
         app = Application.from_application_dictionary(arg)
         self.connected_application[app.id_] = app
 
-    async def _handle_application_connected(self, arg):
+    async def _handle_application_connected(self, arg: dict[str, Any]):
         app = Application.from_application_dictionary(arg)
         self.connected_application[app.id_] = app
 
-    async def _handle_application_sent_data(self, arg):
+    async def _handle_application_sent_data(self, arg: dict[str, Any]):
         response = json.loads(arg["WIRMessageDataKey"])
 
         if "id" in response:
@@ -401,14 +402,14 @@ class WebinspectorService(LockdownService):
         else:
             self.wir_events.append(response)
 
-    async def _handle_application_disconnected(self, arg):
+    async def _handle_application_disconnected(self, arg: dict[str, Any]):
         self.connected_application.pop(arg["WIRApplicationIdentifierKey"], None)
         self.application_pages.pop(arg["WIRApplicationIdentifierKey"], None)
 
     async def _report_identifier(self):
         await self._send_message("_rpc_reportIdentifier:")
 
-    async def _forward_get_listing(self, app_id):
+    async def _forward_get_listing(self, app_id: str):
         self.logger.debug(f"Listing app with id {app_id}")
         await self._send_message("_rpc_forwardGetListing:", {"WIRApplicationIdentifierKey": app_id})
 
@@ -464,7 +465,7 @@ class WebinspectorService(LockdownService):
             },
         )
 
-    async def _send_message(self, selector: str, args=None):
+    async def _send_message(self, selector: str, args: Optional[dict[str, Any]] = None):
         if args is None:
             args = {}
         args["WIRConnectionIdentifierKey"] = self.connection_id

--- a/pymobiledevice3/tcp_forwarder.py
+++ b/pymobiledevice3/tcp_forwarder.py
@@ -31,7 +31,7 @@ class TcpForwarderBase:
         self.listening_event = listening_event
         self._connection_tasks: set[asyncio.Task[None]] = set()
 
-    async def start(self, address="127.0.0.1"):
+    async def start(self, address: str = "127.0.0.1"):
         """forward each connection from given local machine port to remote device port"""
         self.server = await asyncio.start_server(
             self._handle_server_connection, address, self.src_port, backlog=self.MAX_FORWARDED_CONNECTIONS

--- a/pymobiledevice3/usbmux.py
+++ b/pymobiledevice3/usbmux.py
@@ -6,6 +6,7 @@ import socket
 import struct
 import time
 from dataclasses import dataclass
+from types import TracebackType
 from typing import Any, NoReturn, Optional, Union
 
 from construct import (
@@ -273,7 +274,12 @@ class MuxConnection:
     async def __aenter__(self):
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         await self.close()
 
 
@@ -369,7 +375,7 @@ class PlistMuxConnection(BinaryMuxConnection):
             raise NotPairedError("device should be paired first")
         return plistlib.loads(pair_record)
 
-    def _process_device_state(self, response):
+    def _process_device_state(self, response: dict[str, Any]) -> None:
         if response["MessageType"] == "Attached":
             super()._add_device(
                 MuxDevice(

--- a/pymobiledevice3/utils.py
+++ b/pymobiledevice3/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import traceback
+from collections.abc import Coroutine
 from functools import wraps
 from pathlib import Path
 from typing import Any, Callable, Optional, Union, overload
@@ -11,7 +12,7 @@ from tqdm import tqdm
 from traitlets.config import Config
 
 
-def plist_access_path(d, path: tuple[Any, ...], type_=None, required=False):
+def plist_access_path(d: Any, path: tuple[Any, ...], type_: Optional[type] = None, required: bool = False):
     for component in path:
         d = d.get(component)
         if d is None:
@@ -67,7 +68,7 @@ def try_decode(s: bytes, *, errors: Optional[str] = None) -> Union[str, bytes]:
 
 def asyncio_print_traceback(f: Callable[..., Any]):
     @wraps(f)
-    async def wrapper(*args, **kwargs):
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
             return await f(*args, **kwargs)
         except (Exception, RuntimeError) as e:
@@ -88,7 +89,7 @@ def get_asyncio_loop() -> asyncio.AbstractEventLoop:
     return _ASYNCIO_LOOP
 
 
-def run_in_loop(coro):
+def run_in_loop(coro: Coroutine[Any, Any, Any]):
     return get_asyncio_loop().run_until_complete(coro)
 
 
@@ -102,7 +103,7 @@ def start_ipython_shell(*, user_ns: Optional[dict[str, Any]] = None, header: Opt
     IPython.start_ipython(argv=[], config=config, user_ns=user_ns or {})  # pyright: ignore[reportAttributeAccessIssue]
 
 
-def file_download(url: str, outfile: Path, chunk_size=1024) -> None:
+def file_download(url: str, outfile: Path, chunk_size: int = 1024) -> None:
     resp = requests.get(url, stream=True)
     total = int(resp.headers.get("content-length", 0))
     with (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,17 @@ reportUnnecessaryIsInstance = "error"
 reportUnnecessaryCast = "error"
 reportUntypedNamedTuple = "error"
 reportMissingTypeArgument = "error"
+reportMissingParameterType = "error"
 venvPath = "."
 venv = ".venv"
+
+# reportMissingParameterType is enforced across the package, but not on the test suite: test
+# fixtures, monkeypatch callbacks and mock stubs are deliberately loosely-typed and annotating
+# their parameters adds noise without catching real bugs.
+[[tool.pyright.executionEnvironments]]
+root = "tests"
+extraPaths = ["."]
+reportMissingParameterType = "none"
 
 [tool.ruff]
 target-version = "py39"

--- a/tests/cli/developer/dvt/sysmon/test_process_unit.py
+++ b/tests/cli/developer/dvt/sysmon/test_process_unit.py
@@ -31,6 +31,7 @@ from pymobiledevice3.cli.developer.dvt.sysmon.process import (
     sysmon_process_monitor_threshold_task,
 )
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+from pymobiledevice3.services.dvt.instruments.dvt_provider import DvtProvider
 from pymobiledevice3.services.dvt.instruments.sysmontap import Sysmontap
 
 
@@ -393,7 +394,7 @@ async def test_select_process_from_sysmon_skips_first_snapshot(monkeypatch):
     monkeypatch.setattr(process_module.Sysmontap, "create", fake_create)
 
     selected = await _select_process_from_sysmon(
-        object(), {"name": ["second-snapshot"]}, None, ProcessSelectionMode.FIRST
+        cast(DvtProvider, object()), {"name": ["second-snapshot"]}, None, ProcessSelectionMode.FIRST
     )
 
     assert selected == {"pid": 20, "ppid": 2, "name": "second-snapshot"}
@@ -410,7 +411,7 @@ async def test_select_process_from_sysmon_doesnt_skip_first_snapshot_when_cpu_us
     monkeypatch.setattr(process_module.Sysmontap, "create", fake_create)
 
     selected = await _select_process_from_sysmon(
-        object(), {"name": ["first-snapshot"]}, ["pid", "name"], ProcessSelectionMode.FIRST
+        cast(DvtProvider, object()), {"name": ["first-snapshot"]}, ["pid", "name"], ProcessSelectionMode.FIRST
     )
 
     assert selected == {"pid": 10, "ppid": 1, "name": "first-snapshot"}
@@ -424,4 +425,4 @@ async def test_select_process_from_sysmon_raises_when_no_usable_snapshot(monkeyp
     monkeypatch.setattr(process_module.Sysmontap, "create", fake_create)
 
     with pytest.raises(typer.BadParameter, match="Failed to collect a process snapshot"):
-        await _select_process_from_sysmon(object(), {}, None, ProcessSelectionMode.FIRST)
+        await _select_process_from_sysmon(cast(DvtProvider, object()), {}, None, ProcessSelectionMode.FIRST)


### PR DESCRIPTION
## What

Completes the **`reportMissingParameterType`** campaign — annotates all **694 previously-unannotated function parameters** across the package (implicit-`Any` at contract points the caller controls) and flips the rule on globally in `pyproject.toml`.

Landed as separate commits per cycle:
1. **slice 1** — afc, dtx/primitives, irecv, restore/tss, lockdown, xpc_message (~202)
2. **cycle 2a/2b** — the web_protocol/webinspector cluster (~180)
3. **cycle 3 + global flip** — the long tail (~291) + `pyproject.toml` enforcement + removal of the 20 per-file headers

`tests/` is **exempted** from this one rule (via an `executionEnvironments` override) — test fixtures / `monkeypatch` callbacks / mock stubs are deliberately loosely-typed and annotating them is noise, not bug-catching.

## Types were inferred, not guessed

From callers + body usage: construct codec sigs (`stream: IO[bytes]`, `context: Context`, `path: str`), domain types (`str` paths, `bytes` payloads, `int` handles, `By`/`AfcOpcode`/`DtxServiceProvider`/…), CDP/WebDriver protocol dicts → `dict[str, Any]`, canonical `__aexit__`/`__exit__` exception triples. Genuinely-dynamic DTX-RPC/ctypes callback params stay `Any`.

## Real bugs / regressions the typing caught

- **`dtx/service.py` decorators** — `dtx_method`/`dtx_on_invoke`/`dtx_on_data`/… are now typed with an identity `TypeVar` + `@overload` (bare and arg forms), so `self.service.<method>(...)` stays callable and typed. A naïve `fn: Any` had collapsed **every** DVT service method to a non-callable `object` (52-error cascade across `device_info`, `dtx_services`, …).
- **`switch_to.new_window`** — a missing `await` (a coroutine was passed where a window handle was expected); surfaced by typing `session`.
- **`SupportError`/`FeatureNotSupportedError`** — `os_name` → `Optional[str]` (callers pass the possibly-`None` `_os_name`).
- **`img4_create_local_manifest`** — `build_identity` → `Mapping[str, Any]` (a `BuildIdentity` `UserDict`, not a `dict`).

## Verification

pyright 0 (package rule enforced, tests resolve + exempt), ruff clean, `pytest -m cli` 117 passed.

## Process note

One cycle hit a **parallel-agent collision** — an agent ran `git stash` + `drop` and discarded 6 sibling agents' uncommitted work; recovered by committing survivors and re-running the lost files under a git-forbidding rubric (hence the 2a/2b split). Recorded so it doesn't recur.