### PR TITLE
Sign keybag challenges as binary

### DIFF
--- a/pymobiledevice3/services/mobile_config.py
+++ b/pymobiledevice3/services/mobile_config.py
@@ -9,7 +9,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.hazmat.primitives.serialization import Encoding
-from cryptography.hazmat.primitives.serialization.pkcs7 import PKCS7SignatureBuilder
+from cryptography.hazmat.primitives.serialization.pkcs7 import PKCS7Options, PKCS7SignatureBuilder
 
 from pymobiledevice3.exceptions import CloudConfigurationAlreadyPresentError, ConnectionTerminatedError, ProfileError
 from pymobiledevice3.lockdown import LockdownClient
@@ -80,7 +80,7 @@ class MobileConfigService(LockdownService):
             PKCS7SignatureBuilder()
             .set_data(escalate_response["Challenge"])
             .add_signer(cer, private_key, hashes.SHA256())
-            .sign(Encoding.DER, [])
+            .sign(Encoding.DER, [PKCS7Options.Binary])
         )
         await self._send_recv({"RequestType": "EscalateResponse", "SignedRequest": signed_challenge})
         await self._send_recv({"RequestType": "ProceedWithKeybagMigration"})


### PR DESCRIPTION
## Summary

Fixes #1805.

See 361eae79a4e7c8660020b5934dd499c17589cae4 for similar fix for pairing.

When signing the challenge using pyca/cryptography, S/MIME text canonicalization is applied by default. This causes intermittent failures (approx. 8%). Use PKCS7Options.Binary to mark it as binary.

## Testing

`pymobiledevice3 profile install --keybag ...`

## AI Assistance

Claude Opus 4.8
