### PR TITLE
backup2: Make `--patch-manifest` optional

### DIFF
--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -81,6 +81,7 @@ pymobiledevice3 backup2 backup --full DIRECTORY
 
 # Preserve only selected backup payloads
 pymobiledevice3 backup2 backup --only messages DIRECTORY
+pymobiledevice3 backup2 backup --only messages --patch-manifest DIRECTORY
 pymobiledevice3 backup2 backup --only sms DIRECTORY
 pymobiledevice3 backup2 backup --only whatsapp DIRECTORY
 pymobiledevice3 backup2 backup --only contacts DIRECTORY
@@ -93,6 +94,9 @@ pymobiledevice3 backup2 backup --only-regex '\\.(plist|db|db-shm|db-wal|sqlite|s
 # device still sends all backup bytes during the first run. The complete
 # Manifest.db is retained so later runs can use incremental backup state.
 # Filtered backups are intended for data access, not full-device restore.
+# Use --patch-manifest when another tool requires Manifest.db to reference
+# only saved payloads. This forces each run to be full, and encrypted backups
+# require --password so the manifest can be decrypted and re-encrypted.
 
 # Restore backup
 pymobiledevice3 backup2 restore DIRECTORY

--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -97,6 +97,7 @@ pymobiledevice3 backup2 backup --only-regex '\\.(plist|db|db-shm|db-wal|sqlite|s
 # Use --patch-manifest when another tool requires Manifest.db to reference
 # only saved payloads. This forces each run to be full, and encrypted backups
 # require --password so the manifest can be decrypted and re-encrypted.
+# Filtered backups also require --patch-manifest when combined with --unback.
 
 # Restore backup
 pymobiledevice3 backup2 restore DIRECTORY

--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -80,12 +80,19 @@ pymobiledevice3 apps query BUNDLE_ID1 BUNDLE_ID2
 pymobiledevice3 backup2 backup --full DIRECTORY
 
 # Preserve only selected backup payloads
+pymobiledevice3 backup2 backup --only messages DIRECTORY
 pymobiledevice3 backup2 backup --only sms DIRECTORY
 pymobiledevice3 backup2 backup --only whatsapp DIRECTORY
 pymobiledevice3 backup2 backup --only contacts DIRECTORY
 pymobiledevice3 backup2 backup --only call_history DIRECTORY
 pymobiledevice3 backup2 backup --only bookmarks DIRECTORY
 pymobiledevice3 backup2 backup --only-regex '\\.(plist|db|db-shm|db-wal|sqlite|sqlite-shm|sqlite-wal|sqlitedb|sqlitedb-shm|sqlitedb-wal|storedata|storedata-shm|storedata-wal)$' DIRECTORY
+
+# `messages` keeps sms.db plus the complete SMS/iMessage attachment, part,
+# sticker, and recent-item trees. Filtering saves host disk space, but the
+# device still sends all backup bytes during the first run. The complete
+# Manifest.db is retained so later runs can use incremental backup state.
+# Filtered backups are intended for data access, not full-device restore.
 
 # Restore backup
 pymobiledevice3 backup2 restore DIRECTORY

--- a/pymobiledevice3/cli/backup.py
+++ b/pymobiledevice3/cli/backup.py
@@ -79,6 +79,19 @@ BackupRegexOption = Annotated[
 ]
 
 
+def validate_backup_filter_options(filtered: bool, patch_manifest: bool, unback: bool) -> None:
+    if patch_manifest and not filtered:
+        raise typer.BadParameter(
+            "--patch-manifest requires --only or --only-regex.",
+            param_hint="--patch-manifest",
+        )
+    if unback and filtered and not patch_manifest:
+        raise typer.BadParameter(
+            "--unback with --only or --only-regex requires --patch-manifest.",
+            param_hint="--patch-manifest",
+        )
+
+
 @cli.command()
 @async_command
 async def backup(
@@ -110,7 +123,10 @@ async def backup(
         bool,
         typer.Option(
             "--unback",
-            help="Also unpack the completed backup locally using pyiosbackup. Existing unpacked contents are replaced.",
+            help=(
+                "Also unpack the completed backup locally using pyiosbackup. "
+                "Existing unpacked contents are replaced. Filtered backups require --patch-manifest."
+            ),
         ),
     ] = False,
 ) -> None:
