### PR TITLE
ci: Restore python3.9 testing via uv-managed interpreters

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,18 +21,17 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install uv
+      # uv provisions the interpreter (python-build-standalone): unlike actions/setup-python,
+      # it still provides 3.9 on current runner images (ubuntu-24.04, arm64 macOS).
+      - name: Install uv and Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v7
         with:
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml


### PR DESCRIPTION
## Summary

Python 3.9 was dropped from the CI matrix in 01e937a8 because `actions/setup-python` no longer provides 3.9 builds for current runner images (ubuntu-24.04, arm64 macOS) — not because the project stopped supporting it (3.9 remains the declared floor, matching the Python Apple still ships with Command Line Tools, and pyright is pinned to `pythonVersion = "3.9"`).

Since the test job already runs everything through uv, this drops the `actions/setup-python` step and lets `astral-sh/setup-uv` provision the interpreter instead (python-build-standalone), which still ships 3.9 for all three runner OSes. `"3.9"` is added back to the matrix.

## Testing

- `uv run --python 3.9 --extra test pytest -m cli`: 118 passed locally — full dependency set still resolves and installs cleanly on a uv-managed 3.9
- The PR's own CI run exercises the new 3.9×{ubuntu,macos,windows} legs