### PR TITLE
webinspector: serve the browser-level CDP endpoint for VS Code js-debug attach

### DIFF
--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -334,4 +334,8 @@ pymobiledevice3 webinspector launch URL
 
 # Selenium-like interactive shell
 pymobiledevice3 webinspector shell
+
+# CDP bridge: debug pages with Chrome DevTools or VS Code
+# (see the WebView debugging guide)
+pymobiledevice3 webinspector cdp
 ```

--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -1,0 +1,79 @@
+# Debugging Safari and WebViews with Chrome DevTools or VS Code
+
+`pymobiledevice3 webinspector cdp` bridges Apple's Web Inspector protocol to the
+Chrome DevTools Protocol (CDP), so Chrome-compatible debugger clients can attach to
+Safari tabs and WebViews running on a connected device. One bridge instance serves
+both Chrome DevTools (per-page) and browser-level clients such as VS Code's
+JavaScript debugger.
+
+## Device prerequisites
+
+- Enable Web Inspector on the device:
+  - iOS >= 18: Settings -> Apps -> Safari -> Advanced -> Web Inspector
+  - iOS < 18: Settings -> Safari -> Advanced -> Web Inspector
+- Safari tabs (and `SFSafariViewController` pages) are then inspectable as-is.
+- Third-party app `WKWebView`s only appear if the app makes them inspectable: on
+  iOS >= 16.4 the app must set `webView.isInspectable = true`, or be a
+  development/debug-signed build. Production apps that don't opt in cannot be
+  inspected.
+
+## Start the bridge
+
+```shell
+pymobiledevice3 webinspector cdp
+```
+
+The bridge listens on `127.0.0.1:9222` (see `--host`/`--port`). Keep it running for
+the duration of the debugging session.
+
+## Chrome DevTools
+
+Open <http://127.0.0.1:9222/> in Google Chrome and pick a page. Prefer this landing
+page over `chrome://inspect` — see the command's `--help` for why.
+
+## VS Code
+
+VS Code's built-in JavaScript debugger (js-debug) attaches through the browser-level
+endpoint advertised by `/json/version`. No extension is needed.
+
+1. Open your web project's folder in VS Code.
+2. Create `.vscode/launch.json`:
+
+    ```json
+    {
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "Attach to iPhone WebView",
+                "type": "chrome",
+                "request": "attach",
+                "address": "127.0.0.1",
+                "port": 9222,
+                "urlFilter": "*",
+                "webRoot": "${workspaceFolder}"
+            }
+        ]
+    }
+    ```
+
+3. In the Run and Debug sidebar, select **Attach to iPhone WebView** and press F5.
+
+A child debug session appears per matching page. Editor breakpoints, stepping, the
+Debug Console (evaluates on the device), Loaded Scripts, and source maps all work.
+
+Configuration notes:
+
+- `urlFilter` selects which pages to attach to. `"*"` attaches to every inspectable
+  page; narrow it (e.g. `"*myapp.example.com*"`) to pick a specific tab.
+- `webRoot` maps source-mapped URLs to workspace files so breakpoints bind to your
+  original sources — point it at the folder your dev server serves from.
+- Source-map warnings for third-party pages you don't control are harmless; silence
+  them with `"sourceMaps": false` if they get noisy.
+
+## Caveats
+
+- WebKit allows a single inspector session per page: Chrome DevTools and VS Code can
+  debug different tabs concurrently, but not the same tab. A page already held by
+  another debugger is skipped after a short wait — detach the other client first.
+- The page listing is polled, so tabs opened on the device after the attach are
+  discovered (and auto-attached) within a couple of seconds.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ plugins:
         Guides:
           - guides/cli-recipes.md
           - guides/ios17-tunnels.md
+          - guides/webview-debugging.md
           - guides/python-api.md
           - guides/writing-commands-with-service-provider.md
         API reference:
@@ -113,6 +114,7 @@ nav:
   - Guides:
       - CLI recipes: guides/cli-recipes.md
       - iOS 17+ tunnels: guides/ios17-tunnels.md
