### PR TITLE
accessibility: fix run-audit on passing screens; userspace_tunnel: fix the retry crash

### DIFF
--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -749,6 +749,15 @@ async def establish_userspace_rsd(
     route such devices elsewhere (the CLI uses this to fall back to ``tunneld``).
     """
     global _cli_tunnel
+    # In-process retry (the CLI re-runs main() with the userspace env var set after an
+    # InvalidServiceError): reuse the live tunnel — PyTCP's stack is a process-global
+    # singleton, so a second establishment can only fail.
+    if (
+        _cli_tunnel is not None
+        and _cli_tunnel.rsd is not None
+        and (serial is None or serial in (_cli_tunnel.serial, _cli_tunnel.rsd.udid))
+    ):
+        return _cli_tunnel.rsd
     tunnel = UserspaceRsdTunnel(serial=serial, autopair=autopair, remotepairing_fallback=remotepairing_fallback)
     rsd = await tunnel.aopen()
     _cli_tunnel = tunnel

--- a/pymobiledevice3/services/accessibilityaudit.py
+++ b/pymobiledevice3/services/accessibilityaudit.py
@@ -408,7 +408,13 @@ class AccessibilityAudit:
             payload = self._extract_event_payload(args)
             if payload is None:
                 continue
-            return deserialize_object(payload)[0]["value"]
+            raw = deserialize_object(payload)
+            issues = typing.cast(list[typing.Any], raw) if isinstance(raw, list) else [raw]
+            if issues and isinstance(issues[0], dict) and "value" in issues[0]:
+                # older aux-shaped payload: [{"type": ..., "value": [issues]}]
+                return typing.cast(list[AXAuditIssue_v1], issues[0]["value"])
+            # modern shape: the deserialized payload IS the issue list (empty when the audit passes)
+            return typing.cast(list[AXAuditIssue_v1], issues)
 
     async def supported_audits_types(self) -> list[typing.Any]:
         """

--- a/tests/services/test_accessibility.py
+++ b/tests/services/test_accessibility.py
@@ -24,3 +24,11 @@ async def test_invert_colors_in_settings(accessibility_audit: AccessibilityAudit
             found = True
             break
     assert found
+
+
+@pytest.mark.asyncio
+async def test_run_audit_returns_issue_list(accessibility_audit: AccessibilityAudit) -> None:
+    # A screen that passes the audit yields an empty issue list (used to raise IndexError).
+    types = await accessibility_audit.supported_audits_types()
+    issues = await accessibility_audit.run_audit(types[:1])
+    assert isinstance(issues, list)


### PR DESCRIPTION
## Summary

Both crashes reported by @AnNEDoMini in the follow-up comments on #1810 (after the original issue was fixed):

1. **`developer accessibility run-audit` raised `IndexError` when the audit finds no issues.** `run_audit` indexed `deserialize_object(payload)[0]['value']` — a leftover from the old aux-shaped event payload. On modern iOS the completion event carries a plain passthrough whose deserialized value IS the issue list, so a passing audit (`[]`) crashed, and a failing one would have crashed too. The old shape is still handled; the modern shape is returned as-is.

2. **`developer core-device get-display-info` crashed with "a userspace tunnel is already active" instead of the real error.** The device doesn't expose `com.apple.coredevice.deviceinfo` (verified absent from the 61 RSD services on iOS 27), so the command fails with `InvalidServiceError` — and the CLI's retry re-runs `main()` in-process with the userspace env var set. But the first attempt had already established the tunnel via the default path, so the retry hit PyTCP's process-global singleton guard and buried the real error. `establish_userspace_rsd` now reuses the live CLI tunnel when it targets the same device, letting the retry fail with the proper `InvalidServiceError` guidance.

## Testing

Against an iPhone18,4 (iOS 27) over USB:
- `developer accessibility run-audit testTypeHitRegion` now prints `[]` (crashed with `IndexError` before); also verified with all 7 supported audit types.
- `developer core-device get-display-info` now ends with the standard "Failed to start service" guidance ("Apple removed this service, or your iOS version does not support it") instead of the singleton-guard traceback.
- New device test `test_run_audit_returns_issue_list` in `tests/services/test_accessibility.py`.
- `pyright --venvpath .` clean; pre-commit green.