### PR TITLE
syslog: Fix IndexError when label contains format metacharacters

### DIFF
--- a/pymobiledevice3/cli/syslog.py
+++ b/pymobiledevice3/cli/syslog.py
@@ -114,7 +114,7 @@ def format_line(syslog_entry: SyslogEntry, *, include_label: bool, image_offset:
     line_format = "{timestamp} {process_name}{{{image_name}{image_offset_str}}}[{pid}] <{level}>: {message}"
 
     if include_label:
-        line_format += f" {label}"
+        line_format += " {label}"
 
     line = line_format.format(
         timestamp=timestamp,
@@ -124,6 +124,7 @@ def format_line(syslog_entry: SyslogEntry, *, include_label: bool, image_offset:
         level=level,
         message=message,
         image_offset_str=image_offset_str,
+        label=label,
     )
 
     return line

--- a/tests/cli/test_syslog.py
+++ b/tests/cli/test_syslog.py
@@ -310,6 +310,17 @@ async def test_syslog_live_no_info_suppresses_only_info(monkeypatch, capsys):
     assert _FakeOsTraceService.last_stream_flags == (OS_TRACE_RELAY_STREAM_FLAGS_DEFAULT & ~OsActivityStreamFlag.INFO)
 
 
+@pytest.mark.parametrize("color", [False, True])
+def test_format_line_label_with_braces(color: bool) -> None:
+    # https://github.com/doronz88/pymobiledevice3/issues/1826 - a subsystem/category
+    # containing str.format() metacharacters (e.g. "{34}") must be emitted verbatim
+    # instead of being parsed as a replacement field.
+    entry = _create_syslog_entry("hello")
+    entry.label = SyslogLabel(subsystem="com.foo.{34}", category="{bad} {")
+    line = syslog_module.format_line(entry, include_label=True, image_offset=False, color=color)
+    assert "[com.foo.{34}][{bad} {]" in line
+
+
 def test_format_json_line_with_label():
     entry = SyslogEntry(
         pid=42,


### PR DESCRIPTION
With `--label`, the label text (device-controlled subsystem/category strings) was f-string-interpolated into the line format string and then re-parsed by `str.format()`. A label containing braces — e.g. a literal `{34}` emitted on iOS 27 beta — was treated as a positional replacement field, crashing `syslog live` with `IndexError: Replacement index 34 out of range` (any `{`/`{foo}` would crash similarly with `ValueError`/`KeyError`).

Fix: pass `label` as a `.format()` keyword argument like every other field, so device-controlled text is never parsed as a format spec.

Added `test_format_line_label_with_braces` (color on/off) which reproduced the exact `IndexError` before the fix.

Fixes #1826