### PR TITLE
tests: Skip RSD-only service tests when no tunnel is present

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Generator
 from typing import Any, Union
 
 import pytest
@@ -37,6 +37,26 @@ def pytest_addoption(parser):
 
 
 NO_DEVICE_SKIP_REASON = "No test device is available through usbmuxd"
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_call(item: pytest.Item) -> Generator[None, object, object]:
+    """
+    Skip tests that fail solely because an RSD-only service was used without a tunnel.
+
+    iOS 17+ exposes many developer/instruments/relay services only through an RSD
+    tunnel. When the suite runs over plain usbmux (no ``--rsd``/``--tunnel``), starting
+    such a service raises ``InvalidServiceError``; treat that as a skip. If we are already
+    connected through a tunnel, re-raise so genuine regressions still surface.
+    """
+    try:
+        return (yield)
+    except InvalidServiceError as e:
+        funcargs = item.funcargs if isinstance(item, pytest.Function) else {}
+        provider = funcargs.get("service_provider") or funcargs.get("lockdown")
+        if isinstance(provider, RemoteServiceDiscoveryService):
+            raise
+        pytest.skip(f"Service requires an RSD tunnel (rerun with --rsd/--tunnel): {e}")
 
 
 async def _create_usbmux_client() -> UsbmuxLockdownClient:


### PR DESCRIPTION
## Summary

When the test suite runs against a real device over plain `usbmux` (no `--rsd`/`--tunnel`), a large number of service tests **fail or error** with `InvalidServiceError` instead of being **skipped**. On iOS 17+, many developer/instruments/relay services are only reachable through an RSD tunnel, so starting them over a classic lockdown/usbmux connection is expected to fail.

The `dvt` and `xcuitest_service` fixtures already convert `InvalidServiceError` into a skip, but tests that instantiate services directly from the `lockdown`/`service_provider` fixtures (e.g. `AccessibilityAudit`, `Sysmontap`, `InstallationProxyService`) let the error propagate as a failure/error.

## Change

Add a suite-wide `pytest_runtest_call` wrapper in `tests/conftest.py` that converts an uncaught `InvalidServiceError` into a `pytest.skip(...)` — unless the active connection is a `RemoteServiceDiscoveryService` (i.e. an RSD tunnel), in which case it re-raises so genuine regressions on tunneled runs still fail. This generalizes the existing fixture-level skip behavior to every test without annotating each one.

## Testing

Against an iPhone (iOS 26.6) over plain usbmux:

- Before: previously-failing `InvalidServiceError` tests (e.g. `tests/services/test_accessibility.py`, `tests/cli/developer/dvt/sysmon/test_process.py`) reported failures/errors.
- After: the same tests report **skipped** (`7 skipped` across those two files).
- `ruff check` and `ruff format` (pinned hooks) pass on the touched file.
- `pyright 1.1.411 --venvpath .` reports **0 errors, 0 warnings** on `tests/conftest.py`.

## Notes

- `wrapper=True` requires pytest >= 8 (the project currently resolves pytest 9.x).
- The `tests/services/test_afc.py` failures observed in the same run are `AfcException` (live filesystem/device state), not `InvalidServiceError`, and are intentionally **out of scope** here.

Related context: https://github.com/doronz88/pymobiledevice3/issues/1807

---
_Generated with the help of Warp. Conversation: https://app.warp.dev/conversation/8e4b2e69-7e65-4fbf-a219-754a2836d3d3_

Co-Authored-By: Oz <oz-agent@warp.dev>