### PR TITLE
windows: fix the proactor cli loop breaking the strip-ssl DTX handshake

### DIFF
--- a/pymobiledevice3/dtx_service_provider.py
+++ b/pymobiledevice3/dtx_service_provider.py
@@ -39,7 +39,6 @@ from typing_extensions import Self
 from pymobiledevice3.dtx import DTXConnection, DTXService
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
-from pymobiledevice3.service_connection import close_stream_writer
 
 
 class DtxServiceProvider:
@@ -199,35 +198,27 @@ class DtxServiceProvider:
         lockdown = self.lockdown
         attr = await lockdown.get_service_connection_attributes(service_name, False)
         svc = await lockdown.create_service_connection(attr["Port"])
-        await svc._ensure_started()
 
-        if attr.get("EnableServiceSSL", False):
+        if attr.get("EnableServiceSSL", False) and strip_ssl:
+            # Handshake before the socket is bound to the event loop: a stream transport would
+            # race the blocking handshake for the incoming bytes (the proactor loop on Windows
+            # pre-posts an overlapped recv that swallows the ServerHello, timing it out).
+            svc.setblocking(True)
             with lockdown.ssl_file() as f:  # type: ignore[attr-defined]
-                if strip_ssl:
-                    svc.setblocking(True)
-                    svc.ssl_start_sync(cast(str, f))
+                svc.ssl_start_sync(cast(str, f))
+            if svc.socket is not None and hasattr(svc.socket, "_sslobj"):
+                raw_socket: Optional[_socket.socket] = getattr(svc.socket, "_sock", None)
+                if raw_socket is None:
+                    raw_socket = _socket.socket(fileno=svc.socket.detach())
                 else:
-                    await svc.ssl_start(cast(str, f))
-
-        if (
-            strip_ssl
-            and attr.get("EnableServiceSSL", False)
-            and (svc.socket is not None and hasattr(svc.socket, "_sslobj"))
-        ):
-            old_writer = svc.writer
-            raw_socket: Optional[_socket.socket] = getattr(svc.socket, "_sock", None)
-            if raw_socket is None:
-                raw_socket = _socket.socket(fileno=svc.socket.detach())
-            else:
-                # `_sslobj` is a private attribute of ssl-wrapped sockets (guarded by hasattr above)
-                svc.socket._sslobj = None  # pyright: ignore[reportAttributeAccessIssue]
-            if old_writer is not None:
-                await close_stream_writer(old_writer)
-            svc.socket = raw_socket
-            svc.reader = None
-            svc.writer = None
-            svc.socket.setblocking(False)
-            await svc.start()
+                    # `_sslobj` is a private attribute of ssl-wrapped sockets (guarded by hasattr above)
+                    svc.socket._sslobj = None  # pyright: ignore[reportAttributeAccessIssue]
+                svc.socket = raw_socket
+            svc.setblocking(False)
+        elif attr.get("EnableServiceSSL", False):
+            await svc._ensure_started()
+            with lockdown.ssl_file() as f:  # type: ignore[attr-defined]
+                await svc.ssl_start(cast(str, f))
 
         reader, writer = await svc._ensure_started()
         return DTXConnection(reader, writer)

--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -457,10 +457,12 @@ class ServiceConnection:
         try:
             self.socket.settimeout(DEFAULT_SSL_HANDSHAKE_TIMEOUT)
             self.socket = self.create_ssl_context(certfile, keyfile=keyfile).wrap_socket(self.socket)
-        except OSError as e:
-            raise ConnectionTerminatedError() from e
-        finally:
             self.socket.settimeout(None)
