### PR TITLE
typing: clear reportUnknown* package-wide and enforce it

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -9,7 +9,7 @@ import sys
 import textwrap
 import traceback
 import warnings
-from typing import Annotated, Callable, Optional, Union
+from typing import Annotated, Any, Callable, Optional, Union, cast
 
 import coloredlogs
 import typer
@@ -70,7 +70,7 @@ from pymobiledevice3.exceptions import (
 from pymobiledevice3.lockdown import retry_create_using_usbmux
 from pymobiledevice3.osu.os_utils import get_os_utils
 
-coloredlogs.install(level=logging.INFO)
+cast(Any, coloredlogs).install(level=logging.INFO)
 
 logging.getLogger("quic").setLevel(logging.CRITICAL + 1)
 logging.getLogger("asyncio").setLevel(logging.CRITICAL + 1)
@@ -106,7 +106,7 @@ INVALID_SERVICE_MESSAGE = """Failed to start service. Possible reasons are:
   https://github.com/doronz88/pymobiledevice3/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=
 """
 
-CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"], "max_content_width": 400}
+CONTEXT_SETTINGS: dict[str, Any] = {"help_option_names": ["-h", "--help"], "max_content_width": 400}
 
 # Mapping of index options to import file names
 CLI_GROUPS = {
@@ -159,7 +159,7 @@ def _patch_xonsh_completion_detection() -> None:
     if shellingham is None:
         return
 
-    detect_shell = shellingham.detect_shell
+    detect_shell = cast(Any, shellingham).detect_shell
     _ORIGINAL_SHELLINGHAM_DETECT = getattr(detect_shell, "_pymobiledevice3_original", detect_shell)
     if getattr(detect_shell, "_pymobiledevice3_xonsh_patched", False):
         return
@@ -211,7 +211,7 @@ class Pmd3TyperGroup(TyperGroup):
     @staticmethod
     def collect_commands(command: ClickCommand) -> Union[str, list[str]]:
         if isinstance(command, TyperGroup):  # group
-            cmds = []
+            cmds: list[str] = []
             for v in command.commands.values():
                 child = Pmd3TyperGroup.collect_commands(v)
                 if isinstance(child, list):

--- a/pymobiledevice3/bonjour.py
+++ b/pymobiledevice3/bonjour.py
@@ -9,9 +9,10 @@ import socket
 import struct
 import sys
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from types import TracebackType
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar, cast
 
 import ifaddr  # pip install ifaddr
 from typing_extensions import dataclass_transform
@@ -71,8 +72,8 @@ class ServiceInstance:
     instance: str  # "<Instance Name>._type._proto.local."
     host: Optional[str]  # "host.local" (without trailing dot), or None if unresolved
     port: int  # SRV port (always present — browse_service skips port-less SRV entries)
-    addresses: list[Address] = field(default_factory=list)  # IPs with interface names
-    properties: dict[str, str] = field(default_factory=dict)  # TXT key/values
+    addresses: list[Address] = field(default_factory=list[Address])  # IPs with interface names
+    properties: dict[str, str] = field(default_factory=dict[str, str])  # TXT key/values
 
 
 # ---------------- DNS helpers ----------------
@@ -92,7 +93,7 @@ def encode_name(name: str) -> bytes:
 
 
 def decode_name(data: bytes, off: int) -> tuple[str, int]:
-    labels = []
+    labels: list[str] = []
     jumped = False
     orig_end = off
     for _ in range(128):  # loop guard
@@ -128,7 +129,7 @@ def build_query(name: str, qtype: int, unicast: bool = False) -> bytes:
     return hdr + encode_name(name) + struct.pack("!HH", qtype, qclass)
 
 
-def parse_rr(data: bytes, off: int):
+def parse_rr(data: bytes, off: int) -> tuple[dict[str, Any], int]:
     name, off = decode_name(data, off)
     if off + 10 > len(data):
         raise ValueError("truncated RR header")
@@ -137,7 +138,7 @@ def parse_rr(data: bytes, off: int):
     rdata = data[off : off + rdlen]
     off += rdlen
 
-    rr = {"name": name, "type": rtype, "class": rclass & 0x7FFF, "ttl": ttl}
+    rr: dict[str, Any] = {"name": name, "type": rtype, "class": rclass & 0x7FFF, "ttl": ttl}
     if rtype == QTYPE_PTR:
         target, _ = decode_name(data, off - rdlen)
         rr["ptrdname"] = target
@@ -146,7 +147,7 @@ def parse_rr(data: bytes, off: int):
         target, _ = decode_name(data, off - rdlen + 6)
         rr.update({"priority": priority, "weight": weight, "port": port, "target": target})
     elif rtype == QTYPE_TXT:
-        kv = {}
+        kv: dict[str, str] = {}
         i = 0
         while i < rdlen:
             b = rdata[i]
@@ -170,7 +171,7 @@ def parse_rr(data: bytes, off: int):
     return rr, off
 
 
-def parse_mdns_message(data: bytes):
+def parse_mdns_message(data: bytes) -> list[dict[str, Any]]:
     if len(data) < 12:
         return []
     _, _, qd, an, ns, ar = struct.unpack("!HHHHHH", data[:12])
@@ -178,7 +179,7 @@ def parse_mdns_message(data: bytes):
     for _ in range(qd):
         _, off = decode_name(data, off)
         off += 4
-    rrs = []
+    rrs: list[dict[str, Any]] = []
     for _ in range(an + ns + ar):
         rr, off = parse_rr(data, off)
         rrs.append(rr)
@@ -190,7 +191,7 @@ def parse_mdns_message(data: bytes):
 
 class _Adapters:
     def __init__(self):
-        self.adapters = ifaddr.get_adapters() if ifaddr is not None else []
+        self.adapters: Iterable[ifaddr.Adapter] = ifaddr.get_adapters() if ifaddr is not None else []
 
     def pick_iface_for_ip(self, ip_str: str, family: int, v6_scopeid: Optional[int]) -> Optional[str]:
         # Prefer scope id for IPv6 link-local
@@ -204,7 +205,7 @@ class _Adapters:
         if not self.adapters:
             return None
         ip = ipaddress.ip_address(ip_str)
-        best = (None, -1)  # (name, prefix_len)
+        best: tuple[Optional[str], int] = (None, -1)  # (name, prefix_len)
         for ad in self.adapters:
             for ipn in ad.ips:
                 if isinstance(ipn.ip, str):
@@ -269,8 +270,10 @@ async def _bind_ipv6_all_ifaces(queue: asyncio.Queue[tuple[bytes, Any]]):
     return transport, s
 
 
-async def _open_mdns_sockets():
-    queue = asyncio.Queue()
+async def _open_mdns_sockets() -> tuple[
+    list[tuple[asyncio.DatagramTransport, socket.socket]], asyncio.Queue[tuple[bytes, Any]]
+]:
+    queue: asyncio.Queue[tuple[bytes, Any]] = asyncio.Queue()
     transports: list[tuple[asyncio.DatagramTransport, socket.socket]] = []
     t4, s4 = await _bind_ipv4(queue)
     transports.append((t4, s4))
@@ -314,9 +317,9 @@ async def browse_service(service_type: str, timeout: float = 4.0) -> list[Servic
     def _record_addr(rr_name: str, ip_str: str, pkt_addr: Any) -> None:
         # Determine family and possible scopeid from the packet that delivered this RR
         family = socket.AF_INET6 if ":" in ip_str else socket.AF_INET
-        scopeid = None
-        if isinstance(pkt_addr, tuple) and len(pkt_addr) == 4:  # IPv6 remote tuple
-            scopeid = pkt_addr[3]
+        scopeid: Optional[int] = None
+        if isinstance(pkt_addr, tuple) and len(cast(tuple[Any, ...], pkt_addr)) == 4:  # IPv6 remote tuple
+            scopeid = cast(Optional[int], pkt_addr[3])
         iface = adapters.pick_iface_for_ip(ip_str, family, scopeid)
         if iface is None:
             return
@@ -337,7 +340,7 @@ async def browse_service(service_type: str, timeout: float = 4.0) -> list[Servic
             for rr in parse_mdns_message(data):
                 t = rr.get("type")
                 if t == QTYPE_PTR and rr.get("name") == service_type:
-                    ptr_targets.add(rr.get("ptrdname"))
+                    ptr_targets.add(cast(str, rr.get("ptrdname")))
                 elif t == QTYPE_SRV:
                     srv_map[rr["name"]].append({"target": rr.get("target"), "port": rr.get("port")})
                 elif t == QTYPE_TXT:
@@ -499,7 +502,7 @@ class MDNSResponder:
         self._serve_task: Optional[asyncio.Task[None]] = None
 
     def _address_records(self) -> list[bytes]:
-        records = []
+        records: list[bytes] = []
         for family, ip in self.addresses:
             if family == socket.AF_INET:
                 records.append(

--- a/pymobiledevice3/cli/bonjour.py
+++ b/pymobiledevice3/cli/bonjour.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
 import typer
 from typer_injector import InjectingTyper
@@ -17,7 +17,7 @@ cli = InjectingTyper(
 
 
 async def cli_mobdev2_task(timeout: float, pair_records: Optional[Path]) -> None:
-    output = []
+    output: list[dict[str, Any]] = []
     async for ip, lockdown in get_mobdev2_lockdowns(timeout=timeout, pair_records=pair_records):
         short_info = lockdown.short_info
         short_info["ip"] = ip
@@ -44,7 +44,7 @@ async def cli_mobdev2(
 
 
 async def cli_remotepairing_task(timeout: float) -> None:
-    output = []
+    output: list[dict[str, Any]] = []
     for answer in await browse_remotepairing(timeout=timeout):
         for address in answer.addresses:
             output.append({"hostname": address.full_ip, "port": answer.port})
@@ -59,7 +59,7 @@ async def cli_remotepairing(timeout: Annotated[float, typer.Option()] = DEFAULT_
 
 
 async def cli_remotepairing_manual_pairing_task(timeout: float) -> None:
-    output = []
+    output: list[dict[str, Any]] = []
     for answer in await browse_remotepairing_manual_pairing(timeout=timeout):
         for address in answer.addresses:
             output.append({

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -9,7 +9,7 @@ from collections.abc import Coroutine
 from contextlib import suppress
 from functools import wraps
 from textwrap import dedent
-from typing import Annotated, Any, Callable, Optional, TypeVar
+from typing import Annotated, Any, Callable, Optional, TypeVar, cast
 
 import coloredlogs
 import hexdump
@@ -72,8 +72,13 @@ def print_json(buf: Any, colored: Optional[bool] = None, default: Callable[[Any]
         colored = user_requested_colored_output()
     formatted_json = json.dumps(buf, sort_keys=True, indent=4, default=default)
     if colored and os.isatty(sys.stdout.fileno()):
-        colorful_json = highlight(
-            formatted_json, lexers.JsonLexer(), formatters.Terminal256Formatter(style="stata-dark")
+        colorful_json = cast(
+            str,
+            highlight(
+                formatted_json,
+                cast(Any, lexers).JsonLexer(),
+                cast(Any, formatters).Terminal256Formatter(style="stata-dark"),
+            ),
         )
         print(colorful_json)
         return colorful_json
@@ -83,16 +88,20 @@ def print_json(buf: Any, colored: Optional[bool] = None, default: Callable[[Any]
 
 
 def print_hex(data: bytes, colored: bool = True) -> None:
-    hex_dump = hexdump.hexdump(data, result="return")
+    hex_dump = cast(Any, hexdump).hexdump(data, result="return")
     assert isinstance(hex_dump, str)  # result='return' always yields a str
     if colored:
-        print(highlight(hex_dump, lexers.HexdumpLexer(), formatters.Terminal256Formatter(style="native")))
+        print(
+            highlight(
+                hex_dump, cast(Any, lexers).HexdumpLexer(), cast(Any, formatters).Terminal256Formatter(style="native")
+            )
+        )
     else:
         print(hex_dump, end="\n\n")
 
 
 def set_verbosity(level: int) -> None:
-    coloredlogs.set_level(logging.INFO - (level * 10))
+    cast(Any, coloredlogs).set_level(logging.INFO - (level * 10))
     # DTX message traffic is very chatty -- require -vv to see it
     logging.getLogger("pymobiledevice3.dtx").setLevel(logging.DEBUG if level >= 2 else logging.INFO)
 
@@ -128,14 +137,16 @@ def sudo_required(func: Callable[..., Any]) -> Callable[..., Any]:
 def prompt_selection(choices: list[Any], message: str, idx: bool = False) -> Any:
     question = [inquirer3.List("selection", message=message, choices=choices, carousel=True)]
     try:
-        result = inquirer3.prompt(question, theme=GreenPassion(), raise_keyboard_interrupt=True)
+        result = cast(
+            dict[str, Any], cast(Any, inquirer3).prompt(question, theme=GreenPassion(), raise_keyboard_interrupt=True)
+        )
     except KeyboardInterrupt:
         typer.echo(typer.style("No selection was made", fg="red"))
         raise typer.Exit(code=1) from None
     return result["selection"] if not idx else choices.index(result["selection"])
 
 
-def prompt_device_list(device_list: list[Any]):
+def prompt_device_list(device_list: list[Any]) -> Any:
     return prompt_selection(device_list, "Choose device")
 
 

--- a/pymobiledevice3/cli/developer/__init__.py
+++ b/pymobiledevice3/cli/developer/__init__.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from textwrap import dedent
-from typing import Annotated
+from typing import Annotated, Any, cast
 
 import typer
 from pygments import formatters, highlight, lexers
@@ -101,7 +101,9 @@ def developer_shell(
     run_in_loop(provider.connect())
     try:
         start_ipython_shell(
-            header=highlight(SHELL_USAGE, lexers.PythonLexer(), formatters.Terminal256Formatter(style="native")),
+            header=highlight(
+                SHELL_USAGE, cast(Any, lexers).PythonLexer(), formatters.Terminal256Formatter(style="native")
+            ),
             user_ns={
                 "provider": provider,
                 "dtx": provider.dtx,

--- a/pymobiledevice3/cli/developer/accessibility/__init__.py
+++ b/pymobiledevice3/cli/developer/accessibility/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from typer_injector import InjectingTyper
 
@@ -63,7 +64,7 @@ async def accessibility_notifications(service_provider: ServiceProviderDep) -> N
 @async_command
 async def accessibility_list_items(service_provider: ServiceProviderDep) -> None:
     """List elements available in the currently shown menu."""
-    elements = []
+    elements: list[dict[str, Any]] = []
     async with AccessibilityAudit(service_provider) as service:
         async for element in service.iter_elements():
             elements.append(element.to_dict())

--- a/pymobiledevice3/cli/developer/debugserver.py
+++ b/pymobiledevice3/cli/developer/debugserver.py
@@ -155,7 +155,7 @@ async def debugserver_lldb(
             "(run `sudo pymobiledevice3 remote tunneld` and drop --userspace, or use --tunnel)."
         )
 
-    commands = []
+    commands: list[str] = []
     temp_dir = None
     local_app: Optional[Path] = None
     install_source: Optional[Path] = None

--- a/pymobiledevice3/cli/developer/dvt/__init__.py
+++ b/pymobiledevice3/cli/developer/dvt/__init__.py
@@ -3,10 +3,11 @@ import logging
 import os
 import posixpath
 import shlex
+from collections.abc import AsyncIterator
 from datetime import datetime
 from enum import IntEnum
 from pathlib import Path
-from typing import Annotated, NamedTuple, Optional
+from typing import Annotated, Any, NamedTuple, Optional, cast
 
 import typer
 from click.exceptions import BadParameter, MissingParameter, UsageError
@@ -329,7 +330,7 @@ def dvt_shell(service_provider: ServiceProviderDep) -> None:
         start_ipython_shell(
             header=highlight(
                 SHELL_USAGE,
-                lexers.PythonLexer(),
+                cast(Any, lexers).PythonLexer(),
                 formatters.Terminal256Formatter(style="native"),
             ),
             user_ns={"dvt": dvt, "dtx": dvt.dtx},
@@ -372,7 +373,7 @@ async def ls(
 async def device_information(service_provider: ServiceProviderDep) -> None:
     """Print system information"""
     async with DvtProvider(service_provider) as dvt, DeviceInfo(dvt) as device_info:
-        info = {
+        info: dict[str, Any] = {
             "hardware": await device_info.hardware_information(),
             "network": await device_info.network_information(),
             "kernel-name": await device_info.mach_kernel_name(),
@@ -541,7 +542,7 @@ async def dvt_name_for_gid(service_provider: ServiceProviderDep, gid: int) -> No
 async def dvt_oslog(service_provider: ServiceProviderDep, pid: Optional[int] = None) -> None:
     """Sniff device oslog (not very stable, but includes more data and normal syslog)"""
     async with DvtProvider(service_provider) as dvt, ActivityTraceTap(dvt) as tap:
-        async for message in tap:
+        async for message in cast(AsyncIterator[Any], tap):
             message_pid = message.process
             # without message_type maybe signpost have event_type
             message_type = (

--- a/pymobiledevice3/cli/developer/dvt/core_profile_session.py
+++ b/pymobiledevice3/cli/developer/dvt/core_profile_session.py
@@ -7,7 +7,7 @@ import queue
 from enum import Enum
 from itertools import islice
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional, cast
 
 import typer
 from pykdebugparser.pykdebugparser import PyKdebugParser
@@ -165,7 +165,7 @@ async def live_profile_session(
     ] = True,
 ) -> None:
     """Print kevents received from the device in real time."""
-    parser = PyKdebugParser()
+    parser: Any = PyKdebugParser()
     class_filters = class_filters
     subclass_filters = subclass_filters
     parser.filter_class = class_filters
@@ -184,14 +184,14 @@ async def live_profile_session(
     parser.show_args = args
     async with DvtProvider(service_provider) as dvt:
         trace_codes_map = await CoreProfileSessionTap.get_trace_codes(dvt)
-        time_config = await CoreProfileSessionTap.get_time_config(dvt)
+        time_config = cast(dict[str, object], await CoreProfileSessionTap.get_time_config(dvt))
         parser.numer = time_config["numer"]
         parser.denom = time_config["denom"]
         parser.mach_absolute_time = time_config["mach_absolute_time"]
         parser.usecs_since_epoch = time_config["usecs_since_epoch"]
         parser.timezone = time_config["timezone"]
         async with CoreProfileSessionTap(dvt, time_config, filters) as tap:
-            chunk_queue = queue.Queue()
+            chunk_queue: queue.Queue[Any] = queue.Queue()
             stream = tap.get_kdbuf_stream(chunk_queue)
             producer_task = asyncio.create_task(tap.pump_kdbuf_chunks(chunk_queue))
 
@@ -300,8 +300,8 @@ async def parse_live_profile_session(
     """Print traces (syscalls, thread events, etc.) received from the device in real time."""
     async with DvtProvider(service_provider) as dvt:
         print("Receiving time information")
-        time_config = await CoreProfileSessionTap.get_time_config(dvt)
-        parser = PyKdebugParser()
+        time_config = cast(dict[str, object], await CoreProfileSessionTap.get_time_config(dvt))
+        parser: Any = PyKdebugParser()
         parser.filter_class = list(class_filters)
         if bsc:
             subclass_filters.append(BSC_SUBCLASS)
@@ -326,7 +326,7 @@ async def parse_live_profile_session(
             else:
                 print("{:^32}|{:^33}|   Event".format("Time", "Process"))
 
-            chunk_queue = queue.Queue()
+            chunk_queue: queue.Queue[Any] = queue.Queue()
             stream = tap.get_kdbuf_stream(chunk_queue)
             producer_task = asyncio.create_task(tap.pump_kdbuf_chunks(chunk_queue))
 
@@ -379,8 +379,8 @@ async def callstacks_live_profile_session(
     """Print callstacks received from the device in real time."""
     async with DvtProvider(service_provider) as dvt:
         print("Receiving time information")
-        time_config = await CoreProfileSessionTap.get_time_config(dvt)
-        parser = PyKdebugParser()
+        time_config = cast(dict[str, object], await CoreProfileSessionTap.get_time_config(dvt))
+        parser: Any = PyKdebugParser()
         parser.numer = time_config["numer"]
         parser.denom = time_config["denom"]
         parser.mach_absolute_time = time_config["mach_absolute_time"]
@@ -396,9 +396,9 @@ async def callstacks_live_profile_session(
         with importlib.resources.open_text(pymobiledevice3.resources, "dsc_uuid_map.json") as fd:
             dsc_uuid_map = json.load(fd)
 
-        current_dsc_map = {}
+        current_dsc_map: dict[str, str] = {}
         async with CoreProfileSessionTap(dvt, time_config) as tap:
-            chunk_queue = queue.Queue()
+            chunk_queue: queue.Queue[Any] = queue.Queue()
             stream = tap.get_kdbuf_stream(chunk_queue)
             producer_task = asyncio.create_task(tap.pump_kdbuf_chunks(chunk_queue))
 

--- a/pymobiledevice3/cli/developer/dvt/sysmon/__init__.py
+++ b/pymobiledevice3/cli/developer/dvt/sysmon/__init__.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import asdict
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional, cast
 
 import typer
 from typer_injector import InjectingTyper
@@ -42,7 +42,7 @@ async def sysmon_system(
         sysmontap = await Sysmontap.create(dvt)
         async with sysmontap as sysmon:
             system = None
-            system_usage = None
+            system_usage: Optional[dict[str, Any]] = None
             system_usage_seen = False  # Tracks if the first occurrence of SystemCPUUsage
 
             async for row in sysmon:
@@ -64,7 +64,7 @@ async def sysmon_system(
 
     assert system is not None and system_usage is not None  # for type checker
 
-    attrs_dict = {**asdict(system), **system_usage}
+    attrs_dict: dict[str, Any] = {**asdict(system), **system_usage}
     for name, value in attrs_dict.items():
-        if (split_fields is None) or (name in fields):
+        if (split_fields is None) or (name in cast(str, fields)):
             print(f"{name}: {value}")

--- a/pymobiledevice3/cli/developer/dvt/sysmon/process.py
+++ b/pymobiledevice3/cli/developer/dvt/sysmon/process.py
@@ -3,10 +3,11 @@ import contextlib
 import json
 import re
 import sys
+from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Optional, TextIO
+from typing import Annotated, Any, Optional, TextIO, cast
 
 import typer
 from typer_injector import InjectingTyper
@@ -212,9 +213,9 @@ def _should_skip_first_snapshot(keys: Optional[list[str]]) -> bool:
     return (keys is None) or ("cpuUsage" in keys)
 
 
-async def iter_processes(sysmon: Sysmontap, skip_first_snapshot: bool = False):
+async def iter_processes(sysmon: Sysmontap, skip_first_snapshot: bool = False) -> AsyncIterator[list[dict[str, Any]]]:
     should_skip_snapshot = skip_first_snapshot
-    async for process_snapshot in sysmon.iter_processes():
+    async for process_snapshot in cast(AsyncIterator[list[dict[str, Any]]], sysmon.iter_processes()):
         if should_skip_snapshot:
             should_skip_snapshot = False
             continue
@@ -252,10 +253,13 @@ def _select_process_from_candidates(
             f"Matches: {_describe_processes(processes)}"
         )
 
-    selection_index = prompt_selection(
-        [_describe_process(process) for process in sorted_processes],
-        "Choose process to monitor",
-        idx=True,
+    selection_index = cast(
+        int,
+        prompt_selection(
+            [_describe_process(process) for process in sorted_processes],
+            "Choose process to monitor",
+            idx=True,
+        ),
     )
     return sorted_processes[selection_index]
 
@@ -329,7 +333,7 @@ async def sysmon_process_single_task(
     out: Optional[TextIO] = None,
 ) -> None:
     parsed_filters = _parse_process_filters(filter_expressions)
-    result = []
+    result: list[dict[str, Any]] = []
     async with (
         DvtProvider(service_provider) as dvt,
         DeviceInfo(dvt) as device_info,

--- a/pymobiledevice3/cli/developer/fetch_symbols.py
+++ b/pymobiledevice3/cli/developer/fetch_symbols.py
@@ -65,7 +65,7 @@ async def fetch_symbols_download_task(service_provider: LockdownServiceProvider,
         fetch_symbols = DtFetchSymbols(service_provider)
         files = await fetch_symbols.list_files()
 
-        downloaded_files = set()
+        downloaded_files: set[Path] = set()
 
         for i, file in enumerate(files):
             if file.startswith("/"):

--- a/pymobiledevice3/cli/developer/wda.py
+++ b/pymobiledevice3/cli/developer/wda.py
@@ -1,7 +1,7 @@
 import asyncio
 from contextlib import suppress
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional, cast
 
 import typer
 from defusedxml import ElementTree as DefusedET
@@ -269,7 +269,7 @@ async def wda_list_items(
         "XCUIElementTypeImage",
     }
     if types:
-        custom = set()
+        custom: set[str] = set()
         for entry in types:
             for item in entry.split(","):
                 item = item.strip()
@@ -282,7 +282,7 @@ async def wda_list_items(
         if custom:
             clickable_types = custom
 
-    items = []
+    items: list[dict[str, Any]] = []
     for elem in root.iter():
         attrs = elem.attrib
         elem_type = elem.tag
@@ -311,15 +311,18 @@ async def wda_list_items(
                 rect = None
         if not (name or label or value or rect):
             continue
-        item = {
-            "type": elem_type,
-            "name": name,
-            "label": label,
-            "value": value,
-            "enabled": enabled,
-            "visible": visible,
-            "hittable": hittable,
-        }
+        item = cast(
+            dict[str, Any],
+            {
+                "type": elem_type,
+                "name": name,
+                "label": label,
+                "value": value,
+                "enabled": enabled,
+                "visible": visible,
+                "hittable": hittable,
+            },
+        )
         if with_rect:
             item["rect"] = rect
         items.append(item)

--- a/pymobiledevice3/cli/mounter.py
+++ b/pymobiledevice3/cli/mounter.py
@@ -48,7 +48,7 @@ cli = InjectingTyper(
 @async_command
 async def mounter_list(service_provider: ServiceProviderDep) -> None:
     """list all mounted images"""
-    output = []
+    output: list[dict[str, Any]] = []
 
     images = await MobileImageMounterService(lockdown=service_provider).copy_devices()
     for image in images:
@@ -233,7 +233,7 @@ async def mounter_query_personalization_identifiers(service_provider: ServicePro
 @async_command
 async def mounter_query_personalization_manifest(service_provider: ServiceProviderDep) -> None:
     """Query personalization manifest"""
-    result = []
+    result: list[bytes] = []
     mounter = MobileImageMounterService(lockdown=service_provider)
     for device in await mounter.copy_devices():
         result.append(

--- a/pymobiledevice3/cli/pcap.py
+++ b/pymobiledevice3/cli/pcap.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any, Optional, cast
 
 import typer
 from construct import Container
@@ -28,7 +28,10 @@ def print_packet_header(packet: Container[Any], color: bool) -> None:
     if not color:
         print(data)
     else:
-        print(highlight(data, lexers.HspecLexer(), formatters.Terminal256Formatter(style="native")), end="")
+        print(
+            highlight(data, cast(Any, lexers).HspecLexer(), cast(Any, formatters).Terminal256Formatter(style="native")),
+            end="",
+        )
 
 
 def print_packet(packet: Container[Any], color: Optional[bool] = None) -> Container[Any]:

--- a/pymobiledevice3/cli/remote.py
+++ b/pymobiledevice3/cli/remote.py
@@ -4,10 +4,11 @@ import logging
 import platform
 import sys
 import tempfile
+from collections.abc import Awaitable
 from contextlib import nullcontext
 from functools import partial
 from pathlib import Path
-from typing import Annotated, Any, Optional, TextIO, Union
+from typing import Annotated, Any, Callable, Optional, TextIO, Union
 
 import typer
 from typer_injector import InjectingTyper
@@ -49,7 +50,7 @@ TUNNEL_SERVICE_DISCOVERY_ATTEMPTS = 3
 
 
 async def browse_rsd(timeout: float = DEFAULT_BONJOUR_TIMEOUT) -> list[dict[str, Any]]:
-    devices = []
+    devices: list[dict[str, Any]] = []
     for rsd in await get_rsds(timeout):
         assert rsd.peer_info is not None
         devices.append({
@@ -63,7 +64,7 @@ async def browse_rsd(timeout: float = DEFAULT_BONJOUR_TIMEOUT) -> list[dict[str,
 
 
 async def browse_remotepairing(timeout: float = DEFAULT_BONJOUR_TIMEOUT) -> list[dict[str, Any]]:
-    devices = []
+    devices: list[dict[str, Any]] = []
     for remotepairing in await get_remote_pairing_tunnel_services(timeout):
         devices.append({
             "address": remotepairing.hostname,
@@ -221,11 +222,11 @@ async def start_tunnel_task(
 ) -> None:
     if start_tunnel is None:
         raise NotImplementedError("failed to start the tunnel on your platform")
-    get_tunnel_services = {
+    get_tunnel_services: dict[ConnectionType, Callable[..., Awaitable[list[Any]]]] = {
         connection_type.USB: get_core_device_tunnel_services,
         connection_type.WIFI: get_remote_pairing_tunnel_services,
     }
-    tunnel_services = []
+    tunnel_services: list[Any] = []
     for attempt in range(TUNNEL_SERVICE_DISCOVERY_ATTEMPTS):
         tunnel_services = await get_tunnel_services[connection_type](udid=udid)
         if tunnel_services:

--- a/pymobiledevice3/cli/restore.py
+++ b/pymobiledevice3/cli/restore.py
@@ -5,7 +5,7 @@ import tempfile
 import traceback
 from collections.abc import Iterator
 from pathlib import Path
-from typing import IO, Annotated, Any, Optional, Union
+from typing import IO, Annotated, Any, Optional, Union, cast
 
 import requests
 import typer
@@ -207,7 +207,9 @@ async def restore_update_task(
 def restore_shell(device: DeviceDep) -> None:
     """create an IPython shell for interacting with iBoot"""
     start_ipython_shell(
-        header=highlight(SHELL_USAGE, lexers.PythonLexer(), formatters.Terminal256Formatter(style="native")),
+        header=highlight(
+            SHELL_USAGE, cast(Any, lexers).PythonLexer(), cast(Any, formatters).Terminal256Formatter(style="native")
+        ),
         user_ns={
             "irecv": device.irecv,
         },

--- a/pymobiledevice3/cli/usbmux.py
+++ b/pymobiledevice3/cli/usbmux.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import tempfile
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional, Union
 
 import typer
 from typer_injector import InjectingTyper
@@ -111,7 +111,7 @@ async def usbmux_list(
     ] = False,
 ) -> None:
     """List devices known to usbmuxd (USB and Wi-Fi)."""
-    connected_devices = []
+    connected_devices: list[Union[str, dict[str, Any]]] = []
     for device in await usbmux.list_devices(usbmux_address=usbmux_address):
         udid = device.serial
 

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from functools import update_wrapper
 from string import Template
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any, Optional, cast
 
 import inquirer3
 import typer
@@ -22,7 +22,7 @@ from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.styles import style_from_pygments_cls
 from pygments import formatters, highlight, lexers
-from pygments.styles import get_style_by_name
+from pygments import styles as _pygments_styles
 from typer_injector import InjectingTyper
 
 from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command
@@ -143,7 +143,7 @@ cli = InjectingTyper(
 
 
 def catch_errors(func: Callable[..., Any]) -> Callable[..., Any]:
-    errors = {
+    errors: dict[type[Exception], str] = {
         LaunchingApplicationError: "Unable to launch application (try to unlock device)",
         WebInspectorNotEnabledError: "Web inspector is not enabled",
         RemoteAutomationNotEnabledError: "Remote automation is not enabled",
@@ -292,7 +292,9 @@ async def shell_task(service_provider: LockdownServiceProvider, timeout: float) 
         driver = WebDriver(session)
         try:
             start_ipython_shell(
-                header=highlight(SHELL_USAGE, lexers.PythonLexer(), formatters.Terminal256Formatter(style="native")),
+                header=highlight(
+                    SHELL_USAGE, cast(Any, lexers).PythonLexer(), formatters.Terminal256Formatter(style="native")
+                ),
                 user_ns={
                     "driver": driver,
                     "Cookie": Cookie,
@@ -477,9 +479,9 @@ class JsShell(ABC):
     def __init__(self) -> None:
         super().__init__()
         self.prompt_session: PromptSession[str] = PromptSession(
-            lexer=PygmentsLexer(lexers.JavascriptLexer),
+            lexer=PygmentsLexer(cast(Any, lexers).JavascriptLexer),
             auto_suggest=AutoSuggestFromHistory(),
-            style=style_from_pygments_cls(get_style_by_name("stata-dark")),
+            style=style_from_pygments_cls(cast(Any, _pygments_styles).get_style_by_name("stata-dark")),
             history=FileHistory(self.webinspector_history_path()),
             completer=JsShellCompleter(self),
         )
@@ -509,8 +511,13 @@ class JsShell(ABC):
             return
 
         result = await self.evaluate_expression(exp)
-        colorful_result = highlight(
-            f"{result}", lexers.JavascriptLexer(), formatters.Terminal256Formatter(style="stata-dark")
+        colorful_result = cast(
+            str,
+            highlight(
+                f"{result}",
+                cast(Any, lexers).JavascriptLexer(),
+                cast(Any, formatters).Terminal256Formatter(style="stata-dark"),
+            ),
         )
         print(colorful_result, end="")
 
@@ -628,7 +635,9 @@ class InspectorJsShell(JsShell):
             return available_pages[0]
 
         page_query = [inquirer3.List("page", message="choose page", choices=available_pages, carousel=True)]
-        page = inquirer3.prompt(page_query, theme=GreenPassion(), raise_keyboard_interrupt=True)["page"]
+        page = cast(
+            dict[str, Any], cast(Any, inquirer3).prompt(page_query, theme=GreenPassion(), raise_keyboard_interrupt=True)
+        )["page"]
         return page
 
 

--- a/pymobiledevice3/dtx/message_aux.py
+++ b/pymobiledevice3/dtx/message_aux.py
@@ -1,6 +1,6 @@
 import io
 import logging
-from typing import Any, Union
+from typing import Any, Union, cast
 
 from bpylist2 import archiver
 from construct import Bytes, ConstructError, Peek
@@ -16,7 +16,7 @@ class MessageAux(list[Any]):
     """An adapter that parse DISPTACH arguments from/to primitive dictionaries"""
 
     @classmethod
-    def parse(cls, obj: Union[bytes, bytearray, memoryview], context: Any, path: str):
+    def parse(cls, obj: Union[bytes, bytearray, memoryview], context: Any, path: str) -> list[Any]:
         if len(obj) == 0:
             # interpret empty buffers as an empty list
             return []
@@ -26,12 +26,12 @@ class MessageAux(list[Any]):
             raise ConstructError(
                 f"Expected a dictionary for MessageAux, got {type(primitive_dict).__name__}", path=path
             )
-        if len(primitive_dict) != 1 or not isinstance(primitive_dict.get(PNULL), list):
+        if len(cast(Any, primitive_dict)) != 1 or not isinstance(cast(Any, primitive_dict).get(PNULL), list):
             raise ConstructError(
                 f"Expected a dictionary with a single PNULL key mapping to a list, got {primitive_dict}", path=path
             )
-        converted_list = []
-        for arg in primitive_dict[PNULL]:
+        converted_list: list[Any] = []
+        for arg in cast(list[Any], primitive_dict[PNULL]):
             assert isinstance(arg, _PrimitiveBase), (
                 f"Expected all arguments to be primitive types, got {type(arg).__name__}"
             )
@@ -60,7 +60,7 @@ class MessageAux(list[Any]):
         if not obj:
             # nothing is written ¯\_(ツ)_/¯
             return b""
-        converted_list = []
+        converted_list: list[Any] = []
         # translate everything that is not a primitive into a NSKeyedArchiver-encoded blob
         for arg in obj:
             if isinstance(arg, _PrimitiveBase):

--- a/pymobiledevice3/dtx/ns_types.py
+++ b/pymobiledevice3/dtx/ns_types.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import datetime
 import os
 import uuid
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from bpylist2 import archiver
 
@@ -40,7 +40,7 @@ def patch_class_hierarchy(
     hierarchy: list[str],
 ) -> None:
     """Overwrite the '$classes' list for *class_name* in the live archive."""
-    a = archive_obj._archiver  # type: ignore[attr-defined]
+    a = cast(Any, archive_obj._archiver)  # type: ignore[attr-defined]
     uid = a.class_map.get(class_name)
     if uid is not None:
         a.objects[uid.data]["$classes"] = hierarchy
@@ -52,7 +52,7 @@ class DTTapMessage:
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> Any:
         """Decode an archived DTTapMessage by extracting its embedded plist."""
-        return archive_obj.decode("DTTapMessagePlist")
+        return cast(Any, archive_obj.decode("DTTapMessagePlist"))
 
 
 class NSNull:
@@ -74,22 +74,23 @@ class NSError:
 
     def encode_archive(self, archive_obj: archiver.ArchivingObject) -> None:
         """Encode this NSError into an NSKeyedArchive object."""
-        archive_obj.encode("NSDomain", self.domain)
-        archive_obj.encode("NSCode", self.code)
-        archive_obj.encode("NSUserInfo", self.user_info)
+        ao = cast(Any, archive_obj)
+        ao.encode("NSDomain", self.domain)
+        ao.encode("NSCode", self.code)
+        ao.encode("NSUserInfo", self.user_info)
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> NSError:
         """Decode an NSKeyedArchive object into an :class:`NSError` instance."""
-        domain = archive_obj.decode("NSDomain")
-        code = archive_obj.decode("NSCode")
-        user_info = archive_obj.decode("NSUserInfo")
+        domain = cast(Any, archive_obj.decode("NSDomain"))
+        code = cast(Any, archive_obj.decode("NSCode"))
+        user_info = cast(Any, archive_obj.decode("NSUserInfo"))
         assert (
             (user_info is None or isinstance(user_info, dict)) and isinstance(domain, str) and isinstance(code, int)
         ), (
             f"Invalid NSError archive: domain={domain!r} code={code!r} user_info={user_info!r}, archive_obj={archive_obj!r}"
         )
-        return NSError(code, domain, user_info)
+        return NSError(code, domain, cast(Any, user_info))
 
     @staticmethod
     def create_doesnt_respond_to_selector(selector: str) -> NSError:
@@ -116,12 +117,13 @@ class NSUUID(uuid.UUID):
 
     def encode_archive(self, archive_obj: archiver.ArchivingObject) -> None:
         """Encode this NSUUID into an NSKeyedArchive object."""
-        archive_obj.encode("NS.uuidbytes", self.bytes)
+        ao = cast(Any, archive_obj)
+        ao.encode("NS.uuidbytes", self.bytes)
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> NSUUID:
         """Decode an NSKeyedArchive object into an :class:`NSUUID` instance."""
-        return NSUUID(bytes=archive_obj.decode("NS.uuidbytes"))
+        return NSUUID(bytes=cast(Any, archive_obj.decode("NS.uuidbytes")))
 
 
 class NSURL:
@@ -133,8 +135,9 @@ class NSURL:
 
     def encode_archive(self, archive_obj: archiver.ArchivingObject) -> None:
         """Encode this NSURL into an NSKeyedArchive object."""
-        archive_obj.encode("NS.base", self.base)
-        archive_obj.encode("NS.relative", self.relative)
+        ao = cast(Any, archive_obj)
+        ao.encode("NS.base", self.base)
+        ao.encode("NS.relative", self.relative)
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> NSURL:
@@ -148,7 +151,7 @@ class NSValue:
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> Any:
         """Decode an NSKeyedArchive object into the underlying NSValue data."""
-        return archive_obj.decode("NS.rectval")
+        return cast(Any, archive_obj.decode("NS.rectval"))
 
 
 class NSMutableArray(list[Any]):
@@ -166,7 +169,7 @@ class NSMutableArray(list[Any]):
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> NSMutableArray:
-        raw = archive_obj.decode("NS.objects") or []
+        raw = cast(list[Any], archive_obj.decode("NS.objects") or [])
         return NSMutableArray([archive_obj.decode_index(item) for item in raw])
 
 
@@ -176,7 +179,7 @@ class NSMutableData:
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> Any:
         """Decode an NSKeyedArchive object into the underlying bytes data."""
-        return archive_obj.decode("NS.data")
+        return cast(Any, archive_obj.decode("NS.data"))
 
 
 class NSMutableString:
@@ -185,7 +188,7 @@ class NSMutableString:
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> Any:
         """Decode an NSKeyedArchive object into the underlying string."""
-        return archive_obj.decode("NS.string")
+        return cast(Any, archive_obj.decode("NS.string"))
 
 
 class NSDate:
@@ -211,7 +214,7 @@ class NSDate:
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> NSDate:
         """Decode an NSKeyedArchive NSDate object."""
-        t = archive_obj.decode("NS.time")
+        t = cast(Any, archive_obj.decode("NS.time"))
         return NSDate(float(t) if t is not None else 0.0)
 
 
@@ -238,4 +241,5 @@ archiver.update_class_map({
 })
 
 archiver.ARCHIVE_CLASS_MAP[NSMutableArray] = "NSMutableArray"  # type: ignore[index]
-archiver.Archive.inline_types = list({*archiver.Archive.inline_types, bytes})
+_archive_cls: Any = archiver.Archive
+_archive_cls.inline_types = list({*_archive_cls.inline_types, bytes})

--- a/pymobiledevice3/dtx/primitives.py
+++ b/pymobiledevice3/dtx/primitives.py
@@ -293,17 +293,15 @@ PStr = PrimitiveString
 PDict = PrimitiveDictionary
 
 
-_PRIMITIVE_REGISTRY.update({
-    cls._type_code: cls
-    for cls in [
-        PrimitiveNull,
-        PrimitiveString,
-        PrimitiveBuffer,
-        PrimitiveInt32,
-        PrimitiveInt64,
-        PrimitiveDouble,
-        PrimitiveDictionary,
-    ]
-})
+_all_primitive_types: list[type[_PrimitiveBase]] = [
+    PrimitiveNull,
+    PrimitiveString,
+    PrimitiveBuffer,
+    PrimitiveInt32,
+    PrimitiveInt64,
+    PrimitiveDouble,
+    PrimitiveDictionary,
+]
+_PRIMITIVE_REGISTRY.update({cls._type_code: cls for cls in _all_primitive_types})
 PNULL = PrimitiveNull()  # singleton instance for convenience
 PRIMITIVE_TYPES = tuple(_PRIMITIVE_REGISTRY.values())

--- a/pymobiledevice3/dtx/service.py
+++ b/pymobiledevice3/dtx/service.py
@@ -176,7 +176,7 @@ def _apply_primitive_coercions(args: tuple[Any, ...], coercions: tuple[Any, ...]
         if not isinstance(result[i], _PrimitiveBase):
             # Concrete primitive classes mix in a builtin (int/str/bytes/…) whose
             # constructor takes the raw value; _PrimitiveBase itself declares none.
-            result[i] = cast("Callable[[Any], _PrimitiveBase]", coerce_type)(result[i])
+            result[i] = cast(Callable[[Any], _PrimitiveBase], coerce_type)(result[i])
     return tuple(result)
 
 
@@ -216,7 +216,7 @@ def dtx_method(selector_or_fn: Any = None, /, **invoke_kwargs: Any) -> Any:
         @dtx_method("setConfig:", expects_reply=False)
     """
     if callable(selector_or_fn):
-        cast("_DtxMethodFn", selector_or_fn)._dtx_method = (None, {})
+        cast(_DtxMethodFn, selector_or_fn)._dtx_method = (None, {})
         return selector_or_fn
     selector = selector_or_fn
 
@@ -240,7 +240,7 @@ def dtx_on_invoke(selector_or_fn: Any = None, /) -> Any:
         @dtx_on_invoke("_XCT_logMessage:")      # explicit selector
     """
     if callable(selector_or_fn):
-        cast("_DtxOnInvokeFn", selector_or_fn)._dtx_on_invoke = None  # None → infer from method name
+        cast(_DtxOnInvokeFn, selector_or_fn)._dtx_on_invoke = None  # None → infer from method name
         return selector_or_fn
     selector = selector_or_fn
 

--- a/pymobiledevice3/dtx_proxy_service.py
+++ b/pymobiledevice3/dtx_proxy_service.py
@@ -96,8 +96,8 @@ class DtxProxyService(DtxService[_DTXProxyService], Generic[LOCAL_SVC_T, REMOTE_
         # Unwrap the low-level DTXProxyService's sub-service instances.
         # The registry instantiated the inferred sub-service classes, so the
         # casts reflect the runtime types selected by the type parameters.
-        self._local_service = cast("LOCAL_SVC_T", self._service.local_service)
-        self._remote_service = cast("REMOTE_SVC_T", self._service.remote_service)
+        self._local_service = cast(LOCAL_SVC_T, self._service.local_service)
+        self._remote_service = cast(REMOTE_SVC_T, self._service.remote_service)
 
     @property
     def local_service(self) -> LOCAL_SVC_T:

--- a/pymobiledevice3/dtx_service.py
+++ b/pymobiledevice3/dtx_service.py
@@ -123,15 +123,15 @@ class DtxService(Generic[_SVC_T]):
         if self.CHANNEL_IDENTIFIER is not None:
             if self._inferred_service_class is not None:
                 return cast(
-                    "_SVC_T",
+                    _SVC_T,
                     await self._provider.dtx.open_channel(self.CHANNEL_IDENTIFIER, self._inferred_service_class),
                 )
-            return cast("_SVC_T", await self._provider.dtx.open_channel(self.CHANNEL_IDENTIFIER))
+            return cast(_SVC_T, await self._provider.dtx.open_channel(self.CHANNEL_IDENTIFIER))
         assert self._inferred_service_class is not None, (
             "Cannot infer service class — specify CHANNEL_IDENTIFIER or provide a concrete "
             "type parameter, e.g. DtxService[MyService]"
         )
-        return cast("_SVC_T", await self._provider.dtx.open_channel(self._inferred_service_class))
+        return cast(_SVC_T, await self._provider.dtx.open_channel(self._inferred_service_class))
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/pymobiledevice3/dtx_service_provider.py
+++ b/pymobiledevice3/dtx_service_provider.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import logging
 import socket as _socket
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar, Optional, cast
 
 from packaging.version import Version
 from typing_extensions import Self
@@ -205,9 +205,9 @@ class DtxServiceProvider:
             with lockdown.ssl_file() as f:  # type: ignore[attr-defined]
                 if strip_ssl:
                     svc.setblocking(True)
-                    svc.ssl_start_sync(f)
+                    svc.ssl_start_sync(cast(str, f))
                 else:
-                    await svc.ssl_start(f)
+                    await svc.ssl_start(cast(str, f))
 
         if (
             strip_ssl

--- a/pymobiledevice3/irecv.py
+++ b/pymobiledevice3/irecv.py
@@ -4,17 +4,32 @@ import logging
 import math
 import struct
 import time
+from array import array
 from collections.abc import Iterable
 from enum import Enum
 from types import TracebackType
-from typing import Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from tqdm import trange
-from usb.core import Device, USBError, find
-from usb.util import dispose_resources, get_string
+from usb.core import Device, USBError
 
 from pymobiledevice3.exceptions import IRecvError, IRecvNoDeviceConnectedError, PyMobileDevice3Exception
-from pymobiledevice3.irecv_devices import IRECV_DEVICES, IRecvDevice
+from pymobiledevice3.irecv_devices import IRecvDevice
+
+if TYPE_CHECKING:
+    # pyusb (usb.core / usb.util) and IRECV_DEVICES ship no type information, so their symbols
+    # resolve as partially-unknown. Declare precise signatures for type checking while importing
+    # the real implementations at runtime.
+    def find(find_all: bool = False, backend: Any = None, custom_match: Any = None, **args: Any) -> Any: ...
+    def get_string(dev: Any, index: int, langid: Optional[int] = None) -> Optional[str]: ...
+    def dispose_resources(device: Any) -> None: ...
+
+    IRECV_DEVICES: tuple[IRecvDevice, ...]
+else:
+    from usb.core import find
+    from usb.util import dispose_resources, get_string
+
+    from pymobiledevice3.irecv_devices import IRECV_DEVICES
 
 USB_TIMEOUT = 10000
 IRECV_TRANSFER_SIZE_RECOVERY = 0x8000
@@ -63,12 +78,12 @@ logger = logging.getLogger(__name__)
 class IRecv:
     def __init__(self, ecid: Optional[int] = None, timeout: int = 0xFFFFFFFF, is_recovery: Optional[bool] = None):
         self._mode: Optional[Mode] = None
-        self._device_info = {}
+        self._device_info: dict[str, str] = {}
         self._device: Optional[Device] = None
         self._reinit(ecid=ecid, timeout=timeout, is_recovery=is_recovery)
 
     @property
-    def device(self) -> Device:
+    def device(self) -> Any:
         """The connected USB device.
 
         :raises IRecvNoDeviceConnectedError: if no device is connected (before/after ``_reinit``).
@@ -104,7 +119,7 @@ class IRecv:
         return int(self._device_info["BDID"], 16)
 
     @property
-    def serial_number(self) -> int:
+    def serial_number(self) -> str:
         return self._device_info["SRNM"]
 
     @property
@@ -147,15 +162,18 @@ class IRecv:
         logger.debug(f"set_configuration: {configuration}")
         device = self.device
         try:
-            if device.get_active_configuration().bConfigurationValue == configuration:  # pyright: ignore[reportAttributeAccessIssue]
+            active_configuration: Any = device.get_active_configuration()
+            if active_configuration.bConfigurationValue == configuration:
                 return
         except USBError:
             pass
 
         device.set_configuration(configuration=configuration)
 
-    def ctrl_transfer(self, bmRequestType: int, bRequest: int, timeout: int = USB_TIMEOUT, **kwargs: Any):
-        return self.device.ctrl_transfer(bmRequestType, bRequest, timeout=timeout, **kwargs)
+    def ctrl_transfer(
+        self, bmRequestType: int, bRequest: int, timeout: int = USB_TIMEOUT, **kwargs: Any
+    ) -> "array[int]":
+        return cast("array[int]", self.device.ctrl_transfer(bmRequestType, bRequest, timeout=timeout, **kwargs))
 
     def send_buffer(self, buf: bytes):
         device = self.device
@@ -189,7 +207,7 @@ class IRecv:
             packet_index = _offset // packet_size
 
             if mode.is_recovery:
-                n = device.write(0x04, chunk, timeout=USB_TIMEOUT)
+                n = cast(int, device.write(0x04, chunk, timeout=USB_TIMEOUT))
                 if n != len(chunk):
                     raise OSError("failed to upload data")
             else:
@@ -301,12 +319,13 @@ class IRecv:
         while (self._device is None) and (time.time() < end):
             for device in cast(Iterable[Device], find(find_all=True)):
                 try:
-                    if device.manufacturer is None:
+                    usb_device: Any = device
+                    if usb_device.manufacturer is None:
                         continue
-                    if not device.manufacturer.startswith("Apple"):
+                    if not usb_device.manufacturer.startswith("Apple"):
                         continue
 
-                    mode = Mode.get_mode_from_value(device.idProduct)  # pyright: ignore[reportAttributeAccessIssue]
+                    mode = Mode.get_mode_from_value(usb_device.idProduct)
                     if mode is None:
                         # not one of Apple's special modes
                         continue
@@ -330,7 +349,7 @@ class IRecv:
                     continue
 
     def _populate_device_info(self):
-        serial_number = self.device.serial_number
+        serial_number = cast(Optional[str], self.device.serial_number)
         if serial_number is None:
             raise IRecvError("device did not report a serial number")
         for component in serial_number.split(" "):

--- a/pymobiledevice3/irecv_devices.py
+++ b/pymobiledevice3/irecv_devices.py
@@ -9,7 +9,7 @@ class IRecvDevice(NamedTuple):
     display_name: str
 
 
-IRECV_DEVICES = (
+IRECV_DEVICES: tuple[IRecvDevice, ...] = (
     # iPhone
     IRecvDevice(
         product_type="iPhone1,1", hardware_model="m68ap", board_id=0x00, chip_id=0x8900, display_name="iPhone 2G"

--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -8,13 +8,13 @@ import tempfile
 import time
 from abc import ABC, abstractmethod
 from asyncio import IncompleteReadError
-from collections.abc import AsyncIterable, Generator
+from collections.abc import AsyncIterable, Generator, Iterable
 from contextlib import contextmanager, suppress
 from enum import Enum
 from pathlib import Path
 from ssl import SSLZeroReturnError, TLSVersion
 from types import TracebackType
-from typing import Any, Optional, overload
+from typing import Any, Optional, cast, overload
 
 from construct import StreamError
 from cryptography import x509
@@ -26,7 +26,7 @@ from cryptography.hazmat.primitives.serialization.pkcs7 import PKCS7Options, PKC
 from packaging.version import Version
 from typing_extensions import Self
 
-from pymobiledevice3 import usbmux
+from pymobiledevice3 import irecv_devices, usbmux
 from pymobiledevice3.bonjour import DEFAULT_BONJOUR_TIMEOUT, browse_mobdev2
 from pymobiledevice3.ca import generate_pairing_cert_chain
 from pymobiledevice3.common import get_home_folder
@@ -50,11 +50,12 @@ from pymobiledevice3.exceptions import (
     PairingDialogResponsePendingError,
     PairingError,
     PasswordRequiredError,
+    PyMobileDevice3Exception,
     SetProhibitedError,
     StartServiceError,
     UserDeniedPairingError,
 )
-from pymobiledevice3.irecv_devices import IRECV_DEVICES
+from pymobiledevice3.irecv_devices import IRecvDevice
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.osu.os_utils import get_os_utils
 from pymobiledevice3.pair_records import (
@@ -66,6 +67,9 @@ from pymobiledevice3.service_connection import ServiceConnection
 from pymobiledevice3.usbmux import PlistMuxConnection
 
 OSUTIL = get_os_utils()
+# `irecv_devices.IRECV_DEVICES` is a very large tuple literal that pyright infers as `tuple[Unknown, ...]`;
+# route it through an explicit `Any` boundary to recover the element type without touching that module.
+IRECV_DEVICES: tuple[IRecvDevice, ...] = cast(Any, irecv_devices).IRECV_DEVICES
 SYSTEM_BUID = "30142955-444094379208051516"
 RESTORED_SERVICE_TYPE = "com.apple.mobile.restored"
 
@@ -133,9 +137,9 @@ class LockdownClient(ABC, LockdownServiceProvider):
         self.service = service
         self.identifier = identifier
         self.label = label
-        self.host_id = host_id
-        self.system_buid = system_buid
-        self.pair_record = pair_record
+        self.host_id: str = host_id
+        self.system_buid: str = system_buid
+        self.pair_record: Optional[dict[str, Any]] = pair_record
         self.paired = False
         self.session_id = None
         self.pairing_records_cache_folder = pairing_records_cache_folder
@@ -344,7 +348,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
 
         :returns: The display name, or ``None`` when the product type is not in the table.
         """
-        for irecv_device in IRECV_DEVICES:
+        for irecv_device in cast(Iterable[IRecvDevice], IRECV_DEVICES):
             if irecv_device.product_type == self.product_type:
                 return irecv_device.display_name
         return None
@@ -357,7 +361,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
 
         :returns: The hardware model, or ``None`` when the product type is not in the table.
         """
-        for irecv_device in IRECV_DEVICES:
+        for irecv_device in cast(Iterable[IRecvDevice], IRECV_DEVICES):
             if irecv_device.product_type == self.product_type:
                 return irecv_device.hardware_model
         return None
@@ -370,7 +374,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
 
         :returns: The board ID, or ``None`` when the product type is not in the table.
         """
-        for irecv_device in IRECV_DEVICES:
+        for irecv_device in cast(Iterable[IRecvDevice], IRECV_DEVICES):
             if irecv_device.product_type == self.product_type:
                 return irecv_device.board_id
         return None
@@ -383,7 +387,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
 
         :returns: The chip ID, or ``None`` when the product type is not in the table.
         """
-        for irecv_device in IRECV_DEVICES:
+        for irecv_device in cast(Iterable[IRecvDevice], IRECV_DEVICES):
             if irecv_device.product_type == self.product_type:
                 return irecv_device.chip_id
         return None
@@ -650,7 +654,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
             # TODO: consider parsing product_version to support iOS < 4
         )
 
-        pair_record = {
+        pair_record: dict[str, Any] = {
             "DeviceCertificate": device_cert_pem,
             "HostCertificate": host_cert_pem,
             "HostID": self.host_id,
@@ -660,7 +664,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
             "SystemBUID": self.system_buid,
         }
 
-        pair_options = {
+        pair_options: dict[str, Any] = {
             "HostName": socket.gethostname(),
             "PairRecord": pair_record,
             "ProtocolVersion": "2",
@@ -712,7 +716,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
             # TODO: consider parsing product_version to support iOS < 4
         )
 
-        pair_record = {
+        pair_record: dict[str, Any] = {
             "DeviceCertificate": device_cert_pem,
             "HostCertificate": host_cert_pem,
             "HostID": self.host_id,
@@ -722,7 +726,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
             "SystemBUID": self.system_buid,
         }
 
-        pair_options = {
+        pair_options: dict[str, Any] = {
             "PairRecord": pair_record,
             "ProtocolVersion": "2",
             "PairingOptions": {"SupervisorCertificate": public_key, "ExtendedPairingErrors": True},
@@ -789,7 +793,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
         :param key: Specific key to read, or ``None`` to read the whole domain.
         :returns: The requested value, or ``None`` if nothing was returned.
         """
-        options = {}
+        options: dict[str, Any] = {}
         if domain:
             options["Domain"] = domain
         if key:
@@ -804,7 +808,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
             return r.data
         if domain is None and key is None and isinstance(r, dict):
             self.all_values = r
-        return r
+        return cast(Any, r)
 
     async def remove_value(self, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
         """Remove a value on the device via a ``RemoveValue`` request.
@@ -813,7 +817,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
         :param key: Specific key to remove, or ``None``.
         :returns: The lockdownd response to the request.
         """
-        options = {}
+        options: dict[str, Any] = {}
         if domain:
             options["Domain"] = domain
         if key:
@@ -828,7 +832,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
         :param key: Specific key to write, or ``None``.
         :returns: The lockdownd response to the request.
         """
-        options = {}
+        options: dict[str, Any] = {}
         if domain:
             options["Domain"] = domain
         if key:
@@ -1043,7 +1047,7 @@ class LockdownClient(ABC, LockdownServiceProvider):
             # return response if supervisor cert challenge is required, to work with pair_supervisor
             if error == "MCChallengeRequired":
                 return response
-            exception_errors = {
+            exception_errors: dict[str, type[PyMobileDevice3Exception]] = {
                 "PasswordProtected": PasswordRequiredError,
                 "PairingDialogResponsePending": PairingDialogResponsePendingError,
                 "UserDeniedPairing": UserDeniedPairingError,
@@ -1572,7 +1576,7 @@ async def get_mobdev2_lockdowns(
     only_paired: bool = False,
     timeout: float = DEFAULT_BONJOUR_TIMEOUT,
 ) -> AsyncIterable[tuple[str, TcpLockdownClient]]:
-    records = {}
+    records: dict[str, Any] = {}
     if pair_records is None:
         pair_records = get_home_folder()
     for file in pair_records.glob("*.plist"):

--- a/pymobiledevice3/osu/posix_util.py
+++ b/pymobiledevice3/osu/posix_util.py
@@ -4,7 +4,7 @@ import signal
 import socket
 import struct
 from pathlib import Path
-from typing import Union
+from typing import Any, Union, cast
 
 from ifaddr import get_adapters
 
@@ -98,7 +98,7 @@ class Linux(Posix):
     ) -> None:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         # TCP_KEEPIDLE is Linux-only; this class is only instantiated on Linux.
-        tcp_keepidle = socket.TCP_KEEPIDLE  # pyright: ignore[reportAttributeAccessIssue]
+        tcp_keepidle = cast(Any, socket).TCP_KEEPIDLE
         sock.setsockopt(socket.IPPROTO_TCP, tcp_keepidle, after_idle_sec)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, interval_sec)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, max_fails)

--- a/pymobiledevice3/osu/win_util.py
+++ b/pymobiledevice3/osu/win_util.py
@@ -3,7 +3,7 @@ import logging
 import os
 import socket
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import win32security  # pyright: ignore[reportMissingModuleSource]
 from ifaddr import get_adapters
@@ -25,9 +25,9 @@ class Win32(OsUtils):
         :return: True if the current user is an 'Administrator', otherwise False.
         """
         try:
-            admin_sid = win32security.CreateWellKnownSid(win32security.WinBuiltinAdministratorsSid, None)
+            admin_sid = cast(Any, win32security).CreateWellKnownSid(win32security.WinBuiltinAdministratorsSid, None)
             # pywin32 accepts None for TokenHandle (current thread token); the stub only allows int.
-            return win32security.CheckTokenMembership(None, admin_sid)  # pyright: ignore[reportArgumentType]
+            return cast(Any, win32security).CheckTokenMembership(None, admin_sid)
         except Exception:
             return False
 
@@ -70,7 +70,7 @@ class Win32(OsUtils):
 
         if hasattr(ioctl_socket, "ioctl"):
             # SIO_KEEPALIVE_VALS only exists in the socket module on Windows.
-            sio_keepalive_vals = socket.SIO_KEEPALIVE_VALS  # pyright: ignore[reportAttributeAccessIssue]
+            sio_keepalive_vals = cast(Any, socket).SIO_KEEPALIVE_VALS
             ioctl_socket.ioctl(sio_keepalive_vals, (1, after_idle_sec * 1000, interval_sec * 1000))
             return
 

--- a/pymobiledevice3/remote/core_device/core_device_service.py
+++ b/pymobiledevice3/remote/core_device/core_device_service.py
@@ -27,7 +27,7 @@ class CoreDeviceService(RemoteService):
     ) -> Any:
         if input_ is None:
             input_ = {}
-        request = {
+        request: dict[str, Any] = {
             "CoreDevice.CoreDeviceDDIProtocolVersion": XpcInt64Type(2),
             "CoreDevice.coreDeviceVersion": CORE_DEVICE_VERSION,
             "CoreDevice.deviceIdentifier": str(uuid.uuid4()),

--- a/pymobiledevice3/remote/core_device/display_service.py
+++ b/pymobiledevice3/remote/core_device/display_service.py
@@ -97,7 +97,7 @@ class DisplayService(CoreDeviceService):
             fec_enabled=fec_enabled,
             tiles_per_frame=tiles_per_frame,
         )
-        request = {
+        request: dict[str, Any] = {
             "clientSupportedFeatures": XpcUInt64Type(_CLIENT_SUPPORTED_FEATURES),
             "direction": "output",
             "negotiatorOffer": negotiator_offer,
@@ -153,7 +153,7 @@ class DisplayService(CoreDeviceService):
         call_id = new_call_id()
         session_id = random.randint(0, 0xFFFFFFFF)
         negotiator_offer = build_negotiator_offer_audio(call_id=call_id, session_id=session_id)
-        request = {
+        request: dict[str, Any] = {
             "clientSupportedFeatures": XpcUInt64Type(_CLIENT_SUPPORTED_FEATURES),
             "direction": "output",
             "negotiatorOffer": negotiator_offer,

--- a/pymobiledevice3/remote/core_device/hevc_av.py
+++ b/pymobiledevice3/remote/core_device/hevc_av.py
@@ -50,6 +50,11 @@ try:
 except ModuleNotFoundError as e:  # pragma: no cover
     raise ModuleNotFoundError("PyAV is required for the libav HEVC decoder path. Install with: pip install av") from e
 
+# PyAV ships no type information and its stub coverage varies across platforms/wheels, so route
+# every attribute access through Any to stay type-clean regardless of what the installed build
+# exposes to pyright (fully-unknown on CI, partially-typed on some local envs).
+_av: Any = av
+
 
 class HevcToBgraTranscoder:
     """Annex-B HEVC -> raw BGRA bytes via libavcodec.
@@ -89,13 +94,13 @@ class HevcToBgraTranscoder:
         self._on_frame = on_frame
         self._on_decode_error = on_decode_error
 
-        self._codec = av.codec.CodecContext.create("hevc", "r")
+        self._codec: Any = _av.codec.CodecContext.create("hevc", "r")
         # Seed the decoder with the parameter sets so the first AU
         # doesn't need them in-band. Even if the IDR re-carries VPS/
         # SPS/PPS (Apple's stream does), libav tolerates the dupes.
         ps_annexb = b"".join(b"\x00\x00\x00\x01" + nal for nal in (vps, sps, pps))
         with contextlib.suppress(Exception):
-            list(self._codec.decode(av.Packet(ps_annexb)))
+            list(self._codec.decode(_av.Packet(ps_annexb)))
 
         self._inq: queue.Queue[Optional[bytes]] = queue.Queue()
         self._stop = threading.Event()
@@ -148,8 +153,8 @@ class HevcToBgraTranscoder:
             # else (zero frames, or an exception) is a decode error
             # the sticky-recovery path needs to know about.
             try:
-                frames = list(self._codec.decode(av.Packet(item)))
-            except av.error.InvalidDataError as e:
+                frames = list(self._codec.decode(_av.Packet(item)))
+            except _av.error.InvalidDataError as e:
                 logger.debug("av decode rejected AU: %s", e)
                 self._fire_decode_error()
                 continue

--- a/pymobiledevice3/remote/core_device/hevc_rps.py
+++ b/pymobiledevice3/remote/core_device/hevc_rps.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, cast
 
 logger = logging.getLogger(__name__)
 
@@ -89,14 +89,14 @@ class _BitReader:
 
 @dataclass()
 class _ShortTermRps:
-    deltas: list[tuple[int, bool]] = field(default_factory=list)
+    deltas: list[tuple[int, bool]] = field(default_factory=list[tuple[int, bool]])
 
 
 @dataclass()
 class HevcSpsState:
     log2_max_pic_order_cnt_lsb: int = 8
     num_short_term_ref_pic_sets: int = 0
-    short_term_rps_sets: list[_ShortTermRps] = field(default_factory=list)
+    short_term_rps_sets: list[_ShortTermRps] = field(default_factory=list[_ShortTermRps])
     num_long_term_ref_pics_sps: int = 0
     long_term_ref_pics_present_flag: bool = False
     separate_colour_plane_flag: bool = False
@@ -111,8 +111,8 @@ def _skip_profile_tier_level(br: _BitReader, max_num_sub_layers: int) -> None:
     br.read(32)  # general_profile_compatibility_flag
     br.read(48)  # constraint flags + reserved + interop hints
     br.read(8)  # general_level_idc
-    sub_layer_profile_present = []
-    sub_layer_level_present = []
+    sub_layer_profile_present: list[int] = []
+    sub_layer_level_present: list[int] = []
     for _ in range(max_num_sub_layers - 1):
         sub_layer_profile_present.append(br.read1())
         sub_layer_level_present.append(br.read1())
@@ -149,8 +149,8 @@ def _parse_st_ref_pic_set(
             return out
         ref = sets[ref_idx]
         n_ref = len(ref.deltas) + 1
-        used_by_curr = []
-        use_delta = []
+        used_by_curr = cast(list[int], [])
+        use_delta: list[int] = []
         for _ in range(n_ref):
             used_by_curr.append(br.read1())
             udf = 1

--- a/pymobiledevice3/remote/core_device/hid_service.py
+++ b/pymobiledevice3/remote/core_device/hid_service.py
@@ -486,7 +486,7 @@ class UniversalHIDServiceService(RemoteService):
         # Storage block follows the Swift Codable property-list shape:
         # every leaf is {<type-tag>: <value>}, every dict is
         # {"dictionary": {...}}, every list is {"array": [...]}.
-        storage = {
+        storage: dict[str, Any] = {
             "Manufacturer": {"string": manufacturer},
             "Product": {"string": product},
             "ProductID": {"int": prod},

--- a/pymobiledevice3/remote/core_device/pasteboard_service.py
+++ b/pymobiledevice3/remote/core_device/pasteboard_service.py
@@ -24,7 +24,7 @@ frameworks on macOS:
   carries data inline and we don't need to chase promises.
 """
 
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from pymobiledevice3.remote.remote_service import RemoteService
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
@@ -47,10 +47,10 @@ UTI_TEXT = "public.text"
 UTI_URL = "public.url"
 
 # PasteboardDataInclusionPolicy presets.
-POLICY_ALL_RESOLVED = {"allResolved": {}}
-POLICY_ALL_PROMISED = {"allPromised": {}}
-POLICY_MATCH_SOURCE = {"matchSource": {}}
-POLICY_PROMISE_SECONDARY = {"promiseSecondary": {}}
+POLICY_ALL_RESOLVED: dict[str, Any] = {"allResolved": {}}
+POLICY_ALL_PROMISED: dict[str, Any] = {"allPromised": {}}
+POLICY_MATCH_SOURCE: dict[str, Any] = {"matchSource": {}}
+POLICY_PROMISE_SECONDARY: dict[str, Any] = {"promiseSecondary": {}}
 
 
 def policy_threshold(threshold_bytes: int) -> dict[str, Any]:
@@ -85,14 +85,14 @@ def snapshot_text(snapshot: dict[str, Any]) -> Optional[str]:
     """
     pasteboard = snapshot.get("pasteboard")
     if isinstance(pasteboard, dict):
-        snapshot = pasteboard
-    for item in snapshot.get("items", []) or []:
-        data_map = item.get("data") or {}
+        snapshot = cast(dict[str, Any], pasteboard)
+    for item in cast(list[dict[str, Any]], snapshot.get("items", []) or []):
+        data_map = cast(dict[str, Any], item.get("data") or {})
         for uti in (UTI_UTF8_PLAIN_TEXT, UTI_PLAIN_TEXT, UTI_TEXT):
             datum = data_map.get(uti)
             if not isinstance(datum, dict):
                 continue
-            raw = datum.get("data")
+            raw = cast(dict[str, Any], datum).get("data")
             if not raw:
                 continue
             if isinstance(raw, str):

--- a/pymobiledevice3/remote/core_device/screen_stream.py
+++ b/pymobiledevice3/remote/core_device/screen_stream.py
@@ -528,7 +528,7 @@ class _KernelUdp:
 
     async def sendto(self, data: bytes, ip: str, port: int) -> None:
         # loop.sock_sendto exists since Python 3.11; absent from the 3.9 typeshed baseline.
-        await self._loop.sock_sendto(self._sock, data, (ip, port, 0, 0))  # pyright: ignore[reportAttributeAccessIssue]
+        await cast(Any, self._loop).sock_sendto(self._sock, data, (ip, port, 0, 0))
 
     def close(self) -> None:
         with contextlib.suppress(Exception):

--- a/pymobiledevice3/remote/remote_service_discovery.py
+++ b/pymobiledevice3/remote/remote_service_discovery.py
@@ -391,7 +391,7 @@ async def get_remoted_devices(timeout: float = DEFAULT_BONJOUR_TIMEOUT) -> list[
     :param timeout: Bonjour browse timeout, in seconds.
     :returns: a list of `RSDDevice` records, one per discovered device address.
     """
-    result = []
+    result: list[RSDDevice] = []
     for instance in await browse_remoted(timeout):
         for address in instance.addresses:
             async with RemoteServiceDiscoveryService((address.full_ip, RSD_PORT)) as rsd:

--- a/pymobiledevice3/remote/remotexpc.py
+++ b/pymobiledevice3/remote/remotexpc.py
@@ -3,7 +3,7 @@ import contextlib
 import uuid
 from asyncio import IncompleteReadError
 from collections.abc import AsyncIterable
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, Union, cast
 
 from construct import StreamError
 from hyperframe.frame import (
@@ -247,7 +247,9 @@ class RemoteXPCConnection:
 
     def shell(self) -> None:
         start_ipython_shell(
-            header=highlight(SHELL_USAGE, lexers.PythonLexer(), formatters.Terminal256Formatter(style="native")),
+            header=highlight(
+                SHELL_USAGE, cast(Any, lexers).PythonLexer(), formatters.Terminal256Formatter(style="native")
+            ),
             user_ns={
                 "client": self,
                 "XpcInt64Type": XpcInt64Type,

--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -16,13 +16,14 @@ import struct
 import sys
 from abc import ABC, abstractmethod
 from asyncio import CancelledError, StreamReader, StreamWriter
-from collections.abc import AsyncGenerator, Awaitable
+from collections.abc import AsyncGenerator, Awaitable, Mapping
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, suppress
 from pathlib import Path
 from socket import create_connection
 from ssl import VerifyMode
-from typing import Any, Callable, NamedTuple, Optional, TextIO, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, TextIO, Union, cast
 
+import opack2
 from construct import Bytes, Container, GreedyBytes, GreedyRange, Int8ul, Int16ub, Int64ul, Prefixed, Struct
 from construct import Enum as ConstructEnum
 from construct_typed import DataclassMixin, DataclassStruct, csfield
@@ -34,29 +35,30 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey, X25519PublicKey
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-from opack2 import dumps
-from opack2 import loads as opack_loads
 from packaging.version import Version
 from pytun_pmd3 import TunTapDevice
-from qh3.asyncio.client import connect as aioquic_connect
+from qh3.asyncio import client as _aioquic_client
 from qh3.asyncio.protocol import QuicConnectionProtocol, QuicStreamHandler
 from qh3.quic import packet_builder
 from qh3.quic.configuration import QuicConfiguration
 from qh3.quic.connection import QuicConnection
 from qh3.quic.events import ConnectionTerminated, DatagramFrameReceived, QuicEvent, StreamDataReceived
 from srptools import SRPClientSession, SRPContext, SRPServerSession
+from srptools import utils as _srptools_utils
 from srptools.constants import PRIME_3072, PRIME_3072_GEN
-from srptools.utils import hex_from
 
 from pymobiledevice3.construct_compat import const_field
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.osu.os_utils import get_os_utils
 
-try:
-    # sslpsk_pmd3 is an optional dependency (python<3.13 TCP tunnel only).
-    from sslpsk_pmd3.sslpsk import SSLPSKContext  # pyright: ignore[reportMissingImports]
-except ImportError:
-    SSLPSKContext = None
+# sslpsk_pmd3 is an optional dependency (python<3.13 TCP tunnel only).
+if TYPE_CHECKING:
+    SSLPSKContext: Any = None
+else:
+    try:
+        from sslpsk_pmd3.sslpsk import SSLPSKContext
+    except ImportError:
+        SSLPSKContext = None
 
 from pymobiledevice3.bonjour import (
     DEFAULT_BONJOUR_TIMEOUT,
@@ -92,6 +94,15 @@ from pymobiledevice3.remote.xpc_message import XpcInt64Type, XpcUInt64Type
 from pymobiledevice3.service_connection import ServiceConnection
 from pymobiledevice3.utils import asyncio_print_traceback
 from pymobiledevice3.utils import current_task_name as _current_task_name
+
+# These third-party helpers ship only partial type information (Unknown-typed parameters/returns);
+# re-expose them through casts so downstream call sites stay typed.
+dumps = cast(Callable[[Any], bytes], cast(Any, opack2).dumps)
+opack_loads = cast(Callable[[bytes], Mapping[Any, Any]], cast(Any, opack2).loads)
+aioquic_connect = cast(
+    Callable[..., AbstractAsyncContextManager[QuicConnectionProtocol]], cast(Any, _aioquic_client).connect
+)
+hex_from = cast(Callable[[Any], Union[str, bytes]], cast(Any, _srptools_utils).hex_from)
 
 DEFAULT_INTERFACE_NAME = "pymobiledevice3-tunnel"
 TIMEOUT = 1
@@ -212,7 +223,7 @@ def create_tun_device(interface_name: str = DEFAULT_INTERFACE_NAME):
 
 class RemotePairingTunnel(ABC):
     def __init__(self):
-        self._queue = asyncio.Queue()
+        self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self._tun_read_task: Optional[asyncio.Task[None]] = None
         self._logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         # The tunnel link device is one of two duck-typed backends (kernel ``TunTapDevice`` or the
@@ -593,7 +604,7 @@ class RemotePairingProtocol(StartTcpTunnel):
             raise RemotePairingCompletedError()
 
     async def create_quic_listener(self, private_key: RSAPrivateKey) -> dict[str, Any]:
-        request = {
+        request: dict[str, Any] = {
             "request": {
                 "_0": {
                     "createListener": {
@@ -612,7 +623,7 @@ class RemotePairingProtocol(StartTcpTunnel):
 
     async def create_tcp_listener(self) -> dict[str, Any]:
         assert self.encryption_key is not None
-        request = {
+        request: dict[str, Any] = {
             "request": {
                 "_0": {
                     "createListener": {
@@ -643,7 +654,7 @@ class RemotePairingProtocol(StartTcpTunnel):
             max_datagram_frame_size=RemotePairingQuicTunnel.MAX_QUIC_DATAGRAM,
             idle_timeout=max_idle_timeout,
         )
-        configuration.load_cert_chain(
+        cast(Any, configuration).load_cert_chain(
             cert.public_bytes(Encoding.PEM),
             private_key.private_bytes(Encoding.PEM, PrivateFormat.TraditionalOpenSSL, NoEncryption()).decode(),
         )
@@ -834,7 +845,7 @@ class RemotePairingProtocol(StartTcpTunnel):
     def _init_srp_context(self, pairing_consent_result: PairConsentResult) -> None:
         # Receive server public and salt and process them.
         pin = pairing_consent_result.pin or "000000"
-        client_session = SRPClientSession(
+        client_session: Any = SRPClientSession(
             SRPContext("Pair-Setup", password=pin, prime=PRIME_3072, generator=PRIME_3072_GEN, hash_func=hashlib.sha512)
         )
         client_session.process(pairing_consent_result.public_key.hex(), pairing_consent_result.salt.hex())
@@ -1113,7 +1124,7 @@ class RemotePairingProtocol(StartTcpTunnel):
 
     @staticmethod
     def decode_tlv(tlv_list: list[Container[Any]]) -> dict[str, Any]:
-        result = {}
+        result: dict[str, Any] = {}
         for tlv in tlv_list:
             if tlv.type in result:
                 result[tlv.type] += tlv.data
@@ -1462,7 +1473,7 @@ async def start_tunnel(
 async def get_core_device_tunnel_services(
     bonjour_timeout: float = DEFAULT_BONJOUR_TIMEOUT, udid: Optional[str] = None
 ) -> list[CoreDeviceTunnelService]:
-    result = []
+    result: list[CoreDeviceTunnelService] = []
     for rsd in await get_rsds(bonjour_timeout=bonjour_timeout, udid=udid):
         if udid is None and (
             (Version(rsd.product_version) < Version("17.0"))
@@ -1497,7 +1508,7 @@ async def get_core_device_tunnel_services(
 async def get_remote_pairing_tunnel_services(
     bonjour_timeout: float = DEFAULT_BONJOUR_TIMEOUT, udid: Optional[str] = None
 ) -> list[RemotePairingTunnelService]:
-    result = []
+    result: list[RemotePairingTunnelService] = []
     for answer in await browse_remotepairing(timeout=bonjour_timeout):
         for address in answer.addresses:
             for identifier in iter_remote_paired_identifiers():
@@ -1664,7 +1675,7 @@ class PairableHost:
         if handshake.get("hostOptions", {}).get("attemptPairVerify"):
             raise PairingError("device requested pair-verify; only device-initiated pair-setup is supported")
 
-        peer_device_info = {
+        peer_device_info: dict[str, Any] = {
             "udid": self.host_info.udid,
             "deviceKVSIncludesSensitiveInfo": False,
             "identifier": self.host_info.identifier,
@@ -1706,14 +1717,14 @@ class PairableHost:
         salt_hex = salt.hex()
 
         pin = f"{secrets.randbelow(1_000_000):06d}"
-        context = SRPContext(
+        context: Any = SRPContext(
             SRP_USERNAME, password=pin, prime=PRIME_3072, generator=PRIME_3072_GEN, hash_func=hashlib.sha512
         )
         verifier = hex_from(context.get_common_password_verifier(context.get_common_password_hash(int(salt_hex, 16))))
 
         # B is computed from a fresh random server private; regenerate on the rare short value
         while True:
-            srp_server = SRPServerSession(context, verifier)
+            srp_server: Any = SRPServerSession(context, verifier)
             server_public = binascii.unhexlify(srp_server.public)
             if len(server_public) == SRP_PUBLIC_KEY_SIZE:
                 break
@@ -1883,7 +1894,7 @@ class PairableHost:
 
     @staticmethod
     def decode_tlv(tlv_list: list[Container[Any]]) -> dict[str, Any]:
-        result = {}
+        result: dict[str, Any] = {}
         for tlv in tlv_list:
             if tlv.type in result:
                 result[tlv.type] += tlv.data
@@ -1921,7 +1932,7 @@ class PairableHost:
         raise PyMobileDevice3Exception(f"Got an unknown state message: {response}")
 
     async def _send_plain(self, value: dict[str, Any]) -> None:
-        envelope = {
+        envelope: dict[str, Any] = {
             "message": {"plain": {"_0": value}},
             "originatedBy": "device",
             "sequenceNumber": XpcUInt64Type(self._sequence_number),

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -322,7 +322,7 @@ class UserspaceTun:
         runs the pytcp stack. Raises OSError once the socketpair is closed, which ends
         ``tun_read_task``."""
         frame = await asyncio.get_running_loop().sock_recv(self._peer, 65535)
-        packets = []
+        packets: list[bytes] = []
         while True:
             if len(frame) > 14 and frame[12:14] == _ETH_IPV6_BYTES:
                 packets.append(frame[14:])

--- a/pymobiledevice3/remote/utils.py
+++ b/pymobiledevice3/remote/utils.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 async def get_rsds(
     bonjour_timeout: float = DEFAULT_BONJOUR_TIMEOUT, udid: Optional[str] = None
 ) -> list[RemoteServiceDiscoveryService]:
-    result = []
+    result: list[RemoteServiceDiscoveryService] = []
     with stop_remoted():
         for answer in await browse_remoted(timeout=bonjour_timeout):
             for address in answer.addresses:

--- a/pymobiledevice3/remote/xpc_message.py
+++ b/pymobiledevice3/remote/xpc_message.py
@@ -1,7 +1,7 @@
 import dataclasses
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Callable
 
 from construct import (
     Aligned,
@@ -100,7 +100,7 @@ XpcFileTransfer = Struct(
     "msg_id" / Int64ul,
     "data" / LazyBound(lambda: XpcObject),
 )
-_XPC_OBJECT_CASES = {
+_XPC_OBJECT_CASES: dict[Any, Any] = {
     XpcMessageType.DICTIONARY: XpcDictionary,
     XpcMessageType.STRING: XpcString,
     XpcMessageType.INT64: XpcInt64,
@@ -158,14 +158,14 @@ class FileTransferType:
 def _decode_xpc_dictionary(xpc_object: Container[Any]) -> dict[str, Any]:
     if xpc_object.data.count == 0:
         return {}
-    result = {}
+    result: dict[str, Any] = {}
     for entry in xpc_object.data.entries:
         result[entry.key] = decode_xpc_object(entry.value)
     return result
 
 
 def _decode_xpc_array(xpc_object: Container[Any]) -> list[Any]:
-    result = []
+    result: list[Any] = []
     for entry in xpc_object.data.entries:
         result.append(decode_xpc_object(entry))
     return result
@@ -213,7 +213,7 @@ def _decode_xpc_null(xpc_object: Container[Any]) -> None:
 
 
 def decode_xpc_object(xpc_object: Container[Any]) -> Any:
-    decoders = {
+    decoders: dict[Any, Callable[[Container[Any]], Any]] = {
         XpcMessageType.DICTIONARY: _decode_xpc_dictionary,
         XpcMessageType.ARRAY: _decode_xpc_array,
         XpcMessageType.BOOL: _decode_xpc_bool,
@@ -234,7 +234,7 @@ def decode_xpc_object(xpc_object: Container[Any]) -> Any:
 
 
 def _build_xpc_array(payload: list[Any]) -> dict[str, Any]:
-    entries = []
+    entries: list[dict[str, Any]] = []
     for entry in payload:
         entry = _build_xpc_object(entry)
         entries.append(entry)
@@ -242,9 +242,9 @@ def _build_xpc_array(payload: list[Any]) -> dict[str, Any]:
 
 
 def _build_xpc_dictionary(payload: dict[str, Any]) -> dict[str, Any]:
-    entries = []
+    entries: list[dict[str, Any]] = []
     for key, value in payload.items():
-        entry = {"key": key, "value": _build_xpc_object(value)}
+        entry: dict[str, Any] = {"key": key, "value": _build_xpc_object(value)}
         entries.append(entry)
     return {
         "type": XpcMessageType.DICTIONARY,
@@ -314,7 +314,7 @@ def _build_xpc_int64(payload: XpcInt64Type) -> dict[str, Any]:
 def _build_xpc_object(payload: Any) -> dict[str, Any]:
     if payload is None:
         return _build_xpc_null(payload)
-    payload_builders = {
+    payload_builders: dict[Any, Callable[[Any], dict[str, Any]]] = {
         list: _build_xpc_array,
         dict: _build_xpc_dictionary,
         bool: _build_xpc_bool,
@@ -339,7 +339,7 @@ def create_xpc_wrapper(d: dict[str, Any], message_id: int = 0, wanting_reply: bo
     if wanting_reply:
         flags |= XpcFlags.WANTING_REPLY
 
-    xpc_payload = {"message_id": message_id, "payload": {"obj": _build_xpc_object(d)}}
+    xpc_payload: dict[str, Any] = {"message_id": message_id, "payload": {"obj": _build_xpc_object(d)}}
 
-    xpc_wrapper = {"flags": flags, "message": xpc_payload}
+    xpc_wrapper: dict[str, Any] = {"flags": flags, "message": xpc_payload}
     return XpcWrapper.build(xpc_wrapper)

--- a/pymobiledevice3/resources/dsc_uuid_map.py
+++ b/pymobiledevice3/resources/dsc_uuid_map.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os.path
-from typing import Any, Optional
+from typing import Any, Optional, cast
 from uuid import UUID
 
 import click
@@ -98,5 +98,5 @@ def main(dsc: Any, dyld_uuid: UUID, force: bool):
 
 
 if __name__ == "__main__":
-    coloredlogs.install(level=logging.DEBUG)
+    cast(Any, coloredlogs).install(level=logging.DEBUG)
     main()

--- a/pymobiledevice3/resources/firmware_notifications.py
+++ b/pymobiledevice3/resources/firmware_notifications.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import plistlib
+from typing import Any, cast
 
 import click
 import coloredlogs
@@ -49,7 +50,7 @@ def main(root_fs: str):
             if not isinstance(v, dict):
                 logging.error(f"error parsing: {filename}")
                 continue
-            notification = v.get("Notification")
+            notification = cast(Any, v).get("Notification")
             if notification is None:
                 continue
 
@@ -61,5 +62,5 @@ def main(root_fs: str):
 
 
 if __name__ == "__main__":
-    coloredlogs.install(level=logging.DEBUG)
+    cast(Any, coloredlogs).install(level=logging.DEBUG)
     main()

--- a/pymobiledevice3/restore/asr.py
+++ b/pymobiledevice3/restore/asr.py
@@ -91,7 +91,7 @@ class ASRClient:
             "Size": length,
         }
 
-        packet_info = {}
+        packet_info: dict[str, typing.Any] = {}
         if self.checksum_chunks:
             packet_info["Checksum Chunk Size"] = ASR_CHECKSUM_CHUNK_SIZE
 

--- a/pymobiledevice3/restore/base_restore.py
+++ b/pymobiledevice3/restore/base_restore.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from ipsw_parser.exceptions import NoSuchBuildIdentityError
 from ipsw_parser.ipsw import IPSW
@@ -60,7 +60,7 @@ class BaseRestore:
         except NoSuchBuildIdentityError:
             pass
 
-        build_info = self.build_identity.get("Info")
+        build_info = cast(dict[str, Any], self.build_identity).get("Info")
         if build_info is None:
             raise PyMobileDevice3Exception('build identity does not contain an "Info" element')
 
@@ -92,7 +92,7 @@ class BaseRestore:
     ) -> bytes:
         return stitch_component(
             component_name,
-            self.build_identity.get_component(component_name, tss=tss, data=data, path=path).data,
+            cast(Any, self.build_identity).get_component(component_name, tss=tss, data=data, path=path).data,
             tss,
             self.build_identity,
             await self.device.get_ap_parameters(),
@@ -155,7 +155,7 @@ class BaseRestore:
 
         for k in key_list:
             try:
-                v = self.build_identity[k]
+                v = cast(dict[str, Any], self.build_identity)[k]
                 if isinstance(v, str) and v.startswith("0x"):
                     v = int(v, 16)
                 parameters[k] = v
@@ -164,7 +164,7 @@ class BaseRestore:
 
         if additional_keys is None:
             # special treat for RequiresUIDMode
-            info = self.build_identity.get("Info")
+            info = cast(dict[str, Any], self.build_identity).get("Info")
             if info is None:
                 return
             requires_uid_mode = info.get("RequiresUIDMode")

--- a/pymobiledevice3/restore/device.py
+++ b/pymobiledevice3/restore/device.py
@@ -1,5 +1,5 @@
 from contextlib import suppress
-from typing import Any, Optional, overload
+from typing import Any, Optional, cast, overload
 
 from pymobiledevice3.exceptions import MissingValueError
 from pymobiledevice3.irecv import IRecv
@@ -180,11 +180,11 @@ class Device:
         if not isinstance(device_info, dict):
             return None
         # Filter out entries marked disabled or that failed to query.
-        disabled = pinfo.get("DeviceInfoDisabled") or {}
-        failures = pinfo.get("DeviceInfoFailures") or {}
+        disabled: dict[str, Any] = pinfo.get("DeviceInfoDisabled") or {}
+        failures: dict[str, Any] = pinfo.get("DeviceInfoFailures") or {}
         self._preflight_device_info = {
             updater: info
-            for updater, info in device_info.items()
+            for updater, info in cast(dict[str, Any], device_info).items()
             if updater not in disabled and updater not in failures
         }
         return self._preflight_device_info

--- a/pymobiledevice3/restore/fdr.py
+++ b/pymobiledevice3/restore/fdr.py
@@ -86,7 +86,7 @@ class FDRClient:
         if self.ctrlprotoversion != 2:
             raise NotImplementedError("TODO")
 
-        req = {
+        req: dict[str, Any] = {
             "Command": CTRLCMD,
             "CtrlProtoVersion": self.ctrlprotoversion,
         }

--- a/pymobiledevice3/restore/ftab.py
+++ b/pymobiledevice3/restore/ftab.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 from construct import Array, Bytes, Const, Default, Int32ub, Int32ul, Pointer, Struct, this
 
@@ -43,7 +43,7 @@ class Ftab:
 
     def add_entry(self, tag: bytes, data: bytes):
         new_offset = self.parsed.entries[-1].offset + self.parsed.entries[-1].size
-        new_entry = {"tag": tag, "offset": new_offset, "size": len(data), "data": data}
+        new_entry: dict[str, Any] = {"tag": tag, "offset": new_offset, "size": len(data), "data": data}
 
         self.parsed.num_entries += 1  # pyright: ignore[reportAttributeAccessIssue]
         self.parsed.entries.append(new_entry)

--- a/pymobiledevice3/restore/img4.py
+++ b/pymobiledevice3/restore/img4.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from ipsw_parser.build_identity import BuildIdentity
 from pyimg4 import IM4P, IM4R, IMG4, RestoreProperty
@@ -141,7 +141,7 @@ def stitch_component(
     # check if we have a *-TBM entry for the given component
     tbm_dict = tss.get(f"{name}-TBM")
 
-    info = build_identity["Info"]
+    info = cast(dict[str, Any], build_identity["Info"])
     nonce_slot_required = info.get("RequiresNonceSlot", False) and name in ("SEP", "SepStage1", "LLB")
 
     im4r = None

--- a/pymobiledevice3/restore/mbn.py
+++ b/pymobiledevice3/restore/mbn.py
@@ -193,7 +193,7 @@ def _read_elf_headers(data: bytes):
 
 
 def _read_program_headers(data: bytes, kind: str, hdr: Any) -> list[Any]:
-    phdrs = []
+    phdrs: list[Any] = []
     if hdr.e_phnum == 0:
         logger.error("%s: ELF has no program sections", "_read_program_headers")
         return phdrs

--- a/pymobiledevice3/restore/recovery.py
+++ b/pymobiledevice3/restore/recovery.py
@@ -2,8 +2,9 @@ import asyncio
 import contextlib
 import hashlib
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
+from ipsw_parser.build_manifest import BuildManifest
 from ipsw_parser.ipsw import IPSW
 from usb import USBError
 
@@ -36,7 +37,7 @@ class Recovery(BaseRestore):
         self.logger.debug(f"connected mode: {self.device.irecv.mode}")
 
     def get_preboard_manifest(self):
-        overrides = {
+        overrides: dict[str, Any] = {
             "@APTicket": True,
             "ApProductionMode": 0,
             "ApSecurityDomain": 0,
@@ -61,7 +62,7 @@ class Recovery(BaseRestore):
 
     async def get_tss_response(self) -> TSSResponse:
         # populate parameters
-        parameters = {}
+        parameters: dict[str, Any] = {}
 
         parameters["ApECID"] = await self.device.get_ecid()
         ap_nonce = await self.device.get_ap_nonce()
@@ -151,7 +152,7 @@ class Recovery(BaseRestore):
 
     async def get_local_policy_tss_response(self):
         # populate parameters
-        parameters = {
+        parameters: dict[str, Any] = {
             "ApECID": await self.device.get_ecid(),
             "Ap,LocalBoot": False,
             "ApProductionMode": True,
@@ -175,7 +176,7 @@ class Recovery(BaseRestore):
         self.populate_tss_request_from_manifest(parameters)
 
         # Add Ap,LocalPolicy
-        lpol = {
+        lpol: dict[str, Any] = {
             "Digest": hashlib.sha384(lpol_file).digest(),
             "Trusted": True,
         }
@@ -198,7 +199,7 @@ class Recovery(BaseRestore):
 
     async def get_recoveryos_root_ticket_tss_response(self):
         # populate parameters
-        parameters = {
+        parameters: dict[str, Any] = {
             "ApECID": await self.device.get_ecid(),
             "Ap,LocalBoot": False,
             "ApProductionMode": True,
@@ -251,7 +252,8 @@ class Recovery(BaseRestore):
             self.tss_localpolicy = await self.get_local_policy_tss_response()
             self.tss_recoveryos_root_ticket = await self.get_recoveryos_root_ticket_tss_response()
         else:
-            recovery_variant = self.build_identity["Info"].get("RecoveryVariant")
+            info = cast(dict[str, Any], self.build_identity["Info"])
+            recovery_variant = info.get("RecoveryVariant")
             if recovery_variant is not None:
                 self.tss_recoveryos_root_ticket = await self.get_tss_response()
 
@@ -300,7 +302,7 @@ class Recovery(BaseRestore):
         self.device.irecv.send_command("bgcolor 0 0 0")
 
     async def send_loaded_by_iboot(self):
-        manifest = self.build_identity["Manifest"]
+        manifest = cast(dict[str, Any], self.build_identity["Manifest"])
         for key, node in manifest.items():
             iboot = node["Info"].get("IsLoadedByiBoot", False)
             iboot_stg1 = node["Info"].get("IsLoadedByiBootStage1", False)
@@ -313,7 +315,7 @@ class Recovery(BaseRestore):
                 await self.send_component_and_command(key, "firmware")
 
     async def send_iboot_stage1_components(self):
-        manifest = self.build_identity["Manifest"]
+        manifest = cast(dict[str, Any], self.build_identity["Manifest"])
         for key, node in manifest.items():
             iboot = node["Info"].get("IsLoadedByiBoot", False)
             iboot_stg1 = node["Info"].get("IsLoadedByiBootStage1", False)
@@ -418,7 +420,7 @@ class Recovery(BaseRestore):
         if "SRTG" in self.device.irecv._device_info:
             raise PyMobileDevice3Exception("Device failed to enter recovery")
 
-        if self.build_identity.build_manifest.build_major > 8:
+        if cast(BuildManifest, self.build_identity.build_manifest).build_major > 8:
             old_nonce = self.device.irecv.ap_nonce
 
             # reconnect
@@ -449,7 +451,7 @@ class Recovery(BaseRestore):
                 await asyncio.sleep(1)
                 self.device.irecv.send_command("go", b_request=1)
 
-                if self.build_identity.build_manifest.build_major < 20:
+                if cast(BuildManifest, self.build_identity.build_manifest).build_major < 20:
                     with contextlib.suppress(USBError):
                         self.device.irecv.ctrl_transfer(0x21, 1, timeout=5000)
 

--- a/pymobiledevice3/restore/restore.py
+++ b/pymobiledevice3/restore/restore.py
@@ -118,11 +118,11 @@ class Restore(BaseRestore):
         self._pb_verify_restore_old_value = None
 
         # cache for already downloaded url-assets
-        self._url_assets_cache = {}
+        self._url_assets_cache: dict[str, requests.Response] = {}
 
-        self._tasks = []
+        self._tasks: list[asyncio.Task[Any]] = []
 
-        self._handlers = {
+        self._handlers: dict[str, Callable[[dict[str, Any]], typing.Awaitable[Any]]] = {
             # data request messages are sent by restored whenever it requires
             # files sent to the server by the client. these data requests include
             # SystemImageData, RootTicket, KernelCache, NORData and BasebandData requests
@@ -150,7 +150,7 @@ class Restore(BaseRestore):
             "RestoreAttestation": self.handle_restore_attestation,
         }
 
-        self._data_request_handlers = {
+        self._data_request_handlers: dict[str, Callable[[dict[str, Any]], typing.Awaitable[Any]]] = {
             # this request is sent when restored is ready to receive the filesystem
             "SystemImageData": self.send_filesystem,
             "BuildIdentityDict": self.send_buildidentity,
@@ -224,7 +224,9 @@ class Restore(BaseRestore):
     async def send_buildidentity(self, message: dict[str, Any]) -> None:
         self.logger.info("About to send BuildIdentity Dict...")
         service = await self._get_service_for_data_request(message)
-        req = {"BuildIdentityDict": dict(await self.get_build_identity_from_request(message))}
+        req: dict[str, Any] = {
+            "BuildIdentityDict": dict(typing.cast(dict[str, Any], await self.get_build_identity_from_request(message)))
+        }
         arguments = message["Arguments"]
         variant = arguments.get("Variant", "Erase")
         req["Variant"] = variant
@@ -232,7 +234,7 @@ class Restore(BaseRestore):
         await service.send_plist(req)
 
     def extract_global_manifest(self) -> bytes:
-        build_info = self.build_identity.get("Info")
+        build_info = typing.cast(Optional[dict[str, Any]], typing.cast(dict[str, Any], self.build_identity).get("Info"))
         if build_info is None:
             raise PyMobileDevice3Exception('build identity does not contain an "Info" element')
 
@@ -288,7 +290,8 @@ class Restore(BaseRestore):
             data = self.ipsw.system_version
         else:
             data = (
-                (await self.get_build_identity_from_request(message))
+                typing
+                .cast(Any, await self.get_build_identity_from_request(message))
                 .get_component(component_name, tss=self.recovery.tss)
                 .data
             )
@@ -320,7 +323,7 @@ class Restore(BaseRestore):
             build_identity = self.build_identity
 
         # populate parameters
-        parameters = {
+        parameters: dict[str, Any] = {
             "ApECID": await self.device.get_ecid(),
             "Ap,LocalBoot": True,
             "ApProductionMode": True,
@@ -329,10 +332,10 @@ class Restore(BaseRestore):
         }
 
         # BuildIdentity (ipsw_parser) exposes no such method; this macOS-only path would fail at runtime
-        build_identity.populate_tss_request_parameters(parameters)  # pyright: ignore[reportAttributeAccessIssue]
+        typing.cast(Any, build_identity).populate_tss_request_parameters(parameters)  # pyright: ignore[reportAttributeAccessIssue]
 
         # Add Ap,LocalPolicy
-        lpol = {
+        lpol: dict[str, Any] = {
             "Digest": hashlib.sha384(lpol_file).digest(),
             "Trusted": True,
         }
@@ -390,9 +393,9 @@ class Restore(BaseRestore):
             data = self.recovery.tss_recoveryos_root_ticket.ap_img4_ticket
         else:
             # TSSResponse has no ap_ticket property; this legacy img3 path would fail at runtime
-            data = self.recovery.require_tss().ap_ticket  # pyright: ignore[reportAttributeAccessIssue]
+            data = typing.cast(Any, self.recovery.require_tss()).ap_ticket  # pyright: ignore[reportAttributeAccessIssue]
 
-        req = {}
+        req: dict[str, Any] = {}
         if data:
             req["RootTicketData"] = data
         else:
@@ -416,7 +419,7 @@ class Restore(BaseRestore):
         service = await self._get_service_for_data_request(message)
 
         flash_version_1 = False
-        llb_path = self.build_identity.get_component("LLB", tss=self.recovery.tss).path
+        llb_path = typing.cast(Any, self.build_identity).get_component("LLB", tss=self.recovery.tss).path
         llb_filename_offset = llb_path.find("LLB")
 
         arguments = message.get("Arguments")
@@ -429,13 +432,13 @@ class Restore(BaseRestore):
         firmware_path = llb_path[: llb_filename_offset - 1]
         self.logger.info(f"Found firmware path: {firmware_path}")
 
-        firmware_files = {}
+        firmware_files: dict[str, Any] = {}
         try:
             firmware = self.ipsw.get_firmware(firmware_path)
-            firmware_files = firmware.get_files()
+            firmware_files = typing.cast(dict[str, Any], firmware.get_files())
         except (KeyError, FileNotFoundError):
             self.logger.info("Getting firmware manifest from build identity")
-            build_id_manifest = self.build_identity["Manifest"]
+            build_id_manifest = typing.cast(dict[str, Any], self.build_identity["Manifest"])
             for component, manifest_entry in build_id_manifest.items():
                 if isinstance(manifest_entry, dict):
                     is_fw = plist_access_path(manifest_entry, ("Info", "IsFirmwarePayload"), bool)
@@ -479,7 +482,7 @@ class Restore(BaseRestore):
         for component in ("RestoreSEP", "SEP", "SepStage1"):
             if not self.build_identity.has_component(component):
                 continue
-            comp = self.build_identity.get_component(component, tss=self.recovery.tss)
+            comp = typing.cast(Any, self.build_identity).get_component(component, tss=self.recovery.tss)
             if comp.path:
                 if component == "SepStage1":
                     component = "SEPPatch"
@@ -525,13 +528,13 @@ class Restore(BaseRestore):
 
         return bbfw_fn_elem_mav25.get(elem) if bb_chip_id == 0x1F30E1 else bbfw_fn_elem.get(elem)
 
-    def fls_parse(self, buffer: bytes):
+    def fls_parse(self, buffer: bytes) -> bytes:
         raise NotImplementedError()
 
-    def fls_update_sig_blob(self, buffer: bytes, blob: bytes):
+    def fls_update_sig_blob(self, buffer: bytes, blob: bytes) -> bytes:
         raise NotImplementedError()
 
-    def fls_insert_ticket(self, fls: bytes, bbticket: bytes):
+    def fls_insert_ticket(self, fls: bytes, bbticket: bytes) -> bytes:
         raise NotImplementedError()
 
     def sign_bbfw(
@@ -543,7 +546,7 @@ class Restore(BaseRestore):
         if bbfw_dict is None:
             raise PyMobileDevice3Exception('missing "BasebandFirmware" entry in TSS response')
         is_fls = False
-        signed_file = []
+        signed_file: list[str] = []
 
         with tempfile.NamedTemporaryFile(delete=False) as tmp_zip_read:
             tmp_zip_read.write(bbfw_orig)
@@ -663,7 +666,7 @@ class Restore(BaseRestore):
             request.add_common_tags(parameters)
             request.add_baseband_tags(parameters)
 
-            fdr_support = self.build_identity["Info"].get("FDRSupport", False)
+            fdr_support = typing.cast(dict[str, Any], self.build_identity["Info"]).get("FDRSupport", False)
             if fdr_support:
                 request.update({"ApProductionMode": True, "ApSecurityMode": True})
 
@@ -680,7 +683,7 @@ class Restore(BaseRestore):
             )
 
         # get baseband firmware file path from build identity
-        bbfwpath = self.build_identity["Manifest"]["BasebandFirmware"]["Info"]["Path"]
+        bbfwpath = typing.cast(str, self.build_identity["Manifest"]["BasebandFirmware"]["Info"]["Path"])
 
         # extract baseband firmware to temp file
         bbfw = self.ipsw.read(bbfwpath)
@@ -712,7 +715,7 @@ class Restore(BaseRestore):
         arguments = message["Arguments"]
         want_image_list = arguments.get(image_list_k)
         image_name = arguments.get("ImageName")
-        build_id_manifest = self.build_identity["Manifest"]
+        build_id_manifest = typing.cast(dict[str, Any], self.build_identity["Manifest"])
 
         if (
             (not want_image_list)
@@ -733,14 +736,14 @@ class Restore(BaseRestore):
         if want_image_list is None and image_name is None:
             self.logger.info(f"About to send {image_data_k}...")
 
-        matched_images = []
-        data_dict = {}
+        matched_images: list[str] = []
+        data_dict: dict[str, Any] = {}
 
         for component, manifest_entry in build_id_manifest.items():
             if not isinstance(manifest_entry, dict):
                 continue
 
-            is_image_type = manifest_entry["Info"].get(image_type_k)
+            is_image_type = typing.cast(dict[str, Any], manifest_entry["Info"]).get(image_type_k)
             if is_image_type:
                 if want_image_list:
                     self.logger.info(f"found {component} component")
@@ -768,7 +771,7 @@ class Restore(BaseRestore):
                 self.logger.info(f"Sending {image_type_k} now...")
 
         assert self._restored is not None
-        await self._restored.send(req)
+        await self._restored.send(typing.cast(dict[str, Any], req))
 
     async def send_bootability_bundle_data(self, message: dict[str, Any]) -> None:
         self.logger.debug(f"send_bootability_bundle_data: {message}")
@@ -779,14 +782,14 @@ class Restore(BaseRestore):
     async def send_manifest(self) -> None:
         self.logger.debug("send_manifest")
         assert self._restored is not None
-        await self._restored.send({"ReceiptManifest": self.build_identity.manifest})
+        await self._restored.send({"ReceiptManifest": typing.cast(Any, self.build_identity).manifest})
 
     async def get_se_firmware_data(
         self, updater_name: str, info: dict[str, Any], arguments: dict[str, Any]
     ) -> dict[str, Any]:
         chip_id = info.get("SE,ChipID")
         if chip_id is None:
-            chip_id = self.build_identity["Manifest"]["SE,ChipID"]
+            chip_id = typing.cast(int, self.build_identity["Manifest"]["SE,ChipID"])
 
         if chip_id == 0x20211:
             comp_name = "SE,Firmware"
@@ -802,7 +805,7 @@ class Restore(BaseRestore):
             else:
                 raise NotImplementedError("Neither 'SE,Firmware' nor 'SE,UpdatePayload' found in build identity.")
 
-        component_data = self.build_identity.get_component(comp_name).data
+        component_data = typing.cast(Any, self.build_identity).get_component(comp_name).data
 
         if "DeviceGeneratedTags" in arguments:
             response = await self.get_device_generated_firmware_data(updater_name, info, arguments)
@@ -826,7 +829,7 @@ class Restore(BaseRestore):
     async def get_yonkers_firmware_data(self, info: dict[str, Any]):
         # create Yonkers request
         request = TSSRequest()
-        parameters = {}
+        parameters: dict[str, Any] = {}
 
         # add manifest for current build_identity to parameters
         self.populate_tss_request_from_manifest(parameters)
@@ -851,7 +854,7 @@ class Restore(BaseRestore):
             raise PyMobileDevice3Exception("No 'Yonkers,Ticket' in TSS response, this might not work")
 
         # now get actual component data
-        component_data = self.build_identity.get_component(comp_name).data
+        component_data = typing.cast(Any, self.build_identity).get_component(comp_name).data
 
         firmware_data = {
             "YonkersFirmware": component_data,
@@ -895,7 +898,7 @@ class Restore(BaseRestore):
                 raise PyMobileDevice3Exception("No 'Savage,Ticket' in TSS response, this might not work")
 
         # now get actual component data
-        component_data = self.build_identity.get_component(comp_name).data
+        component_data = typing.cast(Any, self.build_identity).get_component(comp_name).data
         component_data = struct.pack("<L", len(component_data)) + b"\x00" * 12
 
         response["FirmwareData"] = component_data
@@ -927,13 +930,13 @@ class Restore(BaseRestore):
             self.logger.error('No "Rap,Ticket" in TSS response, this might not work')
 
         comp_name = "Rap,RTKitOS"
-        component_data = self.build_identity.get_component(comp_name).data
+        component_data = typing.cast(Any, self.build_identity).get_component(comp_name).data
 
         ftab = Ftab(component_data)
 
         comp_name = "Rap,RestoreRTKitOS"
         if self.build_identity.has_component(comp_name):
-            rftab = Ftab(self.build_identity.get_component(comp_name).data)
+            rftab = Ftab(typing.cast(Any, self.build_identity).get_component(comp_name).data)
 
             component_data = rftab.get_entry_data(b"rrko")
             if component_data is None:
@@ -963,7 +966,7 @@ class Restore(BaseRestore):
             if response.get("BMU,Ticket") is None:
                 self.logger.warning('No "BMU,Ticket" in TSS response, this might not work')
 
-        component_data = self.build_identity.get_component(comp_name).data
+        component_data = typing.cast(Any, self.build_identity).get_component(comp_name).data
         fw_map = plistlib.loads(component_data)
         fw_map["fw_map_digest"] = self.build_identity["Manifest"][comp_name]["Digest"]
 
@@ -978,7 +981,7 @@ class Restore(BaseRestore):
 
         # create Baobab request
         request = TSSRequest()
-        parameters = {}
+        parameters: dict[str, Any] = {}
 
         # add manifest for current build_identity to parameters
         self.populate_tss_request_from_manifest(parameters)
@@ -996,7 +999,7 @@ class Restore(BaseRestore):
         if ticket is None:
             self.logger.warning('No "Baobab,Ticket" in TSS response, this might not work')
 
-        response["FirmwareData"] = self.build_identity.get_component(comp_name).data
+        response["FirmwareData"] = typing.cast(Any, self.build_identity).get_component(comp_name).data
 
         return response
 
@@ -1016,7 +1019,7 @@ class Restore(BaseRestore):
             return cached
 
         request = TSSRequest()
-        parameters = {}
+        parameters: dict[str, Any] = {}
 
         # add manifest for current build_identity to parameters
         self.populate_tss_request_from_manifest(parameters, arguments["DeviceGeneratedTags"]["BuildIdentityTags"])
@@ -1056,7 +1059,7 @@ class Restore(BaseRestore):
 
         # create Timer request
         request = TSSRequest()
-        parameters = {}
+        parameters: dict[str, Any] = {}
 
         # add manifest for current build_identity to parameters
         self.populate_tss_request_from_manifest(parameters)
@@ -1099,7 +1102,7 @@ class Restore(BaseRestore):
 
         comp_name = f"Timer,RTKitOS,{tag}"
         if self.build_identity.has_component(comp_name):
-            ftab = Ftab(self.build_identity.get_component(comp_name).data)
+            ftab = Ftab(typing.cast(Any, self.build_identity).get_component(comp_name).data)
             if ftab.tag != b"rkos":
                 self.logger.warning(f"Unexpected tag {ftab.tag}. continuing anyway.")
         else:
@@ -1107,7 +1110,7 @@ class Restore(BaseRestore):
 
         comp_name = f"Timer,RestoreRTKitOS,{tag}"
         if self.build_identity.has_component(comp_name):
-            rftab = Ftab(self.build_identity.get_component(comp_name).data)
+            rftab = Ftab(typing.cast(Any, self.build_identity).get_component(comp_name).data)
 
             component_data = rftab.get_entry_data(b"rrko")
             if component_data is None:
@@ -1154,12 +1157,12 @@ class Restore(BaseRestore):
     @staticmethod
     def _dig(container: dict[str, Any], path: typing.Union[str, list[str]]) -> typing.Any:
         """Navigate a dict by a single key or a list-of-keys path; None if any hop misses."""
-        cur = container
+        cur: Optional[dict[str, Any]] = container
         for key in [path] if isinstance(path, str) else path:
             if not isinstance(cur, dict):
                 return None
-            cur = cur.get(key)
-        return cur
+            cur = typing.cast(Optional[dict[str, Any]], cur.get(key))
+        return typing.cast(typing.Any, cur)
 
     @classmethod
     def _resolve_nonce(cls, container: dict[Any, Any], nonce_key: Optional[str], nonce_path: Optional[list[Any]]):
@@ -1196,7 +1199,7 @@ class Restore(BaseRestore):
             return None  # this ticket type wasn't prefetched
 
         entry = self._prefetched_updater_tss[updater_name]
-        devgen = arguments.get("DeviceGeneratedRequest") or {}
+        devgen: dict[str, Any] = arguments.get("DeviceGeneratedRequest") or {}
         runtime_nonce = self._resolve_nonce(devgen, entry.devgen_nonce, entry.devgen_nonce_path)
         return self._lookup_prefetched_tss(updater_name, runtime_nonce)
 
@@ -1272,6 +1275,7 @@ class Restore(BaseRestore):
                 info = top_info.get(cand.preflight_subkey) if cand.preflight_subkey else top_info
                 if not isinstance(info, dict):
                     continue
+                info = typing.cast(dict[str, Any], info)
                 # Nonce source can be decoupled from the tag-building info: e.g. Vinyl
                 # builds tags from the top-level eUICC,* dict but its nonce is a composite
                 # of the nested eUICC,Gold.Nonce + eUICC,Main.Nonce.
@@ -1652,8 +1656,8 @@ class Restore(BaseRestore):
             self.logger.info("Starting FDR listener task")
             self._tasks.append(start_fdr_task(fdr_type.FDR_CTRL))
 
-        sep = self.build_identity["Manifest"]["SEP"].get("Info")
-        spp = self.build_identity["Info"].get("SystemPartitionPadding")
+        sep = typing.cast(dict[str, Any], self.build_identity["Manifest"]["SEP"]).get("Info")
+        spp = typing.cast(dict[str, Any], self.build_identity["Info"]).get("SystemPartitionPadding")
         opts = RestoreOptions(
             firmware_preflight_info=self._firmware_preflight_info,
             sep=sep,
@@ -1662,7 +1666,7 @@ class Restore(BaseRestore):
             restore_boot_args=self.recovery.restore_boot_args,
             spp=spp,
             restore_behavior=self.build_identity.restore_behavior,
-            msp=self.build_identity.minimum_system_partition,
+            msp=typing.cast(Any, self.build_identity).minimum_system_partition,
         )
 
         # start the restore process

--- a/pymobiledevice3/restore/tss.py
+++ b/pymobiledevice3/restore/tss.py
@@ -311,8 +311,8 @@ class TSSRequest:
         # EUICCGoldNonce / EUICCMainNonce params (the recovery.py AP-batch path sets these).
         for nested, flat in (("eUICC,Gold", "EUICCGoldNonce"), ("eUICC,Main", "EUICCMainNonce")):
             node = parameters.get(nested)
-            if isinstance(node, dict) and node.get("Nonce") is not None:
-                parameters.setdefault(flat, node["Nonce"])
+            if isinstance(node, dict) and typing.cast(dict[str, typing.Any], node).get("Nonce") is not None:
+                parameters.setdefault(flat, typing.cast(dict[str, typing.Any], node)["Nonce"])
         self.add_vinyl_tags(parameters, overrides)
 
     def add_vinyl_tags(

--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -495,7 +495,7 @@ class ServiceConnection:
                     )
                 else:
                     loop = asyncio.get_running_loop()
-                    protocol = writer._protocol  # type: ignore[attr-defined]
+                    protocol = cast(Any, writer)._protocol
                     tls_transport = await asyncio.wait_for(
                         loop.start_tls(
                             writer.transport,
@@ -531,7 +531,9 @@ class ServiceConnection:
     def shell(self) -> None:
         """Start an interactive shell."""
         start_ipython_shell(
-            header=highlight(SHELL_USAGE, lexers.PythonLexer(), formatters.Terminal256Formatter(style="native")),
+            header=highlight(
+                SHELL_USAGE, cast(Any, lexers).PythonLexer(), formatters.Terminal256Formatter(style="native")
+            ),
             user_ns={
                 "client": self,
             },

--- a/pymobiledevice3/services/accessibilityaudit.py
+++ b/pymobiledevice3/services/accessibilityaudit.py
@@ -200,7 +200,7 @@ class AXAuditIssue_v1(SerializedObject):
         return self._fields["BackgroundColorValue_v1"]
 
     def json(self) -> dict[str, typing.Any]:
-        resp = {
+        resp: dict[str, typing.Any] = {
             "element_rect_value": self.rect,
             "issue_classification": self.issue_type,
             "font_size": self.font_size,
@@ -217,7 +217,7 @@ class AXAuditIssue_v1(SerializedObject):
         return json.dumps(self.json())
 
 
-SERIALIZABLE_OBJECTS = {
+SERIALIZABLE_OBJECTS: dict[str, type[SerializedObject]] = {
     "AXAuditDeviceSetting_v1": AXAuditDeviceSetting_v1,
     "AXAuditInspectorFocus_v1": AXAuditInspectorFocus_v1,
     "AXAuditElement_v1": AXAuditElement_v1,
@@ -256,12 +256,13 @@ class Direction(Enum):
 def deserialize_object(d: typing.Any) -> typing.Any:
     if not isinstance(d, dict):
         if isinstance(d, list):
-            return [deserialize_object(x) for x in d]
+            return [deserialize_object(x) for x in typing.cast(list[typing.Any], d)]
         return d
 
+    d = typing.cast(dict[str, typing.Any], d)
     if "ObjectType" not in d:
         # simple dictionary
-        new_dict = {}
+        new_dict: dict[str, typing.Any] = {}
         for k, v in d.items():
             new_dict[k] = deserialize_object(v)
         return new_dict
@@ -269,7 +270,7 @@ def deserialize_object(d: typing.Any) -> typing.Any:
     if d["ObjectType"] == "passthrough":
         return deserialize_object(d["Value"])
     else:
-        return SERIALIZABLE_OBJECTS[d["ObjectType"]](deserialize_object(d["Value"]))
+        return typing.cast(typing.Any, SERIALIZABLE_OBJECTS[d["ObjectType"]](deserialize_object(d["Value"])))
 
 
 class _AccessibilityAuditProvider(DtxServiceProvider):
@@ -355,10 +356,10 @@ class AccessibilityAudit:
     def _extract_event_payload(args: list[typing.Any]) -> typing.Any:
         if not args:
             return None
-        payload = args[0] if len(args) == 1 else args
+        payload: typing.Any = args[0] if len(args) == 1 else args
         if isinstance(payload, list) and payload and isinstance(payload[0], dict) and "value" in payload[0]:
-            return [x["value"] for x in payload]
-        return payload
+            return [x["value"] for x in typing.cast(list[typing.Any], payload)]
+        return typing.cast(typing.Any, payload)
 
     async def _ensure_ready(self) -> None:
         await self._provider.connect()
@@ -507,7 +508,7 @@ class AccessibilityAudit:
         :param element: The platform element value identifying the target element.
         """
         await self._ensure_ready()
-        serialized_element = {
+        serialized_element: dict[str, typing.Any] = {
             "ObjectType": "AXAuditElement_v1",
             "Value": {
                 "ObjectType": "passthrough",
@@ -518,7 +519,7 @@ class AccessibilityAudit:
             },
         }
 
-        action = {
+        action: dict[str, typing.Any] = {
             "ObjectType": "AXAuditElementAttribute_v1",
             "Value": {
                 "ObjectType": "passthrough",
@@ -564,7 +565,7 @@ class AccessibilityAudit:
         :param direction: The `Direction` to move the focus (previous, next, first, or last).
         """
         await self._ensure_ready()
-        options = {
+        options: dict[str, typing.Any] = {
             "ObjectType": "passthrough",
             "Value": {
                 "allowNonAX": {
@@ -592,7 +593,7 @@ class AccessibilityAudit:
         :param value: The new value to assign to the setting.
         """
         await self._ensure_ready()
-        setting = {
+        setting: dict[str, typing.Any] = {
             "ObjectType": "AXAuditDeviceSetting_v1",
             "Value": {
                 "ObjectType": "passthrough",
@@ -634,7 +635,7 @@ class AccessibilityAudit:
 
         # Every focus change is expected to publish "hostInspectorCurrentElementChanged:".
         await self.move_focus_next()
-        visited_identifiers = set()
+        visited_identifiers: set[typing.Any] = set()
         consecutive_timeouts = 0
 
         while True:
@@ -658,9 +659,9 @@ class AccessibilityAudit:
 
             # each such event should contain exactly one element that became in focus
             if isinstance(event.data, list):
-                if not event.data:
+                if not typing.cast(typing.Any, event).data:
                     continue
-                current_item = event.data[0]
+                current_item = typing.cast(list[typing.Any], event.data)[0]
             else:
                 current_item = event.data
             current_identifier = current_item.platform_identifier

--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -21,26 +21,27 @@ import struct
 import sys
 import threading
 import warnings
-from collections.abc import Iterator, MutableMapping, MutableSequence
+from collections.abc import AsyncIterator, Iterator, MutableMapping, MutableSequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from re import Pattern
 from types import TracebackType
-from typing import Any, Callable, NamedTuple, Optional, TextIO, Union, cast
+from typing import Any, Callable, NamedTuple, Optional, TextIO, TypeVar, Union, cast
 
 import hexdump
+import parameter_decorators
+import xonsh.cli_utils
+import xonsh.main
+import xonsh.tools
 from click.exceptions import Exit
 from construct import Bytes, CString, GreedyRange, Int64ul, Tell
 from construct_typed import DataclassMixin, EnumBase, TEnum, TStruct, csfield
-from parameter_decorators import path_to_str
 from pygments import formatters, highlight, lexers
 from pygnuutils.cli.ls import ls as ls_cli
 from pygnuutils.ls import Ls, LsStub
 from tqdm.auto import tqdm
 from xonsh.built_ins import XSH
-from xonsh.cli_utils import Annotated, Arg, ArgParserAlias
-from xonsh.main import main as xonsh_main
-from xonsh.tools import print_color
+from xonsh.cli_utils import Annotated, ArgParserAlias
 
 from pymobiledevice3.construct_compat import const_field
 from pymobiledevice3.exceptions import AfcException, AfcFileNotFoundError, ArgumentError, ConnectionTerminatedError
@@ -48,6 +49,26 @@ from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.services.lockdown_service import LockdownService
 from pymobiledevice3.utils import get_asyncio_loop, try_decode
+
+# These symbols come from untyped third-party modules; re-bind them with explicit types so their
+# uses type-check without leaking Unknown into this module.
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def path_to_str(*args: Any, **kwargs: Any) -> Callable[[_F], _F]:
+    """Signature-preserving wrapper over the untyped ``parameter_decorators.path_to_str``."""
+    return cast(Callable[[_F], _F], cast(Any, parameter_decorators).path_to_str(*args, **kwargs))
+
+
+Arg = cast(Callable[..., Any], cast(Any, xonsh.cli_utils).Arg)
+xonsh_main = cast(Callable[..., Any], cast(Any, xonsh.main).main)
+print_color = cast(Callable[..., Any], cast(Any, xonsh.tools).print_color)
+
+
+def _xsh_ctx() -> dict[str, Any]:
+    """Typed accessor for the untyped ``XSH.ctx`` mapping."""
+    return cast(dict[str, Any], cast(Any, XSH).ctx)
+
 
 MAXIMUM_READ_SIZE = 4 * 1024**2  # 4 MB
 MODE_MASK = 0o0000777
@@ -670,7 +691,7 @@ class AfcService(LockdownService):
             return [filename]
 
         # directory content
-        undeleted_items = []
+        undeleted_items: list[str] = []
         for entry in await self.listdir(filename):
             current_filename = posixpath.join(filename, entry)
 
@@ -716,7 +737,7 @@ class AfcService(LockdownService):
         return list_to_dict(await self._do_operation(AfcOpcode.GET_DEVINFO))
 
     @path_to_str()
-    async def listdir(self, filename: str):
+    async def listdir(self, filename: str) -> list[str]:
         """
         List the entries of a directory on the device.
 
@@ -956,7 +977,7 @@ class AfcService(LockdownService):
                 raise AfcException(f"failed to write last chunk: {status}", status)
 
     @path_to_str()
-    async def resolve_path(self, filename: str):
+    async def resolve_path(self, filename: str) -> str:
         """
         Resolve a symbolic link to its target path.
 
@@ -1016,7 +1037,7 @@ class AfcService(LockdownService):
         await self.fclose(h)
 
     @path_to_str()
-    async def walk(self, dirname: str):
+    async def walk(self, dirname: str) -> AsyncIterator[tuple[str, list[str], list[str]]]:
         """
         Recursively walk a directory tree, similar to `walk`.
 
@@ -1027,8 +1048,8 @@ class AfcService(LockdownService):
         :param dirname: Root directory to walk.
         :yields: ``(dirpath, dirnames, filenames)`` tuples.
         """
-        dirs = []
-        files = []
+        dirs: list[str] = []
+        files: list[str] = []
         for fd in await self.listdir(dirname):
             if fd in (".", "..", ""):
                 continue
@@ -1046,7 +1067,7 @@ class AfcService(LockdownService):
                     yield item
 
     @path_to_str()
-    async def dirlist(self, root: str, depth: int = -1):
+    async def dirlist(self, root: str, depth: int = -1) -> AsyncIterator[str]:
         """
         Recursively yield paths under a directory up to a maximum depth.
 
@@ -1373,7 +1394,7 @@ def path_completer(xsh: Any, action: Any, completer: Any, alias: Any, command: A
     :param command: Command being completed
     :return: List of completion suggestions
     """
-    shell: AfcShell = XSH.ctx["_shell"]
+    shell = cast(AfcShell, _xsh_ctx()["_shell"])
     pwd = shell.cwd
     is_absolute = command.prefix.startswith("/")
     dirpath = posixpath.join(pwd, command.prefix)
@@ -1389,7 +1410,7 @@ def path_completer(xsh: Any, action: Any, completer: Any, alias: Any, command: A
             dirpath = posixpath.dirname(dirpath)
             shell._schedule_completion_cache_refresh(dirpath)
 
-    result = []
+    result: list[str] = []
     for f, is_dir in shell._get_completion_cache(dirpath):
         if is_absolute:
             completion_option = posixpath.join(dirpath, f)
@@ -1415,7 +1436,7 @@ def dir_completer(xsh: Any, action: Any, completer: Any, alias: Any, command: An
     :param command: Command being completed
     :return: List of directory completion suggestions
     """
-    shell: AfcShell = XSH.ctx["_shell"]
+    shell = cast(AfcShell, _xsh_ctx()["_shell"])
     pwd = shell.cwd
     is_absolute = command.prefix.startswith("/")
     dirpath = posixpath.join(pwd, command.prefix)
@@ -1431,7 +1452,7 @@ def dir_completer(xsh: Any, action: Any, completer: Any, alias: Any, command: An
             dirpath = posixpath.dirname(dirpath)
             shell._schedule_completion_cache_refresh(dirpath)
 
-    result = []
+    result: list[str] = []
     for f, is_dir in shell._get_completion_cache(dirpath):
         if not is_dir:
             continue
@@ -1485,13 +1506,13 @@ class AfcShell:
         warnings.filterwarnings("ignore", category=DeprecationWarning)
         args = ["--rc", str(pathlib.Path(__file__).absolute())]
         os.environ["XONSH_COLOR_STYLE"] = "default"
-        XSH.ctx["_class"] = cls
-        XSH.ctx["_lockdown"] = service_provider
-        XSH.ctx["_auto_cd"] = auto_cd
+        _xsh_ctx()["_class"] = cls
+        _xsh_ctx()["_lockdown"] = service_provider
+        _xsh_ctx()["_auto_cd"] = auto_cd
         if service is not None:
-            XSH.ctx["_service"] = service
+            _xsh_ctx()["_service"] = service
         else:
-            XSH.ctx["_service"] = AfcService(service_provider, service_name=service_name)
+            _xsh_ctx()["_service"] = AfcService(service_provider, service_name=service_name)
 
         try:
             logging.getLogger("parso").setLevel(logging.CRITICAL + 1)
@@ -1511,12 +1532,12 @@ class AfcShell:
         """
         self.lockdown = lockdown
         self.afc = _SyncAfcProxy(service)
-        XSH.ctx["_shell"] = self
-        self.cwd = XSH.ctx.get("_auto_cd", "/")
-        self._commands = {}
-        self._orig_aliases = {}
-        assert XSH.env is not None
-        self._orig_prompt = XSH.env["PROMPT"]
+        _xsh_ctx()["_shell"] = self
+        self.cwd: str = _xsh_ctx().get("_auto_cd", "/")
+        self._commands: dict[str, Any] = {}
+        self._orig_aliases: dict[str, Any] = {}
+        assert cast(Any, XSH).env is not None
+        self._orig_prompt = cast(Any, XSH).env["PROMPT"]
         self._completion_cache: dict[str, list[tuple[str, bool]]] = {}
         self._completion_refreshing: set[str] = set()
         self._completion_cache_lock = threading.Lock()
@@ -1539,7 +1560,7 @@ class AfcShell:
             return list(self._completion_cache.get(directory, []))
 
     def _refresh_completion_cache_sync(self, directory: str) -> None:
-        entries = []
+        entries: list[tuple[str, bool]] = []
         for name in self.afc.listdir(directory):
             is_dir = False
             with contextlib.suppress(AfcException):
@@ -1583,7 +1604,7 @@ class AfcShell:
         """
         handler = ArgParserAlias(func=handler, has_args=True, prog=name)
         self._commands[name] = handler
-        aliases = XSH.aliases
+        aliases = cast(Any, XSH).aliases
         assert aliases is not None
         if aliases.get(name):
             self._orig_aliases[name] = aliases[name]
@@ -1597,7 +1618,7 @@ class AfcShell:
         :param handler: Command handler function or executable path
         """
         self._commands[name] = handler
-        aliases = XSH.aliases
+        aliases = cast(Any, XSH).aliases
         assert aliases is not None
         if aliases.get(name):
             self._orig_aliases[name] = aliases[name]
@@ -1611,7 +1632,7 @@ class AfcShell:
         utilities), registers AFC-specific commands, and sets up the custom prompt.
         """
         # clear all host commands except for some useful ones
-        env = XSH.env
+        env = cast(Any, XSH).env
         assert env is not None
         # Env.__getitem__ is untyped; $PATH is an EnvPath (mutable sequence) at runtime
         cast(MutableSequence[str], env["PATH"]).clear()
@@ -1728,7 +1749,9 @@ class AfcShell:
 
         :param directory: Root directory to walk
         """
-        for root, dirs, files in self.afc.walk(self.relative_path(directory)):
+        for root, dirs, files in cast(
+            Iterator[tuple[str, list[str], list[str]]], self.afc.walk(self.relative_path(directory))
+        ):
             for name in files:
                 print(posixpath.join(root, name))
             for name in dirs:
@@ -1812,7 +1835,7 @@ class AfcShell:
 
         :param filename: Path to the file
         """
-        print(hexdump.hexdump(self.afc.get_file_contents(self.relative_path(filename)), result="return"))
+        print(cast(Any, hexdump).hexdump(self.afc.get_file_contents(self.relative_path(filename)), result="return"))
 
     def _do_mkdir(self, filename: Annotated[str, Arg(completer=_path_arg_completer)]):
         """
@@ -1860,10 +1883,13 @@ class AfcShell:
 
     def _update_prompt(self) -> None:
         """Update the shell prompt with syntax highlighting."""
-        self.prompt = highlight(
-            f"[{self.afc.service_name}:{self.cwd}]$ ",
-            lexers.BashSessionLexer(),
-            formatters.Terminal256Formatter(style="solarized-dark"),
+        self.prompt = cast(
+            str,
+            highlight(
+                f"[{self.afc.service_name}:{self.cwd}]$ ",
+                cast(Any, lexers).BashSessionLexer(),
+                cast(Any, formatters).Terminal256Formatter(style="solarized-dark"),
+            ),
         ).strip()
 
     def _complete(self, text: str, line: str, begidx: int, endidx: int):
@@ -1885,7 +1911,7 @@ class AfcShell:
             if filename.startswith(prefix)
         ]
 
-    def _complete_first_arg(self, text: str, line: str, begidx: int, endidx: int):
+    def _complete_first_arg(self, text: str, line: str, begidx: int, endidx: int) -> list[str]:
         """
         Complete only the first argument of a command.
 
@@ -1895,7 +1921,7 @@ class AfcShell:
             return []
         return self._complete(text, line, begidx, endidx)
 
-    def _complete_push_arg(self, text: str, line: str, begidx: int, endidx: int):
+    def _complete_push_arg(self, text: str, line: str, begidx: int, endidx: int) -> list[str]:
         """
         Completion for push command (local path, then remote path).
 
@@ -1909,7 +1935,7 @@ class AfcShell:
         else:
             return []
 
-    def _complete_pull_arg(self, text: str, line: str, begidx: int, endidx: int):
+    def _complete_pull_arg(self, text: str, line: str, begidx: int, endidx: int) -> list[str]:
         """
         Completion for pull command (remote path, then local path).
 
@@ -1955,9 +1981,9 @@ if __name__ == str(pathlib.Path(__file__).absolute()):
     This block is executed when the file is loaded as an xonsh RC script,
     initializing the AFC shell with the context provided by AfcShell.create().
     """
-    rc = XSH.ctx["_class"](XSH.ctx["_lockdown"], XSH.ctx["_service"])
+    rc = cast(AfcShell, _xsh_ctx()["_class"](_xsh_ctx()["_lockdown"], _xsh_ctx()["_service"]))
     # fix fzf conflicts
-    _xsh_env = XSH.env
+    _xsh_env = cast(Any, XSH).env
     assert _xsh_env is not None
     _xsh_env["fzf_history_binding"] = ""  # Ctrl+R
     _xsh_env["fzf_ssh_binding"] = ""  # Ctrl+S

--- a/pymobiledevice3/services/bt_packet_logger.py
+++ b/pymobiledevice3/services/bt_packet_logger.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncGenerator, AsyncIterable
 from dataclasses import dataclass
 from enum import IntEnum
 from struct import pack, unpack
-from typing import BinaryIO, Optional
+from typing import Any, BinaryIO, Optional
 
 import pcapng.blocks as blocks
 from pcapng import FileWriter
@@ -89,7 +89,7 @@ async def write_pcapng_stream(
     # The BTPacketLogger service reports record timestamps as device-local wall-clock time, whereas the pcapng
     # EnhancedPacket timestamp (with the default if_tsresol of 1e-6) is interpreted as UTC. Subtract the device's
     # UTC offset so Wireshark doesn't apply the timezone shift a second time when rendering the display time.
-    shb = blocks.SectionHeader(
+    shb: Any = blocks.SectionHeader(
         options={
             "shb_hardware": "artificial",
             "shb_os": "iOS",
@@ -101,7 +101,7 @@ async def write_pcapng_stream(
         link_type=PCAPNG_LINKTYPE_BLUETOOTH_HCI_H4_WITH_PHDR,
         options={"if_description": "Bluetooth HCI", "if_os": f"iOS {product_version}"},
     )
-    writer = FileWriter(out, shb)
+    writer: Any = FileWriter(out, shb)
 
     async for packet in packet_generator:
         try:

--- a/pymobiledevice3/services/companion.py
+++ b/pymobiledevice3/services/companion.py
@@ -96,7 +96,7 @@ class CompanionProxyService(LockdownService):
         """
         service = await self.lockdown.start_lockdown_service(self.service_name)
 
-        request = {
+        request: dict[str, Any] = {
             "Command": "StartForwardingServicePort",
             "GizmoRemotePortNumber": remote_port,
             "IsServiceLowPriority": False,
@@ -122,6 +122,6 @@ class CompanionProxyService(LockdownService):
         """
         service = await self.lockdown.start_lockdown_service(self.service_name)
 
-        request = {"Command": "StopForwardingServicePort", "GizmoRemotePortNumber": remote_port}
+        request: dict[str, Any] = {"Command": "StopForwardingServicePort", "GizmoRemotePortNumber": remote_port}
 
         return await service.send_recv_plist(request)

--- a/pymobiledevice3/services/crash_reports.py
+++ b/pymobiledevice3/services/crash_reports.py
@@ -9,8 +9,9 @@ from types import TracebackType
 from typing import Any, Callable, ClassVar, Optional, Union, cast
 
 from pycrashreport.crash_report import CrashReportBase, get_crash_report_from_buf
+from xonsh import cli_utils as _xonsh_cli_utils
 from xonsh.built_ins import XSH
-from xonsh.cli_utils import Annotated, Arg
+from xonsh.cli_utils import Annotated
 
 from pymobiledevice3.exceptions import (
     AfcException,
@@ -24,6 +25,10 @@ from pymobiledevice3.services.afc import AfcService, AfcShell, path_completer
 from pymobiledevice3.services.lockdown_service import LockdownService
 from pymobiledevice3.services.notification_proxy import NotificationProxyService
 from pymobiledevice3.services.os_trace import OsTraceService
+
+# xonsh's cli_utils has no py.typed, so Arg's signature is partially unknown; adapt it to a
+# typed callable once here instead of at every Annotated[...] use site.
+Arg = cast(Callable[..., Any], cast(Any, _xonsh_cli_utils).Arg)
 
 # xonsh declares Arg(completer=...) as returning Iterator[str], but any iterable works at
 # runtime; adapt the list-returning completer's declared type once here instead of per call site.
@@ -106,7 +111,7 @@ class CrashReportsManager:
         :param path: Path under the crash reports directory to clear. Defaults to '/'.
         :raises AfcException: If any item other than ``com.apple.appstored`` could not be deleted.
         """
-        undeleted_items = []
+        undeleted_items: list[str] = []
         for filename in await self.ls(path, depth=1):
             undeleted_items.extend(await self.afc.rm(filename, force=True))
 
@@ -127,7 +132,7 @@ class CrashReportsManager:
         :param depth: Listing depth, -1 to list infinite.
         :return: List of files listed.
         """
-        result = []
+        result: list[str] = []
         async for item in self.afc.dirlist(path, depth):
             result.append(item)
         return result[1:]  # skip the root path '/'
@@ -334,7 +339,7 @@ class CrashReportsManager:
 
     async def _get_new_sysdiagnose_filename(self, end_time: Optional[float] = None) -> str:
         sysdiagnose_filename = None
-        excluded_temp_files = []
+        excluded_temp_files: list[str] = []
 
         while sysdiagnose_filename is None:
             try:
@@ -381,7 +386,7 @@ class CrashReportsShell(AfcShell):
         auto_cd: Optional[str] = "/",
     ):
         manager = CrashReportsManager(service_provider)
-        XSH.ctx["_manager"] = manager
+        cast(Any, XSH).ctx["_manager"] = manager
         super(CrashReportsShell, CrashReportsShell).create(service_provider, service=manager.afc)
 
     def _setup_shell_commands(self):
@@ -399,7 +404,7 @@ class CrashReportsShell(AfcShell):
 
         :param filename: Path to the crash report file
         """
-        print(self._run_manager(XSH.ctx["_manager"].parse(filename)))
+        print(self._run_manager(cast(CrashReportsManager, cast(Any, XSH).ctx["_manager"]).parse(filename)))
 
     def _do_parse_latest(
         self,
@@ -413,7 +418,7 @@ class CrashReportsShell(AfcShell):
     ) -> None:
         """Parse latest top-level crash report(s) under a path, ordered by newest first"""
         latest_reports = self._run_manager(
-            XSH.ctx["_manager"].parse_latest(
+            cast(CrashReportsManager, cast(Any, XSH).ctx["_manager"]).parse_latest(
                 path=path,
                 match=match or [],
                 match_insensitive=match_insensitive or [],
@@ -425,4 +430,4 @@ class CrashReportsShell(AfcShell):
 
     def _do_clear(self, path: Annotated[str, Arg(nargs="?", completer=_path_arg_completer)] = "/") -> None:
         """Clear crash reports from the device under a path."""
-        self._run_manager(XSH.ctx["_manager"].clear(path))
+        self._run_manager(cast(CrashReportsManager, cast(Any, XSH).ctx["_manager"]).clear(path))

--- a/pymobiledevice3/services/diagnostics.py
+++ b/pymobiledevice3/services/diagnostics.py
@@ -1065,7 +1065,7 @@ class DiagnosticsService(LockdownService):
             carries no such payload.
         :raises PyMobileDevice3Exception: If the response status is not ``Success``.
         """
-        d = {}
+        d: dict[str, Any] = {}
 
         if plane:
             d["CurrentPlane"] = plane

--- a/pymobiledevice3/services/dtfetchsymbols.py
+++ b/pymobiledevice3/services/dtfetchsymbols.py
@@ -35,7 +35,7 @@ class DtFetchSymbols:
         await service.close()
         if files is None:
             raise PyMobileDevice3Exception("list files response is missing the 'files' entry")
-        return typing.cast("list[str]", files)
+        return typing.cast(list[str], files)
 
     async def get_file(self, fileno: int, stream: typing.IO[bytes], max_bytes: typing.Optional[int] = None):
         """

--- a/pymobiledevice3/services/dvt/instruments/activity_trace_tap.py
+++ b/pymobiledevice3/services/dvt/instruments/activity_trace_tap.py
@@ -2,6 +2,7 @@ import dataclasses
 import math
 import os
 import struct
+from collections.abc import AsyncGenerator, Callable, Generator
 from io import BytesIO
 from typing import Any, cast
 
@@ -70,7 +71,7 @@ def decode_message_format(message: Any) -> str:
         elif type_ in ("data", "uuid"):
             if data is not None:
                 # for these types the payload is a list of bytes chunks, not a single bytes object
-                s += b"".join(cast("list[bytes]", data)).hex()
+                s += b"".join(cast(list[bytes], data)).hex()
         else:
             # by default, make sure the data can be concatenated
             s += str(data)
@@ -100,7 +101,7 @@ class ActivityTraceTap(Tap):
         #   reverse: [DTOSLogLoader _handleRecord:], DTTableRowEncoder::*
         #   to understand each row's structure.
 
-        config = {
+        config: dict[str, Any] = {
             "bm": 0,  # buffer mode
             "combineDataScope": 0,
             "machTimebaseDenom": 3,
@@ -119,10 +120,10 @@ class ActivityTraceTap(Tap):
 
         super().__init__(dvt, self.IDENTIFIER, config)
 
-        self.stack = []
+        self.stack: list[Any] = []
         self.generation = 0
         self.background = 0
-        self.tables = []
+        self.tables: list[Table] = []
         # trailing bytes of an opcode that was split across two DTX frames
         self._carry = b""
 
@@ -280,8 +281,8 @@ class ActivityTraceTap(Tap):
         """push an item and pop it. effectively do nothing"""
         pass
 
-    def _parse(self):
-        operations = {
+    def _parse(self) -> Generator[Any, None, None]:
+        operations: dict[int, Callable[[int], Any]] = {
             CMD_TABLE_RESET: self._handle_table_reset,
             CMD_SENTINEL: self._handle_sentinel,
             CMD_STRUCT: self._handle_struct,
@@ -315,7 +316,7 @@ class ActivityTraceTap(Tap):
             if opcode == CMD_END_ROW and result is not None:
                 yield result
 
-    async def __aiter__(self):
+    async def __aiter__(self) -> AsyncGenerator[Any, None]:
         """
         Continuously receive frames and yield the decoded log entries they contain.
 

--- a/pymobiledevice3/services/dvt/instruments/condition_inducer.py
+++ b/pymobiledevice3/services/dvt/instruments/condition_inducer.py
@@ -54,7 +54,7 @@ class ConditionInducer(DtxService[ConditionInducerService]):
         :raises PyMobileDevice3Exception: If no available profile matches `profile_identifier`.
         """
         for group in await self.list():
-            for profile in cast("list[dict[str, Any]]", group.get("profiles")):
+            for profile in cast(list[dict[str, Any]], group.get("profiles")):
                 if profile_identifier == profile.get("identifier"):
                     self.logger.info(profile.get("description"))
                     await self.service.enable_condition_with_identifier_profile_identifier_(

--- a/pymobiledevice3/services/dvt/instruments/core_profile_session_tap.py
+++ b/pymobiledevice3/services/dvt/instruments/core_profile_session_tap.py
@@ -520,7 +520,7 @@ exclave_textlayout_segments = Struct(
     ),
 )
 
-kcdata_types_structures = {
+kcdata_types_structures: dict[typing.Any, typing.Any] = {
     kcdata_types_enum.KCDATA_TYPE_UINT32_DESC: uint32_desc,
     kcdata_types_enum.KCDATA_TYPE_UINT64_DESC: uint64_desc,
     kcdata_types_enum.STACKSHOT_KCTYPE_JETSAM_LEVEL: jetsam_level,
@@ -578,9 +578,11 @@ kcdata = GreedyRange(kcdata_item)
 
 def clean(d: typing.Any) -> typing.Any:
     if isinstance(d, dict):
-        return {k: clean(v) for k, v in d.items() if not k.startswith("_")}
+        typed_dict = typing.cast(dict[typing.Any, typing.Any], d)
+        return {k: clean(v) for k, v in typed_dict.items() if not k.startswith("_")}
     elif isinstance(d, list):
-        return [clean(v) for v in d]
+        typed_list = typing.cast(list[typing.Any], d)
+        return [clean(v) for v in typed_list]
     else:
         return d
 
@@ -729,12 +731,12 @@ class CoreProfileSessionTap:
         self._provider = dvt
         self._channel: typing.Optional[CoreProfileSessionTapChannel] = None
         self.channel: typing.Optional[TapMessageChannel] = None
-        self.stack_shot = None
+        self.stack_shot: typing.Optional[dict[str, typing.Any]] = None
         self.uuid = str(uuid.uuid4())
 
         if filters is None:
             filters = {0xFFFFFFFF}
-        config = {
+        config: dict[str, typing.Any] = {
             "tc": [
                 {
                     "csd": 128,  # Callstack frame depth.
@@ -788,6 +790,7 @@ class CoreProfileSessionTap:
         if not isinstance(decoded, dict):
             return
 
+        decoded = typing.cast(dict[typing.Any, typing.Any], decoded)
         notice = decoded.get("notice")
         status = decoded.get("status")
         if not notice:
@@ -834,8 +837,8 @@ class CoreProfileSessionTap:
 
         dsc_map = get_dsc_map(str(stackshot["shared_cache_dyld_load_info"]["imageUUID"]))
 
-        for _pid, snapshot in stackshot["task_snapshots"].items():
-            for loaded_image in snapshot.get("dyld_load_info", []):
+        for _pid, snapshot in typing.cast(dict[typing.Any, typing.Any], stackshot["task_snapshots"]).items():
+            for loaded_image in typing.cast(list[typing.Any], snapshot.get("dyld_load_info", [])):
                 image_uuid = str(loaded_image["imageUUID"])
                 if isinstance(dsc_map, dict) and image_uuid in dsc_map:
                     loaded_image["imagePath"] = dsc_map[image_uuid]
@@ -896,7 +899,7 @@ class CoreProfileSessionTap:
         return KdBufStream(chunk_queue)
 
     @staticmethod
-    def parse_stackshot(data: bytes):
+    def parse_stackshot(data: bytes) -> dict[str, typing.Any]:
         """
         Parse raw KCDATA stackshot bytes into a nested dictionary.
 
@@ -907,12 +910,12 @@ class CoreProfileSessionTap:
         parsed = kcdata.parse(data)
         # Required for removing streams from construct output.
         stackshot = clean(parsed)
-        parsed_stack_shot = {}
+        parsed_stack_shot: dict[str, typing.Any] = {}
         jsonify_parsed_stackshot(stackshot, parsed_stack_shot)
         return parsed_stack_shot[predefined_names[kcdata_types_enum.KCDATA_BUFFER_BEGIN_STACKSHOT]]
 
     @staticmethod
-    async def get_time_config(dvt: DtxServiceProvider):
+    async def get_time_config(dvt: DtxServiceProvider) -> dict[str, typing.Any]:
         """
         Build the `time_config` mapping required to construct a `CoreProfileSessionTap`.
 
@@ -924,7 +927,7 @@ class CoreProfileSessionTap:
             `timezone`.
         """
         async with DeviceInfo(dvt) as device_info:
-            time_info = await device_info.mach_time_info()
+            time_info = typing.cast(list[typing.Any], await device_info.mach_time_info())
         mach_absolute_time = time_info[0]
         numer = time_info[1]
         denom = time_info[2]

--- a/pymobiledevice3/services/dvt/instruments/location_simulation.py
+++ b/pymobiledevice3/services/dvt/instruments/location_simulation.py
@@ -24,7 +24,7 @@ class LocationSimulation(DtxService[LocationSimulationService], LocationSimulati
     """
 
     def __init__(self, dvt: DtxServiceProvider):
-        DtxService.__init__(self, dvt)
+        super().__init__(dvt)
         LocationSimulationBase.__init__(self)
 
     async def set(self, latitude: float, longitude: float) -> None:

--- a/pymobiledevice3/services/dvt/instruments/network_monitor.py
+++ b/pymobiledevice3/services/dvt/instruments/network_monitor.py
@@ -1,8 +1,8 @@
 import ipaddress
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 from construct import Adapter, Bytes, Int8ul, Int16ub, Int32ul, Switch, this
 from construct_typed import DataclassMixin, TStruct, csfield
@@ -174,12 +174,12 @@ class NetworkMonitor(DtxService[NetworkMonitorService]):
 
             if message is None:
                 continue
-            if not isinstance(message, (list, tuple)) or len(message) < 2:
+            if not isinstance(message, (list, tuple)) or len(cast(Sequence[Any], message)) < 2:
                 self.logger.warning(f"unsupported event payload: {message!r}")
                 continue
 
             if message[0] == MESSAGE_TYPE_INTERFACE_DETECTION:
-                event = InterfaceDetectionEvent(*message[1])
+                event = InterfaceDetectionEvent(*cast(tuple[Any, ...], message[1]))
             elif message[0] == MESSAGE_TYPE_CONNECTION_DETECTION:
                 (
                     local_address,
@@ -190,7 +190,7 @@ class NetworkMonitor(DtxService[NetworkMonitorService]):
                     recv_buffer_used,
                     serial_number,
                     kind,
-                ) = message[1]
+                ) = cast(tuple[Any, ...], message[1])
                 event = ConnectionDetectionEvent(
                     local_address=address_t.parse(local_address),
                     remote_address=address_t.parse(remote_address),
@@ -202,7 +202,7 @@ class NetworkMonitor(DtxService[NetworkMonitorService]):
                     kind=kind,
                 )
             elif message[0] == MESSAGE_TYPE_CONNECTION_UPDATE:
-                event = ConnectionUpdateEvent(*message[1])
+                event = ConnectionUpdateEvent(*cast(tuple[Any, ...], message[1]))
             else:
                 self.logger.warning(f"unsupported event type: {message[0]}")
             yield event

--- a/pymobiledevice3/services/dvt/instruments/sysmontap.py
+++ b/pymobiledevice3/services/dvt/instruments/sysmontap.py
@@ -1,4 +1,6 @@
 import dataclasses
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from pymobiledevice3.dtx_service_provider import DtxServiceProvider
 from pymobiledevice3.services.dvt.instruments.device_info import DeviceInfo
@@ -36,7 +38,7 @@ class Sysmontap(Tap):
         self.process_attributes_cls = dataclasses.make_dataclass("SysmonProcessAttributes", process_attributes)
         self.system_attributes_cls = dataclasses.make_dataclass("SysmonSystemAttributes", system_attributes)
 
-        config = {
+        config: dict[str, Any] = {
             "ur": Sysmontap.MINIMUM_INTERVAL_MS,  # Output frequency ms
             "bm": 0,
             "procAttrs": process_attributes,
@@ -65,7 +67,7 @@ class Sysmontap(Tap):
             system_attributes = list(await device_info.sysmon_system_attributes())
         return cls(dvt, process_attributes, system_attributes, interval_ms=interval)
 
-    async def iter_processes(self):
+    async def iter_processes(self) -> AsyncGenerator[list[dict[str, Any]], None]:
         """
         Iterate per-process samples, decoded into attribute dicts.
 
@@ -79,7 +81,7 @@ class Sysmontap(Tap):
             if "Processes" not in row:
                 continue
 
-            entries = []
+            entries: list[dict[str, Any]] = []
 
             processes = row["Processes"].items()
             for _pid, process_info in processes:

--- a/pymobiledevice3/services/dvt/testmanaged/xctest_types.py
+++ b/pymobiledevice3/services/dvt/testmanaged/xctest_types.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import copy
 import plistlib
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar, Optional, cast
 
 from bpylist2 import archiver
 
@@ -37,11 +37,12 @@ class XCTCapabilities:
         self.capabilities = capabilities
 
     def encode_archive(self, archive_obj: archiver.ArchivingObject) -> None:
-        archive_obj.encode("capabilities-dictionary", self.capabilities)
+        ao = cast(Any, archive_obj)
+        ao.encode("capabilities-dictionary", self.capabilities)
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> XCTCapabilities:
-        return XCTCapabilities(archive_obj.decode("capabilities-dictionary"))
+        return XCTCapabilities(cast(Any, archive_obj.decode("capabilities-dictionary")))
 
     def __repr__(self) -> str:
         return f"XCTCapabilities({self.capabilities})"
@@ -50,7 +51,7 @@ class XCTCapabilities:
 class XCTestConfiguration:
     """Proxy for ``XCTestConfiguration`` — the launch config sent to the test runner."""
 
-    _default: ClassVar = {
+    _default: ClassVar[dict[str, Any]] = {
         "aggregateStatisticsBeforeCrash": {"XCSuiteRecordsKey": {}},
         "automationFrameworkPath": "/Developer/Library/PrivateFrameworks/XCTAutomationSupport.framework",
         "baselineFileRelativePath": None,
@@ -102,12 +103,13 @@ class XCTestConfiguration:
     def __init__(self, kv: dict[str, Any]):
         assert "testBundleURL" in kv
         assert "sessionIdentifier" in kv
-        self._config = copy.deepcopy(self._default)
+        self._config: dict[str, Any] = copy.deepcopy(self._default)
         self._config.update(kv)
 
     def encode_archive(self, archive_obj: archiver.ArchivingObject) -> None:
+        ao = cast(Any, archive_obj)
         for k, v in self._config.items():
-            archive_obj.encode(k, v)
+            ao.encode(k, v)
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> Any:
@@ -139,7 +141,7 @@ class XCTTestIdentifier:
     - ``3`` — class-level (class only, matches all methods)
     """
 
-    components: list[str] = field(default_factory=list)
+    components: list[str] = field(default_factory=list[str])
     options: int = 2
 
     @classmethod
@@ -174,15 +176,16 @@ class XCTTestIdentifier:
         return self.components == other.components and self.options == other.options
 
     def encode_archive(self, archive_obj: archiver.ArchivingObject) -> None:
-        archive_obj.encode("c", list(self.components))
-        archive_obj.encode("o", self.options)
+        ao = cast(Any, archive_obj)
+        ao.encode("c", list(self.components))
+        ao.encode("o", self.options)
         patch_class_hierarchy(archive_obj, "XCTTestIdentifier", ["XCTTestIdentifier", "NSObject"])
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> XCTTestIdentifier:
-        raw = archive_obj.decode("c")
+        raw = cast(Any, archive_obj.decode("c"))
         components = list(raw) if raw else []
-        options = archive_obj.decode("o") or 2
+        options = cast(Any, archive_obj.decode("o") or 2)
         return XCTTestIdentifier(components=components, options=int(options))
 
 
@@ -200,7 +203,7 @@ class XCTTestIdentifierSet:
     Xcode 15 and go-ios.
     """
 
-    identifiers: list[XCTTestIdentifier] = field(default_factory=list)
+    identifiers: list[XCTTestIdentifier] = field(default_factory=list[XCTTestIdentifier])
 
     @classmethod
     def from_strings(cls, test_specs: list[str]) -> XCTTestIdentifierSet:
@@ -210,12 +213,13 @@ class XCTTestIdentifierSet:
     def encode_archive(self, archive_obj: archiver.ArchivingObject) -> None:
         # Must be NSMutableArray — XCTTestIdentifierSet.identifiers is typed as
         # NSMutableArray<XCTTestIdentifier *> in XCTest's private headers.
-        archive_obj.encode("identifiers", NSMutableArray(self.identifiers))
+        ao = cast(Any, archive_obj)
+        ao.encode("identifiers", NSMutableArray(self.identifiers))
         patch_class_hierarchy(archive_obj, "XCTTestIdentifierSet", ["XCTTestIdentifierSet", "NSObject"])
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> XCTTestIdentifierSet:
-        raw = archive_obj.decode("identifiers")
+        raw = cast(Any, archive_obj.decode("identifiers"))
         identifiers = list(raw) if raw else []
         return XCTTestIdentifierSet(identifiers=identifiers)
 
@@ -240,8 +244,8 @@ class XCTSourceCodeLocation:
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> XCTSourceCodeLocation:
-        file_url = archive_obj.decode("file-url")
-        line_number = archive_obj.decode("line-number") or 0
+        file_url = cast(Any, archive_obj.decode("file-url"))
+        line_number = cast(Any, archive_obj.decode("line-number") or 0)
         return XCTSourceCodeLocation(file_url=file_url, line_number=int(line_number))
 
 
@@ -253,7 +257,7 @@ class XCTSourceCodeContext:
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> XCTSourceCodeContext:
-        location = archive_obj.decode("location")
+        location = cast(Any, archive_obj.decode("location"))
         return XCTSourceCodeContext(location=location)
 
 
@@ -278,10 +282,10 @@ class XCTIssue:
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> XCTIssue:
-        compact = archive_obj.decode("compact-description") or ""
-        detailed = archive_obj.decode("detailed-description")
-        ctx = archive_obj.decode("source-code-context")
-        issue_type = archive_obj.decode("type") or 0
+        compact = cast(Any, archive_obj.decode("compact-description") or "")
+        detailed = cast(Any, archive_obj.decode("detailed-description"))
+        ctx = cast(Any, archive_obj.decode("source-code-context"))
+        issue_type = cast(Any, archive_obj.decode("type") or 0)
         return XCTIssue(
             compact_description=str(compact) if compact else "",
             detailed_description=str(detailed) if detailed else None,
@@ -299,19 +303,19 @@ class XCActivityRecord:
     uuid: Any  # NSUUID or None
     start: Any  # NSDate or None
     finish: Any  # NSDate or None
-    attachments: list[Any] = field(default_factory=list)
+    attachments: list[Any] = field(default_factory=list[Any])
 
     def __str__(self) -> str:
         return f"XCActivityRecord({self.title!r}, type={self.activity_type!r})"
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> XCActivityRecord:
-        title = archive_obj.decode("title") or ""
-        activity_type = archive_obj.decode("activityType") or ""
-        uuid = archive_obj.decode("uuid")
-        start = archive_obj.decode("start")
-        finish = archive_obj.decode("finish")
-        attachments = archive_obj.decode("attachments") or []
+        title = cast(Any, archive_obj.decode("title") or "")
+        activity_type = cast(Any, archive_obj.decode("activityType") or "")
+        uuid = cast(Any, archive_obj.decode("uuid"))
+        start = cast(Any, archive_obj.decode("start"))
+        finish = cast(Any, archive_obj.decode("finish"))
+        attachments = cast(Any, archive_obj.decode("attachments") or [])
         return XCActivityRecord(
             title=str(title) if title else "",
             activity_type=str(activity_type) if activity_type else "",
@@ -330,18 +334,18 @@ class XCTAttachment:
     uniformTypeIdentifier: str
     timestamp: Any  # NSDate or None
     data: Optional[bytes] = None
-    additional_data: dict[str, Any] = field(default_factory=dict)
+    additional_data: dict[str, Any] = field(default_factory=dict[str, Any])
 
     @staticmethod
     def decode_archive(archive_obj: archiver.ArchivedObject) -> XCTAttachment:
-        name = archive_obj.decode("name") or ""
-        uti = archive_obj.decode("uniformTypeIdentifier") or ""
-        timestamp = archive_obj.decode("timestamp")
-        data = archive_obj.decode("data")
+        name = cast(Any, archive_obj.decode("name") or "")
+        uti = cast(Any, archive_obj.decode("uniformTypeIdentifier") or "")
+        timestamp = cast(Any, archive_obj.decode("timestamp"))
+        data = cast(Any, archive_obj.decode("data"))
         # Capture any additional fields that may be present
-        additional_data = {}
+        additional_data: dict[str, Any] = {}
         for key in ("metadata", "file-path", "file-url"):
-            val = archive_obj.decode(key)
+            val = cast(Any, archive_obj.decode(key))
             if val is not None:
                 additional_data[key] = val
         return XCTAttachment(
@@ -358,14 +362,14 @@ class XCTestCaseRunConfiguration:
     """Decoded proxy for ``XCTestCaseRunConfiguration``."""
 
     iteration: int
-    configuration: dict[str, Any] = field(default_factory=dict)
+    configuration: dict[str, Any] = field(default_factory=dict[str, Any])
 
     @staticmethod
     def decode_archive(
         archive_obj: archiver.ArchivedObject,
     ) -> XCTestCaseRunConfiguration:
-        iteration = archive_obj.decode("iteration") or 1
-        configuration = archive_obj.decode("configuration") or {}
+        iteration = cast(Any, archive_obj.decode("iteration") or 1)
+        configuration = cast(Any, archive_obj.decode("configuration") or {})
         return XCTestCaseRunConfiguration(
             iteration=int(iteration),
             configuration=dict(configuration) if configuration else {},

--- a/pymobiledevice3/services/dvt/testmanaged/xcuitest.py
+++ b/pymobiledevice3/services/dvt/testmanaged/xcuitest.py
@@ -350,7 +350,7 @@ def _generate_launch_args(
     assert exec_name.endswith("-Runner"), f"Invalid CFBundleExecutable: {exec_name}"
     target_name = exec_name[: -len("-Runner")]
 
-    app_env = {
+    app_env: dict[str, str] = {
         "CA_ASSERT_MAIN_THREAD_TRANSACTIONS": "0",
         "CA_DEBUG_TRANSACTIONS": "0",
         "DYLD_FRAMEWORK_PATH": app_path + "/Frameworks:",

--- a/pymobiledevice3/services/installation_proxy.py
+++ b/pymobiledevice3/services/installation_proxy.py
@@ -4,10 +4,16 @@ from enum import Enum
 from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, cast
 from zipfile import ZIP_DEFLATED, BadZipFile, ZipFile
 
-from parameter_decorators import str_to_path
+if TYPE_CHECKING:
+    _F = TypeVar("_F", bound=Callable[..., Any])
+
+    def str_to_path(*params: str, reannotate: bool = True) -> Callable[[_F], _F]: ...
+
+else:
+    from parameter_decorators import str_to_path
 
 from pymobiledevice3.exceptions import AppInstallError
 from pymobiledevice3.lockdown import LockdownClient
@@ -425,7 +431,7 @@ class InstallationProxyService(LockdownService):
         """
         if options is None:
             options = {}
-        cmd = {"Command": "CheckCapabilitiesMatch", "ClientOptions": options}
+        cmd: dict[str, Any] = {"Command": "CheckCapabilitiesMatch", "ClientOptions": options}
 
         if capabilities:
             cmd["Capabilities"] = capabilities
@@ -452,7 +458,7 @@ class InstallationProxyService(LockdownService):
         if attributes:
             options["ReturnAttributes"] = attributes
 
-        cmd = {"Command": "Browse", "ClientOptions": options}
+        cmd: dict[str, Any] = {"Command": "Browse", "ClientOptions": options}
 
         await self.service.send_plist(cmd)
 
@@ -464,7 +470,7 @@ class InstallationProxyService(LockdownService):
 
             data = response.get("CurrentList")
             if data is not None:
-                result += cast("list[dict[str, Any]]", data)
+                result += cast(list[dict[str, Any]], data)
 
             if response.get("Status") == "Complete":
                 break
@@ -485,7 +491,7 @@ class InstallationProxyService(LockdownService):
         """
         if options is None:
             options = {}
-        cmd = {"Command": "Lookup", "ClientOptions": options}
+        cmd: dict[str, Any] = {"Command": "Lookup", "ClientOptions": options}
         await self.service.send_plist(cmd)
         return cast(Optional[dict[str, Any]], (await self.service.recv_plist()).get("LookupResult"))
 
@@ -515,7 +521,7 @@ class InstallationProxyService(LockdownService):
             See <https://github.com/doronz88/pymobiledevice3/issues/1602> for details.
         :returns: A dictionary mapping each bundle identifier to its per-app info dictionary.
         """
-        options = {}
+        options: dict[str, Any] = {}
         if bundle_identifiers is not None:
             options["BundleIDs"] = bundle_identifiers
 

--- a/pymobiledevice3/services/mobile_activation.py
+++ b/pymobiledevice3/services/mobile_activation.py
@@ -5,7 +5,7 @@ import plistlib
 import xml.etree.ElementTree as ET
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 import click
 import inquirer3
@@ -113,7 +113,7 @@ class MobileActivationService:
             raise MobileActivationException("Activation server response is invalid")
         title = navigation_bar.get("title")
         description = footer.text
-        fields = []
+        fields: list[Field] = []
         for editable in root.findall("page//editableTextRow"):
             fields.append(
                 Field(
@@ -123,7 +123,7 @@ class MobileActivationService:
                     secure=bool(editable.get("secure", False)),
                 )
             )
-        server_info = {}
+        server_info: dict[str, str] = {}
         for k, v in server_info_node.items():
             server_info[k] = v
         return ActivationForm(title=title, description=description, fields=fields, server_info=server_info)
@@ -165,7 +165,7 @@ class MobileActivationService:
                 ACTIVATION_DRM_HANDSHAKE_DEFAULT_URL, data=plistlib.dumps(blob), headers=headers
             )
 
-        activation_request = {}
+        activation_request: dict[str, Any] = {}
         if session_mode:
             activation_info = await self.create_activation_info_with_session(content)
         else:
@@ -212,13 +212,13 @@ class MobileActivationService:
             else:
                 click.secho(activation_form.title, bold=True)
                 click.secho(activation_form.description)
-                fields = []
+                fields: list[Any] = []
                 for field in activation_form.fields:
                     if field.secure:
                         fields.append(inquirer3.Password(name=field.id, message=f"{field.label}"))
                     else:
                         fields.append(inquirer3.Text(name=field.id, message=f"{field.label}"))
-                data = inquirer3.prompt(fields)
+                data: dict[str, Any] = cast(Any, inquirer3).prompt(fields)
                 data.update(activation_form.server_info)
                 content, headers = self.post(ACTIVATION_DEFAULT_URL, data=data)
                 content_type = headers["Content-Type"]
@@ -312,7 +312,7 @@ class MobileActivationService:
             ``ActivationResponseHeaders``; may be falsy to omit them.
         :returns: the daemon's response to the request.
         """
-        data = {
+        data: dict[str, Any] = {
             "Command": "HandleActivationInfoWithSessionRequest",
             "Value": activation_record,
         }

--- a/pymobiledevice3/services/mobile_config.py
+++ b/pymobiledevice3/services/mobile_config.py
@@ -213,7 +213,7 @@ class MobileConfigService(LockdownService):
         if response.get("Status", None) != "Acknowledged":
             error_chain = response.get("ErrorChain")
             if error_chain is not None:
-                error_code = cast("list[dict[str, Any]]", error_chain)[0]["ErrorCode"]
+                error_code = cast(list[dict[str, Any]], error_chain)[0]["ErrorCode"]
                 if error_code == ERROR_CLOUD_CONFIGURATION_ALREADY_PRESENT:
                     raise CloudConfigurationAlreadyPresentError()
             raise ProfileError(f"invalid response {response}")

--- a/pymobiledevice3/services/mobile_image_mounter.py
+++ b/pymobiledevice3/services/mobile_image_mounter.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 import plistlib
 from pathlib import Path
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar, Optional, cast
 
 from developer_disk_image.repo import DeveloperDiskImageRepository
 from packaging.version import Version
@@ -100,7 +100,7 @@ class MobileImageMounterService(LockdownService):
         if isinstance(signature, list):
             if not signature:
                 raise NotMountedError()
-            return signature[0]
+            return cast(bytes, signature[0])
         return signature
 
     async def is_image_mounted(self, image_type: str) -> bool:
@@ -156,7 +156,7 @@ class MobileImageMounterService(LockdownService):
         if await self.is_image_mounted(image_type):
             raise AlreadyMountedError()
 
-        request = {"Command": "MountImage", "ImageType": image_type, "ImageSignature": signature}
+        request: dict[str, Any] = {"Command": "MountImage", "ImageType": image_type, "ImageSignature": signature}
 
         if extras is not None:
             request.update(extras)
@@ -370,7 +370,7 @@ class PersonalizedImageMounter(MobileImageMounterService):
 
         await self.upload_image(self.IMAGE_TYPE, image_bytes, manifest)
 
-        extras = {}
+        extras: dict[str, Any] = {}
         if info_plist is not None:
             extras["ImageInfoPlist"] = info_plist
         extras["ImageTrustCache"] = trust_cache_bytes
@@ -413,7 +413,7 @@ class PersonalizedImageMounter(MobileImageMounterService):
             raise NoSuchBuildIdentityError(f"Could not find the manifest for board {board_id} and chip {chip_id}")
         manifest = build_identity["Manifest"]
 
-        parameters = {
+        parameters: dict[str, Any] = {
             "ApProductionMode": True,
             "ApSecurityDomain": 1,
             "ApSecurityMode": True,

--- a/pymobiledevice3/services/mobilebackup2.py
+++ b/pymobiledevice3/services/mobilebackup2.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.keywrap import aes_key_unwrap
@@ -32,7 +32,7 @@ from pymobiledevice3.exceptions import (
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.services.afc import AFC_LOCK_EX, AFC_LOCK_UN, AfcError, AfcService
-from pymobiledevice3.services.device_link import DeviceLink
+from pymobiledevice3.services.device_link import DeviceLink, ProgressCallback
 from pymobiledevice3.services.installation_proxy import InstallationProxyService
 from pymobiledevice3.services.lockdown_service import LockdownService
 from pymobiledevice3.services.notification_proxy import NotificationProxyService
@@ -202,7 +202,7 @@ class Mobilebackup2Service(LockdownService):
         self,
         full: bool = True,
         backup_directory: Union[str, Path] = ".",
-        progress_callback: Callable[..., Any] = lambda x: None,
+        progress_callback: ProgressCallback = lambda x: None,
         filter_callback: Optional[BackupFilterCallback] = None,
         password: str = "",
         unback: bool = False,
@@ -329,7 +329,7 @@ class Mobilebackup2Service(LockdownService):
         remove: bool = False,
         password: str = "",
         source: str = "",
-        progress_callback: Callable[..., Any] = lambda x: None,
+        progress_callback: ProgressCallback = lambda x: None,
         skip_apps: bool = False,
     ):
         """
@@ -407,7 +407,7 @@ class Mobilebackup2Service(LockdownService):
         backup_dir = Path(backup_directory)
         self._assert_backup_exists(backup_dir, source if source else self._udid)
         async with self.device_link(backup_dir) as dl:
-            message = {"MessageName": "Info", "TargetIdentifier": self.lockdown.udid}
+            message: dict[str, Any] = {"MessageName": "Info", "TargetIdentifier": self.lockdown.udid}
             if source:
                 message["SourceIdentifier"] = source
             await dl.send_process_message(message)
@@ -446,7 +446,7 @@ class Mobilebackup2Service(LockdownService):
         backup_dir = Path(backup_directory)
         self._assert_backup_exists(backup_dir, source if source else self._udid)
         async with self.device_link(backup_dir) as dl:
-            message = {"MessageName": "Unback", "TargetIdentifier": self.lockdown.udid}
+            message: dict[str, Any] = {"MessageName": "Unback", "TargetIdentifier": self.lockdown.udid}
             if source:
                 message["SourceIdentifier"] = source
             if password:
@@ -494,7 +494,7 @@ class Mobilebackup2Service(LockdownService):
         backup_dir = Path(backup_directory)
         self._assert_backup_exists(backup_dir, source if source else self._udid)
         async with self.device_link(backup_dir) as dl:
-            message = {
+            message: dict[str, Any] = {
                 "MessageName": "Extract",
                 "TargetIdentifier": self.lockdown.udid,
                 "DomainName": domain_name,
@@ -516,7 +516,7 @@ class Mobilebackup2Service(LockdownService):
         :param new: New password. Omit when disabling backup encryption.
         """
         async with self.device_link(Path(backup_directory)) as dl:
-            message = {"MessageName": "ChangePassword", "TargetIdentifier": self.lockdown.udid}
+            message: dict[str, Any] = {"MessageName": "ChangePassword", "TargetIdentifier": self.lockdown.udid}
             if old:
                 message["OldPassword"] = old
             if new:
@@ -553,7 +553,7 @@ class Mobilebackup2Service(LockdownService):
         assert reply[0] == "DLMessageProcessMessage" and reply[1]["ErrorCode"] == 0
         assert reply[1]["ProtocolVersion"] in local_versions
 
-    async def init_mobile_backup_factory_info(self, afc: AfcService):
+    async def init_mobile_backup_factory_info(self, afc: AfcService) -> dict[str, Any]:
         """
         Build the Info.plist dictionary describing the device for a new backup.
 
@@ -573,7 +573,7 @@ class Mobilebackup2Service(LockdownService):
                 # https://github.com/doronz88/pymobiledevice3/issues/1332
                 min_itunes_version = "10.0.1"
             app_dict = {}
-            installed_apps = []
+            installed_apps: list[Any] = []
             apps = await ip.browse(
                 options={"ApplicationType": "User"},
                 attributes=["CFBundleIdentifier", "ApplicationSINF", "iTunesMetadata"],
@@ -598,7 +598,7 @@ class Mobilebackup2Service(LockdownService):
                 else:
                     files[file] = data_buf
 
-            ret = {
+            ret: dict[str, Any] = {
                 "iTunes Version": min_itunes_version if min_itunes_version else "10.0.1",
                 "iTunes Files": files,
                 "Unique Identifier": self._udid.upper(),
@@ -684,7 +684,7 @@ class Mobilebackup2Service(LockdownService):
         if not only:
             return ()
 
-        rules = []
+        rules: list[BackupSelectionRule] = []
         for selection_name in only:
             try:
                 selection = BackupSelection(selection_name.lower())
@@ -757,7 +757,7 @@ class Mobilebackup2Service(LockdownService):
         compiled_patterns = tuple(re.compile(pattern) for pattern in patterns)
 
         def _filter(backup_file: BackupFile) -> bool:
-            candidates = []
+            candidates: list[str] = []
             if backup_file.device_name is not None:
                 candidates.append(backup_file.device_name)
             if backup_file.domain is not None and backup_file.relative_path is not None:
@@ -913,7 +913,7 @@ class Mobilebackup2Service(LockdownService):
         decrypted_manifest_path.write_bytes(keybag.decrypt(manifest_db.read_bytes(), manifest.manifest_key))
 
         parsed_key = encryption_key_struct.parse(manifest.manifest_key)
-        return aes_key_unwrap(keybag.get_key(parsed_key.class_), parsed_key.key)
+        return aes_key_unwrap(cast(Any, keybag).get_key(parsed_key.class_), parsed_key.key)
 
     @staticmethod
     def _encrypt_backup_manifest_db(decrypted_manifest_path: Path, manifest_db_path: Path, manifest_key: bytes) -> None:

--- a/pymobiledevice3/services/pcapd.py
+++ b/pymobiledevice3/services/pcapd.py
@@ -404,7 +404,7 @@ class PcapdService(LockdownService):
         :param out: A writable binary file-like object to receive the pcapng data.
         :param packet_generator: Async iterable yielding parsed packet containers.
         """
-        shb = blocks.SectionHeader(
+        shb: Any = blocks.SectionHeader(
             options={
                 "shb_hardware": "artificial",
                 "shb_os": "iOS",
@@ -416,7 +416,7 @@ class PcapdService(LockdownService):
             link_type=1,
             options={"if_description": "iOS Packet Capture", "if_os": f"iOS {self.lockdown.product_version}"},
         )
-        writer = FileWriter(out, shb)
+        writer: Any = FileWriter(out, shb)
 
         async for packet in packet_generator:
             packet_time = packet.timestamp if hasattr(packet, "timestamp") else time.time()

--- a/pymobiledevice3/services/power_assertion.py
+++ b/pymobiledevice3/services/power_assertion.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import contextlib
-from typing import Optional
+from typing import Any, Optional
 
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
@@ -40,7 +40,7 @@ class PowerAssertionService(LockdownService):
         :param timeout: assertion timeout in seconds, after which the device may release it.
         :param details: optional descriptive detail string attached to the assertion.
         """
-        msg = {
+        msg: dict[str, Any] = {
             "CommandKey": "CommandCreateAssertion",
             "AssertionTypeKey": type_,
             "AssertionNameKey": name,

--- a/pymobiledevice3/services/springboard.py
+++ b/pymobiledevice3/services/springboard.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from typing import Any, Optional, cast
+from typing import Any, Optional, Union, cast
 
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
@@ -53,7 +53,7 @@ class SpringBoardServicesService(LockdownService):
         :param newstate: Icon layout in the same structure returned by `get_icon_state`.
             When ``None``, an empty layout is sent.
         """
-        state = {} if newstate is None else newstate
+        state: Union[list[Any], dict[str, Any]] = {} if newstate is None else newstate
         await self.service.send_recv_prefixed(build_plist({"command": "setIconState", "iconState": state}))
 
     async def get_icon_pngdata(self, bundle_id: str) -> bytes:
@@ -93,7 +93,7 @@ class SpringBoardServicesService(LockdownService):
 
         :returns: Mapping of metric names to their numeric values, as reported by SpringBoard.
         """
-        return cast("dict[str, float]", await self.service.send_recv_plist({"command": "getHomeScreenIconMetrics"}))
+        return cast(dict[str, float], await self.service.send_recv_plist({"command": "getHomeScreenIconMetrics"}))
 
     async def get_wallpaper_info(self, wallpaper_name: str) -> dict[str, Any]:
         """

--- a/pymobiledevice3/services/wda.py
+++ b/pymobiledevice3/services/wda.py
@@ -9,7 +9,7 @@ This module provides:
 import base64
 import json
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import requests
 
@@ -56,6 +56,7 @@ class WdaClient:
         """Format WDA error payloads."""
         message = data.get("value")
         if isinstance(message, dict):
+            message = cast(dict[str, Any], message)
             message = message.get("message") or message.get("error") or message
         return f"WDA error (status={status_code}): {message}"
 
@@ -70,7 +71,7 @@ class WdaClient:
         caps: dict[str, Any] = {}
         if bundle_id:
             caps["bundleId"] = bundle_id
-        payload = {
+        payload: dict[str, Any] = {
             "capabilities": {"alwaysMatch": caps},
             "desiredCapabilities": caps,
         }
@@ -79,7 +80,7 @@ class WdaClient:
         if not session_id:
             value = data.get("value")
             if isinstance(value, dict):
-                session_id = value.get("sessionId")
+                session_id = cast(dict[str, Any], value).get("sessionId")
         if not session_id:
             raise WdaError("WDA did not return a session id")
         self.session_id = session_id
@@ -105,6 +106,7 @@ class WdaClient:
         element = data.get("value")
         if not isinstance(element, dict):
             raise WdaError("WDA did not return an element")
+        element = cast(dict[str, Any], element)
         element_id = (
             element.get("ELEMENT") or element.get("element-6066-11e4-a52e-4f735466cecf") or element.get("element")
         )
@@ -226,7 +228,7 @@ class WdaClient:
         value = data.get("value")
         if not isinstance(value, dict):
             raise WdaError("WDA did not return window size")
-        return value
+        return cast(dict[str, Any], value)
 
     def send_keys(self, text: str, session_id: Optional[str] = None) -> None:
         """Type text into the currently focused element.
@@ -269,7 +271,7 @@ class WdaClient:
         """
         if not session_id:
             raise WdaError("session_id is required")
-        payload = {
+        payload: dict[str, Any] = {
             "fromX": start_x,
             "fromY": start_y,
             "toX": end_x,
@@ -371,7 +373,7 @@ class WdaServiceClient:
                 body_bytes = b"".join(chunks)
 
         try:
-            data = json.loads(body_bytes.decode("utf-8")) if body_bytes else {}
+            data: dict[str, Any] = json.loads(body_bytes.decode("utf-8")) if body_bytes else {}
         except ValueError as exc:
             raise WdaError(f"WDA returned non-JSON response (status={status_code})", status_code=status_code) from exc
 
@@ -408,7 +410,7 @@ class WdaServiceClient:
         caps: dict[str, Any] = {}
         if bundle_id:
             caps["bundleId"] = bundle_id
-        payload = {
+        payload: dict[str, Any] = {
             "capabilities": {"alwaysMatch": caps},
             "desiredCapabilities": caps,
         }
@@ -417,7 +419,7 @@ class WdaServiceClient:
         if not session_id:
             value = data.get("value")
             if isinstance(value, dict):
-                session_id = value.get("sessionId")
+                session_id = cast(dict[str, Any], value).get("sessionId")
         if not session_id:
             raise WdaError("WDA did not return a session id")
         self.session_id = session_id
@@ -443,6 +445,7 @@ class WdaServiceClient:
         element = data.get("value")
         if not isinstance(element, dict):
             raise WdaError("WDA did not return an element")
+        element = cast(dict[str, Any], element)
         element_id = (
             element.get("ELEMENT") or element.get("element-6066-11e4-a52e-4f735466cecf") or element.get("element")
         )
@@ -564,7 +567,7 @@ class WdaServiceClient:
         value = data.get("value")
         if not isinstance(value, dict):
             raise WdaError("WDA did not return window size")
-        return value
+        return cast(dict[str, Any], value)
 
     async def send_keys(self, text: str, session_id: Optional[str] = None) -> None:
         """Type text into the currently focused element.
@@ -607,7 +610,7 @@ class WdaServiceClient:
         """
         if not session_id:
             raise WdaError("session_id is required")
-        payload = {
+        payload: dict[str, Any] = {
             "fromX": start_x,
             "fromY": start_y,
             "toX": end_x,

--- a/pymobiledevice3/services/web_protocol/automation_session.py
+++ b/pymobiledevice3/services/web_protocol/automation_session.py
@@ -58,7 +58,7 @@ class KeyModifier(Enum):
     ALT = "Alt"
 
 
-VIRTUAL_KEYS = {
+VIRTUAL_KEYS: dict[str, tuple[str, Optional[KeyModifier]]] = {
     "\ue001": ("Cancel", None),
     "\ue002": ("Help", None),
     "\ue003": ("Backspace", None),
@@ -235,7 +235,7 @@ class AutomationSession:
         return (await self.protocol.getAllCookies(browsingContextHandle=self.top_level_handle))["cookies"]
 
     async def execute_script(self, script: str, args: Iterable[Any], async_: bool = False):
-        parameters = {
+        parameters: dict[str, Any] = {
             "browsingContextHandle": self.top_level_handle,
             "function": "function(){\n" + script + "\n}",
             "arguments": list(map(json.dumps, args)),
@@ -255,7 +255,7 @@ class AutomationSession:
     async def evaluate_js_function(
         self, function: str, *args: Any, implicit_callback: bool = False, include_frame: bool = True
     ):
-        params = {
+        params: dict[str, Any] = {
             "browsingContextHandle": self.top_level_handle,
             "function": function,
             "arguments": list(map(json.dumps, args)),
@@ -284,7 +284,7 @@ class AutomationSession:
             by = By.CSS_SELECTOR.value
             value = f'[name="{value}"]'
 
-        parameters = {
+        parameters: dict[str, Any] = {
             "browsingContextHandle": self.top_level_handle,
             "function": FIND_NODES,
             "arguments": list(map(json.dumps, [by, root, value, single, self.implicit_wait_timeout])),
@@ -298,7 +298,7 @@ class AutomationSession:
         return result
 
     async def screenshot_as_base64(self, scroll: bool = False, node_id: str = "", clip: bool = True):
-        params = {"handle": self.top_level_handle, "clipToViewport": clip}
+        params: dict[str, Any] = {"handle": self.top_level_handle, "clipToViewport": clip}
         if self.current_handle:
             params["frameHandle"] = self.current_handle
         if scroll:
@@ -379,7 +379,7 @@ class AutomationSession:
         )
 
     async def perform_interaction_sequence(self, sources: list[dict[str, Any]], steps: list[dict[str, Any]]):
-        params = {
+        params: dict[str, Any] = {
             "handle": self.top_level_handle,
             "inputSources": sources,
             "steps": steps,
@@ -389,7 +389,10 @@ class AutomationSession:
         await self.protocol.performInteractionSequence(**params)
 
     async def wait_for_navigation_to_complete(self):
-        params = {"browsingContextHandle": self.top_level_handle, "pageLoadTimeout": self.page_load_timeout}
+        params: dict[str, Any] = {
+            "browsingContextHandle": self.top_level_handle,
+            "pageLoadTimeout": self.page_load_timeout,
+        }
         if self.current_handle:
             params["frameHandle"] = self.current_handle
         await self.protocol.waitForNavigationToComplete(**params)

--- a/pymobiledevice3/services/web_protocol/cdp_screencast.py
+++ b/pymobiledevice3/services/web_protocol/cdp_screencast.py
@@ -22,7 +22,7 @@ class ScreenCast:
         self.quality = quality
         self.max_width = max_width
         self.max_height = max_height
-        self.frames_acked = []
+        self.frames_acked: list[int] = []
         self.frame_id = 1
         self.frame_interval = 250
         self.device_width = 0
@@ -81,7 +81,9 @@ class ScreenCast:
         :param data: Base64 of JPEG data.
         :return: Base 64 of resized JPEG data.
         """
-        resized_img = Image.open(BytesIO(b64decode(data)))
+        # Pillow's stub coverage for the Image method chain varies across versions/platforms
+        # (partially-unknown resize() signature on CI); pin the local to Any to stay type-clean.
+        resized_img: Any = Image.open(BytesIO(b64decode(data)))
         resized_img = resized_img.resize((self.get_scaled_width(), self.get_scaled_height()), Image.Resampling.LANCZOS)
         resized_img = resized_img.convert("RGB")
         resized = BytesIO()

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import uuid
 from contextlib import asynccontextmanager
+from typing import Any
 
 from fastapi import FastAPI, WebSocket
 from fastapi.logger import logger
@@ -22,7 +23,7 @@ app = FastAPI(lifespan=lifespan)
 @app.get("/json{_:path}")
 async def available_targets(_: str):
     app.state.inspector.get_open_pages()
-    targets = []
+    targets: list[dict[str, Any]] = []
     for app_id in app.state.inspector.application_pages:
         for page_id, page in app.state.inspector.application_pages[app_id].items():
             if page.type_ not in (WirTypes.WEB, WirTypes.WEB_PAGE):

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -2,9 +2,10 @@ import asyncio
 import hashlib
 import json
 import logging
+from collections.abc import Awaitable
 from datetime import datetime
 from functools import partial
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from pymobiledevice3.services.web_protocol.cdp_screencast import ScreenCast
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
@@ -95,10 +96,10 @@ class CdpTarget:
         self.session_id = protocol.id_
         self.app_id = protocol.app.id_
         self.page_id = protocol.page.id_
-        self.output_queue = asyncio.Queue()
-        self.input_queue = asyncio.Queue()
+        self.output_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self.input_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self.screencast: Optional[ScreenCast] = None
-        self.from_cdp_special_messages_methods = {
+        self.from_cdp_special_messages_methods: dict[str, Callable[..., Awaitable[Any]]] = {
             "Audits.enable": self._audits_enable,
             "DOM.getBoxModel": self._dom_get_box_model,
             "DOM.enable": partial(self._simple_response, value=None),
@@ -173,7 +174,7 @@ class CdpTarget:
         self._waiting_for_id = 0
         self._input_task = asyncio.create_task(self._input_loop())
         self._receiving_task = asyncio.create_task(self._receive_loop())
-        self._script_source_to_context_id = {}
+        self._script_source_to_context_id: dict[str, Any] = {}
         self._default_execution_id = 0
 
     @classmethod
@@ -199,7 +200,7 @@ class CdpTarget:
         """
         await self.input_queue.put(message)
 
-    async def receive(self):
+    async def receive(self) -> dict[str, Any]:
         """
         Get message from the target to the devtools.
         """
@@ -427,7 +428,7 @@ class CdpTarget:
         if "error" in listeners:
             await self._simple_response(message, None)
             return
-        listeners_out = []
+        listeners_out: list[dict[str, Any]] = []
         for listener in listeners["result"]["listeners"]:
             data = {
                 "type": listener["type"],
@@ -516,7 +517,7 @@ class CdpTarget:
             assert self.screencast is not None
             modifiers = params["modifiers"]
             x, y = params["x"] // self.screencast.get_scale(), params["y"] // self.screencast.get_scale()
-            event_params = {
+            event_params: Any = {
                 "screenX": x,
                 "screenY": y,
                 "clientX": 0,
@@ -676,7 +677,7 @@ class CdpTarget:
         await self.output_queue.put(message)
 
     async def _console_message_added(self, message: dict[str, Any]):
-        log_record = {
+        log_record: dict[str, Any] = {
             "source": LOG_MESSAGE_SOURCES[message["params"]["message"]["source"]],
             "level": LOG_MESSAGE_LEVELS[message["params"]["message"]["level"]],
             "text": message["params"]["message"]["text"],

--- a/pymobiledevice3/services/web_protocol/element.py
+++ b/pymobiledevice3/services/web_protocol/element.py
@@ -6,6 +6,7 @@ from pymobiledevice3.services.web_protocol.automation_session import (
     RESOURCES,
     VIRTUAL_KEYS,
     KeyboardInteractionType,
+    KeyModifier,
     MouseButton,
     MouseInteraction,
     Point,
@@ -120,12 +121,12 @@ class WebElement(SeleniumApi):
         :param value: A string for typing, or setting form fields.
         """
         await self._evaluate_js_function(FOCUS)
-        interactions = []
-        sticky_modifier = set()
+        interactions: list[dict[str, Any]] = []
+        sticky_modifier: set[KeyModifier] = set()
         for key in value:
             if key in VIRTUAL_KEYS:
                 virtual_key, modifier = VIRTUAL_KEYS[key]
-                interaction = {"type": KeyboardInteractionType.INSERT_BY_KEY, "key": virtual_key}
+                interaction: dict[str, Any] = {"type": KeyboardInteractionType.INSERT_BY_KEY, "key": virtual_key}
                 if modifier is not None:
                     sticky_modifier ^= {modifier}
                     interaction["type"] = (

--- a/pymobiledevice3/services/web_protocol/inspector_session.py
+++ b/pymobiledevice3/services/web_protocol/inspector_session.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 from collections import UserDict
-from typing import Any, Optional, cast
+from typing import Any, Callable, Optional, cast
 
 from pymobiledevice3.exceptions import InspectorEvaluateError
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
@@ -59,10 +59,10 @@ class InspectorSession:
         self.protocol = protocol
         self.target_id = target_id
         self.message_id = 1
-        self._last_console_message = {}
-        self._dispatch_message_responses = {}
+        self._last_console_message: dict[str, Any] = {}
+        self._dispatch_message_responses: dict[int, dict[str, Any]] = {}
 
-        self.response_methods = {
+        self.response_methods: dict[str, Callable[[dict[str, Any]], Any]] = {
             "Target.targetCreated": self._target_created,
             "Target.targetDestroyed": self._target_destroyed,
             "Target.dispatchMessageFromTarget": self._target_dispatch_message_from_target,

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -140,11 +140,11 @@ class WebinspectorService(LockdownService):
     def __init__(self, lockdown: LockdownServiceProvider) -> None:
         super().__init__(lockdown, self.SERVICE_NAME if isinstance(lockdown, LockdownClient) else self.RSD_SERVICE_NAME)
         self.connection_id = str(uuid.uuid4()).upper()
-        self.state = None
-        self.connected_application = {}
-        self.application_pages = {}
-        self.wir_message_results = {}
-        self.wir_events = []
+        self.state: Optional[str] = None
+        self.connected_application: dict[str, Application] = {}
+        self.application_pages: dict[str, Any] = {}
+        self.wir_message_results: dict[str, Any] = {}
+        self.wir_events: list[Any] = []
         self.receive_handlers = {
             "_rpc_reportCurrentState:": self._handle_report_current_state,
             "_rpc_reportConnectedApplicationList:": self._handle_report_connected_application_list,
@@ -271,7 +271,7 @@ class WebinspectorService(LockdownService):
         :returns: A mapping of application name to the collection of its `Page` objects, including
             only applications that currently report at least one page.
         """
-        apps = {}
+        apps: dict[str, Any] = {}
         await asyncio.gather(*[self._forward_get_listing(app) for app in self.connected_application])
         for app in self.connected_application:
             if self.application_pages.get(app, False):
@@ -293,7 +293,7 @@ class WebinspectorService(LockdownService):
         # Give some time for `webinspectord` to reply with all inspectable applications
         await asyncio.sleep(timeout)
 
-        result = []
+        result: list[ApplicationPage] = []
         for app in self.connected_application:
             if self.application_pages.get(app, False):
                 for page in self.application_pages[app].values():
@@ -433,7 +433,7 @@ class WebinspectorService(LockdownService):
         )
 
     async def _forward_socket_setup(self, session_id: str, app_id: str, page_id: int, pause: bool = True):
-        message = {
+        message: dict[str, Any] = {
             "WIRApplicationIdentifierKey": app_id,
             "WIRPageIdentifierKey": page_id,
             "WIRSenderKey": session_id,
@@ -478,7 +478,7 @@ class WebinspectorService(LockdownService):
                     return page
         raise KeyError(f"Automation session with id {session_id} not found")
 
-    async def _wait_for_page(self, session_id: str):
+    async def _wait_for_page(self, session_id: str) -> Page:
         while True:
             for app in self.application_pages.values():
                 for page in app.values():

--- a/pymobiledevice3/tunneld/api.py
+++ b/pymobiledevice3/tunneld/api.py
@@ -54,7 +54,7 @@ def _list_tunnels(tunneld_address: tuple[str, int] = TUNNELD_DEFAULT_ADDRESS) ->
 
 
 async def _create_rsds_from_tunnels(tunnels: dict[str, list[dict[str, Any]]]) -> list[RemoteServiceDiscoveryService]:
-    rsds = []
+    rsds: list[RemoteServiceDiscoveryService] = []
     for _udid, details in tunnels.items():
         for tunnel_details in details:
             rsd = RemoteServiceDiscoveryService(

--- a/pymobiledevice3/tunneld/server.py
+++ b/pymobiledevice3/tunneld/server.py
@@ -48,6 +48,7 @@ from pymobiledevice3.remote.remote_service_discovery import RSD_PORT, RemoteServ
 from pymobiledevice3.remote.tunnel_service import (
     CoreDeviceTunnelProxy,
     RemotePairingProtocol,
+    RemotePairingTunnelService,
     TunnelResult,
     create_core_device_tunnel_service_using_rsd,
     get_remote_pairing_tunnel_services,
@@ -195,7 +196,7 @@ class TunneldCore:
         try:
             while True:
                 remote_pairing_tunnel_services = []
-                claimed_services = set()
+                claimed_services: set[RemotePairingTunnelService] = set()
                 try:
                     remote_pairing_tunnel_services = await get_remote_pairing_tunnel_services()
                     for service in remote_pairing_tunnel_services:
@@ -247,7 +248,8 @@ class TunneldCore:
                 while True:
                     await mux.receive_device_state_update()
 
-                    for mux_device in mux.devices:
+                    mux_devices: list[usbmux.MuxDevice] = mux.devices
+                    for mux_device in mux_devices:
                         task_identifier = f"usbmux-{mux_device.serial}-{mux_device.connection_type}"
                         if self.tunnel_exists_for_udid(mux_device.serial):
                             # Skip if already established a tunnel for this udid
@@ -470,7 +472,7 @@ class TunneldCore:
 
     def get_tunnels_ips(self) -> dict[str, list[str]]:
         """Retrieve the available tunnel tasks and format them as {UDID: [IP]}"""
-        tunnels_ips = {}
+        tunnels_ips: dict[str, list[str]] = {}
         for ip, active_tunnel in self.tunnel_tasks.items():
             if (active_tunnel.udid is None) or (active_tunnel.tunnel is None):
                 continue
@@ -592,13 +594,18 @@ class TunneldRunner:
         @self._app.post("/upstream")
         async def add_upstream(body: _UpstreamBody) -> fastapi.Response:
             self._tunneld_core.upstream_urls.add(body.url)
-            data = {"operation": "add_upstream", "url": body.url, "data": True, "message": f"upstream {body.url} added"}
+            data: dict[str, Any] = {
+                "operation": "add_upstream",
+                "url": body.url,
+                "data": True,
+                "message": f"upstream {body.url} added",
+            }
             return generate_http_response(data)
 
         @self._app.delete("/upstream")
         async def remove_upstream(body: _UpstreamBody) -> fastapi.Response:
             self._tunneld_core.upstream_urls.discard(body.url)
-            data = {
+            data: dict[str, Any] = {
                 "operation": "remove_upstream",
                 "url": body.url,
                 "data": True,
@@ -610,19 +617,24 @@ class TunneldRunner:
         async def shutdown() -> fastapi.Response:
             """Shutdown Tunneld"""
             os.kill(os.getpid(), signal.SIGINT)
-            data = {"operation": "shutdown", "data": True, "message": "Server shutting down..."}
+            data: dict[str, Any] = {"operation": "shutdown", "data": True, "message": "Server shutting down..."}
             return generate_http_response(data)
 
         @self._app.get("/clear_tunnels")
         async def clear_tunnels() -> fastapi.Response:
             self._tunneld_core.clear()
-            data = {"operation": "clear_tunnels", "data": True, "message": "Cleared tunnels..."}
+            data: dict[str, Any] = {"operation": "clear_tunnels", "data": True, "message": "Cleared tunnels..."}
             return generate_http_response(data)
 
         @self._app.get("/cancel")
         async def cancel_tunnel(udid: str) -> fastapi.Response:
             self._tunneld_core.cancel(udid=udid)
-            data = {"operation": "cancel", "udid": udid, "data": True, "message": f"tunnel {udid} Canceled ..."}
+            data: dict[str, Any] = {
+                "operation": "cancel",
+                "udid": udid,
+                "data": True,
+                "message": f"tunnel {udid} Canceled ...",
+            }
             return generate_http_response(data)
 
         @self._app.get("/hello")
@@ -643,14 +655,14 @@ class TunneldRunner:
                 t.tunnel for t in self._tunneld_core.tunnel_tasks.values() if t.udid == udid and t.tunnel is not None
             ]
             if len(udid_tunnels) > 0:
-                data = {
+                data: dict[str, Any] = {
                     "interface": udid_tunnels[0].interface,
                     "port": udid_tunnels[0].port,
                     "address": udid_tunnels[0].address,
                 }
                 return generate_http_response(data)
 
-            queue = asyncio.Queue()
+            queue: asyncio.Queue[Optional[TunnelResult]] = asyncio.Queue()
             created_task = False
 
             try:
@@ -717,7 +729,7 @@ class TunneldRunner:
 
             tunnel: Optional[TunnelResult] = await queue.get()
             if tunnel is not None:
-                data = {"interface": tunnel.interface, "port": tunnel.port, "address": tunnel.address}
+                data: dict[str, Any] = {"interface": tunnel.interface, "port": tunnel.port, "address": tunnel.address}
                 return generate_http_response(data)
             else:
                 return fastapi.Response(

--- a/pymobiledevice3/usbmux.py
+++ b/pymobiledevice3/usbmux.py
@@ -228,8 +228,8 @@ class MuxConnection:
     def __init__(self, sock: socket.socket):
         self._sock = sock
         self._connected = False
-        self._tag = 1
-        self.devices = []
+        self._tag: int = 1
+        self.devices: list[MuxDevice] = []
 
     @abc.abstractmethod
     async def _connect(self, device_id: int, port: int):
@@ -261,7 +261,7 @@ class MuxConnection:
         pass
 
     def _raise_mux_exception(self, result: int, message: Optional[str] = None) -> NoReturn:
-        exceptions = {
+        exceptions: dict[int, type[MuxException]] = {
             int(usbmuxd_result.BADCOMMAND): BadCommandError,
             int(usbmuxd_result.BADDEV): BadDevError,
             int(usbmuxd_result.CONNREFUSED): ConnectionFailedError,
@@ -418,7 +418,11 @@ class PlistMuxConnection(BinaryMuxConnection):
         await self._send_receive({"MessageType": "Connect", "DeviceID": device_id, "PortNumber": port})
 
     async def _send(self, data: dict[str, Any]):
-        request = {"ClientVersionString": "qt4i-usbmuxd", "ProgName": "pymobiledevice3", "kLibUSBMuxVersion": 3}
+        request: dict[str, Any] = {
+            "ClientVersionString": "qt4i-usbmuxd",
+            "ProgName": "pymobiledevice3",
+            "kLibUSBMuxVersion": 3,
+        }
         request.update(data)
         await super()._send({
             "header": {"version": self._version, "message": usbmuxd_msgtype.PLIST, "tag": self._tag},

--- a/pymobiledevice3/utils.py
+++ b/pymobiledevice3/utils.py
@@ -3,7 +3,7 @@ import traceback
 from collections.abc import Coroutine
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Optional, Union, overload
+from typing import Any, Callable, Optional, Union, cast, overload
 
 import IPython
 import requests
@@ -100,7 +100,7 @@ def start_ipython_shell(*, user_ns: Optional[dict[str, Any]] = None, header: Opt
     if header is not None:
         print(header)
     # IPython exposes start_ipython lazily via module-level __getattr__, which pyright cannot see.
-    IPython.start_ipython(argv=[], config=config, user_ns=user_ns or {})  # pyright: ignore[reportAttributeAccessIssue]
+    cast(Any, IPython).start_ipython(argv=[], config=config, user_ns=user_ns or {})
 
 
 def file_download(url: str, outfile: Path, chunk_size: int = 1024) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,16 +87,26 @@ reportUnnecessaryCast = "error"
 reportUntypedNamedTuple = "error"
 reportMissingTypeArgument = "error"
 reportMissingParameterType = "error"
+reportUnknownVariableType = "error"
+reportUnknownMemberType = "error"
+reportUnknownArgumentType = "error"
+reportUnknownParameterType = "error"
+reportUnknownLambdaType = "error"
 venvPath = "."
 venv = ".venv"
 
-# reportMissingParameterType is enforced across the package, but not on the test suite: test
-# fixtures, monkeypatch callbacks and mock stubs are deliberately loosely-typed and annotating
-# their parameters adds noise without catching real bugs.
+# The reportMissingParameterType and reportUnknown* rules are enforced across the package, but not
+# on the test suite: test fixtures, monkeypatch callbacks and mock stubs are deliberately
+# loosely-typed and annotating/narrowing them adds noise without catching real bugs.
 [[tool.pyright.executionEnvironments]]
 root = "tests"
 extraPaths = ["."]
 reportMissingParameterType = "none"
+reportUnknownVariableType = "none"
+reportUnknownMemberType = "none"
+reportUnknownArgumentType = "none"
+reportUnknownParameterType = "none"
+reportUnknownLambdaType = "none"
 
 [tool.ruff]
 target-version = "py39"


### PR DESCRIPTION
Completes the third and final bucket of the post-`standard` typing campaign
(after `reportMissingTypeArgument` and `reportMissingParameterType`): eliminates
every `reportUnknown{Variable,Member,Argument,Parameter,Lambda}Type` diagnostic
from the package and promotes the five rules to `error` in `[tool.pyright]`.

## Result
- Package-wide `reportUnknown*`: **~1504 → 0**.
- Base `pyright --venvpath .` stays at **0 errors**; no other rule regressed.
- The five rules are now enforced in `pyproject.toml`, so regressions fail CI.
- `tests/` is exempted via the existing `executionEnvironments` block (same
  rationale as `reportMissingParameterType` — fixtures/mocks are deliberately
  loose).

## Approach
Delivered as reviewable slices (densest files first, then the long tail), each
verified with a JSON-based probe (`--outputjson`) because pyright emits these
diagnostics in a two-line "partially unknown" form that a line-grep silently
misses. All changes are **annotation/cast-only and behaviour-preserving**:

- bare `[]`/`{}`/`set()` collections annotated at their declaration;
- values/members from untyped third-party libraries (pyusb, opack2, qh3,
  srptools, pygments, inquirer3, xonsh, coloredlogs, hexdump, pcapng,
  pyiosbackup, `parameter_decorators`, ipsw_parser `BuildIdentity`,
  win32security) wrapped in `cast(Any, ...)` on the expression, or given a
  `TYPE_CHECKING` signature stub;
- construct/DTX dynamic payloads carried as `dict[str, Any]`;
- `cast(Any, module).attr` for lazy/untyped module attributes (note: a
  `getattr(mod, "const")` workaround is rewritten back to attribute access by
  ruff B009, so the module-cast form is the ruff-stable one).

## Follow-up (not in this PR)
Typing surfaced a probable pre-existing bug in the DVT sysmon field filter
(`cli/developer/dvt/sysmon/__init__.py`): the per-field check matches `name`
against the raw comma-joined option string rather than the parsed field list.
Left untouched here to keep this PR annotation-only; worth a separate fix.