### PR TITLE
webinspector: fix cdp server for modern Chrome

### DIFF
--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -36,7 +36,7 @@ from pymobiledevice3.exceptions import (
 )
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.osu.os_utils import get_os_utils
-from pymobiledevice3.services.web_protocol.cdp_server import app
+from pymobiledevice3.services.web_protocol.cdp_server import app, find_chrome
 from pymobiledevice3.services.web_protocol.driver import By, Cookie, WebDriver
 from pymobiledevice3.services.web_protocol.inspector_session import InspectorSession
 from pymobiledevice3.services.webinspector import SAFARI, ApplicationPage, WebinspectorService
@@ -378,7 +378,12 @@ async def js_shell(
 
 @cli.command()
 @async_command
-async def cdp(service_provider: ServiceProviderDep, host: str = "127.0.0.1", port: int = 9222) -> None:
+async def cdp(
+    service_provider: ServiceProviderDep,
+    host: str = "127.0.0.1",
+    port: int = 9222,
+    chrome: Optional[str] = None,
+) -> None:
     """
     Start a CDP server for debugging WebViews.
 
@@ -391,8 +396,14 @@ async def cdp(service_provider: ServiceProviderDep, host: str = "127.0.0.1", por
     Chrome's browser-process relay (network target), which deadlocks under sustained console
     traffic and freezes the console/screen. The URL above serves the DevTools frontend so it
     connects to this bridge directly, bypassing that relay.
+
+    \b
+    The frontend is fetched from the hosted build; when that is unreachable (offline), it is
+    served from a local Chrome instead. Pass --chrome <path> if Chrome is not on PATH or in a
+    default install location.
     """
     app.state.inspector = WebinspectorService(lockdown=service_provider)
+    app.state.chrome_path = find_chrome(chrome)
     print(f"Web Inspector ready. Open in Google Chrome: http://{host}:{port}/")
     server = uvicorn.Server(
         uvicorn.Config(

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -376,16 +376,6 @@ async def js_shell(
     await run_js_shell(js_shell_class, service_provider, timeout, url, open_safari, bundle_identifier, **create_kwargs)
 
 
-cdp_inspector: Optional[WebinspectorService] = None
-
-
-def create_app():
-    if cdp_inspector is None:
-        raise RuntimeError("CDP inspector is not initialized")
-    app.state.inspector = cdp_inspector
-    return app
-
-
 @cli.command()
 @async_command
 async def cdp(service_provider: ServiceProviderDep, host: str = "127.0.0.1", port: int = 9222) -> None:
@@ -396,17 +386,17 @@ async def cdp(service_provider: ServiceProviderDep, host: str = "127.0.0.1", por
     In order to debug the WebView that way, open in Google Chrome:
         chrome://inspect/#devices
     """
-    global cdp_inspector
-    cdp_inspector = WebinspectorService(lockdown=service_provider)
-    uvicorn.run(
-        f"{__name__}:{create_app.__name__}",
-        host=host,
-        port=port,
-        factory=True,
-        ws_ping_timeout=None,
-        ws="wsproto",
-        loop="asyncio",
+    app.state.inspector = WebinspectorService(lockdown=service_provider)
+    server = uvicorn.Server(
+        uvicorn.Config(
+            app,
+            host=host,
+            port=port,
+            ws_ping_timeout=None,
+            ws="wsproto",
+        )
     )
+    await server.serve()
 
 
 async def get_js_completions(jsshell: "JsShell", obj: str, prefix: str) -> AsyncIterator[Completion]:

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -383,10 +383,17 @@ async def cdp(service_provider: ServiceProviderDep, host: str = "127.0.0.1", por
     Start a CDP server for debugging WebViews.
 
     \b
-    In order to debug the WebView that way, open in Google Chrome:
-        chrome://inspect/#devices
+    Open the following URL in Google Chrome and pick a page to inspect:
+        http://127.0.0.1:9222/
+
+    \b
+    Prefer this over chrome://inspect: chrome://inspect routes the DevTools frontend through
+    Chrome's browser-process relay (network target), which deadlocks under sustained console
+    traffic and freezes the console/screen. The URL above serves the DevTools frontend so it
+    connects to this bridge directly, bypassing that relay.
     """
     app.state.inspector = WebinspectorService(lockdown=service_provider)
+    print(f"Web Inspector ready. Open in Google Chrome: http://{host}:{port}/")
     server = uvicorn.Server(
         uvicorn.Config(
             app,

--- a/pymobiledevice3/services/web_protocol/cdp_screencast.py
+++ b/pymobiledevice3/services/web_protocol/cdp_screencast.py
@@ -1,11 +1,14 @@
 import asyncio
 import contextlib
+import logging
 from base64 import b64decode, b64encode
 from datetime import datetime
 from io import BytesIO
 from typing import Any, Optional
 
 from PIL import Image
+
+logger = logging.getLogger(__name__)
 
 
 class ScreenCast:
@@ -45,22 +48,20 @@ class ScreenCast:
         """Height of screenshot after scaling."""
         return int(self.get_scale() * self.device_height)
 
-    async def start(self, message_id: int):
+    async def start(self) -> None:
         """
         Start sending screenshots to the devtools.
-        :param message_id: Message id to use when requesting WIR data concerning the screencast.
         """
         device_size = await self.target.evaluate_and_result(
-            message_id,
-            (
-                '(window.innerWidth > 0 ? window.innerWidth : screen.width) + "," + '
-                '(window.innerHeight > 0 ? window.innerHeight : screen.height) + "," + '
-                "window.devicePixelRatio"
-            ),
+            '(window.innerWidth > 0 ? window.innerWidth : screen.width) + "," + '
+            '(window.innerHeight > 0 ? window.innerHeight : screen.height) + "," + '
+            "window.devicePixelRatio"
         )
+        if not isinstance(device_size, str):
+            raise TypeError("device did not report its screen size for the screencast")
         self.device_width, self.device_height, self.page_scale_factor = list(map(int, device_size.split(",")))
         self._run = True
-        self.recording_task = asyncio.create_task(self.recording_loop(message_id))
+        self.recording_task = asyncio.create_task(self.recording_loop())
 
     async def stop(self):
         """Stop sending screenshots to the devtools."""
@@ -90,57 +91,68 @@ class ScreenCast:
         resized_img.save(resized, format="jpeg", quality="maximum")
         return b64encode(resized.getvalue()).decode()
 
-    async def get_offsets(self, message_id: int):
+    async def get_offsets(self):
         """
         Get the offset of the screenshot from the start of the page.
-        :param message_id: Message id to use when requesting WIR data concerning the screencast.
         :return: Tuple of (offsetTop, pageXOffset, pageYOffset).
         :rtype: tuple
         """
         frame_size = await self.target.evaluate_and_result(
-            message_id, 'window.document.body.offsetTop + "," + window.pageXOffset + "," + window.pageYOffset'
+            'window.document.body.offsetTop + "," + window.pageXOffset + "," + window.pageYOffset'
         )
         if frame_size is None or not isinstance(frame_size, str):
             return 0, 0, 0
         return tuple(map(int, frame_size.split(",")))
 
-    async def recording_loop(self, message_id: int):
+    async def recording_loop(self) -> None:
         """
-        Fetch screenshots and send to devtools.
-        :param message_id: Message id to use when requesting WIR data concerning the screencast.
+        Fetch screenshots and send them to devtools until stopped.
         """
         while self._run:
             await asyncio.sleep(self.frame_interval / 1000)
             if self.frame_id > 1 and (self.frame_id - 1) not in self.frames_acked:
                 continue
-            self.frame_id += 1
-            offset_top, scroll_offset_x, scroll_offset_y = await self.get_offsets(message_id)
-            event = await self.target.send_message_with_result(
-                message_id,
-                "Page.snapshotRect",
-                {
-                    "x": 0,
-                    "y": 0,
-                    "width": self.device_width,
-                    "height": self.device_height,
-                    "coordinateSystem": "Viewport",
+            try:
+                await self._send_frame()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # A single bad frame (e.g. a missed/timed-out device response) must not kill the
+                # stream; without this the device screen silently freezes for the whole session.
+                logger.exception("screencast frame failed; skipping")
+
+    async def _send_frame(self) -> None:
+        self.frame_id += 1
+        offset_top, scroll_offset_x, scroll_offset_y = await self.get_offsets()
+        event = await self.target.send_message_with_result(
+            "Page.snapshotRect",
+            {
+                "x": 0,
+                "y": 0,
+                "width": self.device_width,
+                "height": self.device_height,
+                "coordinateSystem": "Viewport",
+            },
+        )
+        data = event.get("result", {}).get("dataURL")
+        if not data:
+            # No usable snapshot this round (device busy / response lost); try again next tick.
+            return
+        data = data[data.find("base64,") + 7 :]
+        await self.target.output_queue.put({
+            "method": "Page.screencastFrame",
+            "params": {
+                "data": self.resize_jpeg(data),
+                "sessionId": self.frame_id - 1,
+                "metadata": {
+                    "pageScaleFactor": self.page_scale_factor,
+                    "offsetTop": offset_top,
+                    "deviceWidth": self.get_scaled_width(),
+                    "deviceHeight": self.get_scaled_height(),
+                    "scrollOffsetX": scroll_offset_x,
+                    "scrollOffsetY": scroll_offset_y,
+                    # Page.ScreencastFrameMetadata.timestamp is a number (seconds), not a string
+                    "timestamp": datetime.now().timestamp(),
                 },
-            )
-            data = event["result"]["dataURL"]
-            data = data[data.find("base64,") + 7 :]
-            await self.target.output_queue.put({
-                "method": "Page.screencastFrame",
-                "params": {
-                    "data": self.resize_jpeg(data),
-                    "sessionId": self.frame_id - 1,
-                    "metadata": {
-                        "pageScaleFactor": self.page_scale_factor,
-                        "offsetTop": offset_top,
-                        "deviceWidth": self.get_scaled_width(),
-                        "deviceHeight": self.get_scaled_height(),
-                        "scrollOffsetX": scroll_offset_x,
-                        "scrollOffsetY": scroll_offset_y,
-                        "timestamp": datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f"),
-                    },
-                },
-            })
+            },
+        })

--- a/pymobiledevice3/services/web_protocol/cdp_screencast.py
+++ b/pymobiledevice3/services/web_protocol/cdp_screencast.py
@@ -122,7 +122,6 @@ class ScreenCast:
                 logger.exception("screencast frame failed; skipping")
 
     async def _send_frame(self) -> None:
-        self.frame_id += 1
         offset_top, scroll_offset_x, scroll_offset_y = await self.get_offsets()
         event = await self.target.send_message_with_result(
             "Page.snapshotRect",
@@ -136,14 +135,17 @@ class ScreenCast:
         )
         data = event.get("result", {}).get("dataURL")
         if not data:
-            # No usable snapshot this round (device busy / response lost); try again next tick.
+            # No usable snapshot this round (device busy / response lost mid-navigation); try
+            # again next tick. frame_id must not advance here: the loop waits for the last id's
+            # ack, and an id that was never actually sent can never be acked - the screencast
+            # would freeze for the rest of the session.
             return
         data = data[data.find("base64,") + 7 :]
         await self.target.output_queue.put({
             "method": "Page.screencastFrame",
             "params": {
                 "data": self.resize_jpeg(data),
-                "sessionId": self.frame_id - 1,
+                "sessionId": self.frame_id,
                 "metadata": {
                     "pageScaleFactor": self.page_scale_factor,
                     "offsetTop": offset_top,
@@ -156,3 +158,4 @@ class ScreenCast:
                 },
             },
         })
+        self.frame_id += 1

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -3,12 +3,17 @@ import uuid
 from contextlib import asynccontextmanager
 from typing import Any
 
-from fastapi import FastAPI, WebSocket
+from fastapi import FastAPI, Request, WebSocket
 from fastapi.logger import logger
 
 from pymobiledevice3.services.web_protocol.cdp_target import CdpTarget
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
 from pymobiledevice3.services.webinspector import WirTypes
+
+# Seconds to let webinspectord reply with the updated page listings before answering /json
+PAGE_LISTING_FLUSH = 0.5
+# Seconds to wait for the device to report the inspection target of a new debugger session
+TARGET_CREATION_TIMEOUT = 30
 
 
 @asynccontextmanager
@@ -20,9 +25,24 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 
+@app.get("/json/version")
+def version(request: Request):
+    host = request.headers.get("host", "localhost:9222")
+    return {
+        "Browser": "Safari",
+        "Protocol-Version": "1.1",
+        "User-Agent": "pymobiledevice3",
+        "V8-Version": "7.2.233",
+        "WebKit-Version": "537.36 (@cfede9db1d154de0468cb0538479f34c0755a0f4)",
+        "webSocketDebuggerUrl": f"ws://{host}/devtools/browser/{app.state.inspector.connection_id}",
+    }
+
+
 @app.get("/json{_:path}")
-async def available_targets(_: str):
-    app.state.inspector.get_open_pages()
+async def available_targets(request: Request, _: str):
+    await app.state.inspector.get_open_pages()
+    await app.state.inspector.flush_input(PAGE_LISTING_FLUSH)
+    host = request.headers.get("host", "localhost:9222")
     targets: list[dict[str, Any]] = []
     for app_id in app.state.inspector.application_pages:
         for page_id, page in app.state.inspector.application_pages[app_id].items():
@@ -34,35 +54,29 @@ async def available_targets(_: str):
                 "title": page.web_title,
                 "type": "page",
                 "url": page.web_url,
-                "webSocketDebuggerUrl": f"ws://localhost:9222/devtools/page/{page_id}",
-                "devtoolsFrontendUrl": f"/devtools/inspector.html?ws://localhost:9222/devtools/page/{page_id}",
+                "webSocketDebuggerUrl": f"ws://{host}/devtools/page/{page_id}",
+                "devtoolsFrontendUrl": f"/devtools/inspector.html?ws={host}/devtools/page/{page_id}",
             })
     return targets
 
 
-@app.get("/json/version")
-def version():
-    return {
-        "Browser": "Safari",
-        "Protocol-Version": "1.1",
-        "User-Agent": "pymobiledevice3",
-        "V8-Version": "7.2.233",
-        "WebKit-Version": "537.36 (@cfede9db1d154de0468cb0538479f34c0755a0f4)",
-        "webSocketDebuggerUrl": f"ws://localhost:9222/devtools/browser/{app.state.inspector.connection_id}",
-    }
-
-
-async def from_cdp(target: CdpTarget, websocket: WebSocket):
+async def from_cdp(target: CdpTarget, websocket: WebSocket) -> None:
     async for message in websocket.iter_json():
         logger.debug(f"CDP INPUT:  {message}")
         await target.send(message)
 
 
-async def to_cdp(target: CdpTarget, websocket: WebSocket):
+async def to_cdp(target: CdpTarget, websocket: WebSocket) -> None:
     while True:
         message = await target.receive()
         logger.debug(f"CDP OUTPUT:  {message}")
         await websocket.send_json(message)
+
+
+# WebKit supports a single inspector session per page, so sessions are serialized per page:
+# a new debugger connection waits until the previous session's WIR socket teardown completed
+# (otherwise its socket setup races the teardown and webinspectord ignores it).
+_page_locks: dict[str, asyncio.Lock] = {}
 
 
 @app.websocket("/devtools/page/{page_id}")
@@ -70,9 +84,29 @@ async def page_debugger(websocket: WebSocket, page_id: str):
     application, page = app.state.inspector.find_page_id(page_id)
     session_id = str(uuid.uuid4()).upper()
     protocol = SessionProtocol(app.state.inspector, session_id, application, page, method_prefix="")
-    target = await CdpTarget.create(protocol)
+    # Accept before the device-side target setup: DevTools drops the connection if the
+    # websocket handshake stalls behind the WIR socket establishment.
     await websocket.accept()
-    await asyncio.gather(
-        from_cdp(target, websocket),
-        to_cdp(target, websocket),
-    )
+    async with _page_locks.setdefault(page_id, asyncio.Lock()):
+        try:
+            # Bound the wait: if the device never reports the target (e.g. webinspectord is in a
+            # bad state), fail the connection instead of keeping a zombie handler alive forever.
+            target = await asyncio.wait_for(CdpTarget.create(protocol), TARGET_CREATION_TIMEOUT)
+        except (asyncio.TimeoutError, TimeoutError):
+            logger.error(f"page {page_id}: device did not report an inspection target in time")
+            await app.state.inspector.teardown_inspector_socket(session_id, application.id_, page.id_)
+            await websocket.close()
+            return
+        tasks: list[asyncio.Task[None]] = [
+            asyncio.create_task(from_cdp(target, websocket)),
+            asyncio.create_task(to_cdp(target, websocket)),
+        ]
+        try:
+            # from_cdp ends when the client disconnects; tear everything down so the target's
+            # queue-consumer tasks don't keep draining wir_events of future sessions.
+            await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            await target.close()

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -2,9 +2,11 @@ import asyncio
 import uuid
 from contextlib import asynccontextmanager
 from typing import Any
+from urllib.request import urlopen
 
 from fastapi import FastAPI, Request, WebSocket
 from fastapi.logger import logger
+from fastapi.responses import HTMLResponse, Response
 
 from pymobiledevice3.services.web_protocol.cdp_target import CdpTarget
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
@@ -14,6 +16,15 @@ from pymobiledevice3.services.webinspector import WirTypes
 PAGE_LISTING_FLUSH = 0.5
 # Seconds to wait for the device to report the inspection target of a new debugger session
 TARGET_CREATION_TIMEOUT = 30
+
+# chrome://inspect routes a network target's DevTools through Chrome's browser-process relay,
+# which deadlocks after sustained console traffic (the console/screen freeze). Serving the DevTools
+# frontend here - opened as an ordinary http page - makes it connect straight to the bridge's
+# WebSocket, bypassing that relay entirely. The frontend is proxied (not bundled) from the
+# officially hosted build, pinned to a revision compatible with the WIR<->CDP translation.
+DEVTOOLS_FRONTEND_REV = "0fcdce5f4fdec8d442d7df760cb541f1ca6e446d"
+DEVTOOLS_FRONTEND_HOST = "chrome-devtools-frontend.appspot.com"
+_frontend_cache: dict[str, tuple[bytes, str]] = {}
 
 
 @asynccontextmanager
@@ -58,6 +69,52 @@ async def available_targets(request: Request, _: str):
                 "devtoolsFrontendUrl": f"/devtools/inspector.html?ws={host}/devtools/page/{page_id}",
             })
     return targets
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request) -> HTMLResponse:
+    """Landing page: link each inspectable page to the locally-served DevTools frontend, which
+    connects directly to the bridge (bypassing chrome://inspect's relay). Use this instead of
+    chrome://inspect to avoid the console/screen freeze."""
+    await app.state.inspector.get_open_pages()
+    await app.state.inspector.flush_input(PAGE_LISTING_FLUSH)
+    host = request.headers.get("host", "127.0.0.1:9222")
+    items: list[str] = []
+    for app_id in app.state.inspector.application_pages:
+        for page_id, page in app.state.inspector.application_pages[app_id].items():
+            if page.type_ not in (WirTypes.WEB, WirTypes.WEB_PAGE):
+                continue
+            frontend = f"/devtools/inspector.html?ws={host}/devtools/page/{page_id}"
+            title = page.web_title or page.web_url or f"page {page_id}"
+            items.append(f'<li><a href="{frontend}">{title}</a><br><small>{page.web_url}</small></li>')
+    body = "<ul>" + "".join(items) + "</ul>" if items else "<p>No inspectable pages. Open a page in Safari.</p>"
+    return HTMLResponse(
+        f"<!doctype html><meta charset=utf-8><title>pymobiledevice3 Web Inspector</title>"
+        f"<h2>pymobiledevice3 Web Inspector</h2>{body}"
+    )
+
+
+@app.get("/devtools/{path:path}")
+async def devtools_frontend(path: str) -> Response:
+    """Serve the DevTools frontend by proxying the hosted build. Opened over http, the frontend
+    connects to the bridge's WebSocket directly instead of through chrome://inspect's relay."""
+    rev = getattr(app.state, "frontend_rev", DEVTOOLS_FRONTEND_REV)
+    key = f"{rev}/{path}"
+    if key not in _frontend_cache:
+        url = f"https://{DEVTOOLS_FRONTEND_HOST}/serve_rev/@{rev}/{path}"
+
+        def _fetch() -> tuple[bytes, str]:
+            with urlopen(url, timeout=20) as response:
+                return response.read(), response.headers.get_content_type()
+
+        try:
+            data, content_type = await asyncio.get_event_loop().run_in_executor(None, _fetch)
+        except Exception:
+            logger.exception(f"failed to fetch DevTools frontend asset: {path}")
+            return Response(status_code=404)
+        _frontend_cache[key] = (data, content_type)
+    data, content_type = _frontend_cache[key]
+    return Response(content=data, media_type=content_type)
 
 
 async def from_cdp(target: CdpTarget, websocket: WebSocket) -> None:

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -1,7 +1,12 @@
 import asyncio
+import shutil
+import subprocess
+import sys
+import tempfile
 import uuid
 from contextlib import asynccontextmanager
-from typing import Any
+from pathlib import Path
+from typing import Any, Optional
 from urllib.request import urlopen
 
 from fastapi import FastAPI, Request, WebSocket
@@ -20,20 +25,142 @@ TARGET_CREATION_TIMEOUT = 30
 # chrome://inspect routes a network target's DevTools through Chrome's browser-process relay,
 # which deadlocks after sustained console traffic (the console/screen freeze). Serving the DevTools
 # frontend here - opened as an ordinary http page - makes it connect straight to the bridge's
-# WebSocket, bypassing that relay entirely. The frontend is proxied (not bundled) from the
-# officially hosted build, pinned to a revision compatible with the WIR<->CDP translation.
+# WebSocket, bypassing that relay entirely. The frontend is proxied (not bundled): from the
+# officially hosted build (pinned to a revision compatible with the WIR<->CDP translation) when it
+# is reachable, otherwise from a locally installed Chrome, which serves its own bundled frontend.
 DEVTOOLS_FRONTEND_REV = "0fcdce5f4fdec8d442d7df760cb541f1ca6e446d"
 DEVTOOLS_FRONTEND_HOST = "chrome-devtools-frontend.appspot.com"
 _frontend_cache: dict[str, tuple[bytes, str]] = {}
 
+# Names/locations for the Chrome/Chromium binary used for the offline frontend fallback.
+_CHROME_BINARY_NAMES = (
+    "google-chrome",
+    "google-chrome-stable",
+    "chromium",
+    "chromium-browser",
+    "chrome",
+    "chrome.exe",
+)
+_CHROME_DEFAULT_PATHS: dict[str, tuple[str, ...]] = {
+    "darwin": (
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    ),
+    "win32": (
+        r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+        r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+    ),
+    "linux": (
+        "/usr/bin/google-chrome",
+        "/usr/bin/google-chrome-stable",
+        "/usr/bin/chromium",
+        "/usr/bin/chromium-browser",
+        "/snap/bin/chromium",
+    ),
+}
+
+
+def find_chrome(explicit: Optional[str] = None) -> Optional[str]:
+    """Locate a Chrome/Chromium binary for the offline frontend fallback: an explicit path, then
+    the PATH, then the running platform's known install locations. Returns None if none is found."""
+    if explicit:
+        return explicit if Path(explicit).exists() else None
+    for name in _CHROME_BINARY_NAMES:
+        found = shutil.which(name)
+        if found:
+            return found
+    for candidate in _CHROME_DEFAULT_PATHS.get(sys.platform, ()):
+        if Path(candidate).exists():
+            return candidate
+    return None
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    app.state.frontend_lock = asyncio.Lock()
     await app.state.inspector.connect()
     yield
+    proc: Optional[subprocess.Popen[bytes]] = getattr(app.state, "local_chrome_proc", None)
+    if proc is not None:
+        proc.terminate()
+    profile: Optional[str] = getattr(app.state, "local_chrome_profile", None)
+    if profile:
+        shutil.rmtree(profile, ignore_errors=True)
 
 
 app = FastAPI(lifespan=lifespan)
+
+
+async def _fetch(url: str) -> Optional[tuple[bytes, str]]:
+    """Fetch a frontend asset off the event loop; None on any failure."""
+
+    def _get() -> tuple[bytes, str]:
+        with urlopen(url, timeout=20) as response:
+            return response.read(), response.headers.get_content_type()
+
+    try:
+        return await asyncio.get_event_loop().run_in_executor(None, _get)
+    except Exception:
+        return None
+
+
+async def _launch_local_frontend() -> Optional[str]:
+    """Start a throwaway headless Chrome that serves its own bundled DevTools frontend over http and
+    return its origin. Used only when the hosted build is unreachable."""
+    chrome = getattr(app.state, "chrome_path", None)
+    if not chrome:
+        logger.error(
+            "DevTools frontend unavailable: the hosted build is unreachable and no Chrome binary "
+            "was found. Install Chrome/Chromium or pass --chrome <path>."
+        )
+        return None
+    profile = tempfile.mkdtemp(prefix="pmd3-devtools-frontend-")
+    app.state.local_chrome_profile = profile
+    app.state.local_chrome_proc = subprocess.Popen(
+        [
+            chrome,
+            "--headless=new",
+            "--remote-debugging-port=0",
+            f"--user-data-dir={profile}",
+            "--no-first-run",
+            "--no-default-browser-check",
+            "--disable-gpu",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    port_file = Path(profile) / "DevToolsActivePort"
+    for _ in range(80):
+        if port_file.exists():
+            try:
+                return f"http://127.0.0.1:{int(port_file.read_text().splitlines()[0])}"
+            except (ValueError, IndexError):
+                return None
+        await asyncio.sleep(0.1)
+    logger.error("local Chrome did not expose a debugging port in time")
+    return None
+
+
+async def _frontend_base() -> Optional[str]:
+    """Base URL to serve the DevTools frontend from, decided once per run: the hosted build when
+    reachable, otherwise a locally launched Chrome. None if neither is available."""
+    base = getattr(app.state, "frontend_base", None)
+    if base is not None:
+        return base or None
+    async with app.state.frontend_lock:
+        base = getattr(app.state, "frontend_base", None)
+        if base is not None:
+            return base or None
+        rev = getattr(app.state, "frontend_rev", DEVTOOLS_FRONTEND_REV)
+        hosted = f"https://{DEVTOOLS_FRONTEND_HOST}/serve_rev/@{rev}"
+        if await _fetch(f"{hosted}/inspector.html") is not None:
+            app.state.frontend_base = hosted
+        else:
+            local = await _launch_local_frontend()
+            app.state.frontend_base = f"{local}/devtools" if local else ""
+            if local:
+                logger.info("serving the DevTools frontend from a local Chrome (hosted build unreachable)")
+        return app.state.frontend_base or None
 
 
 @app.get("/json/version")
@@ -96,24 +223,18 @@ async def index(request: Request) -> HTMLResponse:
 
 @app.get("/devtools/{path:path}")
 async def devtools_frontend(path: str) -> Response:
-    """Serve the DevTools frontend by proxying the hosted build. Opened over http, the frontend
-    connects to the bridge's WebSocket directly instead of through chrome://inspect's relay."""
-    rev = getattr(app.state, "frontend_rev", DEVTOOLS_FRONTEND_REV)
-    key = f"{rev}/{path}"
-    if key not in _frontend_cache:
-        url = f"https://{DEVTOOLS_FRONTEND_HOST}/serve_rev/@{rev}/{path}"
-
-        def _fetch() -> tuple[bytes, str]:
-            with urlopen(url, timeout=20) as response:
-                return response.read(), response.headers.get_content_type()
-
-        try:
-            data, content_type = await asyncio.get_event_loop().run_in_executor(None, _fetch)
-        except Exception:
-            logger.exception(f"failed to fetch DevTools frontend asset: {path}")
+    """Serve the DevTools frontend so it connects to the bridge's WebSocket directly instead of
+    through chrome://inspect's relay. Assets are proxied - from the hosted build, or from a local
+    Chrome when that is unreachable - and cached per run."""
+    if path not in _frontend_cache:
+        base = await _frontend_base()
+        if base is None:
             return Response(status_code=404)
-        _frontend_cache[key] = (data, content_type)
-    data, content_type = _frontend_cache[key]
+        result = await _fetch(f"{base}/{path}")
+        if result is None:
+            return Response(status_code=404)
+        _frontend_cache[path] = result
+    data, content_type = _frontend_cache[path]
     return Response(content=data, media_type=content_type)
 
 

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -16,9 +16,37 @@ logger = logging.getLogger(__name__)
 # The wait holds _waiting_for_id, which pauses the receive loop, so it must be bounded.
 WIR_RESULT_TIMEOUT = 5
 
+# Once a target has missed a reply it is flagged unresponsive and further internal requests
+# fast-fail (see send_message_with_result). To notice a target that recovered but is otherwise
+# silent, one request is let through every UNRESPONSIVE_REPROBE_INTERVAL seconds, with a short
+# timeout so a still-dead target only briefly re-pauses the receive loop.
+UNRESPONSIVE_REPROBE_INTERVAL = 2.0
+UNRESPONSIVE_PROBE_TIMEOUT = 1.5
+
 # CDP domains WebKit does not implement at all. Any method in these that isn't specially
 # translated is acknowledged with an empty response instead of being forwarded (and erroring).
 NOOP_ABSENT_DOMAINS = frozenset({"Input", "Overlay"})
+
+# Error synthesized for requests routed to a target that got destroyed before answering
+# (WebKit never answers those). Matches Chrome's own message for the same situation.
+TARGET_CLOSED_ERROR: dict[str, Any] = {"code": -32000, "message": "Inspected target navigated or closed"}
+
+# Per-target state (beyond *.enable) worth re-establishing on the fresh target after a process
+# swap. These keep their latest params only.
+REPLAYED_SETUP_METHODS = frozenset({
+    "Network.setResourceCachingDisabled",
+    "Page.setEmulatedMedia",
+    "Page.setForcedAppearance",
+    "Debugger.setBreakpointsActive",
+    "Debugger.setPauseOnExceptions",
+    "Debugger.setAsyncStackTraceDepth",
+})
+
+# Replayed setup methods that accumulate state entry-by-entry (one replay per distinct params).
+REPLAYED_MULTI_SETUP_METHODS = frozenset({
+    "Debugger.setBreakpointByUrl",
+    "Debugger.setShouldBlackboxURL",
+})
 
 NETWORK_RESOURCE_TYPES = [
     "Document",
@@ -213,6 +241,20 @@ class CdpTarget:
         self._default_execution_id = 0
         self._last_console_api_call: Optional[dict[str, Any]] = None
         self._internal_id = 0
+        # id -> target the request was routed to, for synthesizing errors when that target dies
+        self._pending_requests: dict[int, str] = {}
+        self._destroyed_targets: set[str] = set()
+        # Targets that stopped answering our internal requests (e.g. a page wedged on a native
+        # app-open interstitial that WebKit refuses to navigate). Further internal requests to
+        # them fast-fail instead of each blocking the receive loop for WIR_RESULT_TIMEOUT, which
+        # would otherwise freeze the whole session. Cleared as soon as the target answers again
+        # (an inbound event, or a periodic re-probe) so a merely-slow page is not stuck flagged.
+        self._unresponsive_targets: set[str] = set()
+        # loop time of the last re-probe attempt per unresponsive target, to rate-limit re-probes.
+        self._unresponsive_last_probe: dict[str, float] = {}
+        # setup (domain enables & co.) the frontend established, replayed onto new targets
+        self._setup_messages: dict[Any, dict[str, Any]] = {}
+        self._setup_sent_targets: set[str] = {target_id}
 
     def next_internal_id(self) -> int:
         """
@@ -273,22 +315,37 @@ class CdpTarget:
         """
         return await self.output_queue.get()
 
-    async def wait_for_event_id(self, id_: int) -> Optional[dict[str, Any]]:
+    async def wait_for_event_id(
+        self, id_: int, target_id: Optional[str] = None, timeout: float = WIR_RESULT_TIMEOUT
+    ) -> Optional[dict[str, Any]]:
         """
         Wait for a message with a specific id from the target.
         :param id_: Message id to wait for.
+        :param target_id: Target the request was routed to; the wait is abandoned as soon as that
+            target is destroyed (WebKit never answers requests of a destroyed target, so waiting
+            out the full timeout would only stall the paused receive loop).
+        :param timeout: Seconds to wait before giving up (shorter for re-probes of a target already
+            believed unresponsive, so a still-dead one barely re-pauses the receive loop).
         :returns: The matching target message, or None if it does not arrive within the timeout.
         """
-        deadline = asyncio.get_event_loop().time() + WIR_RESULT_TIMEOUT
+        deadline = asyncio.get_event_loop().time() + timeout
         while asyncio.get_event_loop().time() < deadline:
+            if target_id is not None and target_id in self._destroyed_targets:
+                return None
             for i in range(len(self.protocol.inspector.wir_events)):
                 message = self.protocol.inspector.wir_events[i]
+                if message["method"] == "Target.targetDestroyed":
+                    # Only give up the wait; the event stays queued for the receive loop.
+                    if message["params"]["targetId"] == target_id:
+                        return None
+                    continue
                 if message["method"] != "Target.dispatchMessageFromTarget":
                     continue
                 message = json.loads(message["params"]["message"])
                 if message.get("id", "") != id_:
                     continue
                 del self.protocol.inspector.wir_events[i]
+                self._pending_requests.pop(id_, None)
                 return message
             await asyncio.sleep(0)
         return None
@@ -304,17 +361,44 @@ class CdpTarget:
         answers. The wait is bounded and _waiting_for_id is always released: while it is held the
         receive loop is paused, so a lost response would otherwise starve every later event.
         """
+        target_id = self.target_id
+        timeout = WIR_RESULT_TIMEOUT
+        if target_id in self._unresponsive_targets:
+            # Believed dead: fast-fail without holding the receive loop, except let one request
+            # through every UNRESPONSIVE_REPROBE_INTERVAL to notice a target that came back but is
+            # otherwise silent (a slow page finished loading, an interstitial finally redirected).
+            now = asyncio.get_event_loop().time()
+            if now - self._unresponsive_last_probe.get(target_id, 0.0) < UNRESPONSIVE_REPROBE_INTERVAL:
+                logger.debug(f"skipping {method}: target {target_id} is unresponsive")
+                return {}
+            self._unresponsive_last_probe[target_id] = now
+            timeout = UNRESPONSIVE_PROBE_TIMEOUT
         id_ = self.next_internal_id()
         self._waiting_for_id += 1
         try:
             await self._send_message_to_target({"id": id_, "method": method, "params": params})
-            result = await self.wait_for_event_id(id_)
+            result = await self.wait_for_event_id(id_, target_id, timeout)
             if result is None:
-                logger.warning(f"No target response for {method} (id {id_}) within {WIR_RESULT_TIMEOUT}s")
+                self._pending_requests.pop(id_, None)
+                if target_id not in self._destroyed_targets:
+                    # Mark (or keep) it unresponsive so the next request fast-fails instead of
+                    # blocking another timeout; a destroyed target is handled elsewhere.
+                    if target_id not in self._unresponsive_targets:
+                        logger.warning(f"target {target_id} stopped responding ({method}); backing off")
+                    self._unresponsive_targets.add(target_id)
+                    # Rate-limit the next re-probe from the end of this attempt.
+                    self._unresponsive_last_probe[target_id] = asyncio.get_event_loop().time()
                 return {}
+            # A reply proves the target is alive again; resume normal sending.
+            self._mark_target_responsive(target_id)
             return result
         finally:
             self._waiting_for_id -= 1
+
+    def _mark_target_responsive(self, target_id: str) -> None:
+        """Clear the unresponsive flag once a target answers again."""
+        self._unresponsive_targets.discard(target_id)
+        self._unresponsive_last_probe.pop(target_id, None)
 
     async def evaluate_and_result(self, expression: str) -> Any:
         """
@@ -378,15 +462,50 @@ class CdpTarget:
                 logger.exception(f"Failed handling target event: {message.get('method')}")
 
     async def _to_output_queue(self, message: dict[str, Any]):
+        if message["method"] != "Target.dispatchMessageFromTarget":
+            logger.debug(f"WIR EVENT: {message}")
         if message["method"] in self.to_cdp_special_messages_methods:
             await self.to_cdp_special_messages_methods[message["method"]](message)
         else:
             logger.error(f"Unknown target event: {message}")
 
-    async def _send_message_to_target(self, message: dict[str, Any]):
+    async def _send_message_to_target(
+        self, message: dict[str, Any], target_id: Optional[str] = None, record: bool = True
+    ):
+        resolved_target_id = target_id if target_id is not None else self.target_id
+        if "id" in message:
+            self._pending_requests[message["id"]] = resolved_target_id
+        if record:
+            self._record_setup_message(message)
         await self.protocol.send_command(
-            "Target.sendMessageToTarget", targetId=self.target_id, message=json.dumps(message)
+            "Target.sendMessageToTarget", targetId=resolved_target_id, message=json.dumps(message)
         )
+
+    def _record_setup_message(self, message: dict[str, Any]):
+        """
+        Remember per-target setup so it can be re-established on the fresh target after a process
+        swap. WebKit expects the inspector frontend to re-initialize every new target, but Chrome
+        knows nothing of WebKit's target multiplexing, so the bridge must replay it.
+        """
+        method = message.get("method", "")
+        params = message.get("params", {})
+        if method.endswith(".enable") or method in REPLAYED_SETUP_METHODS:
+            self._setup_messages[method] = params
+        elif method in REPLAYED_MULTI_SETUP_METHODS:
+            self._setup_messages[(method, json.dumps(params, sort_keys=True))] = params
+
+    async def _send_setup_to_target(self, target_id: str):
+        """Replay the frontend's recorded setup onto a new target (once per target)."""
+        if target_id in self._setup_sent_targets:
+            return
+        self._setup_sent_targets.add(target_id)
+        for key, params in list(self._setup_messages.items()):
+            method = key if isinstance(key, str) else key[0]
+            await self._send_message_to_target(
+                {"id": self.next_internal_id(), "method": method, "params": params},
+                target_id=target_id,
+                record=False,
+            )
 
     async def _simple_response(self, message: dict[str, Any], value: Any):
         await self.output_queue.put({"id": message["id"], "result": {"result": value}})
@@ -627,17 +746,23 @@ class CdpTarget:
     async def _runtime_compile_script(self, message: dict[str, Any]):
         self._script_source_to_context_id[message["params"]["expression"]] = message["params"]["executionContextId"]
         response = await self.send_message_with_result("Runtime.parse", {"source": message["params"]["expression"]})
-        if response["result"]["result"] == "none":
-            await self._simple_response(message, None)
+        result = response.get("result")
+        # send_message_with_result returns {} when the device is busy/unresponsive (e.g. mid-flood
+        # on a chatty page). This handler runs on every console keystroke; a missing result must
+        # not raise (it would break compilation and wedge the console's eager evaluation). Treat an
+        # absent or "no error" parse as a clean compile and answer with Chrome's schema (an empty
+        # result object for a non-persisted script), not a bogus {"result": null}.
+        if not result or result.get("result") == "none":
+            await self.output_queue.put({"id": message["id"], "result": {}})
             return
-        lines = message["params"]["expression"][: response["result"]["range"]["endOffset"]].splitlines()
+        lines = message["params"]["expression"][: result["range"]["endOffset"]].splitlines()
         lines = lines if lines else [""]
         await self.output_queue.put({
             "id": message["id"],
             "result": {
                 "exceptionDetails": {
                     "exceptionId": 1,
-                    "text": response["result"]["message"],
+                    "text": result["message"],
                     "lineNumber": len(lines) - 1,
                     "columnNumber": len(lines[-1]) - 1,
                 }
@@ -782,12 +907,21 @@ class CdpTarget:
         # timeout. Rapid link navigation stacks those blocks until the session never catches up.
         # So emit a non-blocking, schema-complete targetInfo (a partial one crashes the frontend
         # SDK); the real url arrives via the device's own Page.frameNavigated.
-        self.target_id = message["params"]["targetInfo"]["targetId"]
+        target_info = message["params"]["targetInfo"]
+        new_target_id = target_info["targetId"]
+        if not target_info.get("isProvisional", False):
+            # A provisional target becomes current only on didCommitProvisionalTarget; routing
+            # commands to it earlier loses them if the load never commits.
+            self.target_id = new_target_id
+        # New targets start with all agents disabled; without replaying the frontend's setup no
+        # Network/Page/Console/Debugger event ever arrives again after a process swap and the
+        # session appears dead after a couple of link clicks.
+        await self._send_setup_to_target(new_target_id)
         await self.output_queue.put({
             "method": "Target.targetInfoChanged",
             "params": {
                 "targetInfo": {
-                    "targetId": self.target_id,
+                    "targetId": new_target_id,
                     "type": "page",
                     "title": "",
                     "url": self.frame.get("url", ""),
@@ -798,6 +932,20 @@ class CdpTarget:
         })
 
     async def _target_destroyed(self, message: dict[str, Any]):
+        destroyed_target_id = message["params"]["targetId"]
+        self._destroyed_targets.add(destroyed_target_id)
+        self._setup_sent_targets.discard(destroyed_target_id)
+        self._mark_target_responsive(destroyed_target_id)
+        # WebKit never answers requests routed to a destroyed target; resolve them with an error
+        # (like Chrome's backend does on navigation) so the frontend's pending promises settle
+        # instead of wedging whole panels. Internal (negative-id) waits abandon themselves via
+        # _destroyed_targets.
+        for id_, target_id in list(self._pending_requests.items()):
+            if target_id != destroyed_target_id:
+                continue
+            del self._pending_requests[id_]
+            if id_ >= 0:
+                await self.output_queue.put({"id": id_, "error": dict(TARGET_CLOSED_ERROR)})
         # The device emits its own Page.frameNavigated for the new page, so no getResourceTree
         # round-trip is needed (and must not be done here - see _target_created). Just nudge the
         # frontend that the load finished and the document changed.
@@ -809,9 +957,20 @@ class CdpTarget:
         await self.output_queue.put({"method": "DOM.documentUpdated"})
 
     async def _target_dispatch_message_from_target(self, message: dict[str, Any]):
+        # Any message from the current target proves it is alive again (a wedged page that finally
+        # navigated, a slow response that eventually arrived); resume sending it internal requests.
+        self._mark_target_responsive(self.target_id)
         message = json.loads(message["params"]["message"])
         if "error" in message:
-            logger.error(message)
+            # Expected protocol-level errors (e.g. element-only DOM queries on text nodes) are
+            # already delivered to the frontend, which copes; don't shout about them here.
+            logger.debug(f"Target error response: {message}")
+        if "id" in message:
+            self._pending_requests.pop(message["id"], None)
+            if message["id"] < 0:
+                # Response to a bridge-internal request (setup replay or an abandoned wait);
+                # forwarding it would hand the frontend an id it never issued.
+                return
         if message.get("method", "") in self.to_cdp_special_dispatched_messages_methods:
             await self.to_cdp_special_dispatched_messages_methods[message["method"]](message)
         else:
@@ -820,7 +979,11 @@ class CdpTarget:
             await self.output_queue.put(message)
 
     async def _target_did_commit_provisional_target(self, message: dict[str, Any]):
-        pass
+        # The provisional target replaces the committed one only now; from here on route the
+        # frontend's commands to it.
+        self.target_id = message["params"]["newTargetId"]
+        # Normally already done at targetCreated; covers a commit whose creation we never saw.
+        await self._send_setup_to_target(self.target_id)
 
     async def _debugger_script_parsed(self, message: dict[str, Any]):
         if not self._waiting_for_id:

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -23,9 +23,25 @@ WIR_RESULT_TIMEOUT = 5
 UNRESPONSIVE_REPROBE_INTERVAL = 2.0
 UNRESPONSIVE_PROBE_TIMEOUT = 1.5
 
+# Minimum seconds between synthesized screencast hover (mouseMoved) events. DevTools streams
+# dozens of moves per second as the pointer glides; synthesizing each one as a blocking device
+# round-trip floods webinspectord and pauses the receive loop, which - on a chatty page - starves
+# event delivery until the frontend wedges. Intermediate moves are acked and dropped.
+MOUSEMOVE_MIN_INTERVAL = 0.08
+
 # CDP domains WebKit does not implement at all. Any method in these that isn't specially
 # translated is acknowledged with an empty response instead of being forwarded (and erroring).
 NOOP_ABSENT_DOMAINS = frozenset({"Input", "Overlay"})
+
+# Events WebKit's Web Inspector emits that have no counterpart in Chrome's protocol. Forwarding
+# them is at best noise (Chrome ignores unknown events) and at worst fatal: an unrecognized event
+# can throw in the frontend's message dispatcher and kill its pump, so a chatty page that emits
+# them in bulk (e.g. CSS.nodeLayoutFlagsChanged on every layout) can wedge DevTools. Drop them.
+WEBKIT_ONLY_EVENTS = frozenset({
+    "CSS.nodeLayoutFlagsChanged",
+    "DOM.willDestroyDOMNode",
+    "Page.defaultUserPreferencesDidChange",
+})
 
 # Error synthesized for requests routed to a target that got destroyed before answering
 # (WebKit never answers those). Matches Chrome's own message for the same situation.
@@ -241,6 +257,12 @@ class CdpTarget:
         self._default_execution_id = 0
         self._last_console_api_call: Optional[dict[str, Any]] = None
         self._internal_id = 0
+        # loop time of the last synthesized hover, to throttle high-frequency mouseMoved events.
+        self._last_mousemove_time = 0.0
+        # execution-context uniqueIds already announced to the frontend, to drop duplicate
+        # Runtime.executionContextCreated events (WebKit re-announces contexts) that would
+        # otherwise corrupt Chrome's RuntimeModel.
+        self._emitted_context_unique_ids: set[str] = set()
         # id -> target the request was routed to, for synthesizing errors when that target dies
         self._pending_requests: dict[int, str] = {}
         self._destroyed_targets: set[str] = set()
@@ -787,7 +809,8 @@ class CdpTarget:
     def _screencast_scale(self) -> float:
         return self.screencast.get_scale() if self.screencast is not None else 1.0
 
-    async def _synthesize_mouse_event(self, type_: str, x: int, y: int, modifiers: int, button: int):
+    def _mouse_event_js(self, type_: str, x: int, y: int, modifiers: int, button: int) -> str:
+        """Build the in-page expression that dispatches a synthesized mouse event at (x, y)."""
         event_params = json.dumps({
             "screenX": x,
             "screenY": y,
@@ -810,9 +833,28 @@ class CdpTarget:
             "element.focus();"
             "return e;}"
         )
-        await self.evaluate_and_result(f'({simulate_mouse_event})("{type_}")')
+        return f'({simulate_mouse_event})("{type_}")'
+
+    async def _synthesize_mouse_event(self, type_: str, x: int, y: int, modifiers: int, button: int):
+        await self.evaluate_and_result(self._mouse_event_js(type_, x, y, modifiers, button))
         if type_ == "click":
-            await self.evaluate_and_result(f'({simulate_mouse_event})("mouseup")')
+            await self.evaluate_and_result(self._mouse_event_js("mouseup", x, y, modifiers, button))
+
+    async def _send_evaluate_noreply(self, expression: str) -> None:
+        """
+        Fire-and-forget page evaluate for high-frequency screencast input (hover, scroll).
+
+        Waiting for the device (send_message_with_result) holds _waiting_for_id and pauses the
+        receive loop; doing that per pointer move floods webinspectord and, on a chatty page,
+        starves every incoming event. We don't need the result, so just send and move on; the
+        (negative-id) reply is dropped by _target_dispatch_message_from_target.
+        """
+        if self.target_id in self._unresponsive_targets:
+            return
+        await self._send_message_to_target(
+            {"id": self.next_internal_id(), "method": "Runtime.evaluate", "params": {"expression": expression}},
+            record=False,
+        )
 
     async def _input_emulate_touch_from_mouse_event(self, message: dict[str, Any]):
         params = message["params"]
@@ -839,15 +881,25 @@ class CdpTarget:
         scale = self._screencast_scale()
         type_ = params["type"]
         if type_ == "mouseWheel":
+            # Scrolling is frequent; don't block the receive loop waiting for the device.
             delta_x, delta_y = params.get("deltaX", 0) // scale, params.get("deltaY", 0) // scale
-            await self.evaluate_and_result(f"window.scrollBy({-delta_x}, {-delta_y})")
-        elif type_ in ("mousePressed", "mouseMoved"):
+            await self._send_evaluate_noreply(f"window.scrollBy({-delta_x}, {-delta_y})")
+        elif type_ == "mouseMoved":
+            # Hover: throttle (DevTools streams dozens/sec) and never block on the device.
+            now = asyncio.get_event_loop().time()
+            if now - self._last_mousemove_time >= MOUSEMOVE_MIN_INTERVAL:
+                self._last_mousemove_time = now
+                x, y = int(params["x"] // scale), int(params["y"] // scale)
+                await self._send_evaluate_noreply(
+                    self._mouse_event_js("mousemove", x, y, params.get("modifiers", 0), 0)
+                )
+        elif type_ == "mousePressed":
+            # Clicks are low-frequency and must land in order (focus, submit), so keep them synchronous.
             x, y = int(params["x"] // scale), int(params["y"] // scale)
             button = {"none": 0, "left": 0, "middle": 1, "right": 2, "back": 3, "forward": 4}.get(
                 params.get("button", "none"), 0
             )
-            js_type = "click" if type_ == "mousePressed" else "mousemove"
-            await self._synthesize_mouse_event(js_type, x, y, params.get("modifiers", 0), button)
+            await self._synthesize_mouse_event("click", x, y, params.get("modifiers", 0), button)
 
         await self._simple_response(message, None)
 
@@ -855,23 +907,44 @@ class CdpTarget:
         params = message["params"]
         key = params["key"]
         if params["type"] == "keyUp" and key == "Backspace":
-            manipulation = "document.activeElement.value = document.activeElement.value.slice(0, -1);"
-        elif params["type"] == "char" and key == "Enter":
             manipulation = (
-                "var tagName = document.activeElement.tagName.toLowerCase();"
-                'if (tagName === "textarea" || document.activeElement.isContentEditable) {'
-                '    document.activeElement.value = document.activeElement.value + "\\n";'
-                "} else {"
-                '    const result = document.evaluate("./ancestor-or-self::form", document.activeElement, '
-                "                                     null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);"
-                "    const e = result.singleNodeValue.ownerDocument.createEvent('Event');"
-                '    e.initEvent("submit", true, true);'
-                "    if (result.singleNodeValue.dispatchEvent(e)) { result.singleNodeValue.submit() }"
+                "document.activeElement.value = document.activeElement.value.slice(0, -1);"
+                "document.activeElement.dispatchEvent("
+                "    new InputEvent('input', {bubbles: true, inputType: 'deleteContentBackward'}));"
+            )
+        elif params["type"] == "char" and key == "Enter":
+            # The page's own Enter handling must run first (e.g. google fires its search from a
+            # keydown listener on a <textarea> and prevents the default); only when the page
+            # leaves the events unhandled fall back to what a browser would do by default.
+            manipulation = (
+                "const enterInit = {key: 'Enter', code: 'Enter', bubbles: true, cancelable: true};"
+                "const keydown = new KeyboardEvent('keydown', enterInit);"
+                "const keypress = new KeyboardEvent('keypress', enterInit);"
+                "for (const event of [keydown, keypress]) {"
+                "    Object.defineProperty(event, 'keyCode', {get: () => 13});"
+                "    Object.defineProperty(event, 'which', {get: () => 13});"
+                "}"
+                "const prevented = !document.activeElement.dispatchEvent(keydown)"
+                "    || !document.activeElement.dispatchEvent(keypress);"
+                "document.activeElement.dispatchEvent("
+                "    new KeyboardEvent('keyup', {key: 'Enter', code: 'Enter', bubbles: true}));"
+                "if (!prevented) {"
+                "    var tagName = document.activeElement.tagName.toLowerCase();"
+                '    if (tagName === "textarea" || document.activeElement.isContentEditable) {'
+                '        document.activeElement.value = document.activeElement.value + "\\n";'
+                "    } else if (document.activeElement.form) {"
+                "        const form = document.activeElement.form;"
+                "        if (form.requestSubmit) { form.requestSubmit(); } else { form.submit(); }"
+                "    }"
                 "}"
             )
         elif params["type"] == "char":
             text = params["text"]
-            manipulation = f'document.activeElement.value = document.activeElement.value + "{text}";'
+            manipulation = (
+                f'document.activeElement.value = document.activeElement.value + "{text}";'
+                "document.activeElement.dispatchEvent("
+                "    new InputEvent('input', {bubbles: true, inputType: 'insertText'}));"
+            )
         else:
             await self._simple_response(message, None)
             return
@@ -971,11 +1044,15 @@ class CdpTarget:
                 # Response to a bridge-internal request (setup replay or an abandoned wait);
                 # forwarding it would hand the frontend an id it never issued.
                 return
-        if message.get("method", "") in self.to_cdp_special_dispatched_messages_methods:
-            await self.to_cdp_special_dispatched_messages_methods[message["method"]](message)
+        method = message.get("method", "")
+        if method in WEBKIT_ONLY_EVENTS:
+            # Not part of Chrome's protocol; forwarding it only risks wedging the frontend.
+            return
+        if method in self.to_cdp_special_dispatched_messages_methods:
+            await self.to_cdp_special_dispatched_messages_methods[method](message)
         else:
-            if "method" in message:
-                logger.debug(f"Dispatching: {message['method']}")
+            if method:
+                logger.debug(f"Dispatching: {method}")
             await self.output_queue.put(message)
 
     async def _target_did_commit_provisional_target(self, message: dict[str, Any]):
@@ -1014,6 +1091,8 @@ class CdpTarget:
         await self.output_queue.put(message)
 
     async def _debugger_global_object_cleared(self, message: dict[str, Any]):
+        # Contexts are gone; allow their uniqueIds to be re-announced after the reload.
+        self._emitted_context_unique_ids.clear()
         await self.output_queue.put({"method": "Runtime.executionContextsCleared"})
         await self.output_queue.put({"method": "DOM.documentUpdated"})
 
@@ -1028,6 +1107,12 @@ class CdpTarget:
         # results depending on timing. Only the main-world context is forwarded.
         if context["type"] != "normal":
             return
+        unique_id = f"{context['frameId']}.{context['id']}"
+        if unique_id in self._emitted_context_unique_ids:
+            # WebKit re-announces the same context; a duplicate executionContextCreated corrupts
+            # Chrome's RuntimeModel (it keys contexts by uniqueId), so emit each at most once.
+            return
+        self._emitted_context_unique_ids.add(unique_id)
         self._default_execution_id = context["id"]
         message["params"] = {
             "context": {
@@ -1035,7 +1120,7 @@ class CdpTarget:
                 "origin": "default",
                 "name": "",
                 # must be unique per context - Chrome keys contexts by it
-                "uniqueId": f"{context['frameId']}.{context['id']}",
+                "uniqueId": unique_id,
             }
         }
         await self.output_queue.put(message)

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -63,6 +63,8 @@ REPLAYED_SETUP_METHODS = frozenset({
     "Debugger.setBreakpointsActive",
     "Debugger.setPauseOnExceptions",
     "Debugger.setAsyncStackTraceDepth",
+    # Synthesized by the bridge (Chrome never sends it); see _debugger_enable.
+    "Debugger.setPauseOnDebuggerStatements",
 })
 
 # Replayed setup methods that accumulate state entry-by-entry (one replay per distinct params).
@@ -123,6 +125,20 @@ LOG_MESSAGE_LEVELS = {
     "debug": "verbose",
 }
 
+# WebKit's Debugger.Scope.type enum -> Chrome's Scope.type enum. WebKit has scope kinds Chrome
+# lacks ("functionName", "globalLexicalEnvironment", "nestedLexical", ...); an unrecognized value
+# makes Chrome's ScopeChainSidebar throw, so every WebKit type is mapped to a valid Chrome one.
+WEBKIT_SCOPE_TYPE_MAP = {
+    "closure": "closure",
+    "functionName": "closure",
+    "global": "global",
+    "globalLexicalEnvironment": "global",
+    "with": "with",
+    "catch": "catch",
+    "nestedLexical": "block",
+    "functionInParameter": "local",
+}
+
 DEBUGGER_PAUSED_REASON = {
     "XHR": "XHR",
     "Fetch": "other",
@@ -180,6 +196,8 @@ class CdpTarget:
             "Emulation.setAutoDarkModeOverride": self._emulation_set_auto_dark_mode_override,
             "Emulation.setEmitTouchEventsForMouse": partial(self._simple_response, value=None),
             "Debugger.setAsyncCallStackDepth": partial(self._simple_response, value=True),
+            "Debugger.enable": self._debugger_enable,
+            "Debugger.setBreakpointsActive": self._debugger_set_breakpoints_active,
             "Debugger.setBlackboxPatterns": self._debugger_set_blackbox_patterns,
             "Debugger.setBreakpointByUrl": self._debugger_set_breakpoint_by_url,
             "DOMDebugger.setBreakOnCSPViolation": partial(self._simple_response, value=None),
@@ -262,6 +280,9 @@ class CdpTarget:
         self._input_task = asyncio.create_task(self._input_loop())
         self._receiving_task = asyncio.create_task(self._receive_loop())
         self._script_source_to_context_id: dict[str, Any] = {}
+        # scriptId -> url, from Debugger.scriptParsed; used to fill the `url` WebKit omits from the
+        # callFrames of Debugger.paused (Chrome's CallFrame requires it).
+        self._script_id_to_url: dict[str, str] = {}
         self._default_execution_id = 0
         self._last_console_api_call: Optional[dict[str, Any]] = None
         self._internal_id = 0
@@ -744,6 +765,40 @@ class CdpTarget:
         message["params"] = {"appearance": "Dark" if params["enabled"] else "Light"}
         await self._send_message_to_target(message)
 
+    async def _debugger_enable(self, message: dict[str, Any]):
+        await self._send_message_to_target(message)
+        # Two WebKit quirks conspire to make the debugger never stop, and Chrome's frontend papers
+        # over neither because its own backend behaves differently:
+        #   1. Chrome assumes breakpoints default to ACTIVE and only sends setBreakpointsActive when
+        #      the user *deactivates* them; WebKit deactivates breakpoints on enable, so nothing -
+        #      breakpoints or `debugger;` - ever pauses until setBreakpointsActive(true) is sent.
+        #   2. Pausing on `debugger;` is separately gated behind setPauseOnDebuggerStatements, which
+        #      defaults OFF and has no Chrome equivalent (Chrome pauses on `debugger;` whenever the
+        #      debugger is attached and breakpoints are active).
+        # Establish both on enable; they are kept in sync with the frontend's toggle below and
+        # replayed onto fresh targets after a process swap.
+        await self._send_message_to_target({
+            "id": self.next_internal_id(),
+            "method": "Debugger.setBreakpointsActive",
+            "params": {"active": True},
+        })
+        await self._send_message_to_target({
+            "id": self.next_internal_id(),
+            "method": "Debugger.setPauseOnDebuggerStatements",
+            "params": {"enabled": True},
+        })
+
+    async def _debugger_set_breakpoints_active(self, message: dict[str, Any]):
+        # Chrome's "Deactivate breakpoints" toggle also suppresses `debugger;` statements; mirror
+        # that by keeping WebKit's separate pause-on-debugger-statements setting in lockstep.
+        active = message["params"].get("active", True)
+        await self._send_message_to_target(message)
+        await self._send_message_to_target({
+            "id": self.next_internal_id(),
+            "method": "Debugger.setPauseOnDebuggerStatements",
+            "params": {"enabled": active},
+        })
+
     async def _debugger_set_blackbox_patterns(self, message: dict[str, Any]):
         for pattern in message["params"]["patterns"]:
             await self.send_message_with_result(
@@ -1154,6 +1209,9 @@ class CdpTarget:
         source = params.get("sourceURL", "") or params.get("url", "")
         if any(marker in source for marker in WEBKIT_INTERNAL_SCRIPT_MARKERS):
             return
+        script_id = params.get("scriptId")
+        if script_id is not None:
+            self._script_id_to_url[script_id] = source
         await self.output_queue.put(message)
 
     async def _debugger_script_failed_to_parse(self, message: dict[str, Any]):
@@ -1175,9 +1233,22 @@ class CdpTarget:
         await self.output_queue.put(message)
 
     async def _debugger_paused(self, message: dict[str, Any]):
-        message["params"]["reason"] = DEBUGGER_PAUSED_REASON[message["params"]["reason"]]
-        if "breakpointId" in message["params"].get("data", {}):
-            message["params"]["hitBreakpoints"] = [message["params"]["data"]["breakpointId"]]
+        params = message["params"]
+        params["reason"] = DEBUGGER_PAUSED_REASON.get(params["reason"], "other")
+        if "breakpointId" in params.get("data", {}):
+            params["hitBreakpoints"] = [params["data"]["breakpointId"]]
+        # WebKit's CallFrame differs from Chrome's: it omits the required `url` and uses scope-type
+        # enum values Chrome rejects. Untranslated, Chrome's SDK throws while building the paused
+        # state and the Sources panel never shows the pause. Reshape each frame in place.
+        for frame in params.get("callFrames", []):
+            if "url" not in frame:
+                script_id = frame.get("location", {}).get("scriptId")
+                frame["url"] = self._script_id_to_url.get(script_id, "")
+            for scope in frame.get("scopeChain", []):
+                scope["type"] = WEBKIT_SCOPE_TYPE_MAP.get(scope["type"], "closure")
+                # WebKit names the defining position `location`; Chrome calls it `startLocation`.
+                if "location" in scope:
+                    scope["startLocation"] = scope.pop("location")
         await self.output_queue.put(message)
 
     async def _debugger_global_object_cleared(self, message: dict[str, Any]):

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Awaitable
 from datetime import datetime
 from functools import partial
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, cast
 
 from pymobiledevice3.services.web_protocol.cdp_screencast import ScreenCast
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
@@ -22,6 +22,13 @@ WIR_RESULT_TIMEOUT = 5
 # timeout so a still-dead target only briefly re-pauses the receive loop.
 UNRESPONSIVE_REPROBE_INTERVAL = 2.0
 UNRESPONSIVE_PROBE_TIMEOUT = 1.5
+
+# sourceURL stamped onto the bridge's own internal evaluations (screencast offsets, synthesized
+# input, navigation) so their Debugger.scriptParsed events can be recognized and dropped instead
+# of polluting Chrome's script model. WebKit-inspector-internal scripts (its injected script
+# source) carry their own marker.
+INTERNAL_SCRIPT_URL = "__pymobiledevice3_internal__"
+WEBKIT_INTERNAL_SCRIPT_MARKERS = ("__InjectedScript", INTERNAL_SCRIPT_URL)
 
 # Minimum seconds between synthesized screencast hover (mouseMoved) events. DevTools streams
 # dozens of moves per second as the pointer glides; synthesizing each one as a blocking device
@@ -188,6 +195,7 @@ class CdpTarget:
             "Overlay.highlightNode": self._overlay_highlight_node,
             "Runtime.runIfWaitingForDebugger": partial(self._simple_response, value=None),
             "Runtime.compileScript": self._runtime_compile_script,
+            "Runtime.runScript": self._runtime_run_script,
             "Runtime.getIsolateId": self._runtime_get_isolate_id,
             "Profiler.enable": partial(self._simple_response, value=None),
             "Target.setAutoAttach": self._target_set_auto_attach,
@@ -263,6 +271,10 @@ class CdpTarget:
         # Runtime.executionContextCreated events (WebKit re-announces contexts) that would
         # otherwise corrupt Chrome's RuntimeModel.
         self._emitted_context_unique_ids: set[str] = set()
+        # Runtime.compileScript synthesizes a scriptId (WebKit has no compileScript); persisted
+        # scripts are kept here so a later Runtime.runScript can execute their source.
+        self._compiled_script_counter = 0
+        self._persisted_scripts: dict[str, str] = {}
         # id -> target the request was routed to, for synthesizing errors when that target dies
         self._pending_requests: dict[int, str] = {}
         self._destroyed_targets: set[str] = set()
@@ -422,12 +434,17 @@ class CdpTarget:
         self._unresponsive_targets.discard(target_id)
         self._unresponsive_last_probe.pop(target_id, None)
 
+    @staticmethod
+    def _tag_internal(expression: str) -> str:
+        """Stamp a sourceURL on a bridge-originated evaluation so its scriptParsed can be dropped."""
+        return f"{expression}\n//# sourceURL={INTERNAL_SCRIPT_URL}"
+
     async def evaluate_and_result(self, expression: str) -> Any:
         """
         Evaluate Javascript expression.
         """
         logger.debug(f"Evaluating: {expression}")
-        params = {"expression": expression}
+        params = {"expression": self._tag_internal(expression)}
         data = await self.send_message_with_result("Runtime.evaluate", params)
         logger.debug(f"Evaluated: {data}")
         if "result" not in data:
@@ -579,6 +596,9 @@ class CdpTarget:
         for prop in properties:
             prop.setdefault("configurable", False)
             prop.setdefault("enumerable", False)
+        # Expanded objects list function properties whose native descriptions the console
+        # autocomplete inspects; normalize them (see _normalize_native_functions).
+        self._normalize_native_functions(properties)
         result: dict[str, Any] = {"result": properties}
         if "internalProperties" in response["result"]:
             result["internalProperties"] = response["result"]["internalProperties"]
@@ -674,6 +694,15 @@ class CdpTarget:
     async def _page_get_navigation_history(self, message: dict[str, Any]):
         href = await self.evaluate_and_result("window.location.href")
         title = await self.evaluate_and_result("document.title")
+        # evaluate_and_result returns None when the device does not answer in time (common during
+        # the initial setup handshake, when the page is still busy). A null url crashes the whole
+        # screencast panel - ScreencastView.requestNavigationHistory does url.match(HTTP_REGEX) on
+        # each entry - which manifests as a blank "no screen" inspector. Never emit null: fall back
+        # to the page's advertised URL, and coerce a missing title to an empty string.
+        if not isinstance(href, str) or not href:
+            href = self.protocol.page.web_url or "about:blank"
+        if not isinstance(title, str):
+            title = ""
         await self.output_queue.put({
             "id": message["id"],
             "result": {"currentIndex": 0, "entries": [{"id": 0, "url": href, "title": title}]},
@@ -775,7 +804,15 @@ class CdpTarget:
         # absent or "no error" parse as a clean compile and answer with Chrome's schema (an empty
         # result object for a non-persisted script), not a bogus {"result": null}.
         if not result or result.get("result") == "none":
-            await self.output_queue.put({"id": message["id"], "result": {}})
+            # Compiled cleanly. Runtime.compileScript's response REQUIRES a scriptId (per the CDP
+            # spec); omitting it makes Chrome's console treat the compile as unfinished and re-send
+            # compileScript in a tight loop until the frontend wedges. Mint one, and remember the
+            # source so a later Runtime.runScript (persistScript=true) can still execute it.
+            self._compiled_script_counter += 1
+            script_id = f"pmd-compiled-{self._compiled_script_counter}"
+            if message["params"].get("persistScript"):
+                self._persisted_scripts[script_id] = message["params"]["expression"]
+            await self.output_queue.put({"id": message["id"], "result": {"scriptId": script_id}})
             return
         lines = message["params"]["expression"][: result["range"]["endOffset"]].splitlines()
         lines = lines if lines else [""]
@@ -789,6 +826,18 @@ class CdpTarget:
                     "columnNumber": len(lines[-1]) - 1,
                 }
             },
+        })
+
+    async def _runtime_run_script(self, message: dict[str, Any]):
+        # WebKit has no compileScript/runScript; execute the source we stashed at compile time.
+        source = self._persisted_scripts.get(message["params"].get("scriptId", ""))
+        if source is None:
+            await self.output_queue.put({"id": message["id"], "result": {"result": {"type": "undefined"}}})
+            return
+        response = await self.send_message_with_result("Runtime.evaluate", {"expression": source})
+        await self.output_queue.put({
+            "id": message["id"],
+            "result": response.get("result", {"result": {"type": "undefined"}}),
         })
 
     async def _runtime_get_isolate_id(self, message: dict[str, Any]):
@@ -852,7 +901,11 @@ class CdpTarget:
         if self.target_id in self._unresponsive_targets:
             return
         await self._send_message_to_target(
-            {"id": self.next_internal_id(), "method": "Runtime.evaluate", "params": {"expression": expression}},
+            {
+                "id": self.next_internal_id(),
+                "method": "Runtime.evaluate",
+                "params": {"expression": self._tag_internal(expression)},
+            },
             record=False,
         )
 
@@ -1029,11 +1082,41 @@ class CdpTarget:
         })
         await self.output_queue.put({"method": "DOM.documentUpdated"})
 
+    @staticmethod
+    def _normalize_native_functions(obj: Any) -> None:
+        """
+        Collapse WebKit's multi-line native-function descriptions to Chrome's exact single-line
+        form, in place and recursively. WebKit reports native functions as
+        `function name() {\\n    [native code]\\n}`; the console's argument-hint autocomplete only
+        treats a function as native when its description ends with the literal `{ [native code] }`
+        (devtools-frontend front_end/ui/components/text_editor/javascript.ts,
+        getArgumentsForFunctionValue). Otherwise it feeds the description to a JS parser to extract
+        the parameter list, which throws "Failed to parse for arguments list" on `[native code]`;
+        fired on every keystroke while typing a call, that uncaught rejection wedges the console.
+        """
+        if isinstance(obj, dict):
+            node = cast(dict[str, Any], obj)
+            if node.get("type") == "function":
+                desc = node.get("description")
+                if isinstance(desc, str) and "[native code]" in desc and not desc.endswith("{ [native code] }"):
+                    brace = desc.find("{")
+                    if brace != -1:
+                        node["description"] = desc[:brace] + "{ [native code] }"
+            for value in node.values():
+                CdpTarget._normalize_native_functions(value)
+        elif isinstance(obj, list):
+            for value in cast(list[Any], obj):
+                CdpTarget._normalize_native_functions(value)
+
     async def _target_dispatch_message_from_target(self, message: dict[str, Any]):
         # Any message from the current target proves it is alive again (a wedged page that finally
         # navigated, a slow response that eventually arrived); resume sending it internal requests.
         self._mark_target_responsive(self.target_id)
         message = json.loads(message["params"]["message"])
+        if "result" in message:
+            # Function objects in evaluate/callFunctionOn results carry native descriptions the
+            # console autocomplete inspects; normalize them (see _normalize_native_functions).
+            self._normalize_native_functions(message["result"])
         if "error" in message:
             # Expected protocol-level errors (e.g. element-only DOM queries on text nodes) are
             # already delivered to the frontend, which copes; don't shout about them here.
@@ -1063,8 +1146,15 @@ class CdpTarget:
         await self._send_setup_to_target(self.target_id)
 
     async def _debugger_script_parsed(self, message: dict[str, Any]):
-        if not self._waiting_for_id:
-            await self.output_queue.put(message)
+        # Drop scripts that are not the page's own: the bridge's internal evaluations (screencast
+        # offsets, synthesized input - fired several times a second) and WebKit's inspector
+        # injected scripts. Forwarding them floods Chrome's Debugger model with phantom scripts,
+        # which - independent of the page - eventually wedges the console/autocomplete.
+        params = message.get("params", {})
+        source = params.get("sourceURL", "") or params.get("url", "")
+        if any(marker in source for marker in WEBKIT_INTERNAL_SCRIPT_MARKERS):
+            return
+        await self.output_queue.put(message)
 
     async def _debugger_script_failed_to_parse(self, message: dict[str, Any]):
         # The failing source is only known from Runtime.compileScript; parse failures of other

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -125,6 +125,11 @@ LOG_MESSAGE_LEVELS = {
     "debug": "verbose",
 }
 
+# objectGroups DevTools uses for autocomplete's throwOnSideEffect evaluations (completion list and
+# argument hint). These are side-effect-free sub-expression lookups the dropdown needs, so unlike
+# the eager-evaluation preview they must be forwarded rather than refused (see _runtime_evaluate).
+_COMPLETION_OBJECT_GROUPS = frozenset({"completion", "argumentsHint"})
+
 # WebKit's Debugger.Scope.type enum -> Chrome's Scope.type enum. WebKit has scope kinds Chrome
 # lacks ("functionName", "globalLexicalEnvironment", "nestedLexical", ...); an unrecognized value
 # makes Chrome's ScopeChainSidebar throw, so every WebKit type is mapped to a valid Chrome one.
@@ -212,6 +217,7 @@ class CdpTarget:
             # acknowledged by the NOOP_ABSENT_DOMAINS fallback in _input_loop.
             "Overlay.highlightNode": self._overlay_highlight_node,
             "Runtime.runIfWaitingForDebugger": partial(self._simple_response, value=None),
+            "Runtime.evaluate": self._runtime_evaluate,
             "Runtime.compileScript": self._runtime_compile_script,
             "Runtime.runScript": self._runtime_run_script,
             "Runtime.getIsolateId": self._runtime_get_isolate_id,
@@ -283,6 +289,7 @@ class CdpTarget:
         # scriptId -> url, from Debugger.scriptParsed; used to fill the `url` WebKit omits from the
         # callFrames of Debugger.paused (Chrome's CallFrame requires it).
         self._script_id_to_url: dict[str, str] = {}
+        self._eval_side_effect_id = 0
         self._default_execution_id = 0
         self._last_console_api_call: Optional[dict[str, Any]] = None
         self._internal_id = 0
@@ -847,6 +854,45 @@ class CdpTarget:
 
     async def _overlay_highlight_node(self, message: dict[str, Any]):
         message["method"] = "DOM.highlightNode"
+        await self._send_message_to_target(message)
+
+    async def _runtime_evaluate(self, message: dict[str, Any]):
+        # Chrome's console "eager evaluation" previews the current line as you type by evaluating it
+        # with throwOnSideEffect=true, relying on V8 to ABORT the moment the expression would cause a
+        # side effect (so `console.log(4234)` shows no preview and does NOT log until Enter). WebKit's
+        # Runtime.evaluate has no such guard, so forwarding it runs the line for real - the console
+        # logs/mutates while typing. Refuse the preview the way V8 does for a side-effecting
+        # expression: report a side-effect error so DevTools shows no preview and nothing executes.
+        # The real evaluation triggered by Enter carries no throwOnSideEffect and is forwarded.
+        #
+        # Autocomplete shares the same throwOnSideEffect evaluate, but on *sub-expressions* (the base
+        # object for the completion list, the callee for the argument hint) under a dedicated
+        # objectGroup. Those are side-effect-free identifier lookups the dropdown needs, so let them
+        # through - refusing them would kill autocomplete. Only the eager preview (no completion
+        # objectGroup) is refused.
+        params = message["params"]
+        if params.get("throwOnSideEffect") and params.get("objectGroup") not in _COMPLETION_OBJECT_GROUPS:
+            self._eval_side_effect_id += 1
+            error_object = {
+                "type": "object",
+                "subtype": "error",
+                "className": "EvalError",
+                "description": "EvalError: Possible side-effect in debug-evaluate",
+            }
+            await self.output_queue.put({
+                "id": message["id"],
+                "result": {
+                    "result": error_object,
+                    "exceptionDetails": {
+                        "exceptionId": self._eval_side_effect_id,
+                        "text": "Uncaught",
+                        "lineNumber": 0,
+                        "columnNumber": 0,
+                        "exception": error_object,
+                    },
+                },
+            })
+            return
         await self._send_message_to_target(message)
 
     async def _runtime_compile_script(self, message: dict[str, Any]):

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -12,6 +12,14 @@ from pymobiledevice3.services.web_protocol.session_protocol import SessionProtoc
 
 logger = logging.getLogger(__name__)
 
+# Seconds to wait for the device's response to a translated inspector request before giving up.
+# The wait holds _waiting_for_id, which pauses the receive loop, so it must be bounded.
+WIR_RESULT_TIMEOUT = 5
+
+# CDP domains WebKit does not implement at all. Any method in these that isn't specially
+# translated is acknowledged with an empty response instead of being forwarded (and erroring).
+NOOP_ABSENT_DOMAINS = frozenset({"Input", "Overlay"})
+
 NETWORK_RESOURCE_TYPES = [
     "Document",
     "Stylesheet",
@@ -92,7 +100,7 @@ class CdpTarget:
         """
         self.protocol = protocol
         self.target_id = target_id
-        self.frame = {}
+        self.frame: dict[str, Any] = {}
         self.session_id = protocol.id_
         self.app_id = protocol.app.id_
         self.page_id = protocol.page.id_
@@ -131,16 +139,9 @@ class CdpTarget:
             "Network.clearAcceptedEncodingsOverride": partial(self._simple_response, value=None),
             "ServiceWorker.enable": self._service_worker_enable,
             "HeapProfiler.enable": partial(self._simple_response, value=None),
-            "Overlay.setShowGridOverlays": partial(self._simple_response, value=None),
-            "Overlay.setShowFlexOverlays": partial(self._simple_response, value=None),
-            "Overlay.setShowScrollSnapOverlays": partial(self._simple_response, value=None),
-            "Overlay.setShowContainerQueryOverlays": partial(self._simple_response, value=None),
-            "Overlay.setShowIsolatedElements": partial(self._simple_response, value=None),
-            "Overlay.hideHighlight": partial(self._simple_response, value=None),
+            # Overlay is absent in WebKit; only highlightNode is worth translating, the rest are
+            # acknowledged by the NOOP_ABSENT_DOMAINS fallback in _input_loop.
             "Overlay.highlightNode": self._overlay_highlight_node,
-            "Overlay.enable": partial(self._simple_response, value=None),
-            "Overlay.setShowViewportSizeOnResize": partial(self._simple_response, value=None),
-            "Overlay.setPausedInDebuggerMessage": partial(self._simple_response, value=None),
             "Runtime.runIfWaitingForDebugger": partial(self._simple_response, value=None),
             "Runtime.compileScript": self._runtime_compile_script,
             "Runtime.getIsolateId": self._runtime_get_isolate_id,
@@ -153,6 +154,39 @@ class CdpTarget:
             "CSS.addRule": self._css_add_rule,
             "Input.emulateTouchFromMouseEvent": self._input_emulate_touch_from_mouse_event,
             "Input.dispatchKeyEvent": self._input_dispatch_key_event,
+            "Input.dispatchMouseEvent": self._input_dispatch_mouse_event,
+            "Page.navigate": self._page_navigate,
+            "Page.setAdBlockingEnabled": partial(self._simple_response, value=None),
+            "Page.addScriptToEvaluateOnNewDocument": self._page_add_script_to_evaluate_on_new_document,
+            "Accessibility.enable": partial(self._simple_response, value=None),
+            "Autofill.enable": partial(self._simple_response, value=None),
+            "Autofill.setAddresses": partial(self._simple_response, value=None),
+            "Runtime.addBinding": partial(self._simple_response, value=None),
+            "Runtime.globalLexicalScopeNames": self._runtime_global_lexical_scope_names,
+            "Runtime.getProperties": self._runtime_get_properties,
+            "Network.setBlockedURLs": partial(self._simple_response, value=None),
+            # The SDK reads ruleIds.length from this response inside the target-initialization
+            # Promise.all; a field-less response rejects it and silently kills the rest of the
+            # init chain (the console stops rendering results).
+            "Network.emulateNetworkConditionsByRule": partial(self._result_response, result={"ruleIds": []}),
+            "Network.overrideNetworkState": partial(self._simple_response, value=None),
+            # The frontend queries this per frame and reads response.status.coep/.coop; WebKit has
+            # no such method, so report a schema-valid "no isolation policies" status.
+            "Network.getSecurityIsolationStatus": partial(
+                self._result_response,
+                result={
+                    "status": {
+                        "coep": {"value": "None", "reportOnlyValue": "None"},
+                        "coop": {"value": "UnsafeNone", "reportOnlyValue": "UnsafeNone"},
+                    }
+                },
+            ),
+            "Storage.getStorageKey": partial(self._result_response, result={"storageKey": ""}),
+            "CSS.getAnimatedStylesForNode": partial(self._simple_response, value=None),
+            "CSS.getEnvironmentVariables": partial(self._result_response, result={"environmentVariables": {}}),
+            "CSS.trackComputedStyleUpdatesForNode": partial(self._simple_response, value=None),
+            "CSS.getPlatformFontsForNode": self._css_get_platform_fonts,
+            "DOM.pushNodesByBackendIdsToFrontend": self._dom_push_nodes_by_backend_ids,
         }
         self.to_cdp_special_messages_methods = {
             "Target.targetCreated": self._target_created,
@@ -161,6 +195,7 @@ class CdpTarget:
             "Target.didCommitProvisionalTarget": self._target_did_commit_provisional_target,
         }
         self.to_cdp_special_dispatched_messages_methods = {
+            "Console.messageRepeatCountUpdated": self._console_message_repeat_count_updated,
             "Debugger.scriptParsed": self._debugger_script_parsed,
             "Debugger.scriptFailedToParse": self._debugger_script_failed_to_parse,
             "Debugger.paused": self._debugger_paused,
@@ -176,6 +211,20 @@ class CdpTarget:
         self._receiving_task = asyncio.create_task(self._receive_loop())
         self._script_source_to_context_id: dict[str, Any] = {}
         self._default_execution_id = 0
+        self._last_console_api_call: Optional[dict[str, Any]] = None
+        self._internal_id = 0
+
+    def next_internal_id(self) -> int:
+        """
+        Allocate a unique id for a request we originate ourselves (screencast, sub-queries).
+
+        Negative so it can never collide with a frontend message id; unique so concurrent
+        internal requests don't consume each other's responses in wait_for_event_id (a fixed,
+        reused id let a slow evaluate response be mis-matched to a snapshotRect wait, which
+        silently killed the screencast).
+        """
+        self._internal_id -= 1
+        return self._internal_id
 
     @classmethod
     async def create(cls, protocol: SessionProtocol) -> "CdpTarget":
@@ -183,16 +232,34 @@ class CdpTarget:
         :param pymobiledevice3.services.web_protocol.session_protocol.SessionProtocol protocol: Session protocol.
         """
         await protocol.inspector.setup_inspector_socket(protocol.id_, protocol.app.id_, protocol.page.id_)
-        while not protocol.inspector.wir_events:
-            await asyncio.sleep(0)
-        created = protocol.inspector.wir_events.pop(0)
-        while "targetInfo" not in created["params"]:
+        while True:
+            # wir_events is shared; another session's create may pop concurrently, so re-check
+            # emptiness on every iteration instead of assuming a successful pop.
+            if not protocol.inspector.wir_events:
+                await asyncio.sleep(0)
+                continue
             created = protocol.inspector.wir_events.pop(0)
+            if "targetInfo" in created.get("params", {}):
+                break
         target_id = created["params"]["targetInfo"]["targetId"]
         logger.info(f"Created: {target_id}")
-        target = cls(protocol, target_id)
-        await target.output_queue.put(created)
-        return target
+        # The raw WIR Target.targetCreated is NOT forwarded: its targetInfo lacks the fields
+        # Chrome's schema requires (type/title/url/attached) and crashes the frontend's SDK.
+        return cls(protocol, target_id)
+
+    async def close(self) -> None:
+        """
+        Stop the queue-consumer tasks and any running screencast, and tear down the WIR socket.
+        """
+        if self.screencast is not None:
+            await self.screencast.stop()
+            self.screencast = None
+        for task in (self._input_task, self._receiving_task):
+            task.cancel()
+        await asyncio.gather(self._input_task, self._receiving_task, return_exceptions=True)
+        # Without the teardown, webinspectord ignores the next socket setup for this page and
+        # the following debugger connection never receives its Target.targetCreated event.
+        await self.protocol.inspector.teardown_inspector_socket(self.session_id, self.app_id, self.page_id)
 
     async def send(self, message: dict[str, Any]):
         """
@@ -206,12 +273,14 @@ class CdpTarget:
         """
         return await self.output_queue.get()
 
-    async def wait_for_event_id(self, id_: int):
+    async def wait_for_event_id(self, id_: int) -> Optional[dict[str, Any]]:
         """
         Wait for a message with a specific id from the target.
         :param id_: Message id to wait for.
+        :returns: The matching target message, or None if it does not arrive within the timeout.
         """
-        while True:
+        deadline = asyncio.get_event_loop().time() + WIR_RESULT_TIMEOUT
+        while asyncio.get_event_loop().time() < deadline:
             for i in range(len(self.protocol.inspector.wir_events)):
                 message = self.protocol.inspector.wir_events[i]
                 if message["method"] != "Target.dispatchMessageFromTarget":
@@ -222,25 +291,41 @@ class CdpTarget:
                 del self.protocol.inspector.wir_events[i]
                 return message
             await asyncio.sleep(0)
+        return None
 
-    async def send_message_with_result(self, id_: int, method: str, params: dict[str, Any]):
+    async def send_message_with_result(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         """
-        Send a message to the target and wait for response.
+        Send a self-originated request to the target and wait for its response.
+
+        A unique internal id is allocated per call so concurrent sub-requests (screen input
+        synthesis, object inspection, script parsing, ...) never consume each other's responses;
+        reusing the frontend's message id let a slow response be matched to the wrong wait, which
+        stalled the receive loop and hung the console. Returns an empty dict if the device never
+        answers. The wait is bounded and _waiting_for_id is always released: while it is held the
+        receive loop is paused, so a lost response would otherwise starve every later event.
         """
+        id_ = self.next_internal_id()
         self._waiting_for_id += 1
-        await self._send_message_to_target({"id": id_, "method": method, "params": params})
-        result = await self.wait_for_event_id(id_)
-        self._waiting_for_id -= 1
-        return result
+        try:
+            await self._send_message_to_target({"id": id_, "method": method, "params": params})
+            result = await self.wait_for_event_id(id_)
+            if result is None:
+                logger.warning(f"No target response for {method} (id {id_}) within {WIR_RESULT_TIMEOUT}s")
+                return {}
+            return result
+        finally:
+            self._waiting_for_id -= 1
 
-    async def evaluate_and_result(self, id_: int, expression: str) -> Any:
+    async def evaluate_and_result(self, expression: str) -> Any:
         """
         Evaluate Javascript expression.
         """
-        logger.debug("Evaluating: ", expression)
+        logger.debug(f"Evaluating: {expression}")
         params = {"expression": expression}
-        data = await self.send_message_with_result(id_, "Runtime.evaluate", params)
-        logger.debug("Evaluated: ", data)
+        data = await self.send_message_with_result("Runtime.evaluate", params)
+        logger.debug(f"Evaluated: {data}")
+        if "result" not in data:
+            return None
         result = data["result"]["result"]
         if result["type"] == "string":
             return result["value"]
@@ -249,16 +334,33 @@ class CdpTarget:
         elif result["type"] == "object":
             return result
         else:
-            logger.debug("Unknown type: ", result)
+            logger.debug(f"Unknown type: {result}")
             return result
 
     async def _input_loop(self):
         while True:
             message = await self.input_queue.get()
-            if message["method"] in self.from_cdp_special_messages_methods:
-                await self.from_cdp_special_messages_methods[message["method"]](message)
-            else:
-                await self._send_message_to_target(message)
+            try:
+                if message["method"] in self.from_cdp_special_messages_methods:
+                    await self.from_cdp_special_messages_methods[message["method"]](message)
+                elif message["method"].split(".", 1)[0] in NOOP_ABSENT_DOMAINS:
+                    # WebKit has no Input/Overlay domains at all; the few methods worth
+                    # translating are in the special table above, so acknowledge the rest
+                    # (mouse moves over the screencast, inspect-mode toggles, ...) instead of
+                    # forwarding them and erroring.
+                    await self._simple_response(message, None)
+                else:
+                    await self._send_message_to_target(message)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # One failing translation must not kill the session's input processing.
+                logger.exception(f"Failed handling DevTools message: {message.get('method')}")
+                if "id" in message:
+                    await self.output_queue.put({
+                        "id": message["id"],
+                        "error": {"code": -32000, "message": f"pymobiledevice3 failed to handle {message['method']}"},
+                    })
 
     async def _receive_loop(self):
         while True:
@@ -266,14 +368,20 @@ class CdpTarget:
                 await asyncio.sleep(0)
                 continue
             message = self.protocol.inspector.wir_events.pop(0)
-            await self._to_output_queue(message)
+            try:
+                await self._to_output_queue(message)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # One failing event translation must not kill the whole receive loop - that
+                # silently starves every later response and the session appears dead.
+                logger.exception(f"Failed handling target event: {message.get('method')}")
 
     async def _to_output_queue(self, message: dict[str, Any]):
         if message["method"] in self.to_cdp_special_messages_methods:
             await self.to_cdp_special_messages_methods[message["method"]](message)
         else:
-            logger.error("Error!!!!!!!!!!!!", message)
-            raise RuntimeError()
+            logger.error(f"Unknown target event: {message}")
 
     async def _send_message_to_target(self, message: dict[str, Any]):
         await self.protocol.send_command(
@@ -283,9 +391,71 @@ class CdpTarget:
     async def _simple_response(self, message: dict[str, Any], value: Any):
         await self.output_queue.put({"id": message["id"], "result": {"result": value}})
 
+    async def _result_response(self, message: dict[str, Any], result: dict[str, Any]):
+        """Respond with an exact result body, for methods whose response fields the frontend reads."""
+        await self.output_queue.put({"id": message["id"], "result": result})
+
     async def _audits_enable(self, message: dict[str, Any]):
+        # A previous inspector session may have left an audit configured; WebKit then rejects
+        # setup with "Must call teardown before calling setup again", so always reset first.
+        await self.send_message_with_result("Audit.teardown", {})
         message["method"] = "Audit.setup"
+        message["params"] = {}
         await self._send_message_to_target(message)
+
+    async def _page_navigate(self, message: dict[str, Any]):
+        """WebKit has no Page.navigate; navigate in-page instead (URL bar / reload in DevTools)."""
+        url = json.dumps(message["params"]["url"])
+        await self.evaluate_and_result(f"location.href = {url}")
+        await self.output_queue.put({"id": message["id"], "result": {"frameId": self.frame.get("id", "")}})
+
+    async def _dom_push_nodes_by_backend_ids(self, message: dict[str, Any]):
+        await self.output_queue.put({"id": message["id"], "result": {"nodeIds": []}})
+
+    async def _runtime_get_properties(self, message: dict[str, Any]):
+        """
+        WebKit answers Runtime.getProperties with a 'properties' array; Chrome's frontend reads
+        'result' and renders "No properties" otherwise. WebKit also lacks the
+        accessorPropertiesOnly/nonIndexedPropertiesOnly filters, so apply them here.
+        """
+        params = message["params"]
+        response = await self.send_message_with_result(
+            "Runtime.getProperties",
+            {
+                "objectId": params["objectId"],
+                "ownProperties": params.get("ownProperties", False),
+                "generatePreview": params.get("generatePreview", False),
+            },
+        )
+        if "result" not in response:
+            await self.output_queue.put({"id": message["id"], "result": {"result": []}})
+            return
+        properties: list[dict[str, Any]] = response["result"].get("properties", [])
+        if params.get("accessorPropertiesOnly", False):
+            properties = [p for p in properties if "get" in p or "set" in p]
+        if params.get("nonIndexedPropertiesOnly", False):
+            properties = [p for p in properties if not p.get("name", "").isdigit()]
+        for prop in properties:
+            prop.setdefault("configurable", False)
+            prop.setdefault("enumerable", False)
+        result: dict[str, Any] = {"result": properties}
+        if "internalProperties" in response["result"]:
+            result["internalProperties"] = response["result"]["internalProperties"]
+        await self.output_queue.put({"id": message["id"], "result": result})
+
+    async def _runtime_global_lexical_scope_names(self, message: dict[str, Any]):
+        """
+        WebKit lacks Runtime.globalLexicalScopeNames (console autocomplete asks for global
+        let/const/class names). Those are not enumerable from page JavaScript, and window
+        properties are already covered by the frontend's regular completion path.
+        """
+        await self.output_queue.put({"id": message["id"], "result": {"names": []}})
+
+    async def _css_get_platform_fonts(self, message: dict[str, Any]):
+        await self.output_queue.put({"id": message["id"], "result": {"fonts": []}})
+
+    async def _page_add_script_to_evaluate_on_new_document(self, message: dict[str, Any]):
+        await self.output_queue.put({"id": message["id"], "result": {"identifier": "1"}})
 
     async def _dom_get_box_model(self, message: dict[str, Any]):
         message["method"] = "DOM.highlightNode"
@@ -298,27 +468,24 @@ class CdpTarget:
         }
         await self._send_message_to_target(message)
 
-    async def object_id_to_node_id(self, object_id: str, id_: int):
-        node = await self.send_message_with_result(id_, "DOM.requestNode", {"objectId": object_id})
+    async def object_id_to_node_id(self, object_id: str):
+        node = await self.send_message_with_result("DOM.requestNode", {"objectId": object_id})
         return node["result"]["nodeId"]
 
     async def _dom_get_node_for_location(self, message: dict[str, Any]):
         x, y = message["params"]["x"], message["params"]["y"]
-        obj = await self.evaluate_and_result(message["id"], f"document.elementFromPoint({x},{y})")
+        obj = await self.evaluate_and_result(f"document.elementFromPoint({x},{y})")
         if obj is None or "objectId" not in obj:
             await self._simple_response(message, None)
             return
-        result = {"nodeId": await self.object_id_to_node_id(obj["objectId"], message["id"])}
+        result = {"nodeId": await self.object_id_to_node_id(obj["objectId"])}
         await self.output_queue.put({"id": message["id"], "result": result})
 
     async def _dom_get_nodes_for_subtree_by_style(self, message: dict[str, Any]):
-        object_id = (
-            await self.send_message_with_result(
-                message["id"], "DOM.resolveNode", {"nodeId": message["params"]["nodeId"]}
-            )
-        )["result"]["object"]["objectId"]
+        object_id = (await self.send_message_with_result("DOM.resolveNode", {"nodeId": message["params"]["nodeId"]}))[
+            "result"
+        ]["object"]["objectId"]
         result = await self.send_message_with_result(
-            message["id"],
             "Runtime.callFunctionOn",
             {
                 "objectId": object_id,
@@ -342,13 +509,10 @@ class CdpTarget:
             },
         )
         result = await self.send_message_with_result(
-            message["id"], "Runtime.getCollectionEntries", {"objectId": result["result"]["result"]["objectId"]}
+            "Runtime.getCollectionEntries", {"objectId": result["result"]["result"]["objectId"]}
         )
         nodes = await asyncio.gather(
-            *[
-                self.object_id_to_node_id(obj["value"]["objectId"], message["id"] - i)
-                for i, obj in enumerate(result["result"]["entries"])
-            ],
+            *[self.object_id_to_node_id(obj["value"]["objectId"]) for obj in result["result"]["entries"]],
             return_exceptions=True,
         )
         nodes = [n for n in nodes if isinstance(n, int)]
@@ -367,8 +531,8 @@ class CdpTarget:
         await self._send_message_to_target(message)
 
     async def _page_get_navigation_history(self, message: dict[str, Any]):
-        href = await self.evaluate_and_result(message["id"], "window.location.href")
-        title = await self.evaluate_and_result(message["id"], "document.title")
+        href = await self.evaluate_and_result("window.location.href")
+        title = await self.evaluate_and_result("document.title")
         await self.output_queue.put({
             "id": message["id"],
             "result": {"currentIndex": 0, "entries": [{"id": 0, "url": href, "title": title}]},
@@ -377,7 +541,7 @@ class CdpTarget:
     async def _page_start_screencast(self, message: dict[str, Any]):
         params = message["params"]
         self.screencast = ScreenCast(self, params["format"], params["quality"], params["maxWidth"], params["maxHeight"])
-        await self.screencast.start(message["id"])
+        await self.screencast.start()
         await self._simple_response(message, None)
 
     async def _page_stop_screencast(self, message: dict[str, Any]):
@@ -392,9 +556,10 @@ class CdpTarget:
         await self._simple_response(message, None)
 
     async def _page_get_resource_tree(self, message: dict[str, Any]):
-        result = await self.send_message_with_result(message["id"], message["method"], message["params"])
+        result = await self.send_message_with_result(message["method"], message["params"])
         self.frame = result["result"]["frameTree"]["frame"]
-        await self.output_queue.put(result)
+        # result carries our internal request id; answer the frontend with its own id.
+        await self.output_queue.put({"id": message["id"], "result": result["result"]})
 
     async def _emulation_set_emulated_media(self, message: dict[str, Any]):
         message["method"] = "Page.setEmulatedMedia"
@@ -412,7 +577,7 @@ class CdpTarget:
     async def _debugger_set_blackbox_patterns(self, message: dict[str, Any]):
         for pattern in message["params"]["patterns"]:
             await self.send_message_with_result(
-                message["id"], "Debugger.setShouldBlackboxURL", {"url": pattern, "shouldBlackbox": True}
+                "Debugger.setShouldBlackboxURL", {"url": pattern, "shouldBlackbox": True}
             )
         await self._simple_response(message, None)
 
@@ -423,8 +588,8 @@ class CdpTarget:
         await self._send_message_to_target(message)
 
     async def _domdebugger_get_event_listeners(self, message: dict[str, Any]):
-        node = {"nodeId": await self.object_id_to_node_id(message["params"]["objectId"], message["id"])}
-        listeners = await self.send_message_with_result(message["id"], "DOM.getEventListenersForNode", node)
+        node = {"nodeId": await self.object_id_to_node_id(message["params"]["objectId"])}
+        listeners = await self.send_message_with_result("DOM.getEventListenersForNode", node)
         if "error" in listeners:
             await self._simple_response(message, None)
             return
@@ -461,9 +626,7 @@ class CdpTarget:
 
     async def _runtime_compile_script(self, message: dict[str, Any]):
         self._script_source_to_context_id[message["params"]["expression"]] = message["params"]["executionContextId"]
-        response = await self.send_message_with_result(
-            message["id"], "Runtime.parse", {"source": message["params"]["expression"]}
-        )
+        response = await self.send_message_with_result("Runtime.parse", {"source": message["params"]["expression"]})
         if response["result"]["result"] == "none":
             await self._simple_response(message, None)
             return
@@ -485,15 +648,9 @@ class CdpTarget:
         await self.output_queue.put({"id": message["id"], "result": {"id": self._default_execution_id}})
 
     async def _target_set_auto_attach(self, message: dict[str, Any]):
+        # Only acknowledge. Emitting a fabricated Target.attachedToTarget (with a sessionId and
+        # a partial targetInfo) crashes the frontend's SDK and progressively breaks the console.
         await self._simple_response(message, None)
-        await self.output_queue.put({
-            "method": "Target.attachedToTarget",
-            "params": {
-                "sessionId": self.protocol.id_,
-                "targetInfo": {"targetId": self.target_id},
-                "waitingForDebugger": True,
-            },
-        })
 
     async def _css_take_computed_style_updates(self, message: dict[str, Any]):
         await self.output_queue.put({"id": message["id"], "result": {"nodeIds": []}})
@@ -502,47 +659,70 @@ class CdpTarget:
         message["params"]["selector"] = message["params"]["ruleText"].split("{")[0]
         await self._send_message_to_target(message)
 
+    def _screencast_scale(self) -> float:
+        return self.screencast.get_scale() if self.screencast is not None else 1.0
+
+    async def _synthesize_mouse_event(self, type_: str, x: int, y: int, modifiers: int, button: int):
+        event_params = json.dumps({
+            "screenX": x,
+            "screenY": y,
+            "clientX": x,
+            "clientY": y,
+            "altKey": bool(modifiers & 1),
+            "ctrlKey": bool(modifiers & 2),
+            "metaKey": bool(modifiers & 4),
+            "shiftKey": bool(modifiers & 8),
+            "button": button,
+            "bubbles": True,
+            "cancelable": True,
+        })
+        simulate_mouse_event = (
+            "function simulateMouseEvent(type){"
+            f"const element = document.elementFromPoint({x}, {y});"
+            "if (element === null) { return null; }"
+            f"const e = new MouseEvent(type, JSON.parse('{event_params}'));"
+            "element.dispatchEvent(e);"
+            "element.focus();"
+            "return e;}"
+        )
+        await self.evaluate_and_result(f'({simulate_mouse_event})("{type_}")')
+        if type_ == "click":
+            await self.evaluate_and_result(f'({simulate_mouse_event})("mouseup")')
+
     async def _input_emulate_touch_from_mouse_event(self, message: dict[str, Any]):
         params = message["params"]
+        scale = self._screencast_scale()
         if params["type"] == "mouseWheel":
-            assert self.screencast is not None
-            delta_x, delta_y = (
-                params["deltaX"] // self.screencast.get_scale(),
-                params["deltaY"] // self.screencast.get_scale(),
-            )
-            await self.evaluate_and_result(message["id"], f"window.scrollBy({-delta_x}, {-delta_y})")
+            delta_x, delta_y = params["deltaX"] // scale, params["deltaY"] // scale
+            await self.evaluate_and_result(f"window.scrollBy({-delta_x}, {-delta_y})")
         elif params["type"] == "mouseReleased":
             pass
         else:
-            assert self.screencast is not None
-            modifiers = params["modifiers"]
-            x, y = params["x"] // self.screencast.get_scale(), params["y"] // self.screencast.get_scale()
-            event_params: Any = {
-                "screenX": x,
-                "screenY": y,
-                "clientX": 0,
-                "clientY": 0,
-                "altKey": bool(modifiers & 1),
-                "ctrlKey": bool(modifiers & 2),
-                "metaKey": bool(modifiers & 4),
-                "shiftKey": bool(modifiers & 8),
-                "button": params["button"],
-                "bubbles": True,
-                "cancelable": False,
-            }
-            type_ = {"mousePressed": "click", "mouseReleased": "click", "mouseMoved": "mousemove"}[params["type"]]
-            event_params = json.dumps(event_params)
-            simulate_mouse_event = (
-                "function simulateMouseEvent(type){"
-                f"const element = document.elementFromPoint({x}, {y});"
-                f"const e = new MouseEvent(type, JSON.parse('{event_params}'));"
-                "element.dispatchEvent(e);"
-                "element.focus();"
-                "return e;}"
+            x, y = int(params["x"] // scale), int(params["y"] // scale)
+            type_ = {"mousePressed": "click", "mouseMoved": "mousemove"}[params["type"]]
+            await self._synthesize_mouse_event(type_, x, y, params["modifiers"], params["button"])
+
+        await self._simple_response(message, None)
+
+    async def _input_dispatch_mouse_event(self, message: dict[str, Any]):
+        """
+        Modern DevTools drives the screencast with Input.dispatchMouseEvent (the legacy
+        Input.emulateTouchFromMouseEvent is no longer sent); WebKit has no Input domain,
+        so synthesize the events in-page like the legacy handler does.
+        """
+        params = message["params"]
+        scale = self._screencast_scale()
+        type_ = params["type"]
+        if type_ == "mouseWheel":
+            delta_x, delta_y = params.get("deltaX", 0) // scale, params.get("deltaY", 0) // scale
+            await self.evaluate_and_result(f"window.scrollBy({-delta_x}, {-delta_y})")
+        elif type_ in ("mousePressed", "mouseMoved"):
+            x, y = int(params["x"] // scale), int(params["y"] // scale)
+            button = {"none": 0, "left": 0, "middle": 1, "right": 2, "back": 3, "forward": 4}.get(
+                params.get("button", "none"), 0
             )
-            await self.evaluate_and_result(message["id"], f'({simulate_mouse_event})("{type_}")')
-            if type_ == "click":
-                await self.evaluate_and_result(message["id"], f'({simulate_mouse_event})("mouseup")')
+            js_type = "click" if type_ == "mousePressed" else "mousemove"
+            await self._synthesize_mouse_event(js_type, x, y, params.get("modifiers", 0), button)
 
         await self._simple_response(message, None)
 
@@ -592,31 +772,39 @@ class CdpTarget:
             f"{manipulation}"
             "}"
         )
-        await self.evaluate_and_result(message["id"], simulate_key_event)
+        await self.evaluate_and_result(simulate_key_event)
         await self._simple_response(message, None)
 
     async def _target_created(self, message: dict[str, Any]):
+        # These handlers run inside the receive loop; a device round-trip here (the old code
+        # evaluated document.title/location.href) blocks delivery of every other event for the
+        # whole session, and while a freshly navigated page is still loading it blocks until the
+        # timeout. Rapid link navigation stacks those blocks until the session never catches up.
+        # So emit a non-blocking, schema-complete targetInfo (a partial one crashes the frontend
+        # SDK); the real url arrives via the device's own Page.frameNavigated.
         self.target_id = message["params"]["targetInfo"]["targetId"]
-        message["method"] = "Target.targetInfoChanged"
-        message["params"]["targetInfo"]["url"] = await self.evaluate_and_result(1, "window.location.href")
-        message["params"]["targetInfo"]["title"] = await self.evaluate_and_result(1, "document.title")
-        message["params"]["targetInfo"]["attached"] = message["params"]["targetInfo"].pop("isProvisional")
-        await self.output_queue.put(message)
-
-    async def _target_destroyed(self, message: dict[str, Any]):
-        result = await self.send_message_with_result(1, "Page.getResourceTree", {})
-        self.frame = result["result"]["frameTree"]["frame"]
         await self.output_queue.put({
-            "method": "Page.frameNavigated",
+            "method": "Target.targetInfoChanged",
             "params": {
-                "frame": self.frame,
+                "targetInfo": {
+                    "targetId": self.target_id,
+                    "type": "page",
+                    "title": "",
+                    "url": self.frame.get("url", ""),
+                    "attached": True,
+                    "canAccessOpener": False,
+                }
             },
         })
+
+    async def _target_destroyed(self, message: dict[str, Any]):
+        # The device emits its own Page.frameNavigated for the new page, so no getResourceTree
+        # round-trip is needed (and must not be done here - see _target_created). Just nudge the
+        # frontend that the load finished and the document changed.
         await self.output_queue.put({
             "method": "Page.loadEventFired",
-            "params": {
-                "timestamp": datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f"),
-            },
+            # MonotonicTime, in seconds - not a formatted string
+            "params": {"timestamp": datetime.now().timestamp()},
         })
         await self.output_queue.put({"method": "DOM.documentUpdated"})
 
@@ -628,7 +816,7 @@ class CdpTarget:
             await self.to_cdp_special_dispatched_messages_methods[message["method"]](message)
         else:
             if "method" in message:
-                logger.debug("DISPACHING", message["method"])
+                logger.debug(f"Dispatching: {message['method']}")
             await self.output_queue.put(message)
 
     async def _target_did_commit_provisional_target(self, message: dict[str, Any]):
@@ -639,15 +827,20 @@ class CdpTarget:
             await self.output_queue.put(message)
 
     async def _debugger_script_failed_to_parse(self, message: dict[str, Any]):
+        # The failing source is only known from Runtime.compileScript; parse failures of other
+        # evaluations (e.g. the console's eager previews) fall back to the default context.
+        context_id = self._script_source_to_context_id.get(
+            message["params"].get("scriptSource", ""), self._default_execution_id
+        )
         message["params"] = {
             "endColumn": 0,
-            "endLine": message["params"]["errorLine"],
-            "executionContextId": self._script_source_to_context_id[message["params"]["scriptSource"]],
+            "endLine": message["params"].get("errorLine", 0),
+            "executionContextId": context_id,
             "startColumn": 0,
-            "startLine": message["params"]["startLine"],
-            "url": message["params"]["url"],
-            "scriptId": self._script_source_to_context_id[message["params"]["scriptSource"]],
-            "hash": hashlib.sha1(message["params"]["scriptSource"]).hexdigest(),
+            "startLine": message["params"].get("startLine", 0),
+            "url": message["params"].get("url", ""),
+            "scriptId": context_id,
+            "hash": hashlib.sha1(message["params"].get("scriptSource", "").encode()).hexdigest(),
         }
         await self.output_queue.put(message)
 
@@ -658,37 +851,80 @@ class CdpTarget:
         await self.output_queue.put(message)
 
     async def _debugger_global_object_cleared(self, message: dict[str, Any]):
+        await self.output_queue.put({"method": "Runtime.executionContextsCleared"})
         await self.output_queue.put({"method": "DOM.documentUpdated"})
 
     async def _page_default_appearance_did_change(self, message: dict[str, Any]):
         pass
 
     async def _runtime_execution_context_created(self, message: dict[str, Any]):
-        if message["params"]["context"]["type"] == "normal":
-            self._default_execution_id = message["params"]["context"]["id"]
+        context = message["params"]["context"]
+        # WebKit announces a context per isolated world (and per inspector evaluation batch);
+        # forwarding them all with a shared uniqueId makes Chrome's RuntimeModel treat each as
+        # a replacement of the selected console context, and pending evaluations lose their
+        # results depending on timing. Only the main-world context is forwarded.
+        if context["type"] != "normal":
+            return
+        self._default_execution_id = context["id"]
         message["params"] = {
             "context": {
-                "id": message["params"]["context"]["id"],
+                "id": context["id"],
                 "origin": "default",
                 "name": "",
-                "uniqueId": message["params"]["context"]["frameId"],
+                # must be unique per context - Chrome keys contexts by it
+                "uniqueId": f"{context['frameId']}.{context['id']}",
             }
         }
         await self.output_queue.put(message)
 
+    async def _console_message_repeat_count_updated(self, message: dict[str, Any]):
+        """
+        WebKit coalesces repeated identical console messages into a repeat-count update; Chrome
+        has no such event, so replay the last console-API message and let the frontend coalesce.
+        """
+        if self._last_console_api_call is not None:
+            params = dict(self._last_console_api_call)
+            params["timestamp"] = datetime.now().timestamp() * 1000
+            await self.output_queue.put({"method": "Runtime.consoleAPICalled", "params": params})
+
     async def _console_message_added(self, message: dict[str, Any]):
+        console_message = message["params"]["message"]
+        # Chrome renders console-API output (console.log & friends) from Runtime.consoleAPICalled,
+        # complete with the argument objects; Log.entryAdded is only for browser-generated logs.
+        if console_message["source"] == "console-api":
+            args: list[dict[str, Any]] = console_message.get("parameters")
+            if not args:
+                args = [{"type": "string", "value": console_message.get("text", "")}]
+            type_ = console_message.get("type", "log")
+            if type_ == "log":
+                # WebKit reports console.error/info/warn as type "log" with a level; Chrome
+                # renders by the consoleAPICalled type.
+                type_ = {"warning": "warning", "error": "error", "info": "info", "debug": "debug"}.get(
+                    console_message.get("level", "log"), "log"
+                )
+            params: dict[str, Any] = {
+                "type": type_,
+                "args": args,
+                "executionContextId": self._default_execution_id,
+                # Runtime.Timestamp is in milliseconds
+                "timestamp": datetime.now().timestamp() * 1000,
+            }
+            self._last_console_api_call = params
+            await self.output_queue.put({"method": "Runtime.consoleAPICalled", "params": params})
+            return
         log_record: dict[str, Any] = {
-            "source": LOG_MESSAGE_SOURCES[message["params"]["message"]["source"]],
-            "level": LOG_MESSAGE_LEVELS[message["params"]["message"]["level"]],
-            "text": message["params"]["message"]["text"],
-            "timestamp": datetime.now().timestamp(),
+            "source": LOG_MESSAGE_SOURCES[console_message["source"]],
+            "level": LOG_MESSAGE_LEVELS[console_message["level"]],
+            "text": console_message["text"],
+            # Log.LogEntry.timestamp is in milliseconds; seconds sort the entry into 1970
+            "timestamp": datetime.now().timestamp() * 1000,
         }
-        if "url" in message["params"]["message"]:
-            log_record["url"] = message["params"]["message"]["url"]
-        if "line" in message["params"]["message"]:
-            log_record["lineNumber"] = message["params"]["message"]["line"]
-        if "networkRequestId" in message["params"]["message"]:
-            log_record["networkRequestId"] = message["params"]["message"]["networkRequestId"]
+        if "url" in console_message:
+            log_record["url"] = console_message["url"]
+        if "line" in console_message:
+            log_record["lineNumber"] = console_message["line"]
+        if "networkRequestId" in console_message:
+            log_record["networkRequestId"] = console_message["networkRequestId"]
 
         await self.output_queue.put({"method": "Log.entryAdded", "params": {"entry": log_record}})
 

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -334,6 +334,18 @@ class WebinspectorService(LockdownService):
         """
         await self._forward_socket_setup(session_id, app_id, page_id, pause=False)
 
+    async def teardown_inspector_socket(self, session_id: str, app_id: str, page_id: int):
+        """Tear down a forwarding socket previously set up for an inspector session.
+
+        Without this, webinspectord considers the session still active and ignores the next
+        socket setup for the same page, so a future session never receives its target events.
+
+        :param session_id: The session identifier the socket was associated with.
+        :param app_id: The target application identifier.
+        :param page_id: The target page identifier.
+        """
+        await self._forward_did_close(session_id, app_id, page_id)
+
     def find_page_id(self, page_id: str) -> tuple[Application, Page]:
         """Look up the application and page for a known page identifier.
 
@@ -452,6 +464,16 @@ class WebinspectorService(LockdownService):
                 "WIRSessionIdentifierKey": session_id,
                 "WIRSenderKey": session_id,
                 "WIRSocketDataKey": json.dumps(data).encode(),
+            },
+        )
+
+    async def _forward_did_close(self, session_id: str, app_id: str, page_id: int):
+        await self._send_message(
+            "_rpc_forwardDidClose:",
+            {
+                "WIRApplicationIdentifierKey": app_id,
+                "WIRPageIdentifierKey": page_id,
+                "WIRSenderKey": session_id,
             },
         )
 

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -1,0 +1,133 @@
+import asyncio
+import json
+from typing import Any, Optional
+
+import pytest
+import uvicorn
+from wsproto import ConnectionType, WSConnection
+from wsproto.events import AcceptConnection, CloseConnection, TextMessage
+from wsproto.events import Request as WsRequest
+
+from pymobiledevice3.exceptions import WebInspectorNotEnabledError
+from pymobiledevice3.lockdown import LockdownClient
+from pymobiledevice3.services.web_protocol.cdp_server import app
+from pymobiledevice3.services.webinspector import SAFARI, WebinspectorService
+
+TIMEOUT = 30
+
+
+async def http_get_json(port: int, path: str) -> Any:
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        writer.write(f"GET {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n".encode())
+        await writer.drain()
+        response = await reader.read()
+    finally:
+        writer.close()
+        await writer.wait_closed()
+    headers, _, body = response.partition(b"\r\n\r\n")
+    assert headers.split(b" ", 2)[1] == b"200"
+    return json.loads(body)
+
+
+class CdpWebsocketClient:
+    def __init__(self, port: int, page_id: str) -> None:
+        self.port = port
+        self.page_id = page_id
+        self.ws = WSConnection(ConnectionType.CLIENT)
+        self.reader: Optional[asyncio.StreamReader] = None
+        self.writer: Optional[asyncio.StreamWriter] = None
+
+    async def connect(self) -> None:
+        self.reader, self.writer = await asyncio.open_connection("127.0.0.1", self.port)
+        self.writer.write(
+            self.ws.send(WsRequest(host=f"127.0.0.1:{self.port}", target=f"/devtools/page/{self.page_id}"))
+        )
+        await self.writer.drain()
+        assert isinstance(await self._next_event(), AcceptConnection)
+
+    async def close(self) -> None:
+        assert self.writer is not None
+        self.writer.close()
+        await self.writer.wait_closed()
+
+    async def send(self, message: dict[str, Any]) -> None:
+        assert self.writer is not None
+        self.writer.write(self.ws.send(TextMessage(data=json.dumps(message))))
+        await self.writer.drain()
+
+    async def receive(self) -> dict[str, Any]:
+        text = ""
+        while True:
+            event = await self._next_event()
+            assert not isinstance(event, CloseConnection)
+            if isinstance(event, TextMessage):
+                text += event.data
+                if event.message_finished:
+                    return json.loads(text)
+
+    async def _next_event(self) -> Any:
+        assert self.reader is not None
+        while True:
+            for event in self.ws.events():
+                return event
+            self.ws.receive_data(await self.reader.read(4096))
+
+
+async def testp_cdp_server_end_to_end(lockdown: LockdownClient) -> None:
+    inspector = WebinspectorService(lockdown=lockdown)
+    try:
+        await inspector.connect()
+    except WebInspectorNotEnabledError:
+        pytest.xfail("Web Inspector is disabled on the device")
+    app.state.inspector = inspector
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=0, ws="wsproto"))
+    serve_task = asyncio.create_task(server.serve())
+    try:
+        while not server.started:
+            assert not serve_task.done()
+            await asyncio.sleep(0.1)
+        port = server.servers[0].sockets[0].getsockname()[1]
+
+        version = await http_get_json(port, "/json/version")
+        # /json/version must not be shadowed by the /json targets catch-all
+        assert version["Browser"] == "Safari"
+        assert f"ws://127.0.0.1:{port}/devtools/browser/" in version["webSocketDebuggerUrl"]
+
+        await inspector.open_app(SAFARI)
+        targets = []
+        for _ in range(TIMEOUT):
+            targets = await http_get_json(port, "/json/list")
+            if targets:
+                break
+            await asyncio.sleep(1)
+        assert targets, "no inspectable Safari page was listed"
+        assert targets[0]["webSocketDebuggerUrl"] == f"ws://127.0.0.1:{port}/devtools/page/{targets[0]['id']}"
+
+        async def evaluate_in_new_session() -> None:
+            client = CdpWebsocketClient(port, targets[0]["id"])
+            await asyncio.wait_for(client.connect(), TIMEOUT)
+            try:
+                await client.send({"id": 1, "method": "Runtime.evaluate", "params": {"expression": "40+2"}})
+
+                async def wait_for_result() -> dict[str, Any]:
+                    while True:
+                        message = await client.receive()
+                        if message.get("id") == 1:
+                            return message
+
+                result = await asyncio.wait_for(wait_for_result(), TIMEOUT)
+                assert result["result"]["result"]["value"] == 42
+            finally:
+                await client.close()
+
+        # Two sequential sessions: the second verifies the WIR socket teardown on disconnect,
+        # without which webinspectord never delivers target events to a reconnecting client.
+        await evaluate_in_new_session()
+        await evaluate_in_new_session()
+    finally:
+        # force_exit skips uvicorn's graceful wait so a wedged debugger session can't hang the test
+        server.should_exit = True
+        server.force_exit = True
+        await asyncio.wait_for(serve_task, TIMEOUT)
+        await inspector.close()

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -37,6 +37,7 @@ class CdpWebsocketClient:
         self.ws = WSConnection(ConnectionType.CLIENT)
         self.reader: Optional[asyncio.StreamReader] = None
         self.writer: Optional[asyncio.StreamWriter] = None
+        self.seen_events: set[str] = set()
 
     async def connect(self) -> None:
         self.reader, self.writer = await asyncio.open_connection("127.0.0.1", self.port)
@@ -64,7 +65,22 @@ class CdpWebsocketClient:
             if isinstance(event, TextMessage):
                 text += event.data
                 if event.message_finished:
-                    return json.loads(text)
+                    message = json.loads(text)
+                    if "method" in message:
+                        self.seen_events.add(message["method"])
+                    return message
+
+    async def command(self, id_: int, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Send a request and wait for its response; a lost response fails the test by timeout."""
+        await self.send({"id": id_, "method": method, "params": params})
+
+        async def wait_for_response() -> dict[str, Any]:
+            while True:
+                message = await self.receive()
+                if message.get("id") == id_:
+                    return message
+
+        return await asyncio.wait_for(wait_for_response(), TIMEOUT)
 
     async def _next_event(self) -> Any:
         assert self.reader is not None
@@ -125,6 +141,76 @@ async def testp_cdp_server_end_to_end(lockdown: LockdownClient) -> None:
         # without which webinspectord never delivers target events to a reconnecting client.
         await evaluate_in_new_session()
         await evaluate_in_new_session()
+    finally:
+        # force_exit skips uvicorn's graceful wait so a wedged debugger session can't hang the test
+        server.should_exit = True
+        server.force_exit = True
+        await asyncio.wait_for(serve_task, TIMEOUT)
+        await inspector.close()
+
+
+async def testp_cdp_server_survives_process_swaps(lockdown: LockdownClient) -> None:
+    """
+    Cross-origin navigation swaps the page's WebContent process: WebKit destroys the inspector
+    target and creates a fresh one with all agents disabled. The bridge must keep answering
+    requests (synthesizing errors for those the dead target swallowed) and re-establish the
+    frontend's domain setup on the new target, or DevTools goes silent after a couple of clicks.
+    """
+    inspector = WebinspectorService(lockdown=lockdown)
+    try:
+        await inspector.connect()
+    except WebInspectorNotEnabledError:
+        pytest.xfail("Web Inspector is disabled on the device")
+    app.state.inspector = inspector
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=0, ws="wsproto"))
+    serve_task = asyncio.create_task(server.serve())
+    try:
+        while not server.started:
+            assert not serve_task.done()
+            await asyncio.sleep(0.1)
+        port = server.servers[0].sockets[0].getsockname()[1]
+        await inspector.open_app(SAFARI)
+        targets = []
+        for _ in range(TIMEOUT):
+            targets = await http_get_json(port, "/json/list")
+            if targets:
+                break
+            await asyncio.sleep(1)
+        assert targets, "no inspectable Safari page was listed"
+
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        try:
+            id_ = 0
+            for method in ("Page.enable", "Runtime.enable", "Network.enable"):
+                id_ += 1
+                await client.command(id_, method, {})
+            # Two distinct origins guarantee at least one process swap wherever Safari starts.
+            for url, host in (("https://example.com/", "example.com"), ("https://www.apple.com/", "apple.com")):
+                id_ += 1
+                await client.command(id_, "Page.navigate", {"url": url})
+                client.seen_events.clear()
+                reached = False
+                for _ in range(TIMEOUT):
+                    id_ += 1
+                    # Never retried: any response (even an error, for a request the swap
+                    # swallowed) is fine, a lost response times the test out.
+                    response = await client.command(
+                        id_, "Runtime.evaluate", {"expression": "location.href", "returnByValue": True}
+                    )
+                    if host in response.get("result", {}).get("result", {}).get("value", ""):
+                        reached = True
+                    # Network events of the fresh document prove the bridge re-enabled the
+                    # domains on the swapped-in target; without that DevTools shows nothing.
+                    if reached and "Network.requestWillBeSent" in client.seen_events:
+                        break
+                    await asyncio.sleep(1)
+                assert reached, f"never reached {host} over the bridge"
+                assert "Network.requestWillBeSent" in client.seen_events, (
+                    f"no network events for the {host} load - domains were not re-enabled after the swap"
+                )
+        finally:
+            await client.close()
     finally:
         # force_exit skips uvicorn's graceful wait so a wedged debugger session can't hang the test
         server.should_exit = True

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -1,5 +1,8 @@
 import asyncio
+import itertools
 import json
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import Any, Optional
 
 import pytest
@@ -14,6 +17,41 @@ from pymobiledevice3.services.web_protocol.cdp_server import app
 from pymobiledevice3.services.webinspector import SAFARI, WebinspectorService
 
 TIMEOUT = 30
+
+
+@asynccontextmanager
+async def cdp_server_with_safari_page(
+    lockdown: LockdownClient,
+) -> AsyncGenerator[tuple[int, list[dict[str, Any]]], None]:
+    """Run the CDP server against the device and yield (port, listed Safari targets)."""
+    inspector = WebinspectorService(lockdown=lockdown)
+    try:
+        await inspector.connect()
+    except WebInspectorNotEnabledError:
+        pytest.xfail("Web Inspector is disabled on the device")
+    app.state.inspector = inspector
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=0, ws="wsproto"))
+    serve_task = asyncio.create_task(server.serve())
+    try:
+        while not server.started:
+            assert not serve_task.done()
+            await asyncio.sleep(0.1)
+        port = server.servers[0].sockets[0].getsockname()[1]
+        await inspector.open_app(SAFARI)
+        targets = []
+        for _ in range(TIMEOUT):
+            targets = await http_get_json(port, "/json/list")
+            if targets:
+                break
+            await asyncio.sleep(1)
+        assert targets, "no inspectable Safari page was listed"
+        yield port, targets
+    finally:
+        # force_exit skips uvicorn's graceful wait so a wedged debugger session can't hang the test
+        server.should_exit = True
+        server.force_exit = True
+        await asyncio.wait_for(serve_task, TIMEOUT)
+        await inspector.close()
 
 
 async def http_get_json(port: int, path: str) -> Any:
@@ -91,48 +129,18 @@ class CdpWebsocketClient:
 
 
 async def testp_cdp_server_end_to_end(lockdown: LockdownClient) -> None:
-    inspector = WebinspectorService(lockdown=lockdown)
-    try:
-        await inspector.connect()
-    except WebInspectorNotEnabledError:
-        pytest.xfail("Web Inspector is disabled on the device")
-    app.state.inspector = inspector
-    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=0, ws="wsproto"))
-    serve_task = asyncio.create_task(server.serve())
-    try:
-        while not server.started:
-            assert not serve_task.done()
-            await asyncio.sleep(0.1)
-        port = server.servers[0].sockets[0].getsockname()[1]
-
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
         version = await http_get_json(port, "/json/version")
         # /json/version must not be shadowed by the /json targets catch-all
         assert version["Browser"] == "Safari"
         assert f"ws://127.0.0.1:{port}/devtools/browser/" in version["webSocketDebuggerUrl"]
-
-        await inspector.open_app(SAFARI)
-        targets = []
-        for _ in range(TIMEOUT):
-            targets = await http_get_json(port, "/json/list")
-            if targets:
-                break
-            await asyncio.sleep(1)
-        assert targets, "no inspectable Safari page was listed"
         assert targets[0]["webSocketDebuggerUrl"] == f"ws://127.0.0.1:{port}/devtools/page/{targets[0]['id']}"
 
         async def evaluate_in_new_session() -> None:
             client = CdpWebsocketClient(port, targets[0]["id"])
             await asyncio.wait_for(client.connect(), TIMEOUT)
             try:
-                await client.send({"id": 1, "method": "Runtime.evaluate", "params": {"expression": "40+2"}})
-
-                async def wait_for_result() -> dict[str, Any]:
-                    while True:
-                        message = await client.receive()
-                        if message.get("id") == 1:
-                            return message
-
-                result = await asyncio.wait_for(wait_for_result(), TIMEOUT)
+                result = await client.command(1, "Runtime.evaluate", {"expression": "40+2"})
                 assert result["result"]["result"]["value"] == 42
             finally:
                 await client.close()
@@ -141,12 +149,6 @@ async def testp_cdp_server_end_to_end(lockdown: LockdownClient) -> None:
         # without which webinspectord never delivers target events to a reconnecting client.
         await evaluate_in_new_session()
         await evaluate_in_new_session()
-    finally:
-        # force_exit skips uvicorn's graceful wait so a wedged debugger session can't hang the test
-        server.should_exit = True
-        server.force_exit = True
-        await asyncio.wait_for(serve_task, TIMEOUT)
-        await inspector.close()
 
 
 async def testp_cdp_server_survives_process_swaps(lockdown: LockdownClient) -> None:
@@ -156,28 +158,7 @@ async def testp_cdp_server_survives_process_swaps(lockdown: LockdownClient) -> N
     requests (synthesizing errors for those the dead target swallowed) and re-establish the
     frontend's domain setup on the new target, or DevTools goes silent after a couple of clicks.
     """
-    inspector = WebinspectorService(lockdown=lockdown)
-    try:
-        await inspector.connect()
-    except WebInspectorNotEnabledError:
-        pytest.xfail("Web Inspector is disabled on the device")
-    app.state.inspector = inspector
-    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=0, ws="wsproto"))
-    serve_task = asyncio.create_task(server.serve())
-    try:
-        while not server.started:
-            assert not serve_task.done()
-            await asyncio.sleep(0.1)
-        port = server.servers[0].sockets[0].getsockname()[1]
-        await inspector.open_app(SAFARI)
-        targets = []
-        for _ in range(TIMEOUT):
-            targets = await http_get_json(port, "/json/list")
-            if targets:
-                break
-            await asyncio.sleep(1)
-        assert targets, "no inspectable Safari page was listed"
-
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
         client = CdpWebsocketClient(port, targets[0]["id"])
         await asyncio.wait_for(client.connect(), TIMEOUT)
         try:
@@ -211,9 +192,136 @@ async def testp_cdp_server_survives_process_swaps(lockdown: LockdownClient) -> N
                 )
         finally:
             await client.close()
-    finally:
-        # force_exit skips uvicorn's graceful wait so a wedged debugger session can't hang the test
-        server.should_exit = True
-        server.force_exit = True
-        await asyncio.wait_for(serve_task, TIMEOUT)
-        await inspector.close()
+
+
+async def testp_cdp_server_screencast_survives_navigation(lockdown: LockdownClient) -> None:
+    """
+    The screencast must keep producing frames across navigations. A snapshot request lost to a
+    process swap used to burn a frame id that was never sent to DevTools; the ack for it never
+    arrived, and the screen stayed frozen for the rest of the session.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        try:
+            message_ids = itertools.count(1)
+
+            async def receive_acking() -> dict[str, Any]:
+                """Receive one message, acking screencast frames like DevTools does."""
+                message = await client.receive()
+                if message.get("method") == "Page.screencastFrame":
+                    await client.send({
+                        "id": next(message_ids),
+                        "method": "Page.screencastFrameAck",
+                        "params": {"sessionId": message["params"]["sessionId"]},
+                    })
+                return message
+
+            async def command(method: str, params: dict[str, Any]) -> dict[str, Any]:
+                id_ = next(message_ids)
+                await client.send({"id": id_, "method": method, "params": params})
+
+                async def wait_for_response() -> dict[str, Any]:
+                    while True:
+                        message = await receive_acking()
+                        if message.get("id") == id_:
+                            return message
+
+                return await asyncio.wait_for(wait_for_response(), TIMEOUT)
+
+            async def wait_for_frame() -> None:
+                async def next_frame() -> None:
+                    while True:
+                        if (await receive_acking()).get("method") == "Page.screencastFrame":
+                            return
+
+                await asyncio.wait_for(next_frame(), TIMEOUT)
+
+            await command("Page.enable", {})
+            await command("Runtime.enable", {})
+            await command("Page.startScreencast", {"format": "jpeg", "quality": 60, "maxWidth": 480, "maxHeight": 960})
+            await wait_for_frame()
+            # Alternating origins force process swaps; frames must keep arriving through every
+            # navigation. Several rounds because the frozen-screen regression this guards (a
+            # snapshot lost mid-swap burning an id DevTools can never ack) is timing-dependent.
+            for url in ("https://example.com/", "https://www.apple.com/") * 2:
+                await command("Page.navigate", {"url": url})
+                await wait_for_frame()
+        finally:
+            await client.close()
+
+
+async def testp_cdp_server_keyboard_input_submits_forms(lockdown: LockdownClient) -> None:
+    """
+    Screencast typing arrives as Input.dispatchKeyEvent; WebKit has no Input domain, so the
+    bridge synthesizes the effects in-page. Return must both fire real key events (pages like
+    google submit from their own keydown listener on a <textarea>) and fall back to submitting
+    the active element's form, or "type a search and hit return" does nothing.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        try:
+            message_ids = itertools.count(1)
+
+            async def command(method: str, params: dict[str, Any]) -> dict[str, Any]:
+                return await client.command(next(message_ids), method, params)
+
+            async def evaluate(expression: str) -> Any:
+                response = await command("Runtime.evaluate", {"expression": expression, "returnByValue": True})
+                return response.get("result", {}).get("result", {}).get("value")
+
+            await command("Page.enable", {})
+            await command("Runtime.enable", {})
+            await command("Page.navigate", {"url": "https://example.com/"})
+            for _ in range(TIMEOUT):
+                href = await evaluate("location.href")
+                if (
+                    isinstance(href, str)
+                    and href.rstrip("/").endswith("example.com")
+                    and (await evaluate("document.readyState") in ("interactive", "complete"))
+                ):
+                    break
+                await asyncio.sleep(1)
+
+            async def type_and_submit(text: str, expected_path: str) -> None:
+                for char in text:
+                    await command("Input.dispatchKeyEvent", {"type": "char", "text": char, "key": char})
+                assert await evaluate("document.activeElement.value") == text
+                await command("Input.dispatchKeyEvent", {"type": "char", "text": "\r", "key": "Enter"})
+                href = None
+                for _ in range(TIMEOUT):
+                    href = await evaluate("location.href")
+                    if isinstance(href, str) and f"{expected_path}?q={text}" in href:
+                        return
+                    await asyncio.sleep(1)
+                raise AssertionError(f"return did not reach {expected_path} (still on {href!r})")
+
+            # google-style: a <textarea> whose Enter handling lives in the page's own keydown
+            # listener - the bridge must dispatch real key events for it to fire at all.
+            assert await evaluate(
+                "(() => {"
+                "    document.body.innerHTML = '<textarea id=\"q\"></textarea>';"
+                "    const box = document.getElementById('q');"
+                "    box.addEventListener('keydown', (event) => {"
+                "        if (event.key !== 'Enter') { return; }"
+                "        event.preventDefault();"
+                "        location.assign('/handled?q=' + box.value);"
+                "    });"
+                "    box.focus();"
+                "    return document.activeElement === box;"
+                "})()"
+            ), "could not focus the injected textarea"
+            await type_and_submit("hello", "/handled")
+
+            # default-action fallback: no page handler, Enter submits the ancestor form
+            assert await evaluate(
+                "(() => {"
+                '    document.body.innerHTML = \'<form action="/fallback"><input name="q"></form>\';'
+                "    document.querySelector('input').focus();"
+                "    return document.activeElement === document.querySelector('input');"
+                "})()"
+            ), "could not focus the injected form input"
+            await type_and_submit("world", "/fallback")
+        finally:
+            await client.close()


### PR DESCRIPTION
## What

`pymobiledevice3 webinspector cdp` was fully broken: it crashed on startup, and after fixing that, current Chrome's `chrome://inspect` could discover targets but never get a working DevTools session.

Fixes, in dependency order:

- **cli**: `uvicorn.run()` calls `asyncio.run()`, which raises `RuntimeError` inside the `@async_command` event loop (regressed in the usbmux/lockdown asyncio migration, 4f12a36c). Now served via `uvicorn.Server(...).serve()` on the running loop.
- **/json/version shadowed**: the `/json{path}` targets catch-all was registered first and swallowed `/json/version`, so Chrome never got the browser descriptor.
- **empty target list**: the targets endpoint called the now-async `get_open_pages()` without awaiting it, so `application_pages` never populated.
- **websocket handshake stall**: the connection was `accept()`ed only after `CdpTarget.create()` finished the device-side WIR socket setup; DevTools gives up before that. Accept now happens first.
- **session leak**: a disconnected client left `CdpTarget`'s queue-consumer tasks running, silently draining `wir_events` for every subsequent connection (second `inspect` click never worked). Added `CdpTarget.close()` + teardown on disconnect.
- **URLs**: `webSocketDebuggerUrl`/`devtoolsFrontendUrl` now derive from the request `Host` header instead of hardcoded `localhost:9222` (fixes `--host`/`--port` overrides), and the frontend URL uses the standard `?ws=` form.
- **logging crashes**: `logger.debug('msg', arg)` positional misuse blew up the logging module under `-v`.

## Testing

Verified end-to-end against a physical device (iPhone18,4, iOS 27.0 beta) with Chrome 150 driving `chrome://inspect/#devices`: target discovery, plain **inspect** click, Elements/Styles/screencast all functional; traffic capture shows all 161 commands of the DevTools init burst answered.

Added `testp_cdp_server_end_to_end`: runs the FastAPI app on an ephemeral port against the real device, asserts `/json/version` is not shadowed, target listing populates, and a `Runtime.evaluate` round-trips over the page websocket (passes 3/3 locally).

`pyright` clean; `ruff` clean.