+        except OSError as e:
+            # No timeout reset here: on handshake failure wrap_socket() has already detached
+            # (and closed) the underlying socket, so touching it raises EBADF/WinError 10038,
+            # masking the original error.
+            raise ConnectionTerminatedError() from e
 
     async def ssl_start(self, certfile: str, keyfile: Optional[str] = None) -> None:
         """

--- a/pymobiledevice3/utils.py
+++ b/pymobiledevice3/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 import traceback
 from collections.abc import Coroutine
 from functools import wraps
@@ -85,7 +86,15 @@ _ASYNCIO_LOOP: Optional[asyncio.AbstractEventLoop] = None
 def get_asyncio_loop() -> asyncio.AbstractEventLoop:
     global _ASYNCIO_LOOP
     if _ASYNCIO_LOOP is None or _ASYNCIO_LOOP.is_closed():
-        _ASYNCIO_LOOP = asyncio.new_event_loop()
+        if sys.platform == "win32":
+            # The proactor loop breaks blocking-socket operations performed while the socket
+            # is attached to a stream transport (its pre-posted overlapped recv consumes the
+            # bytes), e.g. the strip-ssl handshake in DTX services. The selector policy set in
+            # __main__ cannot cover this loop since it is created at import time, before that
+            # policy is applied. See https://github.com/doronz88/pymobiledevice3/issues/1217.
+            _ASYNCIO_LOOP = asyncio.SelectorEventLoop()
+        else:
+            _ASYNCIO_LOOP = asyncio.new_event_loop()
     return _ASYNCIO_LOOP
 
 

--- a/tests/test_service_connection.py
+++ b/tests/test_service_connection.py
@@ -1,9 +1,11 @@
 import asyncio
 import socket
+import ssl
 from typing import cast
 
 import pytest
 
+from pymobiledevice3.exceptions import ConnectionTerminatedError
 from pymobiledevice3.service_connection import ServiceConnection
 
 
@@ -42,3 +44,19 @@ async def test_service_connection_close_aborts_when_wait_closed_hangs(monkeypatc
     assert conn.reader is None
     assert conn.socket is None
     assert sock.fileno() == -1
+
+
+def test_ssl_start_sync_failure_raises_connection_terminated(monkeypatch):
+    # A failed handshake leaves the original socket detached by wrap_socket(); the error
+    # path must not touch it again (used to raise EBADF/WinError 10038, masking the error).
+    client, server = socket.socketpair()
+    server.close()
+    conn = ServiceConnection(client)
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    monkeypatch.setattr(ServiceConnection, "create_ssl_context", lambda self, certfile, keyfile=None: context)
+
+    with pytest.raises(ConnectionTerminatedError):
+        conn.ssl_start_sync("unused-certfile")


### PR DESCRIPTION
## Summary

Fixes #1810 (`accessibility list-items` failing on Windows with `TimeoutError` → `WinError 10038`).

Three distinct bugs stacked up:

1. **The CLI silently runs on a proactor loop on Windows.** `cli_common.py` creates `cli_loop` at import time, before `__main__.py` gets a chance to set `WindowsSelectorEventLoopPolicy`, so the #1217 fix never applied to the CLI loop. The proactor stream transport pre-posts an overlapped recv the moment `_ensure_started()` creates the streams — that recv swallows the TLS ServerHello, so the blocking strip-ssl handshake in `ssl_start_sync()` times out. `get_asyncio_loop()` now creates a `SelectorEventLoop` explicitly on Windows.

2. **`ssl_start_sync()` masked the real error.** On handshake failure `wrap_socket()` has already detached (and closed) the underlying socket, so the `finally: settimeout(None)` raised `EBADF`/`WinError 10038`, hiding the actual failure — that's the confusing traceback in the issue. Regression test included (fails on master with `OSError` at the `finally` line, passes with the fix).

3. **Defense in depth:** `_open_dtx_connection()` now performs the strip-ssl handshake *before* binding the socket to the event loop, so the sequence is correct under any loop type (e.g. library users on Windows under a default `asyncio.run()`).

## Testing

- New unit test for the error-masking path (reproduces cross-platform; verified it fails before the fix).
- Verified `developer accessibility list-items` end-to-end against an iPhone18,4 (iOS 27) over USB — the strip-ssl DTX path this touches.
- `pyright --venvpath .` clean; pre-commit (ruff check/format, pyright) green.
