### PR TITLE
feat(core-device): stream apps/processes + iOS 26 listapps fix

### DIFF
--- a/pymobiledevice3/cli/bonjour.py
+++ b/pymobiledevice3/cli/bonjour.py
@@ -16,15 +16,6 @@ cli = InjectingTyper(
 )
 
 
-async def cli_mobdev2_task(timeout: float, pair_records: Optional[Path]) -> None:
-    output: list[dict[str, Any]] = []
-    async for ip, lockdown in get_mobdev2_lockdowns(timeout=timeout, pair_records=pair_records):
-        short_info = lockdown.short_info
-        short_info["ip"] = ip
-        output.append(short_info)
-    print_json(output)
-
-
 @cli.command("mobdev2")
 @async_command
 async def cli_mobdev2(
@@ -40,14 +31,11 @@ async def cli_mobdev2(
     ] = None,
 ) -> None:
     """browse for mobdev2 devices over bonjour"""
-    await cli_mobdev2_task(timeout, pair_records)
-
-
-async def cli_remotepairing_task(timeout: float) -> None:
     output: list[dict[str, Any]] = []
-    for answer in await browse_remotepairing(timeout=timeout):
-        for address in answer.addresses:
-            output.append({"hostname": address.full_ip, "port": answer.port})
+    async for ip, lockdown in get_mobdev2_lockdowns(timeout=timeout, pair_records=pair_records):
+        short_info = lockdown.short_info
+        short_info["ip"] = ip
+        output.append(short_info)
     print_json(output)
 
 
@@ -55,18 +43,10 @@ async def cli_remotepairing_task(timeout: float) -> None:
 @async_command
 async def cli_remotepairing(timeout: Annotated[float, typer.Option()] = DEFAULT_BONJOUR_TIMEOUT) -> None:
     """browse for remotepairing devices over bonjour (without attempting pair verification)"""
-    await cli_remotepairing_task(timeout=timeout)
-
-
-async def cli_remotepairing_manual_pairing_task(timeout: float) -> None:
     output: list[dict[str, Any]] = []
-    for answer in await browse_remotepairing_manual_pairing(timeout=timeout):
+    for answer in await browse_remotepairing(timeout=timeout):
         for address in answer.addresses:
-            output.append({
-                "hostname": address.full_ip,
-                "port": answer.port,
-                "name": answer.properties["name"],
-            })
+            output.append({"hostname": address.full_ip, "port": answer.port})
     print_json(output)
 
 
@@ -76,7 +56,15 @@ async def cli_remotepairing_manual_pairing(
     timeout: Annotated[float, typer.Option()] = DEFAULT_BONJOUR_TIMEOUT,
 ) -> None:
     """browse for remotepairing-manual-pairing devices over bonjour"""
-    await cli_remotepairing_manual_pairing_task(timeout=timeout)
+    output: list[dict[str, Any]] = []
+    for answer in await browse_remotepairing_manual_pairing(timeout=timeout):
+        for address in answer.addresses:
+            output.append({
+                "hostname": address.full_ip,
+                "port": answer.port,
+                "name": answer.properties["name"],
+            })
+    print_json(output)
 
 
 async def cli_browse_rsd() -> None:

--- a/pymobiledevice3/cli/developer/core_device.py
+++ b/pymobiledevice3/cli/developer/core_device.py
@@ -61,13 +61,6 @@ cli = InjectingTyper(
 )
 
 
