### PR TITLE
tests: extend the RSD-tunnel skip to fixture setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,23 @@ def pytest_addoption(parser):
 NO_DEVICE_SKIP_REASON = "No test device is available through usbmuxd"
 
 
+def _skip_unless_tunneled(item: pytest.Item, e: InvalidServiceError) -> None:
+    funcargs = item.funcargs if isinstance(item, pytest.Function) else {}
+    provider = funcargs.get("service_provider") or funcargs.get("lockdown")
+    if isinstance(provider, RemoteServiceDiscoveryService):
+        raise e
+    pytest.skip(f"Service requires an RSD tunnel (rerun with --rsd/--tunnel): {e}")
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_setup(item: pytest.Item) -> Generator[None, object, object]:
+    """Extend the same skip to fixture setup (services opened by fixtures error out here)."""
+    try:
+        return (yield)
+    except InvalidServiceError as e:
+        _skip_unless_tunneled(item, e)
+
+
 @pytest.hookimpl(wrapper=True)
 def pytest_runtest_call(item: pytest.Item) -> Generator[None, object, object]:
     """
@@ -52,11 +69,7 @@ def pytest_runtest_call(item: pytest.Item) -> Generator[None, object, object]:
     try:
         return (yield)
     except InvalidServiceError as e:
-        funcargs = item.funcargs if isinstance(item, pytest.Function) else {}
-        provider = funcargs.get("service_provider") or funcargs.get("lockdown")
-        if isinstance(provider, RemoteServiceDiscoveryService):
-            raise
-        pytest.skip(f"Service requires an RSD tunnel (rerun with --rsd/--tunnel): {e}")
+        _skip_unless_tunneled(item, e)
 
 
 async def _create_usbmux_client() -> UsbmuxLockdownClient:


### PR DESCRIPTION
## Summary

Follow-up to #1808. Closes #1807. The merged hook only wraps `pytest_runtest_call`, but services opened inside fixtures (e.g. `accessibility_audit` in `tests/services/test_accessibility.py`, and the other ~33 *errors* from the issue report) raise `InvalidServiceError` during the **setup** phase, which pytest reports as an error, not a failure — the call-phase hook never sees it. This wraps `pytest_runtest_setup` with the same logic, shared via a small helper.

## Testing

Verified with a throwaway test pair against a real device over plain usbmux: a bogus `start_lockdown_service` in the test body was already skipped by #1808, while the same call inside a fixture still errored; with this change both phases skip with the same message. Tunneled runs still re-raise.