### PR TITLE
ci: Make the restored Python 3.9 matrix actually pass

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,6 +19,13 @@ jobs:
     if: '! github.event.pull_request.draft'
     runs-on: ${{ matrix.os }}
 
+    # Pin uv to the interpreter it provisioned. Without this it prefers an already-installed
+    # system Python, and macOS runners ship 3.9.6 linked against LibreSSL 2.8.3 -- urllib3 v2
+    # then emits NotOpenSSLWarning on import, which pytest's `filterwarnings = error` turns
+    # into a collection failure for the whole 3.9 job.
+    env:
+      UV_PYTHON_PREFERENCE: only-managed
+
     strategy:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]

--- a/tests/test_service_connection.py
+++ b/tests/test_service_connection.py
@@ -46,6 +46,10 @@ async def test_service_connection_close_aborts_when_wait_closed_hangs(monkeypatc
     assert sock.fileno() == -1
 
 
+# CPython <= 3.10 leaves the half-built SSLSocket unclosed when the handshake fails inside
+# wrap_socket(), so it emits a ResourceWarning when collected. Reproducible with plain CPython and
+# no pymobiledevice3 involved, and the socket is never ours to close -- wrap_socket() owns it.
+@pytest.mark.filterwarnings("ignore::ResourceWarning")
 def test_ssl_start_sync_failure_raises_connection_terminated(monkeypatch):
     # A failed handshake leaves the original socket detached by wrap_socket(); the error
     # path must not touch it again (used to raise EBADF/WinError 10038, masking the error).


### PR DESCRIPTION
`test_ssl_start_sync_failure_raises_connection_terminated` fails on Python 3.9 and 3.10 and passes on 3.11+. Found while verifying master locally, since the Actions outage meant #1822 (restoring the 3.9 matrix) merged without CI actually running.

## Symptom

```
PytestUnraisableExceptionWarning: Exception ignored in:
<ssl.SSLSocket fd=11, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0>
```

pytest's unraisable-exception plugin escalates a `ResourceWarning` into a failure.

| version | before | after |
|---|---|---|
| 3.9 | fail | pass |
| 3.10 | fail | pass |
| 3.11 – 3.14 | pass | pass |

## Cause

On CPython ≤ 3.10 the half-built `SSLSocket` is left unclosed when the handshake fails inside `wrap_socket()`. This is not a pymobiledevice3 bug — it reproduces with plain CPython and no library code involved:

```python
c, s = socket.socketpair(); s.close()
ctx.wrap_socket(c)      # ResourceWarning: unclosed <ssl.SSLSocket fd=3, ...>
```

The socket is never ours to close: `wrap_socket()` creates and owns it, and `ssl_start_sync` deliberately doesn't touch the original afterwards — which is exactly what this test asserts. So the fix belongs in the test rather than the error path.

## Why CI didn't catch it

The workflow runs `pytest -m cli`, which deselects `tests/test_service_connection.py` on every matrix version. Restoring 3.9 didn't surface it and wouldn't have.

## Verification

Full non-device suite on the entire matrix: **236 passed, 5 skipped** on each of 3.9, 3.10, 3.11, 3.12, 3.13, 3.14.

CI's own steps: `SKIP=pyright uvx pre-commit run --all-files` passes; `pytest -m cli` passes on 3.9 and 3.14 (118 each); pyright via a fresh `uv venv` + `uv pip install -e ".[test]"` reports 0 errors.