-async def core_device_list_directory_task(
-    service_provider: RemoteServiceDiscoveryService, domain: DomainName, path: str, identifier: str
-) -> None:
-    async with FileServiceService(service_provider, Domain.from_name(domain), identifier) as file_service:
-        print_json(await file_service.retrieve_directory_list(path))
-
-
 @cli.command("list-directory")
 @async_command
 async def core_device_list_directory(
@@ -77,7 +70,8 @@ async def core_device_list_directory(
     identifier: Annotated[str, typer.Option()] = "",
 ) -> None:
     """List directory contents for a given domain/path."""
-    await core_device_list_directory_task(service_provider, domain, path, identifier)
+    async with FileServiceService(service_provider, Domain.from_name(domain), identifier) as file_service:
+        print_json(await file_service.retrieve_directory_list(path))
 
 
 async def core_device_read_file_task(
@@ -113,21 +107,6 @@ async def core_device_read_file(
         await core_device_read_file_task(service_provider, domain, path, identifier, output_file)
 
 
-async def core_device_propose_empty_file_task(
-    service_provider: RemoteServiceDiscoveryService,
-    domain: DomainName,
-    path: str,
-    identifier: str,
-    file_permissions: int,
-    uid: int,
-    gid: int,
-    creation_time: int,
-    last_modification_time: int,
-) -> None:
-    async with FileServiceService(service_provider, Domain.from_name(domain), identifier) as file_service:
-        await file_service.propose_empty_file(path, file_permissions, uid, gid, creation_time, last_modification_time)
-
-
 @cli.command("propose-empty-file")
 @async_command
 async def core_device_propose_empty_file(
@@ -142,29 +121,15 @@ async def core_device_propose_empty_file(
     last_modification_time: Annotated[Optional[int], typer.Option()] = None,
 ) -> None:
     """Create an empty file at the given domain/path with custom permissions/owner/timestamps."""
-    await core_device_propose_empty_file_task(
-        service_provider,
-        domain,
-        path,
-        identifier,
-        file_permissions,
-        uid,
-        gid,
-        creation_time if creation_time is not None else int(time.time()),
-        last_modification_time if last_modification_time is not None else int(time.time()),
-    )
-
-
-async def core_device_list_launch_application_task(
-    service_provider: RemoteServiceDiscoveryService,
-    bundle_identifier: str,
-    argument: list[str],
-    kill_existing: bool,
-    suspended: bool,
-    env: dict[str, str],
-) -> None:
-    async with AppServiceService(service_provider) as app_service:
-        print_json(await app_service.launch_application(bundle_identifier, argument, kill_existing, suspended, env))
+    async with FileServiceService(service_provider, Domain.from_name(domain), identifier) as file_service:
+        await file_service.propose_empty_file(
+            path,
+            file_permissions,
+            uid,
+            gid,
+            creation_time if creation_time is not None else int(time.time()),
+            last_modification_time if last_modification_time is not None else int(time.time()),
+        )
 
 
 @cli.command("launch-application")
@@ -186,103 +151,72 @@ async def core_device_launch_application(
     ] = None,
 ) -> None:
     """Launch an app; optionally kill existing, wait for debugger, or set env vars."""
-    await core_device_list_launch_application_task(
-        service_provider,
-        bundle_identifier,
-        list(argument),
-        kill_existing,
-        suspended,
-        dict(var.split("=", 1) for var in env or ()),
-    )
-
-
-async def core_device_list_processes_task(service_provider: RemoteServiceDiscoveryService) -> None:
     async with AppServiceService(service_provider) as app_service:
-        print_json(await app_service.list_processes())
+        print_json(
+            await app_service.launch_application(
+                bundle_identifier,
+                list(argument),
+                kill_existing,
+                suspended,
+                dict(var.split("=", 1) for var in env or ()),
+            )
+        )
 
 
 @cli.command("list-processes")
 @async_command
 async def core_device_list_processes(service_provider: RSDServiceProviderDep) -> None:
     """List running processes via CoreDevice."""
-    await core_device_list_processes_task(service_provider)
-
-
-async def core_device_uninstall_app_task(
-    service_provider: RemoteServiceDiscoveryService, bundle_identifier: str
-) -> None:
     async with AppServiceService(service_provider) as app_service:
-        await app_service.uninstall_app(bundle_identifier)
+        print_json(await app_service.list_processes())
 
 
 @cli.command("uninstall")
 @async_command
 async def core_device_uninstall_app(service_provider: RSDServiceProviderDep, bundle_identifier: str) -> None:
     """Uninstall an app by bundle identifier via CoreDevice."""
-    await core_device_uninstall_app_task(service_provider, bundle_identifier)
-
-
-async def core_device_send_signal_to_process_task(
-    service_provider: RemoteServiceDiscoveryService, pid: int, signal: int
-) -> None:
     async with AppServiceService(service_provider) as app_service:
-        print_json(await app_service.send_signal_to_process(pid, signal))
+        await app_service.uninstall_app(bundle_identifier)
 
 
 @cli.command("send-signal-to-process")
 @async_command
 async def core_device_send_signal_to_process(service_provider: RSDServiceProviderDep, pid: int, signal: int) -> None:
     """Send signal to process"""
-    await core_device_send_signal_to_process_task(service_provider, pid, signal)
-
-
-async def core_device_get_device_info_task(service_provider: RemoteServiceDiscoveryService) -> None:
-    async with DeviceInfoService(service_provider) as app_service:
-        print_json(await app_service.get_device_info())
+    async with AppServiceService(service_provider) as app_service:
+        print_json(await app_service.send_signal_to_process(pid, signal))
 
 
 @cli.command("get-device-info")
 @async_command
 async def core_device_get_device_info(service_provider: RSDServiceProviderDep) -> None:
     """Get device information"""
-    await core_device_get_device_info_task(service_provider)
-
-
-async def core_device_get_display_info_task(service_provider: RemoteServiceDiscoveryService) -> None:
     async with DeviceInfoService(service_provider) as app_service:
-        print_json(await app_service.get_display_info())
+        print_json(await app_service.get_device_info())
 
 
 @cli.command("get-display-info")
 @async_command
 async def core_device_get_display_info(service_provider: RSDServiceProviderDep) -> None:
     """Get display information"""
-    await core_device_get_display_info_task(service_provider)
-
-
-async def core_device_query_mobilegestalt_task(service_provider: RemoteServiceDiscoveryService, key: list[str]) -> None:
-    """Query MobileGestalt"""
     async with DeviceInfoService(service_provider) as app_service:
-        print_json(await app_service.query_mobilegestalt(key))
+        print_json(await app_service.get_display_info())
 
 
 @cli.command("query-mobilegestalt")
 @async_command
 async def core_device_query_mobilegestalt(service_provider: RSDServiceProviderDep, key: list[str]) -> None:
     """Query MobileGestalt"""
-    await core_device_query_mobilegestalt_task(service_provider, key)
-
-
-async def core_device_get_lockstate_task(service_provider: RemoteServiceDiscoveryService) -> None:
     async with DeviceInfoService(service_provider) as app_service:
-        print_json(await app_service.get_lockstate())
+        print_json(await app_service.query_mobilegestalt(key))
 
 
 @cli.command("get-lockstate")
 @async_command
 async def core_device_get_lockstate(service_provider: RSDServiceProviderDep) -> None:
     """Get lockstate"""
-    await core_device_get_lockstate_task(service_provider)
+    async with DeviceInfoService(service_provider) as app_service:
+        print_json(await app_service.get_lockstate())
 
 
 @cli.command("paste")
@@ -357,16 +291,12 @@ async def core_device_user_interface_style(
             await config.set_user_interface_style(style.value)
 
 
-async def core_device_list_apps_task(service_provider: RemoteServiceDiscoveryService) -> None:
-    async with AppServiceService(service_provider) as app_service:
-        print_json(await app_service.list_apps())
-
-
 @cli.command("list-apps")
 @async_command
 async def core_device_list_apps(service_provider: RSDServiceProviderDep) -> None:
     """Get application list"""
-    await core_device_list_apps_task(service_provider)
+    async with AppServiceService(service_provider) as app_service:
+        print_json(await app_service.list_apps())
 
 
 @cli.command("stream-apps")
@@ -385,7 +315,16 @@ async def core_device_stream_processes(service_provider: RSDServiceProviderDep) 
         print_json([process async for process in app_service.stream_processes()])
 
 
-async def core_device_sysdiagnose_task(service_provider: RemoteServiceDiscoveryService, output: Path) -> None:
+@cli.command("sysdiagnose")
+@async_command
+async def core_device_sysdiagnose(
+    service_provider: RSDServiceProviderDep,
+    output: Annotated[
+        Path,
+        typer.Argument(dir_okay=True, file_okay=True, exists=True),
+    ],
+) -> None:
+    """Execute sysdiagnose and fetch the output file"""
     async with DiagnosticsServiceService(service_provider) as service:
         response = await service.capture_sysdiagnose(False)
         logger.info(f"Operation response: {response}")
@@ -401,34 +340,12 @@ async def core_device_sysdiagnose_task(service_provider: RemoteServiceDiscoveryS
             )
 
 
-@cli.command("sysdiagnose")
-@async_command
-async def core_device_sysdiagnose(
-    service_provider: RSDServiceProviderDep,
-    output: Annotated[
-        Path,
-        typer.Argument(dir_okay=True, file_okay=True, exists=True),
-    ],
-) -> None:
-    """Execute sysdiagnose and fetch the output file"""
-    await core_device_sysdiagnose_task(service_provider, output)
-
-
 screen_capture_cli = InjectingTyper(
     name="screen-capture",
     help="Capture content from the device's screen (com.apple.coredevice.screencaptureservice).",
     no_args_is_help=True,
 )
 cli.add_typer(screen_capture_cli)
-
-
-async def core_device_screen_capture_screenshot_task(
-    service_provider: RemoteServiceDiscoveryService, output: Path, display_unique_id: Optional[str]
-) -> None:
-    async with ScreenCaptureService(service_provider) as service:
-        response = await service.capture_screenshot(display_unique_id=display_unique_id)
-    output.write_bytes(response["image"])
-    logger.info(f"Screenshot saved to: {output}")
 
 
 @screen_capture_cli.command("screenshot")
@@ -439,7 +356,10 @@ async def core_device_screen_capture_screenshot(
     display_unique_id: Annotated[Optional[str], typer.Option("--display-unique-id")] = None,
 ) -> None:
     """Capture a PNG screenshot of the device's screen."""
-    await core_device_screen_capture_screenshot_task(service_provider, output, display_unique_id)
+    async with ScreenCaptureService(service_provider) as service:
+        response = await service.capture_screenshot(display_unique_id=display_unique_id)
+    output.write_bytes(response["image"])
+    logger.info(f"Screenshot saved to: {output}")
 
 
 # ---------------------------------------------------------------------------

--- a/pymobiledevice3/cli/developer/core_device.py
+++ b/pymobiledevice3/cli/developer/core_device.py
@@ -369,6 +369,22 @@ async def core_device_list_apps(service_provider: RSDServiceProviderDep) -> None
     await core_device_list_apps_task(service_provider)
 
 
+@cli.command("stream-apps")
+@async_command
+async def core_device_stream_apps(service_provider: RSDServiceProviderDep) -> None:
+    """Stream the application list via CoreDevice (works on iOS 26 where list-apps does not)."""
+    async with AppServiceService(service_provider) as app_service:
+        print_json([app async for app in app_service.stream_apps()])
+
+
+@cli.command("stream-processes")
+@async_command
+async def core_device_stream_processes(service_provider: RSDServiceProviderDep) -> None:
+    """Stream the running process list via CoreDevice."""
+    async with AppServiceService(service_provider) as app_service:
+        print_json([process async for process in app_service.stream_processes()])
+
+
 async def core_device_sysdiagnose_task(service_provider: RemoteServiceDiscoveryService, output: Path) -> None:
     async with DiagnosticsServiceService(service_provider) as service:
         response = await service.capture_sysdiagnose(False)

--- a/pymobiledevice3/cli/developer/fetch_symbols.py
+++ b/pymobiledevice3/cli/developer/fetch_symbols.py
@@ -25,7 +25,10 @@ cli = InjectingTyper(
 )
 
 
-async def fetch_symbols_list_task(service_provider: LockdownServiceProvider) -> None:
+@cli.command("list")
+@async_command
+async def fetch_symbols_list(service_provider: ServiceProviderDep) -> None:
+    """list of files to be downloaded"""
     if Version(service_provider.product_version) < Version("17.0"):
         print_json(await DtFetchSymbols(service_provider).list_files())
     else:
@@ -35,13 +38,6 @@ async def fetch_symbols_list_task(service_provider: LockdownServiceProvider) -> 
 
         async with RemoteFetchSymbolsService(service_provider) as fetch_symbols:
             print_json([f.file_path for f in await fetch_symbols.get_dsc_file_list()])
-
-
-@cli.command("list")
-@async_command
-async def fetch_symbols_list(service_provider: ServiceProviderDep) -> None:
-    """list of files to be downloaded"""
-    await fetch_symbols_list_task(service_provider)
 
 
 async def fetch_symbols_download_task(service_provider: LockdownServiceProvider, out: Optional[Path] = None) -> None:

--- a/pymobiledevice3/cli/mounter.py
+++ b/pymobiledevice3/cli/mounter.py
@@ -14,7 +14,6 @@ from pymobiledevice3.exceptions import (
     NotMountedError,
     UnsupportedCommandError,
 )
-from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.services.mobile_image_mounter import (
     DeveloperDiskImageMounter,
     MobileImageMounterService,
@@ -122,15 +121,6 @@ async def mounter_mount_developer(
     logger.info("Developer image mounted successfully")
 
 
-async def mounter_mount_personalized_task(
-    service_provider: LockdownServiceProvider, image: str, trust_cache: str, build_manifest: str
-) -> None:
-    await PersonalizedImageMounter(lockdown=service_provider).mount(
-        Path(image), Path(build_manifest), Path(trust_cache)
-    )
-    logger.info("Personalized image mounted successfully")
-
-
 @cli.command("mount-personalized")
 @catch_errors
 @async_command
@@ -162,26 +152,10 @@ async def mounter_mount_personalized(
     ],
 ) -> None:
     """mount personalized image"""
-    await mounter_mount_personalized_task(service_provider, str(image), str(trust_cache), str(build_manifest))
-
-
-async def mounter_auto_mount_task(
-    service_provider: LockdownServiceProvider, xcode: Optional[str], version: Optional[str]
-) -> None:
-    try:
-        await auto_mount(service_provider, xcode=xcode, version=version)
-        logger.info("DeveloperDiskImage mounted successfully")
-    except URLError:
-        logger.warning("failed to query DeveloperDiskImage versions")
-    except DeveloperDiskImageNotFoundError:
-        logger.error("Unable to find the correct DeveloperDiskImage")
-    except AlreadyMountedError:
-        logger.error("DeveloperDiskImage already mounted")
-    except PermissionError as e:
-        logger.error(
-            f"DeveloperDiskImage could not be saved to Xcode default path ({e.filename}). "
-            f"Please make sure your user has the necessary permissions"
-        )
+    await PersonalizedImageMounter(lockdown=service_provider).mount(
+        Path(image), Path(build_manifest), Path(trust_cache)
+    )
+    logger.info("Personalized image mounted successfully")
 
 
 @cli.command("auto-mount")
@@ -205,7 +179,20 @@ async def mounter_auto_mount(
     ] = None,
 ) -> None:
     """auto-detect correct DeveloperDiskImage and mount it"""
-    await mounter_auto_mount_task(service_provider, str(xcode) if xcode is not None else None, version)
+    try:
+        await auto_mount(service_provider, xcode=str(xcode) if xcode is not None else None, version=version)
+        logger.info("DeveloperDiskImage mounted successfully")
+    except URLError:
+        logger.warning("failed to query DeveloperDiskImage versions")
+    except DeveloperDiskImageNotFoundError:
+        logger.error("Unable to find the correct DeveloperDiskImage")
+    except AlreadyMountedError:
+        logger.error("DeveloperDiskImage already mounted")
+    except PermissionError as e:
+        logger.error(
+            f"DeveloperDiskImage could not be saved to Xcode default path ({e.filename}). "
+            f"Please make sure your user has the necessary permissions"
+        )
 
 
 @cli.command("query-developer-mode-status")

--- a/pymobiledevice3/cli/remote.py
+++ b/pymobiledevice3/cli/remote.py
@@ -309,7 +309,15 @@ class RemotePairingManualPairingDevice:
     identifier: str
 
 
-async def start_remote_pair_task(device_name: Optional[str]) -> None:
+@cli.command("pair")
+@async_command
+async def cli_pair(
+    name: Annotated[
+        Optional[str],
+        typer.Option(help="Device name for a specific device to look for"),
+    ] = None,
+) -> None:
+    """start remote pairing for devices which allow"""
     if start_tunnel is None:
         raise NotImplementedError("failed to start the tunnel on your platform")
 
@@ -317,7 +325,7 @@ async def start_remote_pair_task(device_name: Optional[str]) -> None:
     for answer in await browse_remotepairing_manual_pairing():
         current_device_name = answer.properties["name"]
 
-        if device_name is not None and current_device_name != device_name:
+        if name is not None and current_device_name != name:
             continue
 
         for address in answer.addresses:
@@ -338,18 +346,6 @@ async def start_remote_pair_task(device_name: Optional[str]) -> None:
 
     async with RemotePairingManualPairingService(device.identifier, device.ip, device.port) as service:
         await service.connect(autopair=True)
-
-
-@cli.command("pair")
-@async_command
-async def cli_pair(
-    name: Annotated[
-        Optional[str],
-        typer.Option(help="Device name for a specific device to look for"),
-    ] = None,
-) -> None:
-    """start remote pairing for devices which allow"""
-    await start_remote_pair_task(name)
 
 
 @cli.command("pair-host")

--- a/pymobiledevice3/cli/restore.py
+++ b/pymobiledevice3/cli/restore.py
@@ -272,18 +272,14 @@ async def restore_tss(
         await restore_tss_task(device, ipsw_ctx, out_file, behavior=behavior)
 
 
-async def restore_ramdisk_task(device: Device, ipsw_ctx: contextlib.AbstractContextManager[IPSW]) -> None:
-    with ipsw_ctx as ipsw:
-        await Recovery(ipsw, device).boot_ramdisk()
-
-
 @cli.command("ramdisk")
 @async_command
 async def restore_ramdisk(device: DeviceDep, ipsw_ctx: IPSWCtxDep) -> None:
     """
     Boot only the update ramdisk without performing a restore (IPSW path or URL accepted).
     """
-    await restore_ramdisk_task(device, ipsw_ctx)
+    with ipsw_ctx as ipsw:
+        await Recovery(ipsw, device).boot_ramdisk()
 
 
 @cli.command("update")

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -191,13 +191,6 @@ async def webinspector_service(lockdown: LockdownServiceProvider) -> AsyncGenera
         await inspector.close()
 
 
-async def opened_tabs_task(service_provider: LockdownServiceProvider, timeout: float) -> None:
-    async with webinspector_service(service_provider) as inspector:
-        application_pages = await inspector.get_open_application_pages(timeout=timeout)
-        for application_page in application_pages:
-            print(application_page)
-
-
 @cli.command()
 @catch_errors
 @async_command
@@ -217,23 +210,10 @@ async def opened_tabs(
 
        iOS < 18: Settings -> Safari -> Advanced -> Web Inspector
     """
-    await opened_tabs_task(service_provider, timeout)
-
-
-@catch_errors
-async def launch_task(service_provider: LockdownServiceProvider, url: str, timeout: float) -> None:
     async with webinspector_service(service_provider) as inspector:
-        safari = await inspector.open_app(SAFARI)
-        session = await inspector.automation_session(safari)
-        driver = WebDriver(session)
-        try:
-            print("Starting session")
-            await driver.start_session()
-            print("Getting URL")
-            await driver.get(url)
-            OSUTILS.wait_return()
-        finally:
-            await session.stop_session()
+        application_pages = await inspector.get_open_application_pages(timeout=timeout)
+        for application_page in application_pages:
+            print(application_page)
 
 
 @cli.command()
@@ -260,7 +240,18 @@ async def launch(
         Settings -> Safari -> Advanced -> Remote Automation
 
     """
-    await launch_task(service_provider, url, timeout)
+    async with webinspector_service(service_provider) as inspector:
+        safari = await inspector.open_app(SAFARI)
+        session = await inspector.automation_session(safari)
+        driver = WebDriver(session)
+        try:
+            print("Starting session")
+            await driver.start_session()
+            print("Getting URL")
+            await driver.get(url)
+            OSUTILS.wait_return()
+        finally:
+            await session.stop_session()
 
 
 SHELL_USAGE = """
@@ -282,27 +273,6 @@ driver.add_cookie(
 
 # See selenium api for more features.
 """
-
-
-@catch_errors
-async def shell_task(service_provider: LockdownServiceProvider, timeout: float) -> None:
-    async with webinspector_service(service_provider) as inspector:
-        safari = await inspector.open_app(SAFARI)
-        session = await inspector.automation_session(safari)
-        driver = WebDriver(session)
-        try:
-            start_ipython_shell(
-                header=highlight(
-                    SHELL_USAGE, cast(Any, lexers).PythonLexer(), formatters.Terminal256Formatter(style="native")
-                ),
-                user_ns={
-                    "driver": driver,
-                    "Cookie": Cookie,
-                    "By": By,
-                },
-            )
-        finally:
-            await session.stop_session()
 
 
 @cli.command()
@@ -327,7 +297,23 @@ async def shell(
         Settings -> Safari -> Advanced -> Web Inspector
         Settings -> Safari -> Advanced -> Remote Automation
     """
-    await shell_task(service_provider, timeout)
+    async with webinspector_service(service_provider) as inspector:
+        safari = await inspector.open_app(SAFARI)
+        session = await inspector.automation_session(safari)
+        driver = WebDriver(session)
+        try:
+            start_ipython_shell(
+                header=highlight(
+                    SHELL_USAGE, cast(Any, lexers).PythonLexer(), formatters.Terminal256Formatter(style="native")
+                ),
+                user_ns={
+                    "driver": driver,
+                    "Cookie": Cookie,
+                    "By": By,
+                },
+            )
+        finally:
+            await session.stop_session()
 
 
 @cli.command()

--- a/pymobiledevice3/remote/core_device/app_service.py
+++ b/pymobiledevice3/remote/core_device/app_service.py
@@ -1,4 +1,5 @@
 import plistlib
+from collections.abc import AsyncIterator
 from typing import Any, Optional
 
 from pymobiledevice3.remote.core_device.core_device_service import CoreDeviceService
@@ -23,8 +24,15 @@ class AppServiceService(CoreDeviceService):
         include_hidden_apps: bool = True,
         include_internal_apps: bool = True,
         include_default_apps: bool = True,
+        require_container_access: bool = False,
+        include_app_group_identifiers: bool = False,
+        include_container_paths: bool = False,
     ) -> list[dict[str, Any]]:
-        """List applications"""
+        """List applications.
+
+        Note: on iOS 26 the non-streaming listapps feature accepts the request but never
+        replies (and the stuck call wedges dtappserviced). Use ``stream_apps`` there instead.
+        """
         return await self.invoke(
             "com.apple.coredevice.feature.listapps",
             {
@@ -33,6 +41,11 @@ class AppServiceService(CoreDeviceService):
                 "includeHiddenApps": include_hidden_apps,
                 "includeInternalApps": include_internal_apps,
                 "includeDefaultApps": include_default_apps,
+                # Required since iOS 26 (InstalledAppsRequestParams). requireContainerAccess=True
+                # needs the com.apple.private.CoreDevice.obtainContainerAccess entitlement.
+                "requireContainerAccess": require_container_access,
+                "includeAppGroupIdentifiers": include_app_group_identifiers,
+                "includeContainerPaths": include_container_paths,
             },
         )
 
@@ -68,6 +81,44 @@ class AppServiceService(CoreDeviceService):
     async def list_processes(self) -> list[dict[str, Any]]:
         """List processes"""
         return (await self.invoke("com.apple.coredevice.feature.listprocesses"))["processTokens"]
+
+    async def stream_apps(
+        self,
+        include_app_clips: bool = True,
+        include_removable_apps: bool = True,
+        include_hidden_apps: bool = True,
+        include_internal_apps: bool = True,
+        include_default_apps: bool = True,
+        require_container_access: bool = False,
+        include_app_group_identifiers: bool = False,
+        include_container_paths: bool = False,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Stream the installed application list, yielding each app as it is pushed.
+
+        Streaming counterpart of ``list_apps``; elements share the same shape.
+        """
+        async for app in self.stream_invoke(
+            "com.apple.coredevice.feature.streamapplist",
+            {
+                "includeAppClips": include_app_clips,
+                "includeRemovableApps": include_removable_apps,
+                "includeHiddenApps": include_hidden_apps,
+                "includeInternalApps": include_internal_apps,
+                "includeDefaultApps": include_default_apps,
+                "requireContainerAccess": require_container_access,
+                "includeAppGroupIdentifiers": include_app_group_identifiers,
+                "includeContainerPaths": include_container_paths,
+            },
+        ):
+            yield app
+
+    async def stream_processes(self) -> AsyncIterator[dict[str, Any]]:
+        """Stream the process list, yielding each process token as it is pushed.
+
+        Streaming counterpart of ``list_processes``; elements share the same shape.
+        """
+        async for process in self.stream_invoke("com.apple.coredevice.feature.streamprocesslist"):
+            yield process
 
     async def list_roots(self) -> dict[str, Any]:
         """

--- a/pymobiledevice3/remote/core_device/core_device_service.py
+++ b/pymobiledevice3/remote/core_device/core_device_service.py
@@ -1,4 +1,5 @@
 import uuid
+from collections.abc import AsyncIterator
 from typing import Any, Optional
 
 from pymobiledevice3.exceptions import CoreDeviceError
@@ -16,6 +17,25 @@ def _generate_core_device_version_dict(version: str) -> dict[str, Any]:
 
 
 CORE_DEVICE_VERSION = _generate_core_device_version_dict("629.3")
+
+# Wire keys for the streaming feature protocol (streamapplist/streamprocesslist), verified
+# against iOS 26 (CoreDeviceUtilities StreamingAction.swift: _StreamingActionInputContainer /
+# _StreamProxy / _StreamProxy.SideChannelStatus).
+#
+# Request: CoreDevice.input wraps the normal params under "actualInput" plus a "streamProxy"
+# carrying a client-generated "sideChannel" UUID that opens the side channel.
+# Response: the daemon pushes a series of messages, each keyed by "...sideChannelStatus" whose
+# value is a SideChannelStatus enum -- "pushing" ({"elements": [...]}), then a terminating
+# "finishStreaming", or "receivedError" on failure. Every message echoes the side-channel UUID
+# under "XPCSideChannel.uniqueIdentifier".
+STREAM_INPUT_KEY = "actualInput"
+STREAM_PROXY_KEY = "streamProxy"
+STREAM_SIDE_CHANNEL_KEY = "sideChannel"
+STREAM_STATUS_KEY = "CoreDevice.XPCMessageKey.sideChannelStatus"
+STREAM_PUSHING_KEY = "pushing"
+STREAM_ELEMENTS_KEY = "elements"
+STREAM_FINISH_KEY = "finishStreaming"
+STREAM_RECEIVED_ERROR_KEY = "receivedError"
 
 
 class CoreDeviceService(RemoteService):
@@ -44,3 +64,44 @@ class CoreDeviceService(RemoteService):
         if output is None:
             raise CoreDeviceError(f"Failed to invoke: {feature_identifier}. Got error: {response}")
         return output
+
+    async def stream_invoke(
+        self,
+        feature_identifier: str,
+        input_: Optional[dict[str, Any]] = None,
+    ) -> AsyncIterator[Any]:
+        """Invoke a streaming feature (e.g. streamapplist/streamprocesslist).
+
+        Unlike ``invoke``, a streaming feature returns many responses over time: the daemon
+        pushes ``SideChannelStatus.pushing`` batches over the side channel and ends with
+        ``finishStreaming``. Each element is yielded individually.
+        """
+        if input_ is None:
+            input_ = {}
+        request: dict[str, Any] = {
+            "CoreDevice.CoreDeviceDDIProtocolVersion": XpcInt64Type(2),
+            "CoreDevice.coreDeviceVersion": CORE_DEVICE_VERSION,
+            "CoreDevice.deviceIdentifier": str(uuid.uuid4()),
+            "CoreDevice.featureIdentifier": feature_identifier,
+            "CoreDevice.action": {},
+            "CoreDevice.input": {
+                STREAM_INPUT_KEY: input_,
+                STREAM_PROXY_KEY: {STREAM_SIDE_CHANNEL_KEY: uuid.uuid4()},
+            },
+            "CoreDevice.invocationIdentifier": str(uuid.uuid4()),
+        }
+        async with self.service._request_lock:
+            await self.service.send_request(request, wanting_reply=True)
+            while True:
+                response = await self.service.receive_response()
+                status: Any = response.get(STREAM_STATUS_KEY)
+                if status is None:
+                    raise CoreDeviceError(
+                        f"Failed to invoke streaming feature: {feature_identifier}. Got error: {response}"
+                    )
+                if STREAM_RECEIVED_ERROR_KEY in status:
+                    raise CoreDeviceError(f"Stream {feature_identifier} failed: {status[STREAM_RECEIVED_ERROR_KEY]}")
+                if STREAM_FINISH_KEY in status:
+                    break
+                for element in status[STREAM_PUSHING_KEY][STREAM_ELEMENTS_KEY]:
+                    yield element


### PR DESCRIPTION
## Summary

Adds the CoreDevice **streaming feature protocol** and exposes `streamapplist` / `streamprocesslist`, which is how app/process enumeration now works on iOS 26 (the non-streaming `listapps` no longer replies there).

The daemon delivers a large result as a series of batches over an XPC side channel rather than one giant reply. Recovered from `CoreDeviceUtilities` (`StreamingAction.swift`) and pinned down against a live iOS 26 device (build 27A5209h).

### Wire protocol
- **Request** — `CoreDevice.input` wraps the normal params under `actualInput`, plus a `streamProxy` carrying a client-generated `sideChannel` UUID (native XPC uuid) that opens the channel.
- **Response** — the daemon pushes messages keyed by `CoreDevice.XPCMessageKey.sideChannelStatus`, a `SideChannelStatus` enum: `pushing` (`{"elements": [...]}`) repeated, then `finishStreaming`, or `receivedError` on failure. Each message echoes the UUID under `XPCSideChannel.uniqueIdentifier`.

### Changes
- `CoreDeviceService.stream_invoke()` — generic streaming invoke / receive loop
- `AppServiceService.stream_apps()` / `stream_processes()` — async generators
- CLI: `developer core-device stream-apps` / `stream-processes`
- `list_apps`: added the fields `InstalledAppsRequestParams` requires on iOS 26 (`requireContainerAccess`, `includeAppGroupIdentifiers`, `includeContainerPaths`), and a docstring note that non-streaming `listapps` hangs on iOS 26 — use `stream_apps`.

### Verification
Run end-to-end against iOS 26 (build 27A5209h): **73 apps**, **418 processes**.