+      - WebView debugging: guides/webview-debugging.md
       - Python API: guides/python-api.md
       - Writing CLI commands: guides/writing-commands-with-service-provider.md
       - Device operator skill: guides/codex-device-operator-skill.md

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -392,6 +392,12 @@ async def cdp(
         http://127.0.0.1:9222/
 
     \b
+    Chrome-compatible debugger clients can attach through the browser-level endpoint
+    advertised by /json/version. For VS Code, use a launch.json configuration such as:
+        {"type": "chrome", "request": "attach", "address": "127.0.0.1", "port": 9222,
+         "urlFilter": "*", "webRoot": "${workspaceFolder}"}
+
+    \b
     Prefer this over chrome://inspect: chrome://inspect routes the DevTools frontend through
     Chrome's browser-process relay (network target), which deadlocks under sustained console
     traffic and freezes the console/screen. The URL above serves the DevTools frontend so it

--- a/pymobiledevice3/services/web_protocol/cdp_browser.py
+++ b/pymobiledevice3/services/web_protocol/cdp_browser.py
@@ -1,0 +1,336 @@
+import asyncio
+import logging
+import uuid
+from typing import Any, Optional
+
+from fastapi import WebSocket
+
+from pymobiledevice3.services.web_protocol.cdp_target import CdpTarget
+from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
+from pymobiledevice3.services.webinspector import WebinspectorService, WirTypes
+
+logger = logging.getLogger(__name__)
+
+# Seconds to let webinspectord reply with the updated page listings before answering /json
+PAGE_LISTING_FLUSH = 0.5
+# Seconds to wait for the device to report the inspection target of a new debugger session
+TARGET_CREATION_TIMEOUT = 30
+# Seconds between page-listing refreshes while target discovery/auto-attach is active
+TARGET_POLL_INTERVAL = 2.0
+# Seconds to wait for another debugger session on the same page to tear down before skipping it
+PAGE_LOCK_TIMEOUT = 5
+
+# WebKit supports a single inspector session per page, so sessions are serialized per page:
+# a new debugger connection waits until the previous session's WIR socket teardown completed
+# (otherwise its socket setup races the teardown and webinspectord ignores it). Shared between
+# the page endpoint and browser-endpoint attachments.
+PAGE_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+class _PageSession:
+    """A flat-mode CDP session attached to one device page."""
+
+    def __init__(
+        self, session_id: str, page_id: str, target: CdpTarget, pump: "asyncio.Task[None]", lock: asyncio.Lock
+    ) -> None:
+        self.session_id = session_id
+        self.page_id = page_id
+        self.target = target
+        self.pump = pump
+        self.lock = lock
+
+
+class CdpBrowser:
+    """
+    Browser-level CDP endpoint (flat session mode) over the Web Inspector page targets.
+
+    Chrome-compatible debugger clients (VS Code's js-debug, Puppeteer, ...) connect to the
+    browser websocket advertised by /json/version rather than to a page websocket, then discover
+    and attach pages through the Target domain: Target.attachToBrowserTarget ->
+    Target.setDiscoverTargets -> Target.targetCreated -> Target.attachToTarget, with every
+    per-page message carrying the attachment's sessionId. Each attached page is backed by an
+    ordinary CdpTarget whose messages are tagged/untagged with that sessionId here.
+    """
+
+    def __init__(self, inspector: WebinspectorService, websocket: WebSocket) -> None:
+        self.inspector = inspector
+        self.websocket = websocket
+        # sessionIds handed out by Target.attachToBrowserTarget; commands arriving under them are
+        # browser-level commands, not page messages
+        self._browser_sessions: set[str] = set()
+        self._page_sessions: dict[str, _PageSession] = {}
+        self._attached_pages: dict[str, str] = {}  # page_id -> sessionId
+        self._known_targets: dict[str, dict[str, Any]] = {}  # page_id -> targetInfo
+        self._discover = False
+        self._auto_attach = False
+        # session under which discovery/auto-attach was enabled; lifecycle events are tagged with
+        # it (js-debug listens on the browser session, Puppeteer on the root connection)
+        self._events_session: Optional[str] = None
+        self._poll_task: Optional[asyncio.Task[None]] = None
+        self._refresh_lock = asyncio.Lock()
+        self._send_lock = asyncio.Lock()
+        self._handlers = {
+            "Browser.getVersion": self._browser_get_version,
+            "Browser.close": self._generic_ack,
+            "Target.attachToBrowserTarget": self._target_attach_to_browser_target,
+            "Target.setDiscoverTargets": self._target_set_discover_targets,
+            "Target.setAutoAttach": self._target_set_auto_attach,
+            "Target.getTargets": self._target_get_targets,
+            "Target.getTargetInfo": self._target_get_target_info,
+            "Target.attachToTarget": self._target_attach_to_target,
+            "Target.detachFromTarget": self._target_detach_from_target,
+        }
+
+    async def run(self) -> None:
+        """Serve the connection until the client disconnects."""
+        async for message in self.websocket.iter_json():
+            logger.debug(f"BROWSER CDP INPUT: {message}")
+            try:
+                await self._handle(message)
+            except Exception:
+                logger.exception(f"failed handling browser message: {message}")
+
+    async def close(self) -> None:
+        if self._poll_task is not None:
+            self._poll_task.cancel()
+            await asyncio.gather(self._poll_task, return_exceptions=True)
+            self._poll_task = None
+        for session in list(self._page_sessions.values()):
+            await self._close_session(session, notify=False)
+
+    async def _send(self, message: dict[str, Any]) -> None:
+        logger.debug(f"BROWSER CDP OUTPUT: {message}")
+        async with self._send_lock:
+            await self.websocket.send_json(message)
+
+    async def _reply(self, message: dict[str, Any], result: dict[str, Any]) -> None:
+        response: dict[str, Any] = {"id": message["id"], "result": result}
+        if "sessionId" in message:
+            response["sessionId"] = message["sessionId"]
+        await self._send(response)
+
+    async def _handle(self, message: dict[str, Any]) -> None:
+        session_id = message.get("sessionId")
+        if session_id is not None and session_id not in self._browser_sessions:
+            page_session = self._page_sessions.get(session_id)
+            if page_session is None:
+                if "id" in message:
+                    await self._send({
+                        "id": message["id"],
+                        "sessionId": session_id,
+                        "error": {"code": -32001, "message": f"Session with given id not found: {session_id}"},
+                    })
+                return
+            await page_session.target.send({k: v for k, v in message.items() if k != "sessionId"})
+            return
+        handler = self._handlers.get(message.get("method", ""))
+        if handler is not None:
+            await handler(message)
+        elif "id" in message:
+            # Unsupported browser-level method: acknowledge so clients treating these as
+            # best-effort configuration don't stall on a missing response.
+            logger.debug(f"acking unsupported browser method: {message.get('method')}")
+            await self._reply(message, {})
+
+    async def _generic_ack(self, message: dict[str, Any]) -> None:
+        await self._reply(message, {})
+
+    async def _browser_get_version(self, message: dict[str, Any]) -> None:
+        await self._reply(
+            message,
+            {
+                "protocolVersion": "1.3",
+                "product": "Safari",
+                "revision": "",
+                "userAgent": "pymobiledevice3",
+                "jsVersion": "",
+            },
+        )
+
+    async def _target_attach_to_browser_target(self, message: dict[str, Any]) -> None:
+        session_id = str(uuid.uuid4()).upper()
+        self._browser_sessions.add(session_id)
+        await self._reply(message, {"sessionId": session_id})
+
+    async def _target_set_discover_targets(self, message: dict[str, Any]) -> None:
+        self._discover = bool(message.get("params", {}).get("discover"))
+        if self._discover:
+            self._events_session = message.get("sessionId")
+            # Announce the current pages before answering so a client awaiting the response
+            # observes the initial Target.targetCreated batch immediately after it.
+            await self._refresh_targets()
+            self._ensure_poll()
+        await self._reply(message, {})
+
+    async def _target_set_auto_attach(self, message: dict[str, Any]) -> None:
+        self._auto_attach = bool(message.get("params", {}).get("autoAttach"))
+        if self._auto_attach:
+            self._events_session = message.get("sessionId")
+            await self._refresh_targets()
+            self._ensure_poll()
+        await self._reply(message, {})
+
+    async def _target_get_targets(self, message: dict[str, Any]) -> None:
+        await self._refresh_targets()
+        await self._reply(message, {"targetInfos": list(self._known_targets.values())})
+
+    async def _target_get_target_info(self, message: dict[str, Any]) -> None:
+        target_id = message.get("params", {}).get("targetId")
+        info: Optional[dict[str, Any]] = self._known_targets.get(target_id) if target_id is not None else None
+        if info is None:
+            info = {
+                "targetId": self.inspector.connection_id,
+                "type": "browser",
+                "title": "",
+                "url": "",
+                "attached": True,
+                "canAccessOpener": False,
+            }
+        await self._reply(message, {"targetInfo": info})
+
+    async def _target_attach_to_target(self, message: dict[str, Any]) -> None:
+        page_id = message["params"]["targetId"]
+        session_id = await self._attach_page(page_id)
+        if session_id is None:
+            await self._send({
+                "id": message["id"],
+                **({"sessionId": message["sessionId"]} if "sessionId" in message else {}),
+                "error": {"code": -32000, "message": f"Cannot attach to target: {page_id}"},
+            })
+            return
+        await self._reply(message, {"sessionId": session_id})
+
+    async def _target_detach_from_target(self, message: dict[str, Any]) -> None:
+        session_id = message.get("params", {}).get("sessionId")
+        session = self._page_sessions.get(session_id)
+        if session is not None:
+            await self._close_session(session, notify=False)
+        await self._reply(message, {})
+
+    def _ensure_poll(self) -> None:
+        if self._poll_task is None or self._poll_task.done():
+            self._poll_task = asyncio.create_task(self._poll())
+
+    async def _poll(self) -> None:
+        """Keep the client's target list current: pages opened/closed on the device after the
+        initial discovery are announced/destroyed (and auto-attached) as they appear."""
+        while self._discover or self._auto_attach:
+            await asyncio.sleep(TARGET_POLL_INTERVAL)
+            try:
+                await self._refresh_targets()
+            except Exception:
+                logger.exception("target refresh failed")
+
+    def _list_pages(self) -> dict[str, Any]:
+        pages: dict[str, Any] = {}
+        for app_id in self.inspector.application_pages:
+            for page_id, page in self.inspector.application_pages[app_id].items():
+                if page.type_ in (WirTypes.WEB, WirTypes.WEB_PAGE):
+                    pages[page_id] = page
+        return pages
+
+    async def _refresh_targets(self) -> None:
+        async with self._refresh_lock:
+            await self.inspector.get_open_pages()
+            await self.inspector.flush_input(PAGE_LISTING_FLUSH)
+            pages = self._list_pages()
+            for page_id in [known for known in self._known_targets if known not in pages]:
+                await self._destroy_target(page_id)
+            for page_id, page in pages.items():
+                is_new = page_id not in self._known_targets
+                self._known_targets[page_id] = {
+                    "targetId": page_id,
+                    "type": "page",
+                    "title": page.web_title or "",
+                    "url": page.web_url or "",
+                    "attached": page_id in self._attached_pages,
+                    "canAccessOpener": False,
+                }
+                if is_new and self._discover:
+                    await self._send_event("Target.targetCreated", {"targetInfo": self._known_targets[page_id]})
+                if self._auto_attach and page_id not in self._attached_pages:
+                    await self._auto_attach_page(page_id)
+
+    async def _destroy_target(self, page_id: str) -> None:
+        self._known_targets.pop(page_id, None)
+        session_id = self._attached_pages.get(page_id)
+        if session_id is not None:
+            await self._close_session(self._page_sessions[session_id], notify=True)
+        if self._discover:
+            await self._send_event("Target.targetDestroyed", {"targetId": page_id})
+
+    async def _send_event(self, method: str, params: dict[str, Any]) -> None:
+        event: dict[str, Any] = {"method": method, "params": params}
+        if self._events_session is not None:
+            event["sessionId"] = self._events_session
+        await self._send(event)
+
+    async def _auto_attach_page(self, page_id: str) -> None:
+        session_id = await self._attach_page(page_id)
+        if session_id is None:
+            return
+        await self._send_event(
+            "Target.attachedToTarget",
+            {
+                "sessionId": session_id,
+                "targetInfo": self._known_targets[page_id],
+                "waitingForDebugger": False,
+            },
+        )
+
+    async def _attach_page(self, page_id: str) -> Optional[str]:
+        """Open a WIR debugger session on the page and return its CDP sessionId (an existing
+        attachment's id when already attached), or None when the page cannot be attached."""
+        existing = self._attached_pages.get(page_id)
+        if existing is not None:
+            return existing
+        try:
+            application, page = self.inspector.find_page_id(page_id)
+        except Exception:
+            logger.warning(f"cannot attach: page {page_id} not found")
+            return None
+        lock = PAGE_LOCKS.setdefault(page_id, asyncio.Lock())
+        try:
+            await asyncio.wait_for(lock.acquire(), PAGE_LOCK_TIMEOUT)
+        except (asyncio.TimeoutError, TimeoutError):
+            logger.warning(f"page {page_id}: busy with another debugger session, not attaching")
+            return None
+        wir_session_id = str(uuid.uuid4()).upper()
+        protocol = SessionProtocol(self.inspector, wir_session_id, application, page, method_prefix="")
+        try:
+            target = await asyncio.wait_for(CdpTarget.create(protocol), TARGET_CREATION_TIMEOUT)
+        except (asyncio.TimeoutError, TimeoutError):
+            logger.error(f"page {page_id}: device did not report an inspection target in time")
+            await self.inspector.teardown_inspector_socket(wir_session_id, application.id_, page.id_)
+            lock.release()
+            return None
+        session_id = str(uuid.uuid4()).upper()
+        pump = asyncio.create_task(self._pump(session_id, target))
+        self._page_sessions[session_id] = _PageSession(session_id, page_id, target, pump, lock)
+        self._attached_pages[page_id] = session_id
+        if page_id in self._known_targets:
+            self._known_targets[page_id]["attached"] = True
+        return session_id
+
+    async def _pump(self, session_id: str, target: CdpTarget) -> None:
+        """Forward everything the page target emits to the client, tagged with its sessionId."""
+        while True:
+            message = await target.receive()
+            message["sessionId"] = session_id
+            await self._send(message)
+
+    async def _close_session(self, session: _PageSession, notify: bool) -> None:
+        self._page_sessions.pop(session.session_id, None)
+        self._attached_pages.pop(session.page_id, None)
+        if session.page_id in self._known_targets:
+            self._known_targets[session.page_id]["attached"] = False
+        session.pump.cancel()
+        await asyncio.gather(session.pump, return_exceptions=True)
+        try:
+            await session.target.close()
+        finally:
+            session.lock.release()
+        if notify:
+            await self._send_event(
+                "Target.detachedFromTarget", {"sessionId": session.session_id, "targetId": session.page_id}
+            )

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -13,14 +13,15 @@ from fastapi import FastAPI, Request, WebSocket
 from fastapi.logger import logger
 from fastapi.responses import HTMLResponse, Response
 
+from pymobiledevice3.services.web_protocol.cdp_browser import (
+    PAGE_LISTING_FLUSH,
+    PAGE_LOCKS,
+    TARGET_CREATION_TIMEOUT,
+    CdpBrowser,
+)
 from pymobiledevice3.services.web_protocol.cdp_target import CdpTarget
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
 from pymobiledevice3.services.webinspector import WirTypes
-
-# Seconds to let webinspectord reply with the updated page listings before answering /json
-PAGE_LISTING_FLUSH = 0.5
-# Seconds to wait for the device to report the inspection target of a new debugger session
-TARGET_CREATION_TIMEOUT = 30
 
 # chrome://inspect routes a network target's DevTools through Chrome's browser-process relay,
 # which deadlocks after sustained console traffic (the console/screen freeze). Serving the DevTools
@@ -251,10 +252,16 @@ async def to_cdp(target: CdpTarget, websocket: WebSocket) -> None:
         await websocket.send_json(message)
 
 
-# WebKit supports a single inspector session per page, so sessions are serialized per page:
-# a new debugger connection waits until the previous session's WIR socket teardown completed
-# (otherwise its socket setup races the teardown and webinspectord ignores it).
-_page_locks: dict[str, asyncio.Lock] = {}
+@app.websocket("/devtools/browser/{connection_id}")
+async def browser_debugger(websocket: WebSocket, connection_id: str):
+    """Browser-level endpoint (the one /json/version advertises): flat-session Target-domain
+    debugging for Chrome-compatible clients such as VS Code's js-debug and Puppeteer."""
+    await websocket.accept()
+    browser = CdpBrowser(app.state.inspector, websocket)
+    try:
+        await browser.run()
+    finally:
+        await browser.close()
 
 
 @app.websocket("/devtools/page/{page_id}")
@@ -265,7 +272,7 @@ async def page_debugger(websocket: WebSocket, page_id: str):
     # Accept before the device-side target setup: DevTools drops the connection if the
     # websocket handshake stalls behind the WIR socket establishment.
     await websocket.accept()
-    async with _page_locks.setdefault(page_id, asyncio.Lock()):
+    async with PAGE_LOCKS.setdefault(page_id, asyncio.Lock()):
         try:
             # Bound the wait: if the device never reports the target (e.g. webinspectord is in a
             # bad state), fail the connection instead of keeping a zombie handler alive forever.


### PR DESCRIPTION
## What

`/json/version` has always advertised a `ws://.../devtools/browser/<id>` websocket, but no route served it (connections got HTTP 403). Debugger clients that start from the browser target — VS Code's js-debug foremost — therefore failed their attach, retrying the advertised endpoint until timeout.

This adds `CdpBrowser` (`services/web_protocol/cdp_browser.py`), a flat-session Target-domain endpoint layered over the existing per-page `CdpTarget` translation, and wires it at `/devtools/browser/{connection_id}`:

- Full js-debug attach sequence: `Target.attachToBrowserTarget` → `Target.setDiscoverTargets` → `Target.targetCreated` → `Target.attachToTarget`, with per-page messages tagged/untagged by `sessionId`
- Auto-attach (`Target.setAutoAttach`), detach, `Target.getTargets`/`getTargetInfo`, `Browser.getVersion`
- A periodic page-listing refresh announces pages opened/closed on the device (`targetCreated`/`targetDestroyed`, auto-attach of new pages)
- Page sessions share the per-page serialization locks with the DevTools page endpoint (WebKit allows one inspector session per page); a page busy with another debugger is skipped after a bounded wait instead of stalling the whole attach

One bridge instance now serves both Chrome DevTools (per-page, via the landing page) and browser-level clients such as VS Code — concurrently, on different tabs.

## Docs

- New guide: `docs/guides/webview-debugging.md` — device prerequisites, starting the bridge, Chrome DevTools flow, VS Code `launch.json` setup (`urlFilter`, `webRoot`, source-map notes), and caveats; added to the mkdocs nav
- `webinspector cdp` `--help` now shows the VS Code attach configuration
- CLI recipes: added the `cdp` command to the WebInspector section

## Verification

Tested live against an iOS 27.0 device with js-debug 1.117.0 (the standalone DAP server — the exact engine behind VS Code's JS debugger), driven by a scripted DAP client:

- Attach handshake completes; a child debug session is spawned per matching page
- Script enumeration (`Debugger.scriptParsed` + source-map resolution), threads, breakpoint binding via `Debugger.setBreakpointByUrl`, and REPL `evaluate` against the device all work
- Confirmed end-to-end from the VS Code UI (`{"type": "chrome", "request": "attach", "port": 9222, "urlFilter": "*"}`)
- Chrome DevTools page-level flow re-verified unchanged (raw CDP probe: enable/breakpoint/evaluate)
- `pyright --venvpath .` clean on touched files; ruff check/format clean