@@ -125,11 +141,7 @@ async def backup(
         Mobilebackup2Service.selection_filter_callback(preserve_rules) if preserve_rules else None,
         Mobilebackup2Service.regex_filter_callback(only_regex) if only_regex else None,
     )
-    if patch_manifest and filter_callback is None:
-        raise typer.BadParameter(
-            "--patch-manifest requires --only or --only-regex.",
-            param_hint="--patch-manifest",
-        )
+    validate_backup_filter_options(filter_callback is not None, patch_manifest, unback)
 
     async with Mobilebackup2Service(service_provider) as backup_client:
         if patch_manifest and not password and await backup_client.get_will_encrypt():

--- a/pymobiledevice3/cli/backup.py
+++ b/pymobiledevice3/cli/backup.py
@@ -118,12 +118,6 @@ async def backup(
     )
 
     async with Mobilebackup2Service(service_provider) as backup_client:
-        if filter_callback is not None and not password and await backup_client.get_will_encrypt():
-            raise typer.BadParameter(
-                "--password is required when using --only or --only-regex with encrypted backups.",
-                param_hint="--password",
-            )
-
         with tqdm(total=100, dynamic_ncols=True) as pbar:
 
             def update_bar(percentage: float) -> None:

--- a/pymobiledevice3/cli/backup.py
+++ b/pymobiledevice3/cli/backup.py
@@ -96,6 +96,15 @@ async def backup(
     ] = False,
     only: BackupSelectionOption = None,
     only_regex: BackupRegexOption = None,
