### PR TITLE
Add four RSD services, outbound XPC file transfer, and cryptexd scaffolding

### DIFF
--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -218,6 +218,13 @@ See [iOS 17+ tunnels](ios17-tunnels.md) for tunnel setup.
 ```shell
 # Take a screenshot (PNG)
 pymobiledevice3 developer core-device screen-capture screenshot /path/to/screen.png
+
+# Fetch an application's icon (PNG). Size is given in points; pixel size is size * scale
+pymobiledevice3 developer core-device fetch-app-icon com.apple.Preferences /path/to/icon.png
+pymobiledevice3 developer core-device fetch-app-icon com.example.app /path/to/icon.png --width 176 --height 176 --scale 2
+
+# Fail instead of returning a generic placeholder when the app has no icon
+pymobiledevice3 developer core-device fetch-app-icon com.example.app /path/to/icon.png --no-placeholder
 ```
 
 ### HID input

--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -104,6 +104,13 @@ pymobiledevice3 profile install my.mobileconfig
 pymobiledevice3 profile remove com.example.profile
 ```
 
+## App install records (iOS 17+, RSD tunnel)
+
+```shell
+# LaunchServices install record (DB UUID/sequence, install path, persistent identifier)
+pymobiledevice3 apps install-record com.apple.Preferences --userspace
+```
+
 ## Darwin Notifications
 
 ```shell

--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -104,6 +104,43 @@ pymobiledevice3 profile install my.mobileconfig
 pymobiledevice3 profile remove com.example.profile
 ```
 
+## Cryptexes (iOS 17+, RSD tunnel)
+
+Talks to `cryptexd` directly. `cryptex list` reports a mounted personalized DeveloperDiskImage as
+`com.apple.MobileAsset.DDI`.
+
+```shell
+pymobiledevice3 cryptex list --userspace
+pymobiledevice3 cryptex personalization-identifiers --userspace
+pymobiledevice3 cryptex nonce --userspace
+pymobiledevice3 cryptex nonce --nonce-domain-handle 7 --userspace
+```
+
+State-changing. Rolling a nonce invalidates anything personalized against it, so a mounted
+personalized DDI must be re-personalized and re-mounted afterwards:
+
+```shell
+pymobiledevice3 cryptex roll-nonce --userspace
+pymobiledevice3 cryptex uninstall com.apple.MobileAsset.DDI --userspace
+```
+
+!!! note "Overlap with `mounter`"
+
+    `cryptexd` and the image mounter are two front-ends onto the same cryptex subsystem, so some
+    queries exist in both places. Where they overlap, `cryptex` is the more precise source:
+
+    - `cryptex personalization-identifiers` returns a strict superset of
+      `mounter query-personalization-identifiers` (19 `img4_chip_*` fields versus 8), including
+      the product class used by the `Cryptex1,UseProductClass` personalization variant.
+    - `cryptex nonce` returns the nonce structure (56 bytes, the 48-byte nonce at offset 2);
+      `mounter query-nonce` returns those 48 bytes alone.
+    - `cryptex nonce` validates the domain and fails loudly on an unknown one, whereas
+      `mounter query-nonce` silently falls back to the default nonce for an unrecognized
+      `--image-type`.
+
+    `mounter` still wins when you have no tunnel: it works over plain USB, while every `cryptex`
+    command needs RSD.
+
 ## App install records (iOS 17+, RSD tunnel)
 
 ```shell

