### PR TITLE
cli: exit non-zero when a handled error terminates the command

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -139,6 +139,11 @@ CLI_GROUPS = {
 
 # Set if used the `--reconnect` option
 RECONNECT = False
+
+# Exit code the process should terminate with. Handled exceptions are logged as friendly
+# one-liners instead of tracebacks, but must still fail the process (exit code 1) so callers
+# and scripts can detect the failure (#1682).
+EXIT_CODE = 0
 _ORIGINAL_SHELLINGHAM_DETECT: Optional[Callable[[], tuple[str, str]]] = None
 
 
@@ -304,14 +309,18 @@ def invoke_cli_with_error_handling() -> bool:
     Invoke the command line interface and return `True` if the failure reason of the command was that the device was
     disconnected.
     """
+    global EXIT_CODE
+    EXIT_CODE = 0
     try:
         # Typer apps are callable; this executes the CLI with current sys.argv
         app(args=["--help"] if len(sys.argv) == 1 else None)
     except NoDeviceConnectedError:
         logger.error("Device is not connected")
+        EXIT_CODE = 1
         return True
     except ConnectionTerminatedError:
         logger.error("Connection was terminated abruptly")
+        EXIT_CODE = 1
         return True
     except NotPairedError:
         logger.error("Device is not paired")
@@ -331,6 +340,7 @@ def invoke_cli_with_error_handling() -> bool:
         logger.error("Failed to connect to usbmuxd socket. Make sure it's running.")
     except ConnectionFailedError:
         logger.error("Failed to connect to service port.")
+        EXIT_CODE = 1
         return True
     except MessageNotSupportedError:
         logger.error("Message not supported for this iOS version")
@@ -437,6 +447,9 @@ def invoke_cli_with_error_handling() -> bool:
         logger.error(f"File [{e.filename}] not found during afc operation: {e}")
     except AfcException as e:
         logger.error(f"Failed to perform Afc operation: {e}")
+    else:
+        return False
+    EXIT_CODE = 1
     return False
 
 
@@ -455,6 +468,8 @@ def main() -> None:
         except KeyboardInterrupt:
             print("Aborted.")
             break
+    if EXIT_CODE != 0:
+        sys.exit(EXIT_CODE)
 
 
 if __name__ == "__main__":

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -6,6 +6,7 @@ import pytest
 from typer.testing import CliRunner
 
 from pymobiledevice3 import __main__
+from pymobiledevice3.exceptions import ConnectionTerminatedError, NotPairedError
 
 pytestmark = [pytest.mark.cli]
 ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
@@ -153,3 +154,33 @@ def test_cli_groups(group):
 @pytest.mark.parametrize("group", __main__.CLI_GROUPS.keys())
 def test_cli_from_python_m_flag(group):
     subprocess.run([sys.executable, "-m", "pymobiledevice3", group, "--help"], check=True)
+
+
+def test_main_exits_nonzero_on_handled_disconnect_error(monkeypatch):
+    # Regression for #1682: handled errors (e.g. "Connection was terminated abruptly") were
+    # logged as one-liners but the process still exited 0, so scripts could not detect failure
+    def raise_terminated(*args, **kwargs):
+        raise ConnectionTerminatedError()
+
+    monkeypatch.setattr(__main__, "app", raise_terminated)
+    monkeypatch.setattr(__main__, "RECONNECT", False)
+    with pytest.raises(SystemExit) as exc_info:
+        __main__.main()
+    assert exc_info.value.code == 1
+
+
+def test_main_exits_nonzero_on_handled_fallthrough_error(monkeypatch):
+    def raise_not_paired(*args, **kwargs):
+        raise NotPairedError()
+
+    monkeypatch.setattr(__main__, "app", raise_not_paired)
+    monkeypatch.setattr(__main__, "RECONNECT", False)
+    with pytest.raises(SystemExit) as exc_info:
+        __main__.main()
+    assert exc_info.value.code == 1
+
+
+def test_main_exits_cleanly_on_success(monkeypatch):
+    monkeypatch.setattr(__main__, "app", lambda *args, **kwargs: None)
+    monkeypatch.setattr(__main__, "RECONNECT", False)
+    __main__.main()


### PR DESCRIPTION
## Problem

All handled exceptions in `invoke_cli_with_error_handling()` — `ConnectionTerminatedError` ("Connection was terminated abruptly"), `NoDeviceConnectedError`, `NotPairedError`, and the rest — are logged as friendly one-liners, but `main()` then returns normally, so the process exits **0**. Scripts and CI have no way to detect the failure. This is the core actionable part of #1682:

> iOS ≤ 16: The command exits with code 0 and writes nothing to stdout. Only stderr shows "Connection was terminated abruptly". Since exit code is 0, there's no way to programmatically detect the failure.

## Fix

Track a module-level `EXIT_CODE`, set it to 1 on every handled-error path, and `sys.exit()` with it from `main()` when non-zero. Success still returns cleanly (no `SystemExit(0)` raised through embedders).

Interaction with existing flows:
- **Implicit-tunnel retry** (`InvalidServiceError`/`RSDRequiredError` → recursive `main()`): a successful retry resets the code to 0 before the outer `main()` checks it; a failed retry propagates its own non-zero `SystemExit`.
- **`--reconnect` loop**: unchanged; the final exit code reflects the last attempt.
- Typer/click usage errors already exited 2 via their own `SystemExit` and are unaffected.

## Testing

- New regression tests in `tests/cli/test_cli.py` covering the disconnect path (`return True` handlers), the fall-through path, and the clean-success path — all 67 CLI tests pass.
- End-to-end: `pymobiledevice3 lockdown info --udid nonexistent` now exits 1 (was 0); `pymobiledevice3 usbmux list` still exits 0.
- `ruff check`/`format` clean; pyright reports no errors in touched files.

Fixes the exit-code portion of #1682.