### PR TITLE
mobile_conig: Add the `LiquidGlass` new skip key introduced in iOS 27

### DIFF
--- a/pymobiledevice3/services/mobile_config.py
+++ b/pymobiledevice3/services/mobile_config.py
@@ -411,6 +411,7 @@ class MobileConfigService(LockdownService):
                 "SafetyAndHandling",
                 "Tips",
                 "AgeBasedSafetySettings",
+                "LiquidGlass",
             ],
             "SupervisorHostCertificates": [public_key],
         })


### PR DESCRIPTION
## Summary
new skip key added with iOS/iPadOS/macOS 27