### PR TITLE
irecv: dispose the USB handle in _reinit to fix restore hang after reset

### DIFF
--- a/pymobiledevice3/irecv.py
+++ b/pymobiledevice3/irecv.py
@@ -11,7 +11,7 @@ from typing import Any, Optional, cast
 
 from tqdm import trange
 from usb.core import Device, USBError, find
-from usb.util import get_string
+from usb.util import dispose_resources, get_string
 
 from pymobiledevice3.exceptions import IRecvError, IRecvNoDeviceConnectedError, PyMobileDevice3Exception
 from pymobiledevice3.irecv_devices import IRECV_DEVICES, IRecvDevice
@@ -260,6 +260,12 @@ class IRecv:
             self.send_command("reboot")
 
     def _reinit(self, ecid: Optional[int] = None, timeout: int = 0xFFFFFFFF, is_recovery: Optional[bool] = None):
+        if self._device is not None:
+            # Explicitly release the libusb handle instead of relying on garbage collection: callers
+            # such as send_buffer() keep a local reference to the Device across reset()->_reinit(), so
+            # the object is not collected and its handle would stay claimed — blocking the reset
+            # device from re-enumerating cleanly and hanging the subsequent _find().
+            dispose_resources(self._device)
         self._device = None
         self._device_info = {}
         self._mode = None


### PR DESCRIPTION
## The bug

A device restore that works on **v9.39.0** hangs on **v9.40.0** at `If the restore hangs here, disconnect & reconnect the device` — `_find()` spins forever and never re-acquires the device after `reset()` ("no device in the desired mode"). Re-running the restore from scratch succeeds.

## Root cause — a v9.40.0 regression

v9.40.0 was the pyright-clean release. Its refactor introduced **local captures** of the USB device in `send_buffer()` (`device = self.device`, `mode = self.mode`) that v9.39.0 didn't have — it used `self._device` inline.

The kill chain:
1. `send_buffer()` binds a local `device` → a strong ref to the `usb.core.Device`.
2. Still inside `send_buffer()`, it calls `self.reset()` → `self._reinit()`, which does `self._device = None`.
3. That drops one reference, but the `device` local in the live `send_buffer` frame still holds the object → refcount > 0 → **not garbage-collected** → pyusb's finalizer never runs → the **libusb handle stays claimed**.
4. `_reinit()` → `_find()` → `usb.core.find(find_all=True)` now enumerates with the stale handle still open → it reads the old device (wrong mode) or can't cleanly re-acquire the re-enumerated one → **infinite loop**.

On v9.39.0 there was no local, so `self._device = None` was the last reference → immediate GC → handle disposed → clean re-enumeration.

## Fix

`_reinit()` now calls `usb.util.dispose_resources()` on the outgoing device before dropping it, releasing the libusb handle **explicitly** instead of relying on refcount/GC — so it's correct regardless of any lingering local references.

Reported and root-caused by @doronz88.

pyright 0, ruff clean.