### PR TITLE
mobile_image_mounter: fix auto-mount raising on an already mounted image

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -335,8 +335,11 @@ def invoke_cli_with_error_handling() -> bool:
     except MessageNotSupportedError:
         logger.error("Message not supported for this iOS version")
         traceback.print_exc()
-    except InternalError:
-        logger.error("Internal Error")
+    except InternalError as e:
+        # surface the device's DetailedError (e.g. "Failed to unload launchd jobs" on unmount)
+        response = cast(dict[str, Any], e.args[0]) if e.args and isinstance(e.args[0], dict) else {}
+        detail = str(response.get("DetailedError", ""))
+        logger.error(f"Internal Error: {detail}" if detail else "Internal Error")
     except DeveloperModeIsNotEnabledError:
         logger.error(
             "Developer Mode is disabled. You can try to enable it using: "

--- a/pymobiledevice3/services/mobile_image_mounter.py
+++ b/pymobiledevice3/services/mobile_image_mounter.py
@@ -113,8 +113,17 @@ class MobileImageMounterService(LockdownService):
         try:
             await self.lookup_image(image_type)
         except NotMountedError:
+            pass
+        else:
+            return True
+        # LookupImage may return an empty ImageSignature for a Personalized image that IS mounted
+        # (observed on iOS 27.0), in which case MountImage would fail with "already mounted".
+        # CopyDevices does list such an image, so consult it as well.
+        try:
+            devices = await self.copy_devices()
+        except MessageNotSupportedError:
             return False
-        return True
+        return any(device.get("DiskImageType") == image_type for device in devices)
 
     async def unmount_image(self, mount_path: str) -> None:
         """
@@ -168,6 +177,9 @@ class MobileImageMounterService(LockdownService):
         status = response.get("Status")
 
         if status != "Complete":
+            # backstop for when the pre-mount check above missed the mounted image
+            if "is already mounted" in response.get("DetailedError", ""):
+                raise AlreadyMountedError(response)
             raise PyMobileDevice3Exception(f"command MountImage failed with: {response}")
 
     async def upload_image(self, image_type: str, image: bytes, signature: bytes) -> None:

--- a/tests/services/test_mobile_image_mounter.py
+++ b/tests/services/test_mobile_image_mounter.py
@@ -1,0 +1,14 @@
+import pytest
+
+from pymobiledevice3.lockdown import LockdownClient
+from pymobiledevice3.services.mobile_image_mounter import MobileImageMounterService
+
+
+@pytest.mark.asyncio
+async def test_is_image_mounted_agrees_with_copy_devices(lockdown: LockdownClient) -> None:
+    # Regression: LookupImage may return an empty ImageSignature for a mounted Personalized image,
+    # making is_image_mounted() miss it and a subsequent MountImage fail with "already mounted"
+    async with MobileImageMounterService(lockdown=lockdown) as mounter:
+        mounted_types = {device.get("DiskImageType") for device in await mounter.copy_devices()}
+        for image_type in ("Developer", "Personalized"):
+            assert await mounter.is_image_mounted(image_type) == (image_type in mounted_types)


### PR DESCRIPTION
## What

`pymobiledevice3 mounter auto-mount` raised a raw `PyMobileDevice3Exception` traceback when the Personalized DDI was already mounted, instead of the graceful "DeveloperDiskImage already mounted" message.

## Root cause

Verified live on an iOS 27.0 device with the DDI mounted at `/System/Developer`:

- `LookupImage(ImageType=Personalized)` returns `Status: Complete` with an **empty** `ImageSignature` list, so `is_image_mounted()` reported not-mounted and the pre-mount check passed.
- The device then rejected `MountImage` with `ImageMountFailed` carrying the nested `Code=-3 "A disk image of type Personalized/DeveloperDiskImage is already mounted at /System/Developer."` error, which fell through to the generic exception.
- `CopyDevices` on the same connection correctly lists the mounted image (`DiskImageType: Personalized`, `MountPath: /System/Developer`).

## Fix

- `is_image_mounted()` falls back to `CopyDevices` when `LookupImage` reports nothing (guarded by `MessageNotSupportedError` for devices without `CopyDevices`). This also makes auto-mount bail out early, before the TSS request and image upload.
- Backstop: an `ImageMountFailed` response whose `DetailedError` contains "is already mounted" now raises `AlreadyMountedError` instead of the generic exception, so any future pre-check miss still renders gracefully.

## Testing

- Live repro before the fix, and after it: `mounter auto-mount` on the already-mounted iOS 27.0 device now logs `DeveloperDiskImage already mounted` and exits cleanly
- New physical-device test `test_is_image_mounted_agrees_with_copy_devices` — fails on this device without the fix, passes with it
- `pyright --venvpath .` (1.1.411): 0 errors