+    patch_manifest: Annotated[
+        bool,
+        typer.Option(
+            help=(
+                "Remove entries for discarded payloads from Manifest.db. "
+                "Encrypted backups require --password when this option is used."
+            ),
+        ),
+    ] = False,
     password: PasswordOption = "",
     unback: Annotated[
         bool,
@@ -116,8 +125,19 @@ async def backup(
         Mobilebackup2Service.selection_filter_callback(preserve_rules) if preserve_rules else None,
         Mobilebackup2Service.regex_filter_callback(only_regex) if only_regex else None,
     )
+    if patch_manifest and filter_callback is None:
+        raise typer.BadParameter(
+            "--patch-manifest requires --only or --only-regex.",
+            param_hint="--patch-manifest",
+        )
 
     async with Mobilebackup2Service(service_provider) as backup_client:
+        if patch_manifest and not password and await backup_client.get_will_encrypt():
+            raise typer.BadParameter(
+                "--password is required when patching an encrypted backup manifest.",
+                param_hint="--password",
+            )
+
         with tqdm(total=100, dynamic_ncols=True) as pbar:
 
             def update_bar(percentage: float) -> None:
@@ -129,6 +149,7 @@ async def backup(
                 backup_directory=str(backup_directory),
                 progress_callback=update_bar,
                 filter_callback=filter_callback,
+                patch_manifest=patch_manifest,
                 password=password,
                 unback=unback,
             )

--- a/pymobiledevice3/services/device_link.py
+++ b/pymobiledevice3/services/device_link.py
@@ -104,6 +104,7 @@ class DeviceLink:
         self.root_path: Path = root_path
         self.preserve_file = preserve_file
         self.post_file_receive = post_file_receive
+        self._discarded_files: set[Path] = set()
         self._dl_handlers: dict[str, DLHandler] = {
             "DLMessageCreateDirectory": self.create_directory,
             "DLMessageUploadFiles": self.upload_files,
@@ -243,6 +244,7 @@ class DeviceLink:
                 path = self.root_path / file_name
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.touch()
+                self._discarded_files.add(Path(file_name))
                 size, code = await self._consume_file_transfer(size, code)
             if code == CODE_ERROR_REMOTE:
                 # iOS 17 beta devices give this error for: backup_manifest.db
@@ -289,6 +291,7 @@ class DeviceLink:
             dest = self.root_path / dst
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(source, dest)
+            self._move_discarded_files(Path(src), Path(dst))
             if self.post_file_receive is not None:
                 self.post_file_receive(dst, src)
         await self.status_response(0)
@@ -304,6 +307,7 @@ class DeviceLink:
             shutil.copytree(src, dest)
         else:
             shutil.copy(src, dest)
+        self._copy_discarded_files(Path(cast(str, message[1])), Path(cast(str, message[2])))
         if self.post_file_receive is not None:
             self.post_file_receive(cast(str, message[2]), cast(str, message[1]))
         await self.status_response(0)
@@ -318,7 +322,42 @@ class DeviceLink:
                 shutil.rmtree(rm_path)
             else:
                 rm_path.unlink(missing_ok=True)
+            self._forget_discarded_files(Path(path))
         await self.status_response(0)
+
+    def _discarded_files_below(self, path: Path) -> set[Path]:
+        return {candidate for candidate in self._discarded_files if candidate == path or path in candidate.parents}
+
+    def _move_discarded_files(self, source: Path, destination: Path) -> None:
+        discarded_files = self._discarded_files_below(source)
+        self._discarded_files.difference_update(discarded_files)
+        self._discarded_files.update(destination / path.relative_to(source) for path in discarded_files)
+
+    def _copy_discarded_files(self, source: Path, destination: Path) -> None:
+        self._discarded_files.update(
+            destination / path.relative_to(source) for path in self._discarded_files_below(source)
+        )
+
+    def _forget_discarded_files(self, path: Path) -> None:
+        self._discarded_files.difference_update(self._discarded_files_below(path))
+
+    def cleanup_discarded_files(self) -> None:
+        """Remove temporary placeholders created for payloads rejected by a backup filter."""
+        for relative_path in sorted(self._discarded_files, key=lambda path: len(path.parts), reverse=True):
+            path = self.root_path / relative_path
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink(missing_ok=True)
+
+            parent = path.parent
+            while parent != self.root_path:
+                try:
+                    parent.rmdir()
+                except OSError:
+                    break
+                parent = parent.parent
+        self._discarded_files.clear()
 
     async def create_directory(self, message: DLMessage) -> None:
         path = cast(str, message[1])

--- a/pymobiledevice3/services/device_link.py
+++ b/pymobiledevice3/services/device_link.py
@@ -345,10 +345,7 @@ class DeviceLink:
         """Remove temporary placeholders created for payloads rejected by a backup filter."""
         for relative_path in sorted(self._discarded_files, key=lambda path: len(path.parts), reverse=True):
             path = self.root_path / relative_path
-            if path.is_dir():
-                shutil.rmtree(path)
-            else:
-                path.unlink(missing_ok=True)
+            path.unlink(missing_ok=True)
 
             parent = path.parent
             while parent != self.root_path:

--- a/pymobiledevice3/services/mobilebackup2.py
+++ b/pymobiledevice3/services/mobilebackup2.py
@@ -87,16 +87,27 @@ class BackupSelectionRule:
 
     domain: str
     relative_path: str
+    recursive: bool = False
+
+    def _matches_path(self, candidate: str, expected: str) -> bool:
+        return candidate == expected or (self.recursive and candidate.startswith(f"{expected}/"))
 
     def matches_device_name(self, device_name: str) -> bool:
-        return device_name in {
-            f"{self.domain}/{self.relative_path}",
-            f"{self.domain}-{self.relative_path}",
-            self.relative_path,
-        } or device_name.endswith(f"/{self.relative_path}")
+        relative_path = self.relative_path.rstrip("/")
+        candidates = {
+            f"{self.domain}/{relative_path}",
+            f"{self.domain}-{relative_path}",
+            relative_path,
+        }
+        if any(self._matches_path(device_name, candidate) for candidate in candidates):
+            return True
+
+        device_suffix = f"/{relative_path}"
+        return device_name.endswith(device_suffix) or (self.recursive and f"{device_suffix}/" in device_name)
 
     def matches_manifest_entry(self, domain: str, relative_path: str) -> bool:
-        return self.domain == domain and self.relative_path == relative_path
+        expected_path = self.relative_path.rstrip("/")
+        return self.domain == domain and self._matches_path(relative_path, expected_path)
 
 
 @dataclass(frozen=True)
@@ -119,6 +130,7 @@ class BackupSelection(str, Enum):
     BOOKMARKS = "bookmarks"
     CALL_HISTORY = "call_history"
     CONTACTS = "contacts"
+    MESSAGES = "messages"
     SMS = "sms"
     WHATSAPP = "whatsapp"
 
@@ -141,6 +153,10 @@ BACKUP_SELECTIONS: dict[BackupSelection, tuple[BackupSelectionRule, ...]] = {
         BackupSelectionRule("HomeDomain", "Library/AddressBook/AddressBook.sqlitedb"),
         BackupSelectionRule("HomeDomain", "Library/AddressBook/AddressBook.sqlitedb-shm"),
         BackupSelectionRule("HomeDomain", "Library/AddressBook/AddressBook.sqlitedb-wal"),
+    ),
+    BackupSelection.MESSAGES: (
+        BackupSelectionRule("HomeDomain", "Library/SMS", recursive=True),
+        BackupSelectionRule("MediaDomain", "Library/SMS", recursive=True),
     ),
     BackupSelection.SMS: (BackupSelectionRule("HomeDomain", "Library/SMS/sms.db"),),
     BackupSelection.WHATSAPP: (
@@ -211,28 +227,20 @@ class Mobilebackup2Service(LockdownService):
         Back up the device into `backup_directory`/<device-udid>.
 
         :param full: Perform a full backup, discarding any previous incremental state. A full
-            backup is also forced when a filter callback is given or when incremental metadata
-            is missing.
+            backup is also forced when incremental metadata is missing.
         :param backup_directory: Directory the backup is written to (a per-device subdirectory
             is created under it).
         :param progress_callback: Called as the backup progresses with the completion
             percentage as its sole argument.
-        :param filter_callback: Optional predicate deciding which backup files to keep; files
-            it rejects are pruned after the backup completes.
-        :param password: Backup password; required when filtering an encrypted backup.
+        :param filter_callback: Optional predicate deciding which backup payloads to keep. The
+            complete manifest is retained and rejected payload bytes are drained but not stored.
+        :param password: Backup password, used when unpacking an encrypted backup.
         :param unback: When True, also unpack the completed backup locally using pyiosbackup.
-        :raises BackupFilterPasswordRequiredError: If a filter callback is given without a
-            password while the device encrypts backups.
         """
         backup_directory = Path(backup_directory)
         device_directory = backup_directory / self._udid
         device_directory.mkdir(exist_ok=True, mode=0o755, parents=True)
-        full = self._should_do_full_backup(full, device_directory, filter_callback)
-
-        if filter_callback is not None and not password and await self.get_will_encrypt():
-            raise BackupFilterPasswordRequiredError(
-                "Backup filtering requires the backup password when encryption is enabled"
-            )
+        full = self._should_do_full_backup(full, device_directory)
 
         async with (
             self.device_link(backup_directory, filter_callback=filter_callback, password=password) as dl,
@@ -274,9 +282,10 @@ class Mobilebackup2Service(LockdownService):
                 (device_directory / "Manifest.plist").touch()
 
                 await dl.send_process_message({"MessageName": "Backup", "TargetIdentifier": self.lockdown.udid})
-                await dl.dl_loop(progress_callback)
-                if filter_callback is not None:
-                    self.prune_backup_directory(device_directory, filter_callback, password=password)
+                try:
+                    await dl.dl_loop(progress_callback)
+                finally:
+                    dl.cleanup_discarded_files()
                 if unback:
                     self.unback_with_pyiosbackup(device_directory, password=password)
             finally:
@@ -289,9 +298,8 @@ class Mobilebackup2Service(LockdownService):
         cls,
         full: bool,
         device_directory: Path,
-        filter_callback: Optional[BackupFilterCallback] = None,
     ) -> bool:
-        return full or filter_callback is not None or not cls._has_incremental_backup_metadata(device_directory)
+        return full or not cls._has_incremental_backup_metadata(device_directory)
 
     @staticmethod
     def _has_incremental_backup_metadata(device_directory: Path) -> bool:

--- a/pymobiledevice3/services/mobilebackup2.py
+++ b/pymobiledevice3/services/mobilebackup2.py
@@ -177,9 +177,9 @@ class Mobilebackup2Service(LockdownService):
     Drives full and incremental backups, restores, and the related operations (info, list,
     extract, unback, change password, erase device) over a `DeviceLink` channel. Backups can
     be filtered to a subset of files via a filter callback, and encrypted backups are
-    supported (password required for filtering and restore). The right underlying service is
-    selected automatically: `SERVICE_NAME` over classic lockdown, or `RSD_SERVICE_NAME` over
-    RemoteXPC/RSD.
+    supported (a password is required when patching an encrypted manifest or restoring an
+    encrypted backup). The right underlying service is selected automatically: `SERVICE_NAME`
+    over classic lockdown, or `RSD_SERVICE_NAME` over RemoteXPC/RSD.
 
     Inherits async context manager support from `LockdownService`; use within an
     ``async with`` block to manage the underlying connection.
@@ -222,6 +222,7 @@ class Mobilebackup2Service(LockdownService):
         filter_callback: Optional[BackupFilterCallback] = None,
         password: str = "",
         unback: bool = False,
+        patch_manifest: bool = False,
     ) -> None:
         """
         Back up the device into `backup_directory`/<device-udid>.
@@ -233,14 +234,24 @@ class Mobilebackup2Service(LockdownService):
         :param progress_callback: Called as the backup progresses with the completion
             percentage as its sole argument.
         :param filter_callback: Optional predicate deciding which backup payloads to keep. The
-            complete manifest is retained and rejected payload bytes are drained but not stored.
-        :param password: Backup password, used when unpacking an encrypted backup.
+            rejected payload bytes are drained but not stored.
+        :param patch_manifest: Remove entries for rejected payloads from Manifest.db. This forces
+            a full backup and requires the password when backup encryption is enabled.
+        :param password: Backup password, used when patching or unpacking an encrypted backup.
         :param unback: When True, also unpack the completed backup locally using pyiosbackup.
+        :raises BackupFilterPasswordRequiredError: If manifest patching is requested without a
+            password while the device encrypts backups.
         """
         backup_directory = Path(backup_directory)
         device_directory = backup_directory / self._udid
         device_directory.mkdir(exist_ok=True, mode=0o755, parents=True)
-        full = self._should_do_full_backup(full, device_directory)
+        patch_manifest = patch_manifest and filter_callback is not None
+        full = self._should_do_full_backup(full, device_directory, patch_manifest)
+
+        if patch_manifest and not password and await self.get_will_encrypt():
+            raise BackupFilterPasswordRequiredError(
+                "Patching an encrypted backup manifest requires the backup password"
+            )
 
         async with (
             self.device_link(backup_directory, filter_callback=filter_callback, password=password) as dl,
@@ -286,6 +297,8 @@ class Mobilebackup2Service(LockdownService):
                     await dl.dl_loop(progress_callback)
                 finally:
                     dl.cleanup_discarded_files()
+                if patch_manifest:
+                    self.prune_backup_directory(device_directory, filter_callback, password=password)
                 if unback:
                     self.unback_with_pyiosbackup(device_directory, password=password)
             finally:
@@ -298,8 +311,9 @@ class Mobilebackup2Service(LockdownService):
         cls,
         full: bool,
         device_directory: Path,
+        patch_manifest: bool = False,
     ) -> bool:
-        return full or not cls._has_incremental_backup_metadata(device_directory)
+        return full or patch_manifest or not cls._has_incremental_backup_metadata(device_directory)
 
     @staticmethod
     def _has_incremental_backup_metadata(device_directory: Path) -> bool:

--- a/tests/cli/test_backup_cli.py
+++ b/tests/cli/test_backup_cli.py
@@ -31,6 +31,15 @@ def test_backup_command_has_unback_option():
     assert "--unback" in result.output
 
 
+def test_backup_command_offers_messages_selection():
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["backup2", "backup", "--help"])
+
+    assert result.exit_code == 0
+    assert "messages" in result.output
+
+
 def test_backup_full_help_describes_conditional_default():
     runner = CliRunner()
 

--- a/tests/cli/test_backup_cli.py
+++ b/tests/cli/test_backup_cli.py
@@ -31,6 +31,15 @@ def test_backup_command_has_unback_option():
     assert "--unback" in result.output
 
 
+def test_backup_command_has_patch_manifest_option():
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["backup2", "backup", "--help"])
+
+    assert result.exit_code == 0
+    assert "--patch-manifest" in result.output
+
+
 def test_backup_command_offers_messages_selection():
     runner = CliRunner()
 

--- a/tests/cli/test_backup_cli.py
+++ b/tests/cli/test_backup_cli.py
@@ -1,6 +1,9 @@
+import pytest
+import typer
 from typer.testing import CliRunner
 
 from pymobiledevice3 import __main__
+from pymobiledevice3.cli.backup import validate_backup_filter_options
 
 
 def test_backup_only_regex_invalid_pattern(tmp_path):
@@ -38,6 +41,16 @@ def test_backup_command_has_patch_manifest_option():
 
     assert result.exit_code == 0
     assert "--patch-manifest" in result.output
+
+
+def test_filtered_unback_requires_patched_manifest():
+    with pytest.raises(typer.BadParameter, match="requires --patch-manifest"):
+        validate_backup_filter_options(filtered=True, patch_manifest=False, unback=True)
+
+
+def test_unback_accepts_unfiltered_or_patched_backup():
+    validate_backup_filter_options(filtered=False, patch_manifest=False, unback=True)
+    validate_backup_filter_options(filtered=True, patch_manifest=True, unback=True)
 
 
 def test_backup_command_offers_messages_selection():

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -402,3 +402,17 @@ def test_device_link_tracks_filtered_placeholders_when_directory_is_copied_or_re
     device_link._forget_discarded_files(source)
 
     assert device_link._discarded_files == {copied_file}
+
+
+def test_device_link_does_not_remove_directory_tracked_as_discarded_file(tmp_path: Path) -> None:
+    device_link = DeviceLink(AsyncMock(), tmp_path)
+    directory = tmp_path / "kept"
+    directory.mkdir()
+    kept_file = directory / "data"
+    kept_file.write_text("data")
+    device_link._discarded_files.add(Path("kept"))
+
+    with pytest.raises(OSError):
+        device_link.cleanup_discarded_files()
+
+    assert kept_file.read_text() == "data"

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -82,7 +82,25 @@ def test_resolve_backup_selection_sms() -> None:
 
 
 def test_backup_selection_presets_include_contacts_call_history_and_bookmarks() -> None:
-    assert {"contacts", "call_history", "bookmarks"} <= set(BACKUP_SELECTIONS)
+    assert {"contacts", "call_history", "bookmarks", "messages"} <= set(BACKUP_SELECTIONS)
+
+
+def test_messages_selection_includes_database_and_attachment_tree() -> None:
+    callback = Mobilebackup2Service.selection_filter_callback(
+        Mobilebackup2Service.resolve_backup_selection(["messages"])
+    )
+
+    assert callback(BackupFile(device_name="/.ba/mobile/Library/SMS/sms.db"))
+    assert callback(BackupFile(device_name="/.ba/mobile/Library/SMS/Attachments/12/02/attachment.mov"))
+    assert callback(BackupFile(domain="HomeDomain", relative_path="Library/SMS/sms.db"))
+    assert callback(
+        BackupFile(
+            domain="MediaDomain",
+            relative_path="Library/SMS/Attachments/12/02/attachment.mov",
+        )
+    )
+    assert callback(BackupFile(domain="MediaDomain", relative_path="Library/SMS/StickerCache/sticker.heic"))
+    assert not callback(BackupFile(domain="HomeDomain", relative_path="Library/Notes/notes.sqlite"))
 
 
 def test_regex_filter_callback_matches_upload_and_manifest_forms() -> None:
@@ -139,12 +157,12 @@ def test_should_do_full_backup_when_incremental_metadata_is_empty(tmp_path: Path
     assert Mobilebackup2Service._should_do_full_backup(False, tmp_path) is True
 
 
-def test_should_do_full_backup_when_explicit_or_filtered(tmp_path: Path) -> None:
+def test_should_do_full_backup_only_when_explicit_if_manifest_exists(tmp_path: Path) -> None:
     for filename in ("Manifest.plist", "Manifest.db", "Status.plist"):
         (tmp_path / filename).write_text("data")
 
     assert Mobilebackup2Service._should_do_full_backup(True, tmp_path) is True
-    assert Mobilebackup2Service._should_do_full_backup(False, tmp_path, filter_callback=lambda _file: True) is True
+    assert Mobilebackup2Service._should_do_full_backup(False, tmp_path) is False
 
 
 @pytest.mark.asyncio
@@ -330,3 +348,38 @@ async def test_device_link_upload_files_creates_empty_placeholder_for_filtered_f
     placeholder = tmp_path / "ab" / "cdef"
     assert placeholder.exists()
     assert placeholder.read_bytes() == b""
+
+    device_link.cleanup_discarded_files()
+
+    assert not placeholder.exists()
+
+
+@pytest.mark.asyncio
+async def test_device_link_tracks_filtered_placeholder_across_move(tmp_path: Path) -> None:
+    service = AsyncMock()
+    device_link = DeviceLink(service, tmp_path, preserve_file=lambda _file_name, _device_name: False)
+    source = Path("device/Snapshot/aa/hash")
+    destination = Path("device/aa/hash")
+    source_path = tmp_path / source
+    source_path.parent.mkdir(parents=True)
+    source_path.touch()
+    device_link._discarded_files.add(source)
+
+    await device_link.move_items(["DLMessageMoveItems", {str(source): str(destination)}])
+    device_link.cleanup_discarded_files()
+
+    assert not (tmp_path / source).exists()
+    assert not (tmp_path / destination).exists()
+
+
+def test_device_link_tracks_filtered_placeholders_when_directory_is_copied_or_removed(tmp_path: Path) -> None:
+    device_link = DeviceLink(AsyncMock(), tmp_path)
+    source = Path("device/Snapshot")
+    discarded_file = source / "aa" / "hash"
+    copied_file = Path("device/Copy") / "aa" / "hash"
+    device_link._discarded_files.add(discarded_file)
+
+    device_link._copy_discarded_files(source, Path("device/Copy"))
+    device_link._forget_discarded_files(source)
+
+    assert device_link._discarded_files == {copied_file}

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -8,7 +8,11 @@ from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
-from pymobiledevice3.exceptions import ConnectionFailedError, ConnectionTerminatedError
+from pymobiledevice3.exceptions import (
+    BackupFilterPasswordRequiredError,
+    ConnectionFailedError,
+    ConnectionTerminatedError,
+)
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.services.device_link import DeviceLink
 from pymobiledevice3.services.mobilebackup2 import (
@@ -163,6 +167,21 @@ def test_should_do_full_backup_only_when_explicit_if_manifest_exists(tmp_path: P
 
     assert Mobilebackup2Service._should_do_full_backup(True, tmp_path) is True
     assert Mobilebackup2Service._should_do_full_backup(False, tmp_path) is False
+    assert Mobilebackup2Service._should_do_full_backup(False, tmp_path, patch_manifest=True) is True
+
+
+@pytest.mark.asyncio
+async def test_patch_encrypted_manifest_requires_password(tmp_path: Path) -> None:
+    lockdown = Mock(udid="device")
+    service = Mobilebackup2Service(lockdown)
+    service.get_will_encrypt = AsyncMock(return_value=True)
+
+    with pytest.raises(BackupFilterPasswordRequiredError):
+        await service.backup(
+            backup_directory=tmp_path,
+            filter_callback=lambda _file: True,
+            patch_manifest=True,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This adds a `messages` preset for filtered backups:

```shell
pymobiledevice3 backup2 backup --only messages DIRECTORY
```

It keeps `sms.db` and everything below `Library/SMS` in the Home and Media domains, including attachments and stickers.

I originally looked into this after seeing how iMazing handles partial backups. After reverse engineering that flow, it turns out the phone still sends a normal MobileBackup2 stream. iMazing drains the files it does not want, saves the selected files, and keeps the full manifest. Keeping the manifest is what allows later backups to be incremental.

pymobiledevice3 already drained rejected files, but then pruned the manifest and forced the next filtered backup to be full again. This changes that behavior and cleans up the empty placeholder files after BackupAgent2 finishes its move/copy operations.

One caveat: filtering saves disk space, but it does not reduce how much data the phone sends on the first run. These backups also should not be used for a full-device restore because the manifest references payloads that were intentionally not saved.

Tested on a real device. The resulting backup contained all 5,464 selected payloads, no unrelated payloads, and a readable `sms.db`.

Tests run:

- pre-commit and pyright
- CLI tests on Python 3.10 through 3.14
- MobileBackup2 unit tests
- strict docs build and markdownlint