--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -104,6 +104,24 @@ pymobiledevice3 profile install my.mobileconfig
 pymobiledevice3 profile remove com.example.profile
 ```
 
+## Darwin Notifications
+
+```shell
+# Post a notification
+pymobiledevice3 notification post com.example.notification
+
+# Subscribe and stream notifications as they fire
+pymobiledevice3 notification observe com.example.notification
+```
+
+On iOS 17+ with an RSD tunnel, `--remotexpc` talks to the notification proxy directly over
+RemoteXPC instead of tunnelling the lockdown service through its `.shim.remote` alias:
+
+```shell
+pymobiledevice3 notification observe --remotexpc com.example.notification --userspace
+pymobiledevice3 notification post --remotexpc com.example.notification --userspace
+```
+
 ## SpringBoard UI
 
 ```shell

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -46,6 +46,7 @@ from pymobiledevice3.exceptions import (
     DeviceHasPasscodeSetError,
     DeviceNotFoundError,
     FeatureNotSupportedError,
+    InstallCoordinationError,
     InternalError,
     InvalidServiceError,
     MessageNotSupportedError,
@@ -407,6 +408,8 @@ def invoke_cli_with_error_handling() -> bool:
         logger.error("Not enough disk space")
     except DeprecationError:
         logger.error("failed to query MobileGestalt, MobileGestalt deprecated (iOS >= 17.4).")
+    except InstallCoordinationError as e:
+        logger.error(f"install coordination request failed: {e}")
     except OSNotSupportedError as e:
         logger.error(
             f"Unsupported OS - {e.os_name}. To add support, consider contributing at "

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -40,6 +40,7 @@ from pymobiledevice3.exceptions import (
     ConnectionFailedError,
     ConnectionFailedToUsbmuxdError,
     ConnectionTerminatedError,
+    CryptexdError,
     DeprecationError,
     DeveloperModeError,
     DeveloperModeIsNotEnabledError,
@@ -118,6 +119,7 @@ CLI_GROUPS = {
     "bonjour": "bonjour",
     "companion": "companion_proxy",
     "crash": "crash",
+    "cryptex": "cryptex",
     "developer": "developer",
     "diagnostics": "diagnostics",
     "lockdown": "lockdown",
@@ -408,6 +410,8 @@ def invoke_cli_with_error_handling() -> bool:
         logger.error("Not enough disk space")
     except DeprecationError:
         logger.error("failed to query MobileGestalt, MobileGestalt deprecated (iOS >= 17.4).")
+    except CryptexdError as e:
+        logger.error(f"cryptexd rejected the request: {e}")
     except InstallCoordinationError as e:
         logger.error(f"install coordination request failed: {e}")
     except OSNotSupportedError as e:

--- a/pymobiledevice3/cli/apps.py
+++ b/pymobiledevice3/cli/apps.py
@@ -1,11 +1,19 @@
+import dataclasses
 from pathlib import Path
 from typing import Annotated, Literal
 
 import typer
 from typer_injector import InjectingTyper
 
-from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command, cli_loop, print_json
+from pymobiledevice3.cli.cli_common import (
+    RSDServiceProviderDep,
+    ServiceProviderDep,
+    async_command,
+    cli_loop,
+    print_json,
+)
 from pymobiledevice3.services.house_arrest import HouseArrestService
+from pymobiledevice3.services.install_coordination_proxy import InstallCoordinationProxyService
 from pymobiledevice3.services.installation_proxy import InstallationProxyService
 
 cli = InjectingTyper(
@@ -147,3 +155,11 @@ async def rm(
         lockdown=service_provider, bundle_id=bundle_id, documents_only=documents
     ) as service:
         await service.rm(remote_file)
+
+
+@cli.command("install-record")
+@async_command
+async def install_record(service_provider: RSDServiceProviderDep, bundle_id: str) -> None:
+    """Query an app's LaunchServices install record via installcoordination_proxy."""
+    async with InstallCoordinationProxyService(service_provider) as service:
+        print_json(dataclasses.asdict(await service.query(bundle_id)))

--- a/pymobiledevice3/cli/cryptex.py
+++ b/pymobiledevice3/cli/cryptex.py
@@ -1,0 +1,87 @@
+import dataclasses
+import logging
+from typing import Annotated, Optional
+
+import typer
+from typer_injector import InjectingTyper
+
+from pymobiledevice3.cli.cli_common import RSDServiceProviderDep, async_command, print_json
+from pymobiledevice3.services.cryptexd import CryptexdService
+
+logger = logging.getLogger(__name__)
+
+
+cli = InjectingTyper(
+    name="cryptex",
+    help="Manage cryptexes via cryptexd (iOS 17+, requires an RSD tunnel).",
+    no_args_is_help=True,
+)
+
+NonceDomainOption = Annotated[
+    Optional[int],
+    typer.Option("--nonce-domain", help="Nonce domain index (defaults to the cryptex domain)."),
+]
+NonceDomainHandleOption = Annotated[
+    Optional[int],
+    typer.Option("--nonce-domain-handle", help="Nonce domain handle, as an alternative to --nonce-domain."),
+]
+
+
+@cli.command("list")
+@async_command
+async def cryptex_list(service_provider: RSDServiceProviderDep) -> None:
+    """List installed cryptexes (a mounted personalized DDI appears as com.apple.MobileAsset.DDI)."""
+    cryptexd = CryptexdService(service_provider)
+    print_json([dataclasses.asdict(cryptex) for cryptex in await cryptexd.copy_installed()])
+
+
+@cli.command("personalization-identifiers")
+@async_command
+async def cryptex_personalization_identifiers(service_provider: RSDServiceProviderDep) -> None:
+    """Read the AppleImage4 chip instance used to personalize a cryptex."""
+    cryptexd = CryptexdService(service_provider)
+    print_json(await cryptexd.read_personalization_identifiers())
+
+
+@cli.command("nonce")
+@async_command
+async def cryptex_nonce(
+    service_provider: RSDServiceProviderDep,
+    nonce_domain: NonceDomainOption = None,
+    nonce_domain_handle: NonceDomainHandleOption = None,
+) -> None:
+    """Read the nonce for a nonce domain."""
+    cryptexd = CryptexdService(service_provider)
+    try:
+        print_json(await cryptexd.get_nonce(nonce_domain, nonce_domain_handle))
+    except ValueError as e:
+        raise typer.BadParameter(str(e)) from e
+
+
+@cli.command("roll-nonce")
+@async_command
+async def cryptex_roll_nonce(
+    service_provider: RSDServiceProviderDep,
+    nonce_domain: NonceDomainOption = None,
+    nonce_domain_handle: NonceDomainHandleOption = None,
+) -> None:
+    """Roll a nonce domain's nonce (invalidates a personalized DDI; it must be re-mounted)."""
+    cryptexd = CryptexdService(service_provider)
+    try:
+        await cryptexd.roll_nonce(nonce_domain, nonce_domain_handle)
+    except ValueError as e:
+        raise typer.BadParameter(str(e)) from e
+    logger.info("Nonce rolled")
+
+
+@cli.command("uninstall")
+@async_command
+async def cryptex_uninstall(
+    service_provider: RSDServiceProviderDep,
+    identifier: str,
+    version: Annotated[Optional[str], typer.Option("--version")] = None,
+) -> None:
+    """Uninstall an installed cryptex by its identifier."""
+    cryptexd = CryptexdService(service_provider)
+    await cryptexd.uninstall(identifier, version)
+    logger.info(f"Uninstalled {identifier}")

--- a/pymobiledevice3/cli/developer/core_device.py
+++ b/pymobiledevice3/cli/developer/core_device.py
@@ -32,6 +32,7 @@ from pymobiledevice3.remote.core_device.hid_service import (
     UniversalHIDServiceService,
     touch_session,
 )
+from pymobiledevice3.remote.core_device.icon_service import IconService
 from pymobiledevice3.remote.core_device.location_service import LocationService
 from pymobiledevice3.remote.core_device.orientation_service import OrientationService
 from pymobiledevice3.remote.core_device.pasteboard_service import (
@@ -305,6 +306,33 @@ async def core_device_stream_apps(service_provider: RSDServiceProviderDep) -> No
     """Stream the application list via CoreDevice (works on iOS 26 where list-apps does not)."""
     async with AppServiceService(service_provider) as app_service:
         print_json([app async for app in app_service.stream_apps()])
+
+
+@cli.command("fetch-app-icon")
+@async_command
+async def core_device_fetch_app_icon(
+    service_provider: RSDServiceProviderDep,
+    bundle_identifier: Annotated[str, typer.Argument()],
+    output: Annotated[Path, typer.Argument()],
+    width: Annotated[float, typer.Option("--width")] = 60.0,
+    height: Annotated[float, typer.Option("--height")] = 60.0,
+    scale: Annotated[float, typer.Option("--scale")] = 2.0,
+    no_placeholder: Annotated[bool, typer.Option("--no-placeholder")] = False,
+) -> None:
+    """Fetch an application's icon as a PNG (com.apple.coredevice.iconservice)."""
+    async with IconService(service_provider) as icon_service:
+        icon = await icon_service.fetch_icon(
+            bundle_identifier=bundle_identifier,
+            width=width,
+            height=height,
+            scale=scale,
+            allow_placeholder=not no_placeholder,
+        )
+    output.write_bytes(icon.png_data)
+    logger.info(
+        f"Icon saved to: {output} ({icon.pixel_size[0]:.0f}x{icon.pixel_size[1]:.0f}px"
+        f"{', placeholder' if icon.is_placeholder else ''})"
+    )
 
 
 @cli.command("stream-processes")

--- a/pymobiledevice3/cli/notification.py
+++ b/pymobiledevice3/cli/notification.py
@@ -1,14 +1,44 @@
 import logging
-from typing import Annotated
+from contextlib import AsyncExitStack
+from typing import Annotated, Union
 
 import typer
 from typer_injector import InjectingTyper
 
 from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command
+from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
 from pymobiledevice3.resources.firmware_notifications import get_notifications
-from pymobiledevice3.services.notification_proxy import NotificationProxyService
+from pymobiledevice3.services.notification_proxy import NotificationProxyService, RemoteNotificationProxyService
 
 logger = logging.getLogger(__name__)
+
+
+RemoteXpcOption = Annotated[
+    bool,
+    typer.Option(
+        "--remotexpc",
+        help=(
+            "Talk to the notification proxy directly over RemoteXPC instead of tunnelling the "
+            "lockdown service through its shim. Requires an RSD tunnel (--rsd/--tunnel/--userspace)."
+        ),
+    ),
+]
+InsecureOption = Annotated[
+    bool,
+    typer.Option(help="Use the insecure relay meant for untrusted clients instead of the trusted channel."),
+]
+
+
+async def _open_service(
+    stack: AsyncExitStack, service_provider: LockdownServiceProvider, insecure: bool, remotexpc: bool
+) -> Union[NotificationProxyService, RemoteNotificationProxyService]:
+    """Open either the lockdown notification proxy or its RemoteXPC counterpart."""
+    if not remotexpc:
+        return NotificationProxyService(lockdown=service_provider, insecure=insecure)
+    if not isinstance(service_provider, RemoteServiceDiscoveryService):
+        raise typer.BadParameter("--remotexpc requires an RSD tunnel (--rsd/--tunnel/--userspace)")
+    return await stack.enter_async_context(RemoteNotificationProxyService(service_provider, insecure=insecure))
 
 
 cli = InjectingTyper(
@@ -23,15 +53,14 @@ cli = InjectingTyper(
 async def post(
     service_provider: ServiceProviderDep,
     names: list[str],
-    insecure: Annotated[
-        bool,
-        typer.Option(help="Use the insecure relay meant for untrusted clients instead of the trusted channel."),
-    ] = False,
+    insecure: InsecureOption = False,
+    remotexpc: RemoteXpcOption = False,
 ) -> None:
     """Post one or more Darwin notifications (notify_post)."""
-    service = NotificationProxyService(lockdown=service_provider, insecure=insecure)
-    for name in names:
-        await service.notify_post(name)
+    async with AsyncExitStack() as stack:
+        service = await _open_service(stack, service_provider, insecure, remotexpc)
+        for name in names:
+            await service.notify_post(name)
 
 
 @cli.command()
@@ -39,33 +68,31 @@ async def post(
 async def observe(
     service_provider: ServiceProviderDep,
     names: list[str],
-    insecure: Annotated[
-        bool,
-        typer.Option(help="Use the insecure relay meant for untrusted clients instead of the trusted channel."),
-    ] = False,
+    insecure: InsecureOption = False,
+    remotexpc: RemoteXpcOption = False,
 ) -> None:
     """Subscribe and stream notifications (notify_register_dispatch)."""
-    service = NotificationProxyService(lockdown=service_provider, insecure=insecure)
-    for name in names:
-        await service.notify_register_dispatch(name)
+    async with AsyncExitStack() as stack:
+        service = await _open_service(stack, service_provider, insecure, remotexpc)
+        for name in names:
+            await service.notify_register_dispatch(name)
 
-    async for event in service.receive_notification():
-        logger.info(event)
+        async for event in service.receive_notification():
+            logger.info(event)
 
 
 @cli.command("observe-all")
 @async_command
 async def observe_all(
     service_provider: ServiceProviderDep,
-    insecure: Annotated[
-        bool,
-        typer.Option(help="Use the insecure relay meant for untrusted clients instead of the trusted channel."),
-    ] = False,
+    insecure: InsecureOption = False,
+    remotexpc: RemoteXpcOption = False,
 ) -> None:
     """Subscribe to all known firmware notifications and stream events."""
-    service = NotificationProxyService(lockdown=service_provider, insecure=insecure)
-    for notification in get_notifications():
-        await service.notify_register_dispatch(notification)
+    async with AsyncExitStack() as stack:
+        service = await _open_service(stack, service_provider, insecure, remotexpc)
+        for notification in get_notifications():
+            await service.notify_register_dispatch(notification)
 
-    async for event in service.receive_notification():
-        logger.info(event)
+        async for event in service.receive_notification():
+            logger.info(event)

--- a/pymobiledevice3/darwin_errno.py
+++ b/pymobiledevice3/darwin_errno.py
@@ -1,0 +1,139 @@
+"""Darwin (device-side) ``errno`` values.
+
+Several device services report failures as a raw ``errno`` produced by the *device*, which runs
+Darwin. Those numbers must not be rendered with `os.strerror` or the stdlib `errno` module: both
+resolve against the C runtime of the **host** running pymobiledevice3, so a Windows or Linux host
+prints the wrong name for the same number. ``ENOTCAPABLE`` (107) does not exist on Linux at all,
+and the numbering above ~34 diverges between all three platforms.
+
+The table below is generated from Darwin's ``sys/errno.h`` and is therefore correct regardless of
+what the host is.
+"""
+
+#: Darwin errno number -> symbolic name, from the discrete (``__DARWIN_UNIX03``/kernel) numbering
+#: the device actually reports. ``EWOULDBLOCK`` is a pure alias of ``EAGAIN`` (35) and so is not
+#: listed. ``EOPNOTSUPP`` is *not* an alias here: it is discrete at 102, and only collapses onto
+#: ``ENOTSUP`` (45) in legacy non-UNIX03 builds.
+DARWIN_ERRNO_NAMES: dict[int, str] = {
+    1: "EPERM",
+    2: "ENOENT",
+    3: "ESRCH",
+    4: "EINTR",
+    5: "EIO",
+    6: "ENXIO",
+    7: "E2BIG",
+    8: "ENOEXEC",
+    9: "EBADF",
+    10: "ECHILD",
+    11: "EDEADLK",
+    12: "ENOMEM",
+    13: "EACCES",
+    14: "EFAULT",
+    15: "ENOTBLK",
+    16: "EBUSY",
+    17: "EEXIST",
+    18: "EXDEV",
+    19: "ENODEV",
+    20: "ENOTDIR",
+    21: "EISDIR",
+    22: "EINVAL",
+    23: "ENFILE",
+    24: "EMFILE",
+    25: "ENOTTY",
+    26: "ETXTBSY",
+    27: "EFBIG",
+    28: "ENOSPC",
+    29: "ESPIPE",
+    30: "EROFS",
+    31: "EMLINK",
+    32: "EPIPE",
+    33: "EDOM",
+    34: "ERANGE",
+    35: "EAGAIN",
+    36: "EINPROGRESS",
+    37: "EALREADY",
+    38: "ENOTSOCK",
+    39: "EDESTADDRREQ",
+    40: "EMSGSIZE",
+    41: "EPROTOTYPE",
+    42: "ENOPROTOOPT",
+    43: "EPROTONOSUPPORT",
+    44: "ESOCKTNOSUPPORT",
+    45: "ENOTSUP",
+    46: "EPFNOSUPPORT",
+    47: "EAFNOSUPPORT",
+    48: "EADDRINUSE",
+    49: "EADDRNOTAVAIL",
+    50: "ENETDOWN",
+    51: "ENETUNREACH",
+    52: "ENETRESET",
+    53: "ECONNABORTED",
+    54: "ECONNRESET",
+    55: "ENOBUFS",
+    56: "EISCONN",
+    57: "ENOTCONN",
+    58: "ESHUTDOWN",
+    59: "ETOOMANYREFS",
+    60: "ETIMEDOUT",
+    61: "ECONNREFUSED",
+    62: "ELOOP",
+    63: "ENAMETOOLONG",
+    64: "EHOSTDOWN",
+    65: "EHOSTUNREACH",
+    66: "ENOTEMPTY",
+    67: "EPROCLIM",
+    68: "EUSERS",
+    69: "EDQUOT",
+    70: "ESTALE",
+    71: "EREMOTE",
+    72: "EBADRPC",
+    73: "ERPCMISMATCH",
+    74: "EPROGUNAVAIL",
+    75: "EPROGMISMATCH",
+    76: "EPROCUNAVAIL",
+    77: "ENOLCK",
+    78: "ENOSYS",
+    79: "EFTYPE",
+    80: "EAUTH",
+    81: "ENEEDAUTH",
+    82: "EPWROFF",
+    83: "EDEVERR",
+    84: "EOVERFLOW",
+    85: "EBADEXEC",
+    86: "EBADARCH",
+    87: "ESHLIBVERS",
+    88: "EBADMACHO",
+    89: "ECANCELED",
+    90: "EIDRM",
+    91: "ENOMSG",
+    92: "EILSEQ",
+    93: "ENOATTR",
+    94: "EBADMSG",
+    95: "EMULTIHOP",
+    96: "ENODATA",
+    97: "ENOLINK",
+    98: "ENOSR",
+    99: "ENOSTR",
+    100: "EPROTO",
+    101: "ETIME",
+    102: "EOPNOTSUPP",
+    103: "ENOPOLICY",
+    104: "ENOTRECOVERABLE",
+    105: "EOWNERDEAD",
+    106: "EQFULL",
+    107: "ENOTCAPABLE",
+}
+
+#: Frequently checked values, for callers that want to branch on a specific failure.
+ENOENT = 2
+EINVAL = 22
+ENOTSUP = 45
+
+
+def describe_errno(error: int) -> str:
+    """Render a device-side Darwin errno as ``NAME (n)``, or ``errno n`` when unrecognized.
+
+    :param error: errno reported by the device.
+    """
+    name = DARWIN_ERRNO_NAMES.get(error)
+    return f"{name} ({error})" if name is not None else f"errno {error}"

--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -33,6 +33,7 @@ __all__ = [
     "IRecvNoDeviceConnectedError",
     "IncorrectModeError",
     "InspectorEvaluateError",
+    "InstallCoordinationError",
     "InternalError",
     "InvalidConnectionError",
     "InvalidHostIDError",
@@ -442,6 +443,12 @@ class AppNotInstalledError(PyMobileDevice3Exception):
 
 
 class CoreDeviceError(PyMobileDevice3Exception):
+    pass
+
+
+class InstallCoordinationError(PyMobileDevice3Exception):
+    """installcoordination_proxy reported a failed request"""
+
     pass
 
 

--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -33,7 +33,6 @@ __all__ = [
     "IRecvNoDeviceConnectedError",
     "IncorrectModeError",
     "InspectorEvaluateError",
-    "InstallCoordinationError",
     "InternalError",
     "InvalidConnectionError",
     "InvalidHostIDError",
@@ -443,6 +442,12 @@ class AppNotInstalledError(PyMobileDevice3Exception):
 
 
 class CoreDeviceError(PyMobileDevice3Exception):
+    pass
+
+
+class CryptexdError(PyMobileDevice3Exception):
+    """cryptexd rejected a routine, reporting a CFError or a non-zero error code"""
+
     pass
 
 

--- a/pymobiledevice3/remote/core_device/app_service.py
+++ b/pymobiledevice3/remote/core_device/app_service.py
@@ -186,20 +186,3 @@ class AppServiceService(CoreDeviceService):
                 "signal": XpcInt64Type(signal),
             },
         )
-
-    async def fetch_icons(
-        self, bundle_identifier: str, width: float, height: float, scale: float, allow_placeholder: bool
-    ) -> dict[str, Any]:
-        """
-        Fetch given application's icons
-        """
-        return await self.invoke(
-            "com.apple.coredevice.feature.fetchappicons",
-            {
-                "width": width,
-                "height": height,
-                "scale": scale,
-                "allowPlaceholder": allow_placeholder,
-                "bundleIdentifier": bundle_identifier,
-            },
-        )

--- a/pymobiledevice3/remote/core_device/icon_service.py
+++ b/pymobiledevice3/remote/core_device/icon_service.py
@@ -1,0 +1,97 @@
+import dataclasses
+import struct
+from typing import Any, Optional
+
+from pymobiledevice3.remote.core_device.core_device_service import CoreDeviceService
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+
+FETCH_APP_ICONS_FEATURE = "com.apple.coredevice.feature.fetchappicons"
+
+
+def _to_float32(value: float) -> float:
+    """Round *value* through IEEE-754 binary32 and back.
+
+    ``FetchAppIconParams`` declares ``width``/``height``/``scale`` as Swift ``Float``, so the
+    daemon's decoder rejects Double-encoded values whose low mantissa bits don't fit in Float32.
+    """
+    return struct.unpack("<f", struct.pack("<f", float(value)))[0]
+
+
+@dataclasses.dataclass
+class AppIcon:
+    """A rendered application icon returned by ``com.apple.coredevice.iconservice``."""
+
+    png_data: bytes
+    #: Icon dimensions in pixels (``size`` multiplied by ``scale``).
+    pixel_size: tuple[float, float]
+    #: Icon dimensions in points, as actually rendered — may be smaller than requested.
+    size: tuple[float, float]
+    scale: float
+    #: ``True`` when the device had no real icon and returned a generic placeholder.
+    is_placeholder: bool
+
+
+class IconService(CoreDeviceService):
+    """
+    Fetch application icons as PNGs (``com.apple.coredevice.iconservice``).
+
+    Note this is a distinct service from ``com.apple.coredevice.appservice``, which does not
+    advertise the ``fetchappicons`` feature and rejects the request.
+    """
+
+    SERVICE_NAME = "com.apple.coredevice.iconservice"
+
+    def __init__(self, rsd: RemoteServiceDiscoveryService):
+        super().__init__(rsd, self.SERVICE_NAME)
+
+    async def fetch_icon(
+        self,
+        bundle_identifier: Optional[str] = None,
+        app_path: Optional[str] = None,
+        width: float = 60.0,
+        height: float = 60.0,
+        scale: float = 2.0,
+        allow_placeholder: bool = True,
+    ) -> AppIcon:
+        """
+        Fetch a single application's icon.
+
+        Exactly one of `bundle_identifier` or `app_path` identifies the app.
+
+        :param bundle_identifier: Bundle identifier of the app to fetch, e.g. ``com.apple.Preferences``.
+        :param app_path: On-device path of the app bundle, as an alternative to `bundle_identifier`.
+        :param width: Requested width in points.
+        :param height: Requested height in points.
+        :param scale: Requested scale factor; pixel dimensions are the point size times this.
+        :param allow_placeholder: When ``True``, a generic placeholder is returned for apps with no
+                                  icon instead of raising.
+        :raises ValueError: if neither or both of `bundle_identifier` and `app_path` are given.
+        :raises CoreDeviceError: if the device could not produce an icon.
+        """
+        if (bundle_identifier is None) == (app_path is None):
+            raise ValueError("exactly one of bundle_identifier or app_path must be given")
+        response = await self.invoke(
+            FETCH_APP_ICONS_FEATURE,
+            {
+                "bundleIdentifier": bundle_identifier,
+                "appPath": app_path,
+                "width": _to_float32(width),
+                "height": _to_float32(height),
+                "scale": _to_float32(scale),
+                "allowPlaceholder": allow_placeholder,
+            },
+        )
+        return self._parse(response)
+
+    @staticmethod
+    def _parse(response: dict[str, Any]) -> AppIcon:
+        info = response["appIconInfo"]
+        pixel_size = info["pixelSize"]
+        size = info["size"]
+        return AppIcon(
+            png_data=info["pngData"],
+            pixel_size=(pixel_size[0], pixel_size[1]),
+            size=(size[0], size[1]),
+            scale=info["scale"],
+            is_placeholder=info["isAppIconPlaceholder"],
+        )

--- a/pymobiledevice3/remote/remotexpc.py
+++ b/pymobiledevice3/remote/remotexpc.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import uuid
 from asyncio import IncompleteReadError
+from collections import deque
 from collections.abc import AsyncIterable
 from typing import Any, Callable, Optional, Union, cast
 
@@ -43,6 +44,12 @@ WINDOW_UPDATE_THRESHOLD = 1024 * 1024
 FRAME_HEADER_SIZE = 9
 HTTP2_MAGIC = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
 
+# HTTP/2 defaults for the peer's side of flow control, until its SETTINGS say otherwise.
+DEFAULT_PEER_WINDOW_SIZE = 65535
+MAX_OUTBOUND_FRAME_SIZE = 16384
+# How long to wait for the peer to grant more outbound window before giving up on a transfer.
+FILE_TRANSFER_WINDOW_TIMEOUT = 30
+
 ROOT_CHANNEL = 1
 REPLY_CHANNEL = 3
 
@@ -73,6 +80,19 @@ class RemoteXPCConnection:
         self._reader: Optional[asyncio.StreamReader] = None
         self._writer: Optional[asyncio.StreamWriter] = None
         self._pending_window_updates: dict[int, int] = {}
+        # Outbound (peer-granted) flow control, needed to push file transfers larger than the
+        # peer's initial window. Both default to the HTTP/2 spec value until the peer's SETTINGS
+        # and WINDOW_UPDATE frames say otherwise.
+        self._peer_initial_window_size = DEFAULT_PEER_WINDOW_SIZE
+        self._outbound_connection_window = DEFAULT_PEER_WINDOW_SIZE
+        self._outbound_stream_windows: dict[int, int] = {}
+        # Client-initiated streams must be odd; ROOT_CHANNEL and REPLY_CHANNEL take 1 and 3.
+        self._next_outbound_stream_id = 5
+        # Data frames read out of turn during a file transfer, replayed by receive_response().
+        self._buffered_data_frames: deque[DataFrame] = deque()
+        # Streams we finished pushing a file transfer on. The device resets them once it has the
+        # payload, which is normal completion rather than an error.
+        self._finished_file_transfer_streams: set[int] = set()
         self._file_chunk_queues: dict[int, asyncio.Queue[Union[bytes, BaseException]]] = {}
         self._file_chunk_reader_task: Optional[asyncio.Task[None]] = None
         # Serialise request/response round-trips. ``send_receive_request`` is a
@@ -297,10 +317,114 @@ class RemoteXPCConnection:
         self.next_message_id[REPLY_CHANNEL] += 1
 
         settings_frame = await asyncio.wait_for(self._receive_frame(), FIRST_REPLY_TIMEOUT)
-        if not isinstance(settings_frame, SettingsFrame):
-            raise ProtocolError(f"Got unexpected frame: {settings_frame} instead of a SettingsFrame")
+        while not isinstance(settings_frame, SettingsFrame):
+            # The peer grants its connection window before ACKing settings; record it rather than
+            # discarding it, otherwise outbound file transfers stall at the 65535 default.
+            if not self._apply_flow_control_frame(settings_frame):
+                raise ProtocolError(f"Got unexpected frame: {settings_frame} instead of a SettingsFrame")
+            settings_frame = await asyncio.wait_for(self._receive_frame(), FIRST_REPLY_TIMEOUT)
+        self._apply_flow_control_frame(settings_frame)
 
         await self._send_frame(SettingsFrame(flags=["ACK"]))
+
+    def _outbound_budget(self, stream_id: int) -> int:
+        stream_window = self._outbound_stream_windows.get(stream_id, self._peer_initial_window_size)
+        return max(0, min(self._outbound_connection_window, stream_window, MAX_OUTBOUND_FRAME_SIZE))
+
+    def _consume_outbound(self, stream_id: int, amount: int) -> None:
+        self._outbound_connection_window -= amount
+        self._outbound_stream_windows[stream_id] = (
+            self._outbound_stream_windows.get(stream_id, self._peer_initial_window_size) - amount
+        )
+
+    def _apply_flow_control_frame(self, frame: Frame) -> bool:
+        """Consume a peer frame that only affects flow control. Returns True if it was handled."""
+        if isinstance(frame, WindowUpdateFrame):
+            if frame.stream_id == 0:
+                self._outbound_connection_window += frame.window_increment
+            else:
+                current = self._outbound_stream_windows.get(frame.stream_id, self._peer_initial_window_size)
+                self._outbound_stream_windows[frame.stream_id] = current + frame.window_increment
+            return True
+        if isinstance(frame, SettingsFrame) and "ACK" not in frame.flags:
+            new_initial = frame.settings.get(SettingsFrame.INITIAL_WINDOW_SIZE)
+            if new_initial is not None:
+                # A new INITIAL_WINDOW_SIZE retroactively shifts every open stream's window.
+                delta = new_initial - self._peer_initial_window_size
+                self._peer_initial_window_size = new_initial
+                for open_stream in self._outbound_stream_windows:
+                    self._outbound_stream_windows[open_stream] += delta
+            return True
+        return False
+
+    async def _send_flow_controlled(self, stream_id: int, data: bytes, offset: int, total: int) -> int:
+        """Send one window-sized DATA chunk from *data* at *offset*, blocking until there is room.
+
+        :returns: how many bytes were sent.
+        """
+        budget = self._outbound_budget(stream_id)
+        while budget == 0:
+            try:
+                await asyncio.wait_for(self._pump_one_frame(), FILE_TRANSFER_WINDOW_TIMEOUT)
+            except asyncio.TimeoutError as e:
+                raise ProtocolError(
+                    f"Timed out waiting for the device to grant flow-control window on stream "
+                    f"{stream_id} after {offset}/{total} bytes"
+                ) from e
+            budget = self._outbound_budget(stream_id)
+        chunk = data[offset : offset + budget]
+        await self._send_frame(DataFrame(stream_id=stream_id, data=chunk))
+        self._consume_outbound(stream_id, len(chunk))
+        return len(chunk)
+
+    async def send_file_transfer(self, transfer_id: int, data: bytes) -> None:
+        """Push the payload of a previously announced `FileTransferType` to the device.
+
+        The announcement (a `FileTransferType` in a request) only declares the size and a
+        ``transfer_id``; the bytes travel on their own HTTP/2 stream. That stream must be
+        client-initiated and therefore **odd** — the device answers HEADERS on an even stream with
+        ``GOAWAY``/``invalid stream_id`` — and its opening frame must carry the ``transfer_id`` as
+        the XPC ``message_id``, which is how the device correlates stream to announcement
+        (``Found pending stream ID for <id>``). The device acknowledges with a
+        ``FILE_TX_STREAM_RESPONSE`` preamble, but that arrives *after* the payload and is not a
+        gate: holding the stream open waiting for it makes the device reset it (``RST_STREAM``
+        error 5), so the bytes follow the preamble immediately.
+
+        :param transfer_id: identifier used in the corresponding `FileTransferType`.
+        :param data: payload bytes; must match the announced ``transfer_size``.
+        """
+        stream_id = self._next_outbound_stream_id
+        self._next_outbound_stream_id += 2
+
+        await self._send_frame(HeadersFrame(stream_id=stream_id, flags=["END_HEADERS"]))
+        # The preamble is a DATA frame, so it is flow controlled too. Sending it unaccounted
+        # overruns the connection window once a previous transfer has drained it, and the device
+        # answers with GOAWAY error 3 (FLOW_CONTROL_ERROR).
+        preamble = XpcWrapper.build({
+            "flags": XpcFlags.FILE_TX_STREAM_REQUEST | XpcFlags.ALWAYS_SET,
+            "message": {"message_id": transfer_id, "payload": None},
+        })
+        await self._send_flow_controlled(stream_id, preamble, 0, len(preamble))
+        offset = 0
+        while offset < len(data):
+            offset += await self._send_flow_controlled(stream_id, data, offset, len(data))
+        await self._send_frame(DataFrame(stream_id=stream_id, data=b"", flags=["END_STREAM"]))
+        self._finished_file_transfer_streams.add(stream_id)
+
+    async def _pump_one_frame(self) -> Frame:
+        """Read one frame, applying flow control and buffering data frames meant for others."""
+        while True:
+            frame = await self._receive_frame()
+            if isinstance(frame, GoAwayFrame):
+                raise StreamClosedError(f"Got {frame}")
+            if isinstance(frame, RstStreamFrame):
+                if frame.stream_id in self._finished_file_transfer_streams:
+                    continue
+                raise StreamClosedError(f"Got {frame}")
+            if self._apply_flow_control_frame(frame):
+                return frame
+            if isinstance(frame, DataFrame):
+                return frame
 
     async def _open_channel(self, stream_id: int, flags: Any) -> None:
         # flags is a construct FlagsEnum value (BitwisableString), not a plain int: `int()` on it
@@ -318,11 +442,16 @@ class RemoteXPCConnection:
 
     async def _receive_next_data_frame(self) -> DataFrame:
         while True:
+            if self._buffered_data_frames:
+                return self._buffered_data_frames.popleft()
             frame = await self._receive_frame()
+            self._apply_flow_control_frame(frame)
 
             if isinstance(frame, GoAwayFrame):
                 raise StreamClosedError(f"Got {frame}")
             if isinstance(frame, RstStreamFrame):
+                if frame.stream_id in self._finished_file_transfer_streams:
+                    continue
                 raise StreamClosedError(f"Got {frame}")
             if not isinstance(frame, DataFrame):
                 continue

--- a/pymobiledevice3/remote/xpc_message.py
+++ b/pymobiledevice3/remote/xpc_message.py
@@ -152,7 +152,14 @@ class XpcUInt64Type(int):
 
 @dataclasses.dataclass
 class FileTransferType:
+    """An XPC file-transfer object: the payload itself travels on its own HTTP/2 stream.
+
+    ``transfer_id`` correlates the announcement with that stream. It is unset (0) on objects
+    decoded from the device, whose stream is derived positionally by the receiving code.
+    """
+
     transfer_size: int
+    transfer_id: int = 0
 
 
 def _decode_xpc_dictionary(xpc_object: Container[Any]) -> dict[str, Any]:
@@ -290,6 +297,16 @@ def _build_xpc_uuid(payload: uuid.UUID) -> dict[str, Any]:
     }
 
 
+def _build_xpc_file_transfer(payload: FileTransferType) -> dict[str, Any]:
+    return {
+        "type": XpcMessageType.FILE_TRANSFER,
+        "data": {
+            "msg_id": payload.transfer_id,
+            "data": _build_xpc_dictionary({"s": XpcUInt64Type(payload.transfer_size)}),
+        },
+    }
+
+
 def _build_xpc_null(payload: None) -> dict[str, Any]:
     return {
         "type": XpcMessageType.NULL,
@@ -323,6 +340,7 @@ def _build_xpc_object(payload: Any) -> dict[str, Any]:
         bytearray: _build_xpc_data,
         float: _build_xpc_double,
         uuid.UUID: _build_xpc_uuid,
+        FileTransferType: _build_xpc_file_transfer,
         "XpcUInt64Type": _build_xpc_uint64,
         "XpcInt64Type": _build_xpc_int64,
     }

--- a/pymobiledevice3/restore/tss.py
+++ b/pymobiledevice3/restore/tss.py
@@ -20,6 +20,18 @@ from pymobiledevice3.utils import bytes_to_uint, plist_access_path
 # defaults write com.apple.configurator.xpc.DeviceService AuthInstallSigningServerURL http://gs.apple.com:80
 # defaults write com.apple.AMPDevicesAgent AuthInstallSigningServerURL http://gs.apple.com:80
 # ```
+#
+# CoreDevice (Xcode / `devicectl`) does not use `AuthInstallSigningServerURL`. Its equivalent knob
+# is `ddiSigningServer`, alongside `mountCryptexDDI(... signingServerURL: ...)` in
+# CoreDevice.framework:
+#
+# ```shell
+# defaults write com.apple.CoreDevice.CoreDeviceService ddiSigningServer http://gs.apple.com:80
+# ```
+#
+# Note this is untested: CoreDevice caches the personalization ticket, so repeated DDI installs
+# make no TSS request at all to redirect (verified with tcpdump -- zero packets to gs.apple.com
+# across several installs). Invalidate the cached ticket first, e.g. by rolling the cryptex nonce.
 TSS_CONTROLLER_ACTION_URL = "http://gs.apple.com/TSS/controller?action=2"
 
 TSS_CLIENT_VERSION_STRING = "libauthinstall-1104.0.9"
@@ -360,6 +372,68 @@ class TSSRequest:
 
         if overrides is not None:
             self._request.update(overrides)
+
+    def add_cryptex1_tags(
+        self,
+        build_identity: dict[str, typing.Any],
+        chip_instance: dict[str, typing.Any],
+        nonce: bytes,
+    ) -> None:
+        """Build a Cryptex1 personalization request (``@Cryptex1,Ticket``).
+
+        Cryptex1 tickets are a different shape from the AP tickets `add_ap_tags` produces, which is
+        why that method skips every ``Cryptex1,*`` key. The signed manifest carries the Cryptex1
+        chip parameters (``fchp``/``type``/``styp``/``clas``/``ndom``/``upcl``/``vnum``/``pave``)
+        and digests for only the *personalized* components — the generic DMG is declared
+        ``Personalize: False`` in the build manifest and must be left out.
+
+        :param build_identity: the build identity whose ``Info.Variant`` names a cryptex, i.e. the
+            one carrying ``Cryptex1,*`` manifest entries.
+        :param chip_instance: the device's AppleImage4 chip instance, as returned by
+            `CryptexdService.read_personalization_identifiers`.
+        :param nonce: the cryptex nonce for the identity's ``Cryptex1,NonceDomain``.
+        """
+        self._request.update({
+            "@Cryptex1,Ticket": True,
+            "ApChipID": chip_instance["img4_chip_chip"],
+            "ApBoardID": chip_instance["img4_chip_bord"],
+            "ApECID": chip_instance["img4_chip_ecid"],
+            "ApSecurityDomain": chip_instance["img4_chip_sdom"],
+            "ApProductionMode": bool(chip_instance["img4_chip_cpro"]),
+            "ApSecurityMode": bool(chip_instance["img4_chip_csec"]),
+            "Cryptex1,ChipID": int(str(build_identity["Cryptex1,ChipID"]), 0),
+            "Cryptex1,Type": build_identity["Cryptex1,Type"],
+            "Cryptex1,SubType": build_identity["Cryptex1,SubType"],
+            "Cryptex1,ProductClass": int(str(build_identity["Cryptex1,ProductClass"]), 0),
+            "Cryptex1,UseProductClass": build_identity["Cryptex1,UseProductClass"],
+            "Cryptex1,NonceDomain": build_identity["Cryptex1,NonceDomain"],
+            "Cryptex1,Version": build_identity["Cryptex1,Version"],
+            "Cryptex1,PreauthorizationVersion": build_identity["Cryptex1,PreauthorizationVersion"],
+            "Cryptex1,Nonce": nonce,
+        })
+
+        parameters: dict[str, typing.Any] = {
+            "ApProductionMode": bool(chip_instance["img4_chip_cpro"]),
+            "ApSecurityMode": bool(chip_instance["img4_chip_csec"]),
+            "ApSecurityDomain": chip_instance["img4_chip_sdom"],
+            "ApSupportsImg4": True,
+        }
+        for key, manifest_entry in build_identity["Manifest"].items():
+            if not key.startswith("Cryptex1,"):
+                continue
+            info_dict = manifest_entry.get("Info", {})
+            if not info_dict.get("Personalize", False):
+                logger.debug(f"skipping {key} as it is not personalized")
+                continue
+
+            tss_entry = dict(manifest_entry)
+            tss_entry.pop("Info", None)
+            rules = info_dict.get("RestoreRequestRules")
+            if rules:
+                tss_entry = self.apply_restore_request_rules(tss_entry, parameters, rules)
+            if manifest_entry.get("Digest") is None:
+                tss_entry["Digest"] = b""
+            self._request[key] = tss_entry
 
     def add_ap_tags(self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None):
         """loop over components from build manifest"""

--- a/pymobiledevice3/services/cryptexd.py
+++ b/pymobiledevice3/services/cryptexd.py
@@ -1,0 +1,394 @@
+import dataclasses
+import plistlib
+from pathlib import Path
+from typing import Any, Optional
+
+from pymobiledevice3.darwin_errno import describe_errno
+from pymobiledevice3.exceptions import CryptexdError
+from pymobiledevice3.remote.remote_service import RemoteService
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+from pymobiledevice3.remote.xpc_message import FileTransferType, XpcInt64Type, XpcUInt64Type
+from pymobiledevice3.restore.tss import TSSRequest
+
+#: ``nonce-domain`` index used for the cryptex nonce on current devices. The daemon resolves the
+#: index through its own nonce-domain table, so unsupported indices fail with a ``cferr``.
+NONCE_DOMAIN_CRYPTEX = 2
+
+#: Identifier the mounted personalized DeveloperDiskImage is installed under.
+DDI_CRYPTEX_IDENTIFIER = "com.apple.MobileAsset.DDI"
+
+#: Values Xcode sends when installing the DDI cryptex, captured from a ``devicectl`` install.
+CLIENT_VERSION = 3
+DDI_IMAGE_TYPE_INDEX = 10
+DDI_PERSISTENCE = 2
+DDI_NONCE_PERSISTENCE = 1
+
+
+#: Where Xcode unpacks ``CoreDevice/CandidateDDIs/iOS_DDI.dmg``. The Cryptex1 assets live only
+#: here — the DDI repository pymobiledevice3 caches for the image mounter ships the
+#: ``PersonalizedDMG`` variant, which has no ``cryptex_info`` or ``root_hash``.
+XCODE_DDI_RESTORE_DIR = Path("/Library/Developer/DeveloperDiskImages/iOS_DDI/Restore")
+
+#: The one build identity that describes a cryptex, out of ~141 in the DDI's BuildManifest.
+CRYPTEX_VARIANT_SUFFIX = "Developer Disk Image Cryptex"
+
+
+def unwrap_nonce(blob: bytes) -> bytes:
+    """Extract the nonce from cryptexd's nonce structure.
+
+    ``get-nonce`` returns 56 bytes: a 2-byte lead, the nonce, then a little-endian uint32 length.
+    The nonce inside is what TSS wants (verified: it matches both
+    `MobileImageMounterService.query_nonce` and the ``cnch`` tag of Xcode's ticket byte-for-byte).
+    """
+    return blob[2 : 2 + int.from_bytes(blob[-4:], "little")]
+
+
+@dataclasses.dataclass
+class InstalledCryptex:
+    """A cryptex currently installed on the device (e.g. the mounted DeveloperDiskImage)."""
+
+    identifier: str
+    version: str
+
+
+@dataclasses.dataclass
+class Cryptex1Assets:
+    """The four payloads and the parameters needed to install a Cryptex1 image."""
+
+    image: bytes
+    trustcache: bytes
+    info: bytes
+    volumehash: bytes
+    cryptex1_properties: dict[str, Any]
+    build_identity: dict[str, Any]
+
+    @property
+    def nonce_domain(self) -> int:
+        return int(self.build_identity["Cryptex1,NonceDomain"])
+
+
+def load_cryptex1_assets(restore_dir: Path = XCODE_DDI_RESTORE_DIR) -> Cryptex1Assets:
+    """
+    Load the Cryptex1 DDI payloads and parameters out of Xcode's DDI bundle.
+
+    Unlike the mounter's ``PersonalizedDMG``, the ``Cryptex1,GenericDmg`` is not personalized —
+    it is byte-identical across devices, and only the info plist, trust cache and volume hash are.
+
+    :param restore_dir: Xcode's unpacked DDI ``Restore`` directory.
+    :raises FileNotFoundError: if the bundle (or its cryptex build identity) is not present.
+    """
+    manifest_path = restore_dir / "BuildManifest.plist"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"no DDI BuildManifest at {manifest_path}; is Xcode installed?")
+    build_manifest = plistlib.loads(manifest_path.read_bytes())
+    build_identity = next(
+        (
+            identity
+            for identity in build_manifest["BuildIdentities"]
+            if identity.get("Info", {}).get("Variant", "").endswith(CRYPTEX_VARIANT_SUFFIX)
+        ),
+        None,
+    )
+    if build_identity is None:
+        raise FileNotFoundError(f"no {CRYPTEX_VARIANT_SUFFIX!r} build identity in {manifest_path}")
+
+    manifest = build_identity["Manifest"]
+
+    def read(key: str) -> bytes:
+        return (restore_dir / manifest[key]["Info"]["Path"]).read_bytes()
+
+    # Mirrors the dict Xcode sends; the integers must be uint64 or the daemon rejects them.
+    cryptex1_properties: dict[str, Any] = {
+        "Cryptex1,UseProductClass": build_identity["Cryptex1,UseProductClass"],
+        "MountedCryptex": False,
+        "Cryptex1,SubType": XpcUInt64Type(build_identity["Cryptex1,SubType"]),
+        "Cryptex1,NonceDomain": XpcUInt64Type(build_identity["Cryptex1,NonceDomain"]),
+        "Cryptex1,Version": build_identity["Cryptex1,Version"],
+        "Cryptex1,PreauthVersion": build_identity["Cryptex1,PreauthorizationVersion"],
+    }
+    return Cryptex1Assets(
+        image=read("Cryptex1,GenericDmg"),
+        trustcache=read("Cryptex1,GenericTrustCache"),
+        info=read("Cryptex1,CryptexInfoPlist"),
+        volumehash=read("Cryptex1,GenericVolume"),
+        cryptex1_properties=cryptex1_properties,
+        build_identity=build_identity,
+    )
+
+
+class CryptexdService(RemoteService):
+    """
+    Query ``cryptexd`` over RemoteXPC (``com.apple.security.cryptexd.remote``).
+
+    The service takes ``{"routine": <name>, "argv": {...}}`` requests and answers with either
+    ``{"error": 0, "argv": <result>}`` on success or ``{"cferr": {...}}`` on failure, where
+    ``error`` is a device-side Darwin errno.
+
+    All six routines the daemon dispatches are implemented: ``read-personalization-id``,
+    ``copy-installed``, ``get-nonce``, ``roll-nonce``, ``uninstall`` and ``install``. The last one
+    delivers its payloads as out-of-band XPC file transfers, so unlike the others it keeps one
+    connection open across the request and the transfers.
+
+    The daemon serves exactly one routine per connection and then closes it — a second request on
+    the same connection fails with an incomplete read, whether or not the first one succeeded. Each
+    call therefore opens and closes its own connection, and instances are freely reusable.
+
+    Requires an iOS 17+ RSD tunnel.
+    """
+
+    SERVICE_NAME = "com.apple.security.cryptexd.remote"
+
+    def __init__(self, rsd: RemoteServiceDiscoveryService):
+        super().__init__(rsd, self.SERVICE_NAME)
+
+    async def connect(self) -> None:
+        """No-op: cryptexd is one-routine-per-connection, so `invoke` manages its own connection."""
+
+    async def close(self) -> None:
+        """No-op: `invoke` closes the connection it opened."""
+
+    async def invoke(self, routine: str, argv: dict[str, Any]) -> Any:
+        """
+        Send a single ``routine`` request on a fresh connection and return its ``argv`` payload.
+
+        :param routine: routine name, e.g. ``read-personalization-id``.
+        :param argv: named arguments for the routine.
+        :raises CryptexdError: if the daemon answered with a ``cferr`` or a non-zero ``error``.
+        """
+        connection = self.rsd.start_remote_service(self.SERVICE_NAME)
+        await connection.connect()
+        try:
+            response = await connection.send_receive_request({"routine": routine, "argv": argv})
+        finally:
+            await connection.close()
+        return self._unwrap(routine, response)
+
+    @staticmethod
+    def _unwrap(routine: str, response: dict[str, Any]) -> Any:
+        """Raise on a failed reply, otherwise return its ``argv`` payload."""
+        cferr: Optional[dict[str, Any]] = response.get("cferr")
+        if cferr is not None:
+            user_info: dict[str, Any] = cferr.get("cferr_userinfo") or {}
+            raise CryptexdError(
+                f"{routine} failed: {user_info.get('NSLocalizedDescription', cferr)} "
+                f"({cferr.get('cferr_domain')}: {cferr.get('cferr_code')})"
+            )
+        # Successful replies carry error=0; read-personalization-id omits the key entirely.
+        error = response.get("error", 0)
+        if error:
+            raise CryptexdError(f"{routine} failed: {describe_errno(error)}")
+        return response.get("argv")
+
+    async def install(
+        self,
+        image: bytes,
+        trustcache: bytes,
+        im4m: bytes,
+        info: bytes,
+        volumehash: bytes,
+        cryptex1_properties: dict[str, Any],
+        image_type_index: int = DDI_IMAGE_TYPE_INDEX,
+        persistence: int = DDI_PERSISTENCE,
+        nonce_persistence: int = DDI_NONCE_PERSISTENCE,
+        auth: int = 0,
+    ) -> None:
+        """
+        Install a cryptex.
+
+        The five payloads are announced in the request as XPC file transfers and then pushed on
+        their own streams; the daemon only replies once it has consumed all of them.
+
+        The request shape mirrors what Xcode sends, captured off the wire during a
+        ``devicectl`` DDI install. Two details are easy to get wrong: the cryptex is identified
+        solely by `info` (a ``CryptexInfoPlist``) — there is no identifier argument, and omitting
+        it makes the daemon log every line as ``[anonymous]`` — and the integers inside
+        `cryptex1_properties` must be **uint64**, since int64 is rejected with
+        ``Cryptex1,NonceDomain [79: Inappropriate file type or format]``.
+
+        .. note::
+            The request itself is verified: the daemon accepts it, consumes all five payloads and
+            proceeds to image4 trust evaluation. Completing an install additionally needs an `im4m`
+            that is a *Cryptex1* ticket bound to the current cryptex nonce; producing one is not
+            implemented (see `TSSRequest.add_cryptex1_tags`).
+
+        :param image: the cryptex disk image, i.e. the build manifest's ``Cryptex1,GenericDmg``.
+        :param trustcache: ``Cryptex1,GenericTrustCache``.
+        :param im4m: the Cryptex1 personalization ticket.
+        :param info: ``Cryptex1,CryptexInfoPlist``; names and versions the cryptex.
+        :param volumehash: ``Cryptex1,GenericVolume`` root hash; without it the daemon reports
+            "AuthAPFS will not be supported".
+        :param cryptex1_properties: the ``Cryptex1,*`` parameters from the build identity.
+        :param image_type_index: index of the image type within the cryptex.
+        :param persistence: cryptex persistence mode.
+        :param nonce_persistence: nonce persistence mode.
+        :param auth: authentication mode.
+        :raises CryptexdError: if the daemon rejected the request or the install failed.
+        """
+        transfers = [
+            ("image", image),
+            ("trustcache", trustcache),
+            ("im4m", im4m),
+            ("info", info),
+            ("volumehash", volumehash),
+        ]
+        argv: dict[str, Any] = {
+            "auth": XpcUInt64Type(auth),
+            "client-version": XpcUInt64Type(CLIENT_VERSION),
+            "cryptex1-properties": cryptex1_properties,
+            "image-type-index": XpcInt64Type(image_type_index),
+            "nonce-persistence": XpcUInt64Type(nonce_persistence),
+            "persistence": XpcUInt64Type(persistence),
+        }
+        for transfer_id, (key, payload) in enumerate(transfers, start=1):
+            argv[key] = FileTransferType(transfer_size=len(payload), transfer_id=transfer_id)
+
+        connection = self.rsd.start_remote_service(self.SERVICE_NAME)
+        await connection.connect()
+        try:
+            await connection.send_request({"routine": "install", "argv": argv}, wanting_reply=True)
+            for transfer_id, (_, payload) in enumerate(transfers, start=1):
+                await connection.send_file_transfer(transfer_id, payload)
+            response = await connection.receive_response()
+        finally:
+            await connection.close()
+        self._unwrap("install", response)
+
+    @staticmethod
+    def _nonce_selector(nonce_domain: Optional[int], nonce_domain_handle: Optional[int]) -> dict[str, Any]:
+        """Build the argv selecting a nonce domain, by index or by handle.
+
+        The daemon accepts either form and reports them separately ("nonce domain doesn't exist for
+        index: ..." versus "... for handle: ...").
+        """
+        if nonce_domain is not None and nonce_domain_handle is not None:
+            raise ValueError("pass either nonce_domain or nonce_domain_handle, not both")
+        if nonce_domain_handle is not None:
+            return {"nonce-domain-handle": XpcUInt64Type(nonce_domain_handle)}
+        domain = NONCE_DOMAIN_CRYPTEX if nonce_domain is None else nonce_domain
+        return {"nonce-domain": XpcUInt64Type(domain)}
+
+    async def cryptex_nonce(self, nonce_domain: int) -> bytes:
+        """Read a nonce domain's nonce, unwrapped from the daemon's nonce structure.
+
+        :param nonce_domain: index into the daemon's nonce-domain table.
+        """
+        return unwrap_nonce(await self.get_nonce(nonce_domain=nonce_domain))
+
+    async def auto_install_ddi(self, restore_dir: Path = XCODE_DDI_RESTORE_DIR) -> InstalledCryptex:
+        """
+        Personalize and install the DeveloperDiskImage cryptex entirely through ``cryptexd``.
+
+        Assembles everything from Xcode's DDI bundle, requests a Cryptex1 ticket, and installs.
+
+        .. warning::
+            Not working end to end: `TSSRequest.add_cryptex1_tags` does not yet produce a ticket
+            Apple will sign, so this currently fails at image4 trust evaluation. Everything either
+            side of that step is verified against a device.
+
+        :param restore_dir: Xcode's unpacked DDI ``Restore`` directory.
+        :returns: the installed cryptex, as reported back by `copy_installed`.
+        :raises CryptexdError: if the daemon rejected the image.
+        """
+        assets = load_cryptex1_assets(restore_dir)
+        request = TSSRequest()
+        request.add_cryptex1_tags(
+            assets.build_identity,
+            await self.read_personalization_identifiers(),
+            await self.cryptex_nonce(assets.nonce_domain),
+        )
+        response = await request.send_receive()
+        im4m = response.get("Cryptex1,Ticket") or response["ApImg4Ticket"]
+
+        await self.install(
+            assets.image,
+            assets.trustcache,
+            im4m,
+            assets.info,
+            assets.volumehash,
+            assets.cryptex1_properties,
+        )
+        installed = await self.copy_installed()
+        ddi = next((cryptex for cryptex in installed if cryptex.identifier == DDI_CRYPTEX_IDENTIFIER), None)
+        if ddi is None:
+            raise CryptexdError(f"install reported success but {DDI_CRYPTEX_IDENTIFIER} is not installed")
+        return ddi
+
+    async def read_personalization_identifiers(self) -> dict[str, Any]:
+        """
+        Read the device's AppleImage4 chip instance, used to personalize a cryptex.
+
+        The returned mapping uses the daemon's ``img4_chip_*`` key names, e.g. ``img4_chip_chip``
+        (ChipID), ``img4_chip_bord`` (BoardID) and ``img4_chip_ecid`` (ECID).
+        """
+        return await self.invoke("read-personalization-id", {})
+
+    async def copy_installed(self) -> list[InstalledCryptex]:
+        """
+        List the cryptexes currently installed on the device.
+
+        On a device with a mounted personalized DeveloperDiskImage this reports
+        ``com.apple.MobileAsset.DDI`` together with its version.
+        """
+        argv: dict[str, Any] = await self.invoke("copy-installed", {}) or {}
+        entries: list[dict[str, Any]] = argv.get("remote-cryptex-array", [])
+        return [
+            InstalledCryptex(
+                identifier=entry["remote-cryptex-identifier"],
+                version=entry["remote-cryptex-version"],
+            )
+            for entry in entries
+        ]
+
+    async def get_nonce(self, nonce_domain: Optional[int] = None, nonce_domain_handle: Optional[int] = None) -> bytes:
+        """
+        Read the nonce for a nonce domain.
+
+        The returned blob is the nonce structure, not the bare nonce: on current devices it is
+        56 bytes carrying the 48-byte nonce at offset 2. `MobileImageMounterService.query_nonce`
+        returns those 48 bytes alone.
+
+        :param nonce_domain: index into the daemon's nonce-domain table; defaults to
+                             `NONCE_DOMAIN_CRYPTEX` when neither selector is given.
+        :param nonce_domain_handle: handle of the nonce domain, as an alternative to `nonce_domain`.
+        :raises ValueError: if both selectors are given.
+        :raises CryptexdError: if the domain does not exist or has no nonce.
+        """
+        argv = await self.invoke("get-nonce", self._nonce_selector(nonce_domain, nonce_domain_handle))
+        return argv["nonce"]
+
+    async def roll_nonce(self, nonce_domain: Optional[int] = None, nonce_domain_handle: Optional[int] = None) -> None:
+        """
+        Roll (regenerate) the nonce for a nonce domain.
+
+        This invalidates anything personalized against the previous nonce — notably a mounted
+        personalized DeveloperDiskImage, which must be re-personalized and re-mounted afterwards.
+
+        .. warning::
+            Unverified: no argv shape found so far actually rolls the nonce. Placing the selector
+            in ``argv`` (which is where ``get-nonce`` reads it, and where uint64 works) fails with
+            ``key nonce-domain doesn't exist``; placing it at the top level of the request returns
+            a reply with no error but leaves the nonce unchanged. The daemon reads it from
+            somewhere else again — ``_sub_remote_service_demux`` fetches both selectors with
+            ``xpc_dictionary_get_uint64``, so the type is right and only the location is wrong.
+
+        :param nonce_domain: index into the daemon's nonce-domain table; defaults to
+                             `NONCE_DOMAIN_CRYPTEX` when neither selector is given.
+        :param nonce_domain_handle: handle of the nonce domain, as an alternative to `nonce_domain`.
+        :raises ValueError: if both selectors are given.
+        :raises CryptexdError: if the domain does not exist or the roll failed.
+        """
+        await self.invoke("roll-nonce", self._nonce_selector(nonce_domain, nonce_domain_handle))
+
+    async def uninstall(self, identifier: str, version: Optional[str] = None) -> None:
+        """
+        Uninstall an installed cryptex.
+
+        :param identifier: cryptex identifier as reported by `copy_installed`, e.g.
+                           ``com.apple.MobileAsset.DDI``.
+        :param version: optional version to scope the removal to.
+        :raises CryptexdError: if no such cryptex is installed (``errno 2``) or removal failed.
+        """
+        argv: dict[str, Any] = {"remote-cryptex-identifier": identifier}
+        if version is not None:
+            argv["remote-cryptex-version"] = version
+        await self.invoke("uninstall", argv)

--- a/pymobiledevice3/services/install_coordination_proxy.py
+++ b/pymobiledevice3/services/install_coordination_proxy.py
@@ -1,0 +1,114 @@
+import dataclasses
+import plistlib
+import uuid
+from typing import Any, Optional, cast
+
+from pymobiledevice3.exceptions import InstallCoordinationError
+from pymobiledevice3.remote.remote_service import RemoteService
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+from pymobiledevice3.remote.xpc_message import XpcUInt64Type
+
+#: Both version gates are validated by the daemon; a request missing either is silently dropped and
+#: the connection is torn down without any reply.
+REQUEST_VERSION = 1
+PROTOCOL_VERSION = 1
+
+REQUEST_TYPE_INSTALL = 1
+REQUEST_TYPE_REVERT_STASH = 2
+REQUEST_TYPE_UNINSTALL = 3
+REQUEST_TYPE_QUERY = 4
+
+#: CoreFoundation's marker for an NSURL encoded into an XPC dictionary. The daemon rejects a plain
+#: string where it expects a URL, so URLs must be sent in this form.
+CFURL_MAGIC = uuid.UUID("C3853DCC-9776-4114-B6C1-FD9F51944A6D")
+
+
+def encode_url(url: str) -> dict[str, Any]:
+    """Encode *url* the way CoreFoundation serializes an NSURL into an XPC dictionary."""
+    return {
+        "com.apple.CFURL.magic": CFURL_MAGIC,
+        "com.apple.CFURL.base": None,
+        "com.apple.CFURL.string": url,
+    }
+
+
+def decode_url(value: Any) -> Optional[str]:
+    """Extract the string from a CoreFoundation-encoded NSURL, or ``None`` if it is not one."""
+    if isinstance(value, dict):
+        url: Optional[str] = cast(dict[str, Any], value).get("com.apple.CFURL.string")
+        return url
+    return None
+
+
+def _describe_error_data(error_data: bytes) -> str:
+    """Best-effort human-readable message out of an archived NSError.
+
+    ``ErrorData`` is an ``NSKeyedArchiver`` archive of an ``NSError``. Rather than registering
+    classes for a full unarchive, pull the longest string out of ``$objects``, which in practice is
+    the localized description.
+    """
+    try:
+        archive = plistlib.loads(error_data)
+        strings = [obj for obj in archive.get("$objects", []) if isinstance(obj, str) and " " in obj]
+        if strings:
+            return max(strings, key=len)
+    except Exception:
+        pass
+    return f"<undecodable NSError, {len(error_data)} bytes>"
+
+
+@dataclasses.dataclass
+class InstallRecord:
+    """The LaunchServices install record the daemon holds for an installed application."""
+
+    db_uuid: str
+    db_sequence: int
+    install_path: Optional[str]
+    persistent_identifier: bytes
+
+
+class InstallCoordinationProxyService(RemoteService):
+    """
+    Query the install-coordination proxy (``com.apple.remote.installcoordination_proxy``).
+
+    Unlike most RemoteXPC services this one does not use XPC request/reply correlation: the daemon
+    answers by sending fresh messages on the connection, so replies are read off the stream. Every
+    request must carry ``RequestVersion`` and ``ProtocolVersion``; if either is missing or wrong the
+    daemon cancels the connection without answering.
+
+    Only the read-only ``Query`` request is implemented. The daemon also exposes ``Install``
+    (which streams its payload over an out-of-band XPC file transfer), ``Uninstall`` and
+    ``RevertStash``.
+
+    Requires an iOS 17+ RSD tunnel. Use as an async context manager.
+    """
+
+    SERVICE_NAME = "com.apple.remote.installcoordination_proxy"
+
+    def __init__(self, rsd: RemoteServiceDiscoveryService):
+        super().__init__(rsd, self.SERVICE_NAME)
+
+    async def query(self, bundle_identifier: str) -> InstallRecord:
+        """
+        Look up the install record for an installed application.
+
+        :param bundle_identifier: bundle identifier to look up, e.g. ``com.apple.Preferences``.
+        :raises InstallCoordinationError: if the application is unknown or the daemon reported a failure.
+        """
+        await self.service.send_request({
+            "RequestVersion": XpcUInt64Type(REQUEST_VERSION),
+            "ProtocolVersion": XpcUInt64Type(PROTOCOL_VERSION),
+            "RequestType": XpcUInt64Type(REQUEST_TYPE_QUERY),
+            "BundleID": bundle_identifier,
+        })
+        response = await self.service.receive_response()
+        if not response.get("Success"):
+            error_data = response.get("ErrorData")
+            detail = _describe_error_data(error_data) if isinstance(error_data, bytes) else "no error detail"
+            raise InstallCoordinationError(f"query failed for {bundle_identifier}: {detail}")
+        return InstallRecord(
+            db_uuid=response["DBUUID"],
+            db_sequence=response["DBSequence"],
+            install_path=decode_url(response.get("InstallPath")),
+            persistent_identifier=response["PersistentIdentifier"],
+        )

--- a/pymobiledevice3/services/mobile_image_mounter.py
+++ b/pymobiledevice3/services/mobile_image_mounter.py
@@ -396,86 +396,112 @@ class PersonalizedImageMounter(MobileImageMounterService):
         """
         Request an IM4M personalization manifest from Apple's TSS server.
 
-        Selects the build identity in ``build_manifest`` matching the device's board and chip IDs,
-        builds a TSS request from the device's personalization identifiers and nonce, and submits it.
-
         :param build_manifest: Parsed ``BuildManifest.plist`` contents.
         :returns: The signed IM4M ticket (``ApImg4Ticket``) returned by the TSS server.
         :raises NoSuchBuildIdentityError: If no build identity matches the device's board and chip IDs.
         """
-        request = TSSRequest()
+        return await request_personalization_manifest(
+            build_manifest,
+            await self.query_personalization_identifiers(),
+            self.lockdown.ecid,
+            await self.query_nonce("DeveloperDiskImage"),
+            logger=self.logger,
+        )
 
-        personalization_identifiers = await self.query_personalization_identifiers()
-        for key, value in personalization_identifiers.items():
-            if key.startswith("Ap,"):
-                request.update({key: value})
 
-        board_id = personalization_identifiers["BoardId"]
-        chip_id = personalization_identifiers["ChipID"]
+async def request_personalization_manifest(
+    build_manifest: dict[str, Any],
+    personalization_identifiers: dict[str, Any],
+    ecid: int,
+    ap_nonce: bytes,
+    logger: logging.Logger = logger,
+) -> bytes:
+    """
+    Request an IM4M personalization manifest from Apple's TSS server.
 
-        build_identity = None
-        for tmp_build_identity in build_manifest["BuildIdentities"]:
-            if (
-                int(tmp_build_identity["ApBoardID"], 0) == board_id
-                and int(tmp_build_identity["ApChipID"], 0) == chip_id
-            ):
-                build_identity = tmp_build_identity
-                break
-        else:
-            raise NoSuchBuildIdentityError(f"Could not find the manifest for board {board_id} and chip {chip_id}")
-        manifest = build_identity["Manifest"]
+    Selects the build identity in ``build_manifest`` matching the device's board and chip IDs,
+    builds a TSS request from the supplied personalization identifiers and nonce, and submits it.
+    Kept independent of any one service so both the image mounter and ``cryptexd`` can personalize
+    the same image.
 
-        parameters: dict[str, Any] = {
-            "ApProductionMode": True,
-            "ApSecurityDomain": 1,
-            "ApSecurityMode": True,
-            "ApSupportsImg4": True,
-        }
+    :param build_manifest: Parsed ``BuildManifest.plist`` contents.
+    :param personalization_identifiers: Device identifiers, as reported by
+        `MobileImageMounterService.query_personalization_identifiers`.
+    :param ecid: The device's ECID.
+    :param ap_nonce: The nonce to personalize against.
+    :param logger: Logger for the per-entry decisions.
+    :returns: The signed IM4M ticket (``ApImg4Ticket``) returned by the TSS server.
+    :raises NoSuchBuildIdentityError: If no build identity matches the device's board and chip IDs.
+    """
+    request = TSSRequest()
 
-        request.update({
-            "@ApImg4Ticket": True,
-            "@BBTicket": True,
-            "ApBoardID": board_id,
-            "ApChipID": chip_id,
-            "ApECID": self.lockdown.ecid,
-            "ApNonce": await self.query_nonce("DeveloperDiskImage"),
-            "ApProductionMode": True,
-            "ApSecurityDomain": 1,
-            "ApSecurityMode": True,
-            "SepNonce": b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
-            "UID_MODE": False,
-        })
+    for key, value in personalization_identifiers.items():
+        if key.startswith("Ap,"):
+            request.update({key: value})
 
-        for key, manifest_entry in manifest.items():
-            info_dict = manifest_entry.get("Info")
-            if info_dict is None:
-                continue
+    board_id = personalization_identifiers["BoardId"]
+    chip_id = personalization_identifiers["ChipID"]
 
-            if not manifest_entry.get("Trusted", False):
-                self.logger.debug(f"skipping {key} as it is not trusted")
-                continue
+    build_identity = None
+    for tmp_build_identity in build_manifest["BuildIdentities"]:
+        if int(tmp_build_identity["ApBoardID"], 0) == board_id and int(tmp_build_identity["ApChipID"], 0) == chip_id:
+            build_identity = tmp_build_identity
+            break
+    else:
+        raise NoSuchBuildIdentityError(f"Could not find the manifest for board {board_id} and chip {chip_id}")
+    manifest = build_identity["Manifest"]
 
-            # copy this entry
-            tss_entry = dict(manifest_entry)
+    parameters: dict[str, Any] = {
+        "ApProductionMode": True,
+        "ApSecurityDomain": 1,
+        "ApSecurityMode": True,
+        "ApSupportsImg4": True,
+    }
 
-            # remove obsolete Info node
-            tss_entry.pop("Info")
+    request.update({
+        "@ApImg4Ticket": True,
+        "@BBTicket": True,
+        "ApBoardID": board_id,
+        "ApChipID": chip_id,
+        "ApECID": ecid,
+        "ApNonce": ap_nonce,
+        "ApProductionMode": True,
+        "ApSecurityDomain": 1,
+        "ApSecurityMode": True,
+        "SepNonce": b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+        "UID_MODE": False,
+    })
 
-            # handle RestoreRequestRules
-            if "RestoreRequestRules" in manifest["LoadableTrustCache"]["Info"]:
-                rules = manifest["LoadableTrustCache"]["Info"]["RestoreRequestRules"]
-                if rules:
-                    self.logger.debug(f"Applying restore request rules for entry {key}")
-                    tss_entry = request.apply_restore_request_rules(tss_entry, parameters, rules)
+    for key, manifest_entry in manifest.items():
+        info_dict = manifest_entry.get("Info")
+        if info_dict is None:
+            continue
 
-            # Make sure we have a Digest key for Trusted items even if empty
-            if manifest_entry.get("Digest") is None:
-                tss_entry["Digest"] = b""
+        if not manifest_entry.get("Trusted", False):
+            logger.debug(f"skipping {key} as it is not trusted")
+            continue
 
-            request.update({key: tss_entry})
+        # copy this entry
+        tss_entry = dict(manifest_entry)
 
-        response = await request.send_receive()
-        return response["ApImg4Ticket"]
+        # remove obsolete Info node
+        tss_entry.pop("Info")
+
+        # handle RestoreRequestRules
+        if "RestoreRequestRules" in manifest["LoadableTrustCache"]["Info"]:
+            rules = manifest["LoadableTrustCache"]["Info"]["RestoreRequestRules"]
+            if rules:
+                logger.debug(f"Applying restore request rules for entry {key}")
+                tss_entry = request.apply_restore_request_rules(tss_entry, parameters, rules)
+
+        # Make sure we have a Digest key for Trusted items even if empty
+        if manifest_entry.get("Digest") is None:
+            tss_entry["Digest"] = b""
+
+        request.update({key: tss_entry})
+
+    response = await request.send_receive()
+    return response["ApImg4Ticket"]
 
 
 async def auto_mount_developer(
@@ -535,15 +561,15 @@ async def auto_mount_developer(
     await image_mounter.mount(image_path, signature)
 
 
-async def auto_mount_personalized(lockdown: LockdownServiceProvider) -> None:
+def fetch_personalized_ddi() -> tuple[Path, Path, Path]:
     """
-    Download (if needed) and mount the Personalized Developer Disk Image.
+    Return the cached Personalized DeveloperDiskImage, downloading it if needed.
 
     Caches the image, build manifest and trust cache under the home folder, re-downloading them from
     the bundled repository when missing or when the cached build id does not match
-    `LATEST_DDI_BUILD_ID`, then mounts them via `PersonalizedImageMounter`.
+    `LATEST_DDI_BUILD_ID`.
 
-    :param lockdown: Lockdown service provider for the target device.
+    :returns: paths to the image, its ``BuildManifest.plist`` and its trust cache.
     """
     local_path = get_home_folder() / "Xcode_iOS_DDI_Personalized"
     local_path.mkdir(parents=True, exist_ok=True)
@@ -569,7 +595,16 @@ async def auto_mount_personalized(lockdown: LockdownServiceProvider) -> None:
                 "Downloaded personalized image has unexpected ProductBuildVersion "
                 f"{downloaded_ddi_build_id}. Please update pymobiledevice3!"
             )
+    return image, build_manifest, trustcache
 
+
+async def auto_mount_personalized(lockdown: LockdownServiceProvider) -> None:
+    """
+    Download (if needed) and mount the Personalized Developer Disk Image.
+
+    :param lockdown: Lockdown service provider for the target device.
+    """
+    image, build_manifest, trustcache = fetch_personalized_ddi()
     await PersonalizedImageMounter(lockdown=lockdown).mount(image, build_manifest, trustcache)
 
 

--- a/pymobiledevice3/services/notification_proxy.py
+++ b/pymobiledevice3/services/notification_proxy.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Union
 
 from pymobiledevice3.exceptions import NotificationTimeoutError
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+from pymobiledevice3.remote.remote_service import RemoteService
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
 from pymobiledevice3.service_connection import ServiceConnection
 from pymobiledevice3.services.lockdown_service import LockdownService
@@ -89,3 +90,58 @@ class NotificationProxyService(LockdownService):
                 yield await self.service.recv_plist()
             except socket.timeout as e:
                 raise NotificationTimeoutError from e
+
+
+class RemoteNotificationProxyService(RemoteService):
+    """
+    Post and observe Darwin notifications over the native RemoteXPC notification proxy.
+
+    This is the RSD-native counterpart of `NotificationProxyService`: instead of tunnelling the
+    classic lockdown service through its ``.shim.remote`` alias, it talks to the notification proxy
+    daemon directly over RemoteXPC. The message vocabulary is identical (``PostNotification`` /
+    ``ObserveNotification`` / ``RelayNotification``), only the transport differs.
+
+    Requires an iOS 17+ RSD tunnel. Use as an async context manager.
+    """
+
+    SERVICE_NAME = "com.apple.mobile.notification_proxy.remote"
+    INSECURE_SERVICE_NAME = "com.apple.mobile.insecure_notification_proxy.remote"
+
+    def __init__(self, rsd: RemoteServiceDiscoveryService, insecure: bool = False):
+        """
+        :param rsd: RSD provider used to open the RemoteXPC service.
+        :param insecure: when True, use the insecure relay meant for untrusted clients.
+        """
+        super().__init__(rsd, self.INSECURE_SERVICE_NAME if insecure else self.SERVICE_NAME)
+
+    async def notify_post(self, name: str) -> None:
+        """
+        Post a notification on the device.
+
+        :param name: notification name to post (e.g. a Darwin notification name).
+        """
+        await self.service.send_request({"Command": "PostNotification", "Name": name})
+
+    async def notify_register_dispatch(self, name: str) -> None:
+        """
+        Register interest in a notification so the device relays it back.
+
+        Once registered, the device sends a ``RelayNotification`` message whenever the named
+        notification fires, which can be read via `receive_notification`.
+
+        :param name: notification name to observe.
+        """
+        self.logger.info(f"Observing {name}")
+        await self.service.send_request({"Command": "ObserveNotification", "Name": name})
+
+    async def receive_notification(self) -> AsyncGenerator[dict[str, Any], None]:
+        """
+        Yield notifications relayed from the device for previously observed names.
+
+        Each yielded message is a dict of the form
+        ``{"Command": "RelayNotification", "Name": <notification name>}``.
+
+        :returns: an async generator of the relayed notification messages.
+        """
+        while True:
+            yield await self.service.receive_response()

--- a/tests/remote/core_device/test_icon_service.py
+++ b/tests/remote/core_device/test_icon_service.py
@@ -1,0 +1,117 @@
+import struct
+from typing import Any, cast
+
+import pytest
+
+from pymobiledevice3.remote.core_device.icon_service import AppIcon, IconService
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+from pymobiledevice3.remote.remotexpc import RemoteXPCConnection
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+SAMPLE_RESPONSE = {
+    "appIconInfo": {
+        "isAppIconPlaceholder": False,
+        "pixelSize": [352.0, 352.0],
+        "pngData": PNG_MAGIC + b"rest-of-png",
+        "size": [176.0, 176.0],
+        "scale": 2.0,
+    }
+}
+
+
+def _service(response: dict[str, Any]) -> tuple[IconService, list[dict[str, Any]]]:
+    """An IconService whose RemoteXPC connection records requests and replays *response*."""
+    sent: list[dict[str, Any]] = []
+
+    class FakeConnection:
+        async def send_receive_request(self, request: dict[str, Any]) -> dict[str, Any]:
+            sent.append(request)
+            return {"CoreDevice.output": response}
+
+    service = object.__new__(IconService)
+    service.rsd = cast(RemoteServiceDiscoveryService, object())
+    service._service = cast(RemoteXPCConnection, FakeConnection())
+    return service, sent
+
+
+def test_service_name_is_iconservice() -> None:
+    # Regression: fetchappicons used to be sent to com.apple.coredevice.appservice, which does
+    # not advertise the feature and rejects the request.
+    assert IconService.SERVICE_NAME == "com.apple.coredevice.iconservice"
+
+
+@pytest.mark.asyncio
+async def test_fetch_icon_parses_response() -> None:
+    service, _ = _service(SAMPLE_RESPONSE)
+
+    icon = await service.fetch_icon(bundle_identifier="com.apple.Preferences")
+
+    assert icon == AppIcon(
+        png_data=PNG_MAGIC + b"rest-of-png",
+        pixel_size=(352.0, 352.0),
+        size=(176.0, 176.0),
+        scale=2.0,
+        is_placeholder=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_icon_sends_expected_input() -> None:
+    service, sent = _service(SAMPLE_RESPONSE)
+
+    await service.fetch_icon(bundle_identifier="com.apple.Preferences", width=176.0, height=176.0, scale=2.0)
+
+    (request,) = sent
+    assert request["CoreDevice.featureIdentifier"] == "com.apple.coredevice.feature.fetchappicons"
+    assert request["CoreDevice.input"] == {
+        "bundleIdentifier": "com.apple.Preferences",
+        "appPath": None,
+        "width": 176.0,
+        "height": 176.0,
+        "scale": 2.0,
+        "allowPlaceholder": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_icon_rounds_floats_to_float32() -> None:
+    # FetchAppIconParams declares these as Swift Float; a Double that doesn't fit binary32 is
+    # rejected by the daemon's decoder.
+    service, sent = _service(SAMPLE_RESPONSE)
+
+    await service.fetch_icon(bundle_identifier="com.apple.Preferences", width=0.1, height=0.1, scale=0.1)
+
+    (request,) = sent
+    for key in ("width", "height", "scale"):
+        value = request["CoreDevice.input"][key]
+        assert struct.unpack("<f", struct.pack("<f", value))[0] == value
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"bundle_identifier": "com.apple.Preferences", "app_path": "/Applications/Preferences.app"},
+    ],
+)
+async def test_fetch_icon_requires_exactly_one_specifier(kwargs: dict[str, Any]) -> None:
+    service, _ = _service(SAMPLE_RESPONSE)
+
+    with pytest.raises(ValueError):
+        await service.fetch_icon(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_fetch_icon_from_device(service_provider) -> None:
+    """Exercise the real service against a connected device."""
+    if not isinstance(service_provider, RemoteServiceDiscoveryService):
+        pytest.skip("iconservice requires an RSD tunnel")
+
+    async with IconService(service_provider) as icon_service:
+        icon = await icon_service.fetch_icon(bundle_identifier="com.apple.Preferences", width=60.0, height=60.0)
+
+    assert icon.png_data.startswith(PNG_MAGIC)
+    assert not icon.is_placeholder
+    assert icon.pixel_size[0] > 0 and icon.pixel_size[1] > 0

--- a/tests/services/test_cryptexd.py
+++ b/tests/services/test_cryptexd.py
@@ -1,0 +1,321 @@
+from typing import Any, cast
+
+import pytest
+
+from pymobiledevice3.exceptions import CryptexdError
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+from pymobiledevice3.services.cryptexd import (
+    NONCE_DOMAIN_CRYPTEX,
+    CryptexdService,
+    InstalledCryptex,
+    unwrap_nonce,
+)
+
+
+class FakeConnection:
+    """Records requests and replays a canned response; tracks its own open/close lifecycle."""
+
+    def __init__(self, response: dict[str, Any], sent: list[dict[str, Any]]) -> None:
+        self._response = response
+        self._sent = sent
+        self.connected = False
+        self.closed = False
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def send_receive_request(self, request: dict[str, Any]) -> dict[str, Any]:
+        assert self.connected and not self.closed, "request sent outside an open connection"
+        self._sent.append(request)
+        return self._response
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeRsd:
+    def __init__(self, response: dict[str, Any], sent: list[dict[str, Any]]) -> None:
+        self._response = response
+        self._sent = sent
+        self.connections: list[FakeConnection] = []
+
+    def start_remote_service(self, name: str) -> Any:
+        assert name == CryptexdService.SERVICE_NAME
+        connection = FakeConnection(self._response, self._sent)
+        self.connections.append(connection)
+        return connection
+
+
+def _service(response: dict[str, Any]) -> tuple[CryptexdService, list[dict[str, Any]]]:
+    sent: list[dict[str, Any]] = []
+    service = CryptexdService(cast(RemoteServiceDiscoveryService, FakeRsd(response, sent)))
+    return service, sent
+
+
+def test_service_name() -> None:
+    assert CryptexdService.SERVICE_NAME == "com.apple.security.cryptexd.remote"
+
+
+@pytest.mark.asyncio
+async def test_invoke_wraps_routine_and_argv() -> None:
+    service, sent = _service({"error": 0, "argv": {"ok": True}})
+
+    result = await service.invoke("some-routine", {"a": 1})
+
+    assert sent == [{"routine": "some-routine", "argv": {"a": 1}}]
+    assert result == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_invoke_raises_on_cferr() -> None:
+    service, _ = _service({
+        "cferr": {
+            "cferr_code": 10,
+            "cferr_domain": "com.apple.security.cryptex",
+            "cferr_userinfo": {"NSLocalizedDescription": "nonce domain doesn't exist for index: 0"},
+        }
+    })
+
+    with pytest.raises(CryptexdError, match="nonce domain doesn't exist"):
+        await service.invoke("get-nonce", {})
+
+
+@pytest.mark.asyncio
+async def test_invoke_raises_on_nonzero_error() -> None:
+    service, _ = _service({"error": 2})
+
+    with pytest.raises(CryptexdError, match=r"ENOENT \(2\)"):
+        await service.invoke("copy-installed", {})
+
+
+@pytest.mark.asyncio
+async def test_get_nonce_accepts_a_domain_handle() -> None:
+    service, sent = _service({"error": 0, "argv": {"nonce": b"\x01"}})
+
+    await service.get_nonce(nonce_domain_handle=7)
+
+    assert sent[0]["argv"] == {"nonce-domain-handle": 7}
+    assert "nonce-domain" not in sent[0]["argv"]
+
+
+@pytest.mark.asyncio
+async def test_nonce_selectors_are_mutually_exclusive() -> None:
+    service, _ = _service({"error": 0, "argv": {"nonce": b""}})
+
+    with pytest.raises(ValueError):
+        await service.get_nonce(nonce_domain=2, nonce_domain_handle=7)
+    with pytest.raises(ValueError):
+        await service.roll_nonce(nonce_domain=2, nonce_domain_handle=7)
+
+
+@pytest.mark.asyncio
+async def test_roll_nonce_sends_roll_routine() -> None:
+    service, sent = _service({"error": 0, "argv": {}})
+
+    await service.roll_nonce()
+
+    assert sent[0]["routine"] == "roll-nonce"
+    assert int(sent[0]["argv"]["nonce-domain"]) == NONCE_DOMAIN_CRYPTEX
+
+
+@pytest.mark.asyncio
+async def test_uninstall_sends_identifier_only_by_default() -> None:
+    service, sent = _service({"error": 0, "argv": {}})
+
+    await service.uninstall("com.apple.MobileAsset.DDI")
+
+    assert sent[0]["routine"] == "uninstall"
+    assert sent[0]["argv"] == {"remote-cryptex-identifier": "com.apple.MobileAsset.DDI"}
+
+
+@pytest.mark.asyncio
+async def test_uninstall_includes_version_when_given() -> None:
+    service, sent = _service({"error": 0, "argv": {}})
+
+    await service.uninstall("com.apple.MobileAsset.DDI", "27.1.5228.8")
+
+    assert sent[0]["argv"]["remote-cryptex-version"] == "27.1.5228.8"
+
+
+@pytest.mark.asyncio
+async def test_uninstall_of_unknown_cryptex_raises_enoent() -> None:
+    # Verified against the device: a bogus identifier passes validation and fails with ENOENT.
+    service, _ = _service({"error": 2})
+
+    with pytest.raises(CryptexdError, match=r"ENOENT \(2\)"):
+        await service.uninstall("com.example.not-installed")
+
+
+@pytest.mark.asyncio
+async def test_read_personalization_identifiers_tolerates_missing_error_key() -> None:
+    # read-personalization-id replies omit "error" entirely on success.
+    chip = {"img4_chip_chip": 32816, "img4_chip_bord": 4}
+    service, sent = _service({"argv": chip})
+
+    assert await service.read_personalization_identifiers() == chip
+    assert sent[0]["routine"] == "read-personalization-id"
+
+
+@pytest.mark.asyncio
+async def test_copy_installed_parses_entries() -> None:
+    service, _ = _service({
+        "error": 0,
+        "argv": {
+            "remote-cryptex-array": [
+                {"remote-cryptex-identifier": "com.apple.MobileAsset.DDI", "remote-cryptex-version": "27.1.5228.8"}
+            ]
+        },
+    })
+
+    assert await service.copy_installed() == [
+        InstalledCryptex(identifier="com.apple.MobileAsset.DDI", version="27.1.5228.8")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_copy_installed_handles_empty() -> None:
+    service, _ = _service({"error": 0, "argv": {}})
+
+    assert await service.copy_installed() == []
+
+
+@pytest.mark.asyncio
+async def test_get_nonce_sends_domain_and_returns_nonce() -> None:
+    service, sent = _service({"error": 0, "argv": {"nonce": b"\x01\x02"}})
+
+    assert await service.get_nonce() == b"\x01\x02"
+    assert sent[0]["routine"] == "get-nonce"
+    assert int(sent[0]["argv"]["nonce-domain"]) == NONCE_DOMAIN_CRYPTEX
+
+
+@pytest.mark.asyncio
+async def test_each_invoke_uses_a_fresh_closed_connection() -> None:
+    # cryptexd serves one routine per connection; reusing one fails with an incomplete read.
+    service, sent = _service({"error": 0, "argv": {}})
+    rsd = cast(FakeRsd, service.rsd)
+
+    await service.invoke("copy-installed", {})
+    await service.invoke("copy-installed", {})
+
+    assert len(sent) == 2
+    assert len(rsd.connections) == 2
+    assert all(connection.closed for connection in rsd.connections)
+
+
+@pytest.mark.asyncio
+async def test_connection_is_closed_even_when_the_routine_fails() -> None:
+    service, _ = _service({"cferr": {"cferr_code": 10, "cferr_domain": "d", "cferr_userinfo": {}}})
+    rsd = cast(FakeRsd, service.rsd)
+
+    with pytest.raises(CryptexdError):
+        await service.invoke("get-nonce", {})
+
+    assert rsd.connections[0].closed
+
+
+@pytest.mark.asyncio
+async def test_cryptexd_from_device(service_provider) -> None:
+    """Exercise the read-only routines against a connected device."""
+    if not isinstance(service_provider, RemoteServiceDiscoveryService):
+        pytest.skip("cryptexd requires an RSD tunnel")
+
+    cryptexd = CryptexdService(service_provider)
+    identifiers = await cryptexd.read_personalization_identifiers()
+    # A second routine on the same instance must work, each on its own connection.
+    installed = await cryptexd.copy_installed()
+
+    assert "img4_chip_chip" in identifiers
+    assert "img4_chip_ecid" in identifiers
+    assert all(isinstance(cryptex, InstalledCryptex) for cryptex in installed)
+
+
+class RecordingConnection:
+    """Captures the install request plus every file transfer pushed on the same connection."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        self._response = response
+        self.request: dict[str, Any] = {}
+        self.transfers: list[tuple[int, bytes]] = []
+        self.closed = False
+
+    async def connect(self) -> None: ...
+
+    async def send_request(self, request: dict[str, Any], wanting_reply: bool = False) -> None:
+        self.request = request
+
+    async def send_file_transfer(self, transfer_id: int, data: bytes) -> None:
+        self.transfers.append((transfer_id, data))
+
+    async def receive_response(self) -> dict[str, Any]:
+        return self._response
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _install_service(response: dict[str, Any]) -> tuple[CryptexdService, RecordingConnection]:
+    connection = RecordingConnection(response)
+
+    class Rsd:
+        def start_remote_service(self, name: str) -> Any:
+            return connection
+
+    return CryptexdService(cast(RemoteServiceDiscoveryService, Rsd())), connection
+
+
+@pytest.mark.asyncio
+async def test_install_announces_transfers_and_pushes_them() -> None:
+    service, connection = _install_service({"error": 0})
+
+    await service.install(b"image-bytes", b"tc", b"im4m", b"info", b"vol", {})
+
+    argv = connection.request["argv"]
+    assert connection.request["routine"] == "install"
+    # Each payload is announced by size and id, then pushed under the same id.
+    assert argv["image"].transfer_size == len(b"image-bytes")
+    assert [argv[k].transfer_id for k in ("image", "trustcache", "im4m", "info", "volumehash")] == [1, 2, 3, 4, 5]
+    assert connection.transfers == [(1, b"image-bytes"), (2, b"tc"), (3, b"im4m"), (4, b"info"), (5, b"vol")]
+    assert connection.closed
+
+
+@pytest.mark.asyncio
+async def test_install_sends_the_scalar_keys_the_daemon_requires() -> None:
+    # Verified against the device: omitting any of these fails validation with EINVAL, and
+    # image-type-index must be int64 while the rest are uint64.
+    service, connection = _install_service({"error": 0})
+
+    await service.install(b"i", b"t", b"m", b"info", b"vol", {"Cryptex1,SubType": 2})
+
+    argv = connection.request["argv"]
+    assert type(argv["image-type-index"]).__name__ == "XpcInt64Type"
+    for key in ("persistence", "nonce-persistence", "auth", "client-version"):
+        assert type(argv[key]).__name__ == "XpcUInt64Type"
+    # Captured from Xcode: the cryptex is named by the info plist, not by argv keys.
+    assert "remote-cryptex-identifier" not in argv
+    assert "remote-cryptex-version" not in argv
+    assert argv["cryptex1-properties"] == {"Cryptex1,SubType": 2}
+    assert int(argv["client-version"]) == 3
+    assert int(argv["image-type-index"]) == 10
+    assert (int(argv["persistence"]), int(argv["nonce-persistence"])) == (2, 1)
+
+
+@pytest.mark.asyncio
+async def test_install_raises_on_a_cferr_reply() -> None:
+    service, _ = _install_service({
+        "cferr": {
+            "cferr_code": 13,
+            "cferr_domain": "com.apple.security.cryptex.posix",
+            "cferr_userinfo": {"NSLocalizedDescription": "initialization failed [13: Permission denied]"},
+        }
+    })
+
+    with pytest.raises(CryptexdError, match="Permission denied"):
+        await service.install(b"i", b"t", b"m", b"info", b"vol", {})
+
+
+def test_unwrap_nonce_extracts_the_nonce_from_the_daemon_structure() -> None:
+    # get-nonce returns 2-byte lead + nonce + LE uint32 length; verified against the mounter's
+    # query_nonce and the cnch tag of Xcode's ticket.
+    nonce = bytes(range(48))
+    blob = b"\x00\x00" + nonce + b"\x00\x00" + (48).to_bytes(4, "little")
+    assert unwrap_nonce(blob) == nonce

--- a/tests/services/test_install_coordination_proxy.py
+++ b/tests/services/test_install_coordination_proxy.py
@@ -1,0 +1,111 @@
+import plistlib
+from typing import Any, cast
+
+import pytest
+
+from pymobiledevice3.exceptions import InstallCoordinationError
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+from pymobiledevice3.remote.remotexpc import RemoteXPCConnection
+from pymobiledevice3.services.install_coordination_proxy import (
+    CFURL_MAGIC,
+    REQUEST_TYPE_QUERY,
+    InstallCoordinationProxyService,
+    decode_url,
+    encode_url,
+)
+
+INSTALL_PATH = "file:///Applications/Preferences.app/"
+
+
+def _service(response: dict[str, Any]) -> tuple[InstallCoordinationProxyService, list[dict[str, Any]]]:
+    sent: list[dict[str, Any]] = []
+
+    class FakeConnection:
+        async def send_request(self, request: dict[str, Any]) -> None:
+            sent.append(request)
+
+        async def receive_response(self) -> dict[str, Any]:
+            return response
+
+    service = InstallCoordinationProxyService(cast(RemoteServiceDiscoveryService, object()))
+    service._service = cast(RemoteXPCConnection, FakeConnection())
+    return service, sent
+
+
+def test_url_round_trip() -> None:
+    encoded = encode_url(INSTALL_PATH)
+    assert encoded["com.apple.CFURL.magic"] == CFURL_MAGIC
+    assert decode_url(encoded) == INSTALL_PATH
+
+
+def test_decode_url_returns_none_for_non_url() -> None:
+    assert decode_url("not a url dict") is None
+
+
+@pytest.mark.asyncio
+async def test_query_sends_both_version_gates() -> None:
+    # Omitting either version makes the daemon drop the connection without replying.
+    service, sent = _service({
+        "Success": True,
+        "DBUUID": "D1D20BD4-9669-47A6-B577-F6D62ED45B43",
+        "DBSequence": 276,
+        "InstallPath": encode_url(INSTALL_PATH),
+        "PersistentIdentifier": b"\x00\x01",
+    })
+
+    await service.query("com.apple.Preferences")
+
+    (request,) = sent
+    assert int(request["RequestVersion"]) == 1
+    assert int(request["ProtocolVersion"]) == 1
+    assert int(request["RequestType"]) == REQUEST_TYPE_QUERY
+    assert request["BundleID"] == "com.apple.Preferences"
+
+
+@pytest.mark.asyncio
+async def test_query_parses_install_record() -> None:
+    service, _ = _service({
+        "Success": True,
+        "DBUUID": "D1D20BD4-9669-47A6-B577-F6D62ED45B43",
+        "DBSequence": 276,
+        "InstallPath": encode_url(INSTALL_PATH),
+        "PersistentIdentifier": b"\x00\x01",
+    })
+
+    record = await service.query("com.apple.Preferences")
+
+    assert record.db_uuid == "D1D20BD4-9669-47A6-B577-F6D62ED45B43"
+    assert record.db_sequence == 276
+    assert record.install_path == INSTALL_PATH
+    assert record.persistent_identifier == b"\x00\x01"
+
+
+@pytest.mark.asyncio
+async def test_query_raises_and_surfaces_archived_error_text() -> None:
+    error_data = plistlib.dumps({"$objects": ["$null", "The operation could not be completed"]})
+    service, _ = _service({"Success": False, "ErrorData": error_data})
+
+    with pytest.raises(InstallCoordinationError, match="could not be completed"):
+        await service.query("com.example.missing")
+
+
+@pytest.mark.asyncio
+async def test_query_raises_without_error_data() -> None:
+    service, _ = _service({"Success": False})
+
+    with pytest.raises(InstallCoordinationError, match="no error detail"):
+        await service.query("com.example.missing")
+
+
+@pytest.mark.asyncio
+async def test_query_from_device(service_provider) -> None:
+    """Query a stock application against a connected device."""
+    if not isinstance(service_provider, RemoteServiceDiscoveryService):
+        pytest.skip("installcoordination_proxy requires an RSD tunnel")
+
+    async with InstallCoordinationProxyService(service_provider) as service:
+        record = await service.query("com.apple.Preferences")
+
+    assert record.install_path is not None
+    assert record.install_path.endswith(".app/")
+    assert record.db_sequence > 0

--- a/tests/services/test_notification_proxy_remote.py
+++ b/tests/services/test_notification_proxy_remote.py
@@ -1,0 +1,101 @@
+import asyncio
+from typing import Any, Optional, cast
+
+import pytest
+
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+from pymobiledevice3.remote.remotexpc import RemoteXPCConnection
+from pymobiledevice3.services.notification_proxy import RemoteNotificationProxyService
+
+PROBE_NOTIFICATION = "com.apple.pymobiledevice3.test.notification"
+
+
+class FakeConnection:
+    def __init__(self, inbound: list[dict[str, Any]]) -> None:
+        self.sent: list[dict[str, Any]] = []
+        self._inbound = list(inbound)
+
+    async def send_request(self, request: dict[str, Any]) -> None:
+        self.sent.append(request)
+
+    async def receive_response(self) -> dict[str, Any]:
+        if not self._inbound:
+            raise asyncio.CancelledError
+        return self._inbound.pop(0)
+
+
+def _service(
+    inbound: Optional[list[dict[str, Any]]] = None,
+) -> tuple[RemoteNotificationProxyService, FakeConnection]:
+    connection = FakeConnection(inbound if inbound is not None else [])
+    service = RemoteNotificationProxyService(cast(RemoteServiceDiscoveryService, object()))
+    service._service = cast(RemoteXPCConnection, connection)
+    return service, connection
+
+
+def test_service_names() -> None:
+    # The native RemoteXPC services, not the ".shim.remote" lockdown aliases.
+    assert RemoteNotificationProxyService.SERVICE_NAME == "com.apple.mobile.notification_proxy.remote"
+    assert RemoteNotificationProxyService.INSECURE_SERVICE_NAME == "com.apple.mobile.insecure_notification_proxy.remote"
+
+
+@pytest.mark.parametrize(
+    ("insecure", "expected"),
+    [
+        (False, "com.apple.mobile.notification_proxy.remote"),
+        (True, "com.apple.mobile.insecure_notification_proxy.remote"),
+    ],
+)
+def test_insecure_selects_service(insecure: bool, expected: str) -> None:
+    service = RemoteNotificationProxyService(cast(RemoteServiceDiscoveryService, object()), insecure=insecure)
+    assert service.service_name == expected
+
+
+@pytest.mark.asyncio
+async def test_notify_post_sends_post_command() -> None:
+    service, connection = _service()
+
+    await service.notify_post(PROBE_NOTIFICATION)
+
+    assert connection.sent == [{"Command": "PostNotification", "Name": PROBE_NOTIFICATION}]
+
+
+@pytest.mark.asyncio
+async def test_notify_register_dispatch_sends_observe_command() -> None:
+    service, connection = _service()
+
+    await service.notify_register_dispatch(PROBE_NOTIFICATION)
+
+    assert connection.sent == [{"Command": "ObserveNotification", "Name": PROBE_NOTIFICATION}]
+
+
+@pytest.mark.asyncio
+async def test_receive_notification_yields_relayed_messages() -> None:
+    relayed = {"Command": "RelayNotification", "Name": PROBE_NOTIFICATION}
+    service, _ = _service([relayed])
+
+    async for event in service.receive_notification():
+        assert event == relayed
+        break
+
+
+@pytest.mark.asyncio
+async def test_observe_post_relay_round_trip_on_device(service_provider) -> None:
+    """Observe a notification, post it, and confirm the device relays it back."""
+    if not isinstance(service_provider, RemoteServiceDiscoveryService):
+        pytest.skip("the native notification proxy requires an RSD tunnel")
+
+    async with RemoteNotificationProxyService(service_provider) as observer:
+        await observer.notify_register_dispatch(PROBE_NOTIFICATION)
+        async with RemoteNotificationProxyService(service_provider) as poster:
+            await asyncio.sleep(1)
+            await poster.notify_post(PROBE_NOTIFICATION)
+
+            async def first_relay() -> dict[str, Any]:
+                async for event in observer.receive_notification():
+                    return event
+                raise AssertionError("stream ended without a relay")
+
+            event = await asyncio.wait_for(first_relay(), 15)
+
+    assert event == {"Command": "RelayNotification", "Name": PROBE_NOTIFICATION}

--- a/tests/test_darwin_errno.py
+++ b/tests/test_darwin_errno.py
@@ -1,0 +1,47 @@
+import errno as host_errno
+import platform
+
+from pymobiledevice3.darwin_errno import DARWIN_ERRNO_NAMES, EINVAL, ENOENT, ENOTSUP, describe_errno
+
+
+def test_describe_known_errno() -> None:
+    assert describe_errno(ENOENT) == "ENOENT (2)"
+    assert describe_errno(EINVAL) == "EINVAL (22)"
+    assert describe_errno(ENOTSUP) == "ENOTSUP (45)"
+
+
+def test_describe_unknown_errno_falls_back_to_the_number() -> None:
+    assert describe_errno(9999) == "errno 9999"
+
+
+def test_table_covers_the_darwin_range() -> None:
+    # sys/errno.h runs 1..107 (ELAST is 106, ENOTCAPABLE 107) with no gaps.
+    assert set(DARWIN_ERRNO_NAMES) == set(range(1, 108))
+
+
+def test_names_do_not_come_from_the_host_runtime() -> None:
+    """The whole point of this module: these are device-side numbers.
+
+    On a non-Darwin host `os.strerror`/`errno` resolve the same integers to different meanings, so
+    the table must be independent of them. Asserted on values where the platforms actually diverge.
+    """
+    assert DARWIN_ERRNO_NAMES[45] == "ENOTSUP"
+    assert DARWIN_ERRNO_NAMES[60] == "ETIMEDOUT"
+    assert DARWIN_ERRNO_NAMES[107] == "ENOTCAPABLE"
+    # Linux ENOTSUP is 95 and has no errno 107 at all; if we had used the host tables these would
+    # disagree on any non-Darwin CI runner.
+    if platform.system() != "Darwin":  # pragma: no cover - only meaningful off Darwin
+        assert host_errno.errorcode.get(45) != "ENOTSUP"
+
+
+def test_pure_aliases_are_not_in_the_table() -> None:
+    # EWOULDBLOCK is an unconditional alias of EAGAIN, so only the canonical name is kept.
+    assert DARWIN_ERRNO_NAMES[35] == "EAGAIN"
+    assert "EWOULDBLOCK" not in DARWIN_ERRNO_NAMES.values()
+
+
+def test_enotsup_and_eopnotsupp_are_distinct() -> None:
+    # sys/errno.h aliases EOPNOTSUPP to ENOTSUP only in legacy non-UNIX03 builds; under
+    # __DARWIN_UNIX03 (and in the kernel) it is discrete at 102, which is what the device reports.
+    assert DARWIN_ERRNO_NAMES[45] == "ENOTSUP"
+    assert DARWIN_ERRNO_NAMES[102] == "EOPNOTSUPP"

--- a/tests/test_remotexpc.py
+++ b/tests/test_remotexpc.py
@@ -1,16 +1,21 @@
 import asyncio
 from types import MethodType
-from typing import cast
+from typing import Any, cast
 
 import pytest
-from hyperframe.frame import DataFrame
+from hyperframe.frame import DataFrame, Frame, HeadersFrame, RstStreamFrame, SettingsFrame, WindowUpdateFrame
 
+from pymobiledevice3.exceptions import StreamClosedError
 from pymobiledevice3.remote.remotexpc import (
+    DEFAULT_PEER_WINDOW_SIZE,
     DEFAULT_SETTINGS_INITIAL_WINDOW_SIZE,
     DEFAULT_WIN_SIZE_INCR,
+    FRAME_HEADER_SIZE,
+    MAX_OUTBOUND_FRAME_SIZE,
     WINDOW_UPDATE_THRESHOLD,
     RemoteXPCConnection,
 )
+from pymobiledevice3.remote.xpc_message import XpcWrapper
 
 
 class FakeWriter:
@@ -100,3 +105,176 @@ async def test_iter_file_chunks_routes_interleaved_streams():
         [b"a", b"c"],
         [b"b", b"d"],
     ]
+
+
+def _parse_written_frames(writer: FakeWriter) -> list[Any]:
+    """Re-parse everything a FakeWriter captured back into frames.
+
+    Typed as Any because hyperframe's base ``Frame`` has no ``data``/``flags``; every caller here
+    inspects concrete DataFrame/HeadersFrame instances.
+    """
+    buf = b"".join(writer.writes)
+    frames: list[Any] = []
+    while buf:
+        frame, length = Frame.parse_frame_header(memoryview(buf[:FRAME_HEADER_SIZE]))
+        frame.parse_body(memoryview(buf[FRAME_HEADER_SIZE : FRAME_HEADER_SIZE + length]))
+        frames.append(frame)
+        buf = buf[FRAME_HEADER_SIZE + length :]
+    return frames
+
+
+def _sending_connection(window: int = DEFAULT_PEER_WINDOW_SIZE) -> tuple[RemoteXPCConnection, FakeWriter]:
+    connection = RemoteXPCConnection(("localhost", 0))
+    writer = FakeWriter()
+    connection._writer = cast(asyncio.StreamWriter, writer)
+    connection._outbound_connection_window = window
+    connection._peer_initial_window_size = window
+    return connection, writer
+
+
+@pytest.mark.asyncio
+async def test_send_file_transfer_uses_odd_stream_and_carries_transfer_id():
+    # The device rejects HEADERS on an even stream with GOAWAY "invalid stream_id", and rejects a
+    # preamble whose msg_id is 0 with "Got HEADER with invalid msg_id 0".
+    connection, writer = _sending_connection()
+
+    await connection.send_file_transfer(transfer_id=7, data=b"payload")
+
+    frames = _parse_written_frames(writer)
+    stream_ids = {f.stream_id for f in frames}
+    assert stream_ids == {5}
+    assert all(stream_id % 2 == 1 for stream_id in stream_ids)
+    assert isinstance(frames[0], HeadersFrame)
+    preamble = XpcWrapper.parse(frames[1].data)
+    assert preamble.message.message_id == 7
+    assert preamble.flags.FILE_TX_STREAM_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_send_file_transfer_sends_payload_then_end_stream():
+    connection, writer = _sending_connection()
+
+    await connection.send_file_transfer(transfer_id=1, data=b"abcdef")
+
+    frames = _parse_written_frames(writer)
+    assert frames[2].data == b"abcdef"
+    assert "END_STREAM" not in frames[2].flags
+    assert frames[-1].data == b""
+    assert "END_STREAM" in frames[-1].flags
+
+
+@pytest.mark.asyncio
+async def test_send_file_transfer_allocates_a_fresh_stream_each_time():
+    connection, writer = _sending_connection()
+
+    await connection.send_file_transfer(transfer_id=1, data=b"a")
+    await connection.send_file_transfer(transfer_id=2, data=b"b")
+
+    assert sorted({f.stream_id for f in _parse_written_frames(writer)}) == [5, 7]
+
+
+@pytest.mark.asyncio
+async def test_send_file_transfer_splits_payload_into_max_sized_frames():
+    connection, writer = _sending_connection(window=10 * MAX_OUTBOUND_FRAME_SIZE)
+
+    await connection.send_file_transfer(transfer_id=1, data=b"z" * (MAX_OUTBOUND_FRAME_SIZE * 2 + 5))
+
+    payload_frames = [f for f in _parse_written_frames(writer)[2:] if f.data]
+    assert [len(f.data) for f in payload_frames] == [MAX_OUTBOUND_FRAME_SIZE, MAX_OUTBOUND_FRAME_SIZE, 5]
+
+
+@pytest.mark.asyncio
+async def test_send_file_transfer_waits_for_window_then_resumes():
+    """A payload larger than the peer's window must block until it grants more."""
+    connection, writer = _sending_connection(window=MAX_OUTBOUND_FRAME_SIZE)
+    # A real peer replenishes both the connection window and the stream's; either one left at zero
+    # is enough to block the sender, so the fake must grant both.
+    grants = iter([
+        WindowUpdateFrame(stream_id=0, window_increment=MAX_OUTBOUND_FRAME_SIZE),
+        WindowUpdateFrame(stream_id=5, window_increment=MAX_OUTBOUND_FRAME_SIZE),
+    ])
+    granted = 0
+
+    async def receive_frame():
+        nonlocal granted
+        granted += 1
+        return next(grants)
+
+    connection._receive_frame = receive_frame
+
+    await connection.send_file_transfer(transfer_id=1, data=b"z" * (MAX_OUTBOUND_FRAME_SIZE + 1))
+
+    assert granted == 2, "expected to block until the peer replenished both windows"
+    frames = _parse_written_frames(writer)
+    preamble_len = len(frames[1].data)
+    payload_frames = [f for f in frames[2:] if f.data]
+    # The preamble is flow controlled too, so the first chunk is short by its length.
+    assert [len(f.data) for f in payload_frames] == [
+        MAX_OUTBOUND_FRAME_SIZE - preamble_len,
+        MAX_OUTBOUND_FRAME_SIZE + 1 - (MAX_OUTBOUND_FRAME_SIZE - preamble_len),
+    ]
+    assert sum(len(f.data) for f in payload_frames) == MAX_OUTBOUND_FRAME_SIZE + 1
+
+
+@pytest.mark.asyncio
+async def test_preamble_consumes_flow_control_window():
+    """The opening frame is DATA; not charging it overruns the window (GOAWAY error 3)."""
+    connection, writer = _sending_connection()
+    before = connection._outbound_connection_window
+
+    await connection.send_file_transfer(transfer_id=1, data=b"")
+
+    preamble_len = len(_parse_written_frames(writer)[1].data)
+    assert connection._outbound_connection_window == before - preamble_len
+
+
+def test_window_update_frames_grow_the_outbound_windows():
+    connection, _ = _sending_connection()
+    before = connection._outbound_connection_window
+
+    assert connection._apply_flow_control_frame(WindowUpdateFrame(stream_id=0, window_increment=100))
+    assert connection._outbound_connection_window == before + 100
+
+    assert connection._apply_flow_control_frame(WindowUpdateFrame(stream_id=5, window_increment=50))
+    assert connection._outbound_stream_windows[5] == DEFAULT_PEER_WINDOW_SIZE + 50
+
+
+def test_settings_initial_window_size_shifts_open_stream_windows():
+    connection, _ = _sending_connection()
+    connection._outbound_stream_windows[5] = DEFAULT_PEER_WINDOW_SIZE
+
+    connection._apply_flow_control_frame(
+        SettingsFrame(settings={SettingsFrame.INITIAL_WINDOW_SIZE: DEFAULT_PEER_WINDOW_SIZE + 1000})
+    )
+
+    assert connection._peer_initial_window_size == DEFAULT_PEER_WINDOW_SIZE + 1000
+    assert connection._outbound_stream_windows[5] == DEFAULT_PEER_WINDOW_SIZE + 1000
+
+
+@pytest.mark.asyncio
+async def test_reset_of_a_finished_transfer_stream_is_not_an_error():
+    """The device resets a transfer stream once it has the payload; that is normal completion."""
+    connection, _ = _sending_connection()
+    connection._finished_file_transfer_streams.add(5)
+    data_frame = DataFrame(stream_id=1, data=b"later")
+    frames = iter([RstStreamFrame(stream_id=5), data_frame])
+
+    async def receive_frame():
+        return next(frames)
+
+    connection._receive_frame = receive_frame
+
+    assert await connection._pump_one_frame() is data_frame
+
+
+@pytest.mark.asyncio
+async def test_reset_of_an_unrelated_stream_still_raises():
+    connection, _ = _sending_connection()
+
+    async def receive_frame():
+        return RstStreamFrame(stream_id=9)
+
+    connection._receive_frame = receive_frame
+
+    with pytest.raises(StreamClosedError):
+        await connection._pump_one_frame()

--- a/tests/test_tss_cryptex1.py
+++ b/tests/test_tss_cryptex1.py
@@ -1,0 +1,102 @@
+import plistlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pymobiledevice3.restore.tss import TSSRequest
+
+XCODE_DDI = Path("/Library/Developer/DeveloperDiskImages/iOS_DDI/Restore/BuildManifest.plist")
+
+# Values as reported by CryptexdService.read_personalization_identifiers on an iPhone12,1.
+CHIP_INSTANCE: dict[str, Any] = {
+    "img4_chip_chip": 32816,
+    "img4_chip_bord": 4,
+    "img4_chip_ecid": 586125774848046,
+    "img4_chip_sdom": 1,
+    "img4_chip_cpro": 1,
+    "img4_chip_csec": 1,
+    "img4_chip_cepo": 1,
+    "img4_chip_clas": 242,
+    "img4_chip_fchp": 65296,
+    "img4_chip_type": 3,
+}
+NONCE = bytes(range(48))
+
+CRYPTEX_IDENTITY: dict[str, Any] = {
+    "Cryptex1,ChipID": "0xFF10",
+    "Cryptex1,ProductClass": "0xF2",
+    "Cryptex1,Type": 3,
+    "Cryptex1,SubType": 2,
+    "Cryptex1,NonceDomain": 4,
+    "Cryptex1,UseProductClass": True,
+    "Cryptex1,Version": "39.999.999.0.0,0",
+    "Cryptex1,PreauthorizationVersion": "39.999.999.0.0,0",
+    "Manifest": {
+        # Personalize: False -- must be omitted; the signed manifest carries no dmg digest.
+        "Cryptex1,GenericDmg": {"Digest": b"\x01", "Info": {"Personalize": False}},
+        "Cryptex1,CryptexInfoPlist": {"Digest": b"\x02", "Info": {"Personalize": True}},
+        "Cryptex1,GenericTrustCache": {"Digest": b"\x03", "Info": {"Personalize": True}},
+        "Cryptex1,GenericVolume": {"Digest": b"\x04", "Info": {"Personalize": True}},
+    },
+}
+
+
+def _request() -> dict[str, Any]:
+    request = TSSRequest()
+    request.add_cryptex1_tags(CRYPTEX_IDENTITY, CHIP_INSTANCE, NONCE)
+    return request._request
+
+
+def test_requests_a_cryptex1_ticket_not_an_ap_ticket() -> None:
+    assert _request()["@Cryptex1,Ticket"] is True
+
+
+def test_carries_the_cryptex1_chip_parameters() -> None:
+    # These become the fchp/type/styp/clas/ndom/upcl/vnum/pave tags in the signed manifest.
+    request = _request()
+    assert request["Cryptex1,ChipID"] == 0xFF10
+    assert request["Cryptex1,ProductClass"] == 0xF2
+    assert request["Cryptex1,Type"] == 3
+    assert request["Cryptex1,SubType"] == 2
+    assert request["Cryptex1,NonceDomain"] == 4
+    assert request["Cryptex1,UseProductClass"] is True
+    assert request["Cryptex1,Version"] == "39.999.999.0.0,0"
+    assert request["Cryptex1,PreauthorizationVersion"] == "39.999.999.0.0,0"
+
+
+def test_nonce_is_sent_raw() -> None:
+    # Verified on-device: the signed cnch tag equals the nonce byte-for-byte, unhashed.
+    assert _request()["Cryptex1,Nonce"] == NONCE
+
+
+def test_device_identity_comes_from_the_chip_instance() -> None:
+    request = _request()
+    assert request["ApECID"] == CHIP_INSTANCE["img4_chip_ecid"]
+    assert request["ApChipID"] == CHIP_INSTANCE["img4_chip_chip"]
+    assert request["ApProductionMode"] is True
+
+
+def test_only_personalized_components_are_included() -> None:
+    # Cryptex1,GenericDmg is Personalize: False; Xcode's ticket signs only ginf/gtcd/gtgv.
+    request = _request()
+    assert "Cryptex1,GenericDmg" not in request
+    for key in ("Cryptex1,CryptexInfoPlist", "Cryptex1,GenericTrustCache", "Cryptex1,GenericVolume"):
+        assert key in request
+        assert "Info" not in request[key]
+
+
+@pytest.mark.skipif(not XCODE_DDI.exists(), reason="Xcode DDI bundle not installed")
+def test_against_the_real_build_manifest() -> None:
+    """The one cryptex identity in Xcode's DDI must drive a complete request."""
+    build_manifest = plistlib.loads(XCODE_DDI.read_bytes())
+    identity = next(
+        bi for bi in build_manifest["BuildIdentities"] if "Cryptex" in bi.get("Info", {}).get("Variant", "")
+    )
+
+    request = TSSRequest()
+    request.add_cryptex1_tags(identity, CHIP_INSTANCE, NONCE)
+
+    assert request._request["Cryptex1,NonceDomain"] == 4
+    assert "Cryptex1,GenericDmg" not in request._request
+    assert "Cryptex1,CryptexInfoPlist" in request._request


### PR DESCRIPTION
Adds four previously-unimplemented RSD services found by diffing `remote rsd-info` against the repo, plus the transport capability they exposed as missing.

Each feature is its own commit; every wire-format claim below was established against an iPhone 11 on iOS 27.0, either from device syslog or from a packet capture of `devicectl`.

## Working and verified on hardware

| commit | what |
|---|---|
| `remotexpc` | Outbound XPC file transfer + outbound flow control |
| `darwin_errno` | Device-side (Darwin) errno table, host-independent |
| `core-device` | `iconservice` — fetch app icons as PNG |
| `notification` | RemoteXPC notification proxy (`--remotexpc`) |
| `apps` | `install-record` via `installcoordination_proxy` |
| `cryptex` | `cryptexd` service + CLI group |

Highlights:

- **`send_file_transfer`** — the transport could receive file transfers but not send them. Four wire rules (odd stream, transfer id as XPC `message_id`, payload before the ack, ignore the completion reset) plus outbound flow control, which did not exist: `WINDOW_UPDATE` frames were discarded outright. Verified moving a 15.9 MB image plus four smaller payloads in a single request.
- **`cryptex list`** reports a mounted personalized DDI as `com.apple.MobileAsset.DDI` — nothing else in the repo surfaces that.
- **Bug fixed along the way**: `AppServiceService.fetch_icons` sent `fetchappicons` to `com.apple.coredevice.appservice`, which does not advertise the feature. Dead code that never worked; removed and replaced by the real service.

## Scaffolding, explicitly not working

Two pieces are committed unfinished, with the limitation stated in both the code and the commit message:

- **`roll-nonce`** does not roll the nonce. No argv placement found so far works — in `argv` the daemon reports the key missing, at top level it replies without error and leaves the nonce unchanged.
- **`add_cryptex1_tags` / `install`** — the install request is byte-shaped like Xcode's (captured from a `devicectl` install) and the daemon accepts it, consumes all five payloads and proceeds to image4 trust evaluation. It cannot complete until the Cryptex1 TSS request is right; Apple currently rejects it.

Both are included deliberately so the remaining work is a ticket-shaping problem rather than a rediscovery problem. The Cryptex1 asset mapping, the `cryptex1-properties` dict, the uint64 typing requirement and the signed-manifest tag set are all recorded in code and tests.

## Notes for review

- `cryptex` is a new top-level group rather than a `mounter` subcommand: every command needs an RSD tunnel while `mounter` works over USB, and the mounter is a consumer of the cryptex subsystem rather than its parent.
- `darwin_errno` is deliberately not in `osu/posix_util.py` — that is a host-OS abstraction swapped for `win_util` on Windows, which is exactly the platform the table needs to be correct on.
- The `mounter` refactor is behaviour-preserving; it only splits `get_manifest_from_tss` and `auto_mount_personalized` so cryptex personalization can reuse the pieces.

## Verification

`ruff check` and `ruff format --check` clean, `pyright --venvpath .` reports 0 errors, 240 tests pass (9 skipped — the device-backed ones, which skip without `--rsd`/`--tunnel`). Each of the eight commits imports cleanly on its own.
