### PR TITLE
cryptex: Install the DDI through cryptexd alone

### DIFF
--- a/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -26,6 +26,9 @@ Many `developer dvt` and related developer commands need all of the following:
    `uvx --from . pymobiledevice3 amfi enable-developer-mode`
 2. Developer image mounted:
    `uvx --from . pymobiledevice3 mounter auto-mount`
+   On iOS 17+ the same image can instead be installed as a cryptex, bypassing the image
+   mounter: `uvx --from . pymobiledevice3 cryptex auto-install` (needs RSD; both cache the
+   download under `~/.pymobiledevice3` and end up mounted at `/System/Developer`).
 3. A CoreDevice transport path. On iOS 17.4+ this needs **no setup**: the no-root
    userspace tunnel is established automatically when the command runs. Only iOS
    17.0-17.3 devices (which predate CoreDeviceProxy) route to `tunneld` and need a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,16 +51,20 @@ Guidance for AI coding agents and automation contributors working in this reposi
 
 ## Running Developer Commands Against Devices
 
-- Developer/DVT commands on iOS 17+ devices require an RSD tunnel. Prefer
-  `--userspace` over a `tunneld` tunnel: it establishes the tunnel in-process
-  with a pure-Python userspace network stack and needs **no `sudo`/root**, so
-  agents can run unattended.
-  - Example: `pymobiledevice3 developer dvt oslog --userspace`.
-  - You can also set `PYMOBILEDEVICE3_USERSPACE=1` instead of passing the flag.
-- Only fall back to a privileged `tunneld` (which needs root) when `--userspace`
-  is not viable — e.g. when you need higher host->device throughput, since
-  userspace host->device transfers (DDI mounts, file pushes) are deliberately
-  slower.
+- Developer/DVT commands on iOS 17+ devices require an RSD tunnel, and every
+  command that requires one **already establishes it in-process by default**,
+  with a pure-Python userspace network stack and **no `sudo`/root**. Just run
+  the command — do not reach for a flag.
+  - Example: `pymobiledevice3 developer dvt oslog`, `pymobiledevice3 cryptex list`.
+- `--userspace` only *forces* that path; it is redundant on a required-RSD
+  command. It matters on iOS 17.0-17.3, which the default deliberately routes to
+  `tunneld` instead (those versions predate CoreDeviceProxy, so the no-root path
+  is the fragile Wi-Fi-only RemotePairing one). `PYMOBILEDEVICE3_USERSPACE=1` is
+  the env-var equivalent.
+- Use a privileged `tunneld` (needs root) only when the userspace tunnel is not
+  viable — e.g. when you need higher host->device throughput, since userspace
+  host->device transfers (DDI mounts, file pushes) are deliberately slower.
+  `PYMOBILEDEVICE3_PREFER_TUNNELD=1` opts out of the userspace default entirely.
 - `--userspace` is mutually exclusive with `--rsd`/`--tunnel`.
 
 ## Testing Expectations

--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -122,18 +122,35 @@ Talks to `cryptexd` directly. `cryptex list` reports a mounted personalized Deve
 `com.apple.MobileAsset.DDI`.
 
 ```shell
-pymobiledevice3 cryptex list --userspace
-pymobiledevice3 cryptex personalization-identifiers --userspace
-pymobiledevice3 cryptex nonce --userspace
-pymobiledevice3 cryptex nonce --nonce-domain-handle 7 --userspace
+pymobiledevice3 cryptex list
+pymobiledevice3 cryptex personalization-identifiers
+pymobiledevice3 cryptex nonce
+pymobiledevice3 cryptex nonce --nonce-domain-handle 7
 ```
 
 State-changing. Rolling a nonce invalidates anything personalized against it, so a mounted
 personalized DDI must be re-personalized and re-mounted afterwards:
 
 ```shell
-pymobiledevice3 cryptex roll-nonce --userspace
-pymobiledevice3 cryptex uninstall com.apple.MobileAsset.DDI --userspace
+pymobiledevice3 cryptex roll-nonce
+pymobiledevice3 cryptex uninstall com.apple.MobileAsset.DDI
+```
+
+`cryptex auto-install` is the cryptex counterpart of `mounter auto-mount` — a cryptex is
+*installed*, not mounted, which is why the verb differs. It personalizes and installs the
+DeveloperDiskImage over `cryptexd` alone, without the image mounter: it has Apple sign a Cryptex1
+ticket for this device and installs the payloads, leaving the DDI's developer services (DVT,
+testmanagerd, …) usable. The end result is indistinguishable from a `mounter auto-mount` —
+`mounter list` reports it as a `Personalized` image at `/System/Developer`.
+
+Also like `mounter auto-mount`, it downloads the DDI it needs and caches it under
+`~/.pymobiledevice3`, so no Xcode installation is required and it works on any host:
+
+```shell
+pymobiledevice3 cryptex auto-install
+
+# Use a local bundle instead of the download, e.g. Xcode's own
+pymobiledevice3 cryptex auto-install --restore-dir /Library/Developer/DeveloperDiskImages/iOS_DDI/Restore
 ```
 
 !!! note "Overlap with `mounter`"

--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -226,7 +226,15 @@ pymobiledevice3 amfi enable-developer-mode
 
 # Auto-mount DeveloperDiskImage
 pymobiledevice3 mounter auto-mount
+
+# Or install it as a cryptex instead, over cryptexd (iOS 17+, needs RSD)
+pymobiledevice3 cryptex auto-install
 ```
+
+Both download the DDI and cache it under `~/.pymobiledevice3`, and both end with the image mounted
+at `/System/Developer`. `mounter auto-mount` works over plain USB and covers iOS < 17 as well;
+`cryptex auto-install` needs an RSD tunnel but bypasses the image mounter entirely. See
+[Cryptexes](#cryptexes-ios-17-rsd-tunnel) for the differences.
 
 For iOS 17+ tunnel setup, see:
 [iOS 17+ tunnels](ios17-tunnels.md)

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -26,6 +26,9 @@ Many `developer dvt` and related developer commands need all of the following:
    `uvx --from . pymobiledevice3 amfi enable-developer-mode`
 2. Developer image mounted:
    `uvx --from . pymobiledevice3 mounter auto-mount`
+   On iOS 17+ the same image can instead be installed as a cryptex, bypassing the image
+   mounter: `uvx --from . pymobiledevice3 cryptex auto-install` (needs RSD; both cache the
+   download under `~/.pymobiledevice3` and end up mounted at `/System/Developer`).
 3. A CoreDevice transport path. On iOS 17.4+ this needs **no setup**: the no-root
    userspace tunnel is established automatically when the command runs. Only iOS
    17.0-17.3 devices (which predate CoreDeviceProxy) route to `tunneld` and need a

--- a/pymobiledevice3/cli/cryptex.py
+++ b/pymobiledevice3/cli/cryptex.py
@@ -1,12 +1,14 @@
 import dataclasses
 import logging
+from pathlib import Path
 from typing import Annotated, Optional
 
 import typer
 from typer_injector import InjectingTyper
 
 from pymobiledevice3.cli.cli_common import RSDServiceProviderDep, async_command, print_json
-from pymobiledevice3.services.cryptexd import CryptexdService
+from pymobiledevice3.exceptions import AlreadyMountedError
+from pymobiledevice3.services.cryptexd import XCODE_DDI_RESTORE_DIR, CryptexdService
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +35,34 @@ async def cryptex_list(service_provider: RSDServiceProviderDep) -> None:
     """List installed cryptexes (a mounted personalized DDI appears as com.apple.MobileAsset.DDI)."""
     cryptexd = CryptexdService(service_provider)
     print_json([dataclasses.asdict(cryptex) for cryptex in await cryptexd.copy_installed()])
+
+
+@cli.command("auto-install")
+@async_command
+async def cryptex_auto_install(
+    service_provider: RSDServiceProviderDep,
+    restore_dir: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--restore-dir",
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            help="Unpacked DDI Restore directory holding the Cryptex1 assets, e.g. Xcode's own "
+            f"({XCODE_DDI_RESTORE_DIR}). Defaults to downloading and caching the DDI.",
+        ),
+    ] = None,
+) -> None:
+    """Personalize and install the DeveloperDiskImage cryptex, using only cryptexd."""
+    cryptexd = CryptexdService(service_provider)
+    try:
+        installed = await cryptexd.auto_install_ddi(restore_dir)
+    except FileNotFoundError as e:
+        raise typer.BadParameter(str(e)) from e
+    except AlreadyMountedError as e:
+        logger.error(f"DeveloperDiskImage cryptex already installed ({e}); uninstall it first")
+        raise typer.Exit(1) from e
+    logger.info(f"Installed {installed.identifier} {installed.version}")
 
 
 @cli.command("personalization-identifiers")

--- a/pymobiledevice3/restore/tss.py
+++ b/pymobiledevice3/restore/tss.py
@@ -29,9 +29,23 @@ from pymobiledevice3.utils import bytes_to_uint, plist_access_path
 # defaults write com.apple.CoreDevice.CoreDeviceService ddiSigningServer http://gs.apple.com:80
 # ```
 #
-# Note this is untested: CoreDevice caches the personalization ticket, so repeated DDI installs
-# make no TSS request at all to redirect (verified with tcpdump -- zero packets to gs.apple.com
-# across several installs). Invalidate the cached ticket first, e.g. by rolling the cryptex nonce.
+# That redirect does not help in practice, though: CoreDevice caches the personalization ticket, so
+# repeated DDI installs make no TSS request at all (verified with tcpdump -- zero packets to
+# gs.apple.com while `devicectl` reinstalled the cryptex). No user-readable on-disk ticket cache was
+# found to invalidate, and neither nonce-roll routine actually rolls a domain, so the cache cannot
+# be forced to miss either. MITM is no better: gs.apple.com is pinned, and mitmproxy only gets
+# "Server TLS handshake failed / self-signed certificate in certificate chain".
+#
+# Read the request out of the unified log instead. `CoreDeviceService` logs the whole dictionary it
+# is about to sign, verbatim, under `com.apple.libcryptex:scrivener` -- run a DDI install and then:
+#
+# ```shell
+# log show --last 5m --info --debug --predicate 'process == "CoreDeviceService"' \
+#     | awk '/tss request = \{/,/^\}/'
+# ```
+#
+# This is how `TSSRequest.add_cryptex1_tags` was derived; the device side is equally chatty, so
+# streaming its syslog filtered to the `cryptex` subsystem explains rejections a key at a time.
 TSS_CONTROLLER_ACTION_URL = "http://gs.apple.com/TSS/controller?action=2"
 
 TSS_CLIENT_VERSION_STRING = "libauthinstall-1104.0.9"

--- a/pymobiledevice3/restore/tss.py
+++ b/pymobiledevice3/restore/tss.py
@@ -39,6 +39,18 @@ TSS_CLIENT_VERSION_STRING = "libauthinstall-1104.0.9"
 logger = logging.getLogger(__name__)
 
 
+def cryptex1_udid(chip_instance: dict[str, typing.Any]) -> bytes:
+    """Build the ``Cryptex1,UDID`` identifying the device in a Cryptex1 TSS request.
+
+    It is the 16-byte concatenation of the chip ID and the ECID, both big-endian, and ends up in
+    the signed ticket verbatim as the ``UDID`` property.
+
+    :param chip_instance: the device's AppleImage4 chip instance, as returned by
+        `CryptexdService.read_personalization_identifiers`.
+    """
+    return chip_instance["img4_chip_chip"].to_bytes(8, "big") + chip_instance["img4_chip_ecid"].to_bytes(8, "big")
+
+
 def get_with_or_without_comma(obj: dict[str, typing.Any], k: str, default: typing.Any = None) -> typing.Any:
     val = obj.get(k, obj.get(k.replace(",", "")))
     if val is None and default is not None:
@@ -382,10 +394,16 @@ class TSSRequest:
         """Build a Cryptex1 personalization request (``@Cryptex1,Ticket``).
 
         Cryptex1 tickets are a different shape from the AP tickets `add_ap_tags` produces, which is
-        why that method skips every ``Cryptex1,*`` key. The signed manifest carries the Cryptex1
-        chip parameters (``fchp``/``type``/``styp``/``clas``/``ndom``/``upcl``/``vnum``/``pave``)
-        and digests for only the *personalized* components — the generic DMG is declared
-        ``Personalize: False`` in the build manifest and must be left out.
+        why that method skips every ``Cryptex1,*`` key. The device is identified by
+        ``Cryptex1,UDID`` alone — none of the ``Ap*`` tags an AP request carries appear here — and
+        each personalized component contributes nothing but its ``Digest``. The generic DMG is
+        declared ``Personalize: False`` in the build manifest and is left out entirely.
+
+        The exact shape was taken from Xcode: ``CoreDeviceService`` logs the dictionary it is about
+        to sign under the ``com.apple.libcryptex:scrivener`` subsystem, so a DDI install can be
+        observed with::
+
+            log show --last 5m --info --debug --predicate 'process == "CoreDeviceService"'
 
         :param build_identity: the build identity whose ``Info.Variant`` names a cryptex, i.e. the
             one carrying ``Cryptex1,*`` manifest entries.
@@ -395,12 +413,6 @@ class TSSRequest:
         """
         self._request.update({
             "@Cryptex1,Ticket": True,
-            "ApChipID": chip_instance["img4_chip_chip"],
-            "ApBoardID": chip_instance["img4_chip_bord"],
-            "ApECID": chip_instance["img4_chip_ecid"],
-            "ApSecurityDomain": chip_instance["img4_chip_sdom"],
-            "ApProductionMode": bool(chip_instance["img4_chip_cpro"]),
-            "ApSecurityMode": bool(chip_instance["img4_chip_csec"]),
             "Cryptex1,ChipID": int(str(build_identity["Cryptex1,ChipID"]), 0),
             "Cryptex1,Type": build_identity["Cryptex1,Type"],
             "Cryptex1,SubType": build_identity["Cryptex1,SubType"],
@@ -410,30 +422,18 @@ class TSSRequest:
             "Cryptex1,Version": build_identity["Cryptex1,Version"],
             "Cryptex1,PreauthorizationVersion": build_identity["Cryptex1,PreauthorizationVersion"],
             "Cryptex1,Nonce": nonce,
+            "Cryptex1,ProductionMode": bool(chip_instance["img4_chip_cpro"]),
+            "Cryptex1,UDID": cryptex1_udid(chip_instance),
+            "Cryptex1,UniqueTagList": b"",
         })
 
-        parameters: dict[str, typing.Any] = {
-            "ApProductionMode": bool(chip_instance["img4_chip_cpro"]),
-            "ApSecurityMode": bool(chip_instance["img4_chip_csec"]),
-            "ApSecurityDomain": chip_instance["img4_chip_sdom"],
-            "ApSupportsImg4": True,
-        }
         for key, manifest_entry in build_identity["Manifest"].items():
             if not key.startswith("Cryptex1,"):
                 continue
-            info_dict = manifest_entry.get("Info", {})
-            if not info_dict.get("Personalize", False):
+            if not manifest_entry.get("Info", {}).get("Personalize", False):
                 logger.debug(f"skipping {key} as it is not personalized")
                 continue
-
-            tss_entry = dict(manifest_entry)
-            tss_entry.pop("Info", None)
-            rules = info_dict.get("RestoreRequestRules")
-            if rules:
-                tss_entry = self.apply_restore_request_rules(tss_entry, parameters, rules)
-            if manifest_entry.get("Digest") is None:
-                tss_entry["Digest"] = b""
-            self._request[key] = tss_entry
+            self._request[key] = {"Digest": manifest_entry["Digest"]}
 
     def add_ap_tags(self, parameters: dict[str, typing.Any], overrides: typing.Optional[dict[str, typing.Any]] = None):
         """loop over components from build manifest"""

--- a/pymobiledevice3/services/cryptexd.py
+++ b/pymobiledevice3/services/cryptexd.py
@@ -1,14 +1,21 @@
 import dataclasses
+import logging
 import plistlib
 from pathlib import Path
 from typing import Any, Optional
 
+from developer_disk_image.repo import DeveloperDiskImageRepository
+
+from pymobiledevice3.common import get_home_folder
 from pymobiledevice3.darwin_errno import describe_errno
-from pymobiledevice3.exceptions import CryptexdError
+from pymobiledevice3.exceptions import AlreadyMountedError, CryptexdError
 from pymobiledevice3.remote.remote_service import RemoteService
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
 from pymobiledevice3.remote.xpc_message import FileTransferType, XpcInt64Type, XpcUInt64Type
 from pymobiledevice3.restore.tss import TSSRequest
+from pymobiledevice3.services.mobile_image_mounter import LATEST_DDI_BUILD_ID
+
+logger = logging.getLogger(__name__)
 
 #: ``nonce-domain`` index used for the cryptex nonce on current devices. The daemon resolves the
 #: index through its own nonce-domain table, so unsupported indices fail with a ``cferr``.
@@ -24,13 +31,78 @@ DDI_PERSISTENCE = 2
 DDI_NONCE_PERSISTENCE = 1
 
 
-#: Where Xcode unpacks ``CoreDevice/CandidateDDIs/iOS_DDI.dmg``. The Cryptex1 assets live only
-#: here — the DDI repository pymobiledevice3 caches for the image mounter ships the
-#: ``PersonalizedDMG`` variant, which has no ``cryptex_info`` or ``root_hash``.
+#: Where Xcode unpacks ``CoreDevice/CandidateDDIs/iOS_DDI.dmg``, for hosts that have Xcode.
 XCODE_DDI_RESTORE_DIR = Path("/Library/Developer/DeveloperDiskImages/iOS_DDI/Restore")
 
 #: The one build identity that describes a cryptex, out of ~141 in the DDI's BuildManifest.
 CRYPTEX_VARIANT_SUFFIX = "Developer Disk Image Cryptex"
+
+#: Manifest key declaring where a payload lives -> the `CryptexImage` field holding its bytes.
+CRYPTEX1_PAYLOAD_KEYS = {
+    "Cryptex1,GenericDmg": "image",
+    "Cryptex1,GenericTrustCache": "trustcache",
+    "Cryptex1,CryptexInfoPlist": "cryptex_info",
+    "Cryptex1,GenericVolume": "root_hash",
+}
+
+
+def fetch_cryptex_ddi() -> Path:
+    """
+    Return a cached Cryptex1 DDI ``Restore`` directory, downloading it if needed.
+
+    The cryptex assets are downloaded from the DeveloperDiskImage repository and cached under the
+    home folder, exactly as `fetch_personalized_ddi` does for the image mounter, so installing a
+    DDI over ``cryptexd`` needs no Xcode and works on any host. The cache is refreshed when it is
+    missing or when its build id does not match `LATEST_DDI_BUILD_ID`.
+
+    Each payload is written to the relative path the downloaded ``BuildManifest.plist`` declares
+    for it, which makes the cache a `Restore` directory `load_cryptex1_assets` reads directly.
+
+    :returns: path to the cached ``Restore`` directory.
+    """
+    local_path = get_home_folder() / "Xcode_iOS_DDI_Cryptex"
+    local_path.mkdir(parents=True, exist_ok=True)
+    build_manifest = local_path / "BuildManifest.plist"
+
+    if (
+        not build_manifest.exists()
+        or plistlib.loads(build_manifest.read_bytes()).get("ProductBuildVersion") != LATEST_DDI_BUILD_ID
+    ):
+        logger.info("Downloading the Cryptex1 DeveloperDiskImage")
+        cryptex_image = DeveloperDiskImageRepository.create().get_cryptex_disk_image()
+
+        build_manifest.write_bytes(cryptex_image.build_manifest)
+        identity = _cryptex_build_identity(plistlib.loads(cryptex_image.build_manifest), build_manifest)
+        for key, field in CRYPTEX1_PAYLOAD_KEYS.items():
+            payload = local_path / identity["Manifest"][key]["Info"]["Path"]
+            payload.parent.mkdir(parents=True, exist_ok=True)
+            payload.write_bytes(getattr(cryptex_image, field))
+
+        downloaded_build_id = plistlib.loads(cryptex_image.build_manifest).get("ProductBuildVersion")
+        if downloaded_build_id != LATEST_DDI_BUILD_ID:
+            logger.warning(
+                f"Downloaded cryptex image has unexpected ProductBuildVersion {downloaded_build_id}. "
+                "Please update pymobiledevice3!"
+            )
+    return local_path
+
+
+def _cryptex_build_identity(build_manifest: dict[str, Any], source: Path) -> dict[str, Any]:
+    """Return the one build identity in `build_manifest` that describes a cryptex.
+
+    :raises FileNotFoundError: if the manifest has no cryptex identity.
+    """
+    identity = next(
+        (
+            identity
+            for identity in build_manifest["BuildIdentities"]
+            if identity.get("Info", {}).get("Variant", "").endswith(CRYPTEX_VARIANT_SUFFIX)
+        ),
+        None,
+    )
+    if identity is None:
+        raise FileNotFoundError(f"no {CRYPTEX_VARIANT_SUFFIX!r} build identity in {source}")
+    return identity
 
 
 def unwrap_nonce(blob: bytes) -> bytes:
@@ -64,34 +136,40 @@ class Cryptex1Assets:
 
     @property
     def nonce_domain(self) -> int:
+        """Handle (not index) of the nonce domain this cryptex is personalized against."""
         return int(self.build_identity["Cryptex1,NonceDomain"])
 
 
-def load_cryptex1_assets(restore_dir: Path = XCODE_DDI_RESTORE_DIR) -> Cryptex1Assets:
+def load_cryptex1_assets(restore_dir: Optional[Path] = None) -> Cryptex1Assets:
     """
-    Load the Cryptex1 DDI payloads and parameters out of Xcode's DDI bundle.
+    Load the Cryptex1 DDI payloads and parameters out of an unpacked DDI ``Restore`` directory.
 
     Unlike the mounter's ``PersonalizedDMG``, the ``Cryptex1,GenericDmg`` is not personalized —
     it is byte-identical across devices, and only the info plist, trust cache and volume hash are.
 
-    :param restore_dir: Xcode's unpacked DDI ``Restore`` directory.
+    Payload locations are read from the build manifest rather than assumed, so this works both on
+    Xcode's own bundle and on a copy published by the DeveloperDiskImage repository, whose file
+    names are normalized (its manifest is rewritten to match).
+
+    :param restore_dir: an unpacked DDI ``Restore`` directory; defaults to the cached download from
+        the DeveloperDiskImage repository, so no Xcode installation is required.
     :raises FileNotFoundError: if the bundle (or its cryptex build identity) is not present.
     """
+    if restore_dir is None:
+        restore_dir = fetch_cryptex_ddi()
     manifest_path = restore_dir / "BuildManifest.plist"
     if not manifest_path.exists():
         raise FileNotFoundError(f"no DDI BuildManifest at {manifest_path}; is Xcode installed?")
     build_manifest = plistlib.loads(manifest_path.read_bytes())
-    build_identity = next(
-        (
-            identity
-            for identity in build_manifest["BuildIdentities"]
-            if identity.get("Info", {}).get("Variant", "").endswith(CRYPTEX_VARIANT_SUFFIX)
-        ),
-        None,
-    )
-    if build_identity is None:
-        raise FileNotFoundError(f"no {CRYPTEX_VARIANT_SUFFIX!r} build identity in {manifest_path}")
 
+    build_id = build_manifest.get("ProductBuildVersion")
+    if build_id != LATEST_DDI_BUILD_ID:
+        logger.warning(
+            f"DDI bundle at {restore_dir} has build id {build_id}, but this release expects "
+            f"{LATEST_DDI_BUILD_ID}. Update Xcode, or pymobiledevice3, if the install is rejected."
+        )
+
+    build_identity = _cryptex_build_identity(build_manifest, manifest_path)
     manifest = build_identity["Manifest"]
 
     def read(key: str) -> bytes:
@@ -205,11 +283,11 @@ class CryptexdService(RemoteService):
         `cryptex1_properties` must be **uint64**, since int64 is rejected with
         ``Cryptex1,NonceDomain [79: Inappropriate file type or format]``.
 
-        .. note::
-            The request itself is verified: the daemon accepts it, consumes all five payloads and
-            proceeds to image4 trust evaluation. Completing an install additionally needs an `im4m`
-            that is a *Cryptex1* ticket bound to the current cryptex nonce; producing one is not
-            implemented (see `TSSRequest.add_cryptex1_tags`).
+        The `im4m` must be a *Cryptex1* ticket bound to the current nonce of the identity's
+        ``Cryptex1,NonceDomain`` — see `TSSRequest.add_cryptex1_tags`. A ticket personalized
+        against any other nonce is rejected while importing the first asset, which the device
+        reports as ``invalid asset: ginf`` and logs as
+        ``Manifest no longer valid [70: Stale NFS file handle]``.
 
         :param image: the cryptex disk image, i.e. the build manifest's ``Cryptex1,GenericDmg``.
         :param trustcache: ``Cryptex1,GenericTrustCache``.
@@ -267,28 +345,42 @@ class CryptexdService(RemoteService):
         domain = NONCE_DOMAIN_CRYPTEX if nonce_domain is None else nonce_domain
         return {"nonce-domain": XpcUInt64Type(domain)}
 
-    async def cryptex_nonce(self, nonce_domain: int) -> bytes:
+    async def cryptex_nonce(self, nonce_domain_handle: int) -> bytes:
         """Read a nonce domain's nonce, unwrapped from the daemon's nonce structure.
 
-        :param nonce_domain: index into the daemon's nonce-domain table.
-        """
-        return unwrap_nonce(await self.get_nonce(nonce_domain=nonce_domain))
+        .. note::
+            The selector is a **handle**, which is what a build identity's ``Cryptex1,NonceDomain``
+            holds — not an index. The two tables overlap but disagree: on an iPhone 11 the DDI
+            cryptex nonce is handle 4, which is index 10, while index 4 is an unrelated domain.
+            Personalizing against the index-4 nonce produces a ticket the device rejects at import
+            with ``Manifest no longer valid [70: Stale NFS file handle]``.
 
-    async def auto_install_ddi(self, restore_dir: Path = XCODE_DDI_RESTORE_DIR) -> InstalledCryptex:
+        :param nonce_domain_handle: handle of the nonce domain, e.g. a ``Cryptex1,NonceDomain``.
+        """
+        return unwrap_nonce(await self.get_nonce(nonce_domain_handle=nonce_domain_handle))
+
+    async def auto_install_ddi(self, restore_dir: Optional[Path] = None) -> InstalledCryptex:
         """
         Personalize and install the DeveloperDiskImage cryptex entirely through ``cryptexd``.
 
-        Assembles everything from Xcode's DDI bundle, requests a Cryptex1 ticket, and installs.
+        This is the cryptex equivalent of the image mounter's ``auto-mount``: it assembles the
+        payloads, reads the device's personalization identifiers and cryptex nonce, has Apple sign
+        a Cryptex1 ticket for them, and installs the result — all over ``cryptexd``, without the
+        image mounter.
 
-        .. warning::
-            Not working end to end: `TSSRequest.add_cryptex1_tags` does not yet produce a ticket
-            Apple will sign, so this currently fails at image4 trust evaluation. Everything either
-            side of that step is verified against a device.
-
-        :param restore_dir: Xcode's unpacked DDI ``Restore`` directory.
+        :param restore_dir: an unpacked DDI ``Restore`` directory; defaults to the cached download
+            from the DeveloperDiskImage repository, so no Xcode installation is required.
         :returns: the installed cryptex, as reported back by `copy_installed`.
+        :raises AlreadyMountedError: if the DDI cryptex is already installed.
         :raises CryptexdError: if the daemon rejected the image.
+        :raises TSSError: if Apple refused to sign the personalization request.
         """
+        already_installed = await self._installed_ddi()
+        if already_installed is not None:
+            raise AlreadyMountedError(
+                f"{already_installed.identifier} {already_installed.version} is already installed"
+            )
+
         assets = load_cryptex1_assets(restore_dir)
         request = TSSRequest()
         request.add_cryptex1_tags(
@@ -307,11 +399,15 @@ class CryptexdService(RemoteService):
             assets.volumehash,
             assets.cryptex1_properties,
         )
-        installed = await self.copy_installed()
-        ddi = next((cryptex for cryptex in installed if cryptex.identifier == DDI_CRYPTEX_IDENTIFIER), None)
+        ddi = await self._installed_ddi()
         if ddi is None:
             raise CryptexdError(f"install reported success but {DDI_CRYPTEX_IDENTIFIER} is not installed")
         return ddi
+
+    async def _installed_ddi(self) -> Optional[InstalledCryptex]:
+        """Return the installed DeveloperDiskImage cryptex, or ``None`` if there is none."""
+        installed = await self.copy_installed()
+        return next((cryptex for cryptex in installed if cryptex.identifier == DDI_CRYPTEX_IDENTIFIER), None)
 
     async def read_personalization_identifiers(self) -> dict[str, Any]:
         """

--- a/pymobiledevice3/services/mobile_image_mounter.py
+++ b/pymobiledevice3/services/mobile_image_mounter.py
@@ -28,7 +28,9 @@ from pymobiledevice3.services.lockdown_service import LockdownService
 
 logger = logging.getLogger(__name__)
 
-LATEST_DDI_BUILD_ID = "27A5194q"
+#: Build id of the DDI this release expects, matching what the DeveloperDiskImage repository
+#: publishes. Both the personalized image and the Cryptex1 bundle are checked against it.
+LATEST_DDI_BUILD_ID = "27A5228h"
 
 
 class MobileImageMounterService(LockdownService):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "hyperframe",
     "srptools",
     "qh3>=1.0.0,<2",
-    "developer_disk_image>=0.0.2",
+    "developer_disk_image>=0.3.0",
     "opack2",
     "psutil",
     "pytun-pmd3>=3.0.3",

--- a/tests/services/test_cryptexd.py
+++ b/tests/services/test_cryptexd.py
@@ -1,15 +1,23 @@
+import logging
+import plistlib
+import re
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
-from pymobiledevice3.exceptions import CryptexdError
+from pymobiledevice3.exceptions import AlreadyMountedError, CryptexdError
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+from pymobiledevice3.services import cryptexd
 from pymobiledevice3.services.cryptexd import (
+    DDI_CRYPTEX_IDENTIFIER,
     NONCE_DOMAIN_CRYPTEX,
     CryptexdService,
     InstalledCryptex,
+    load_cryptex1_assets,
     unwrap_nonce,
 )
+from pymobiledevice3.services.mobile_image_mounter import LATEST_DDI_BUILD_ID
 
 
 class FakeConnection:
@@ -311,6 +319,181 @@ async def test_install_raises_on_a_cferr_reply() -> None:
 
     with pytest.raises(CryptexdError, match="Permission denied"):
         await service.install(b"i", b"t", b"m", b"info", b"vol", {})
+
+
+@pytest.mark.asyncio
+async def test_cryptex_nonce_selects_the_domain_by_handle() -> None:
+    # Cryptex1,NonceDomain is a handle, not an index, and the two tables disagree: on an
+    # iPhone 11 the DDI cryptex is handle 4 == index 10, while index 4 is a different domain.
+    # Personalizing against the index-4 nonce yields a ticket the device rejects at import with
+    # "Manifest no longer valid [70: Stale NFS file handle]".
+    nonce = bytes(range(48))
+    blob = b"\x00\x00" + nonce + b"\x00\x00" + (48).to_bytes(4, "little")
+    service, sent = _service({"error": 0, "argv": {"nonce": blob}})
+
+    assert await service.cryptex_nonce(4) == nonce
+    assert int(sent[0]["argv"]["nonce-domain-handle"]) == 4
+    assert "nonce-domain" not in sent[0]["argv"]
+
+
+@pytest.mark.asyncio
+async def test_auto_install_ddi_refuses_when_already_installed() -> None:
+    # Guard before personalizing: the daemon would otherwise fail the install with EEXIST after
+    # a pointless TSS round-trip.
+    service, sent = _service({
+        "error": 0,
+        "argv": {
+            "remote-cryptex-array": [
+                {"remote-cryptex-identifier": DDI_CRYPTEX_IDENTIFIER, "remote-cryptex-version": "27.1.5228.8"}
+            ]
+        },
+    })
+
+    with pytest.raises(AlreadyMountedError, match=re.escape("27.1.5228.8")):
+        await service.auto_install_ddi()
+
+    assert [request["routine"] for request in sent] == ["copy-installed"]
+
+
+def _write_cryptex_bundle(restore: Path, build_id: str, names: dict[str, str]) -> None:
+    """Write a minimal Cryptex1 DDI bundle, laid out however `names` says."""
+    manifest = {}
+    for key, name in names.items():
+        (restore / name).parent.mkdir(parents=True, exist_ok=True)
+        (restore / name).write_bytes(key.encode())
+        manifest[key] = {"Digest": b"", "Info": {"Path": name, "Personalize": True}}
+    (restore / "BuildManifest.plist").write_bytes(
+        plistlib.dumps({
+            "ProductBuildVersion": build_id,
+            "BuildIdentities": [
+                {
+                    "Info": {"Variant": "iOS Customer Developer Disk Image Cryptex"},
+                    "Cryptex1,UseProductClass": True,
+                    "Cryptex1,SubType": 2,
+                    "Cryptex1,NonceDomain": 4,
+                    "Cryptex1,Version": "39.999.999.0.0,0",
+                    "Cryptex1,PreauthorizationVersion": "39.999.999.0.0,0",
+                    "Manifest": manifest,
+                }
+            ],
+        })
+    )
+
+
+#: Xcode's own layout embeds a build number; the DeveloperDiskImage repository normalizes the
+#: names and rewrites the manifest to match. Both must load.
+BUNDLE_LAYOUTS = {
+    "xcode": {
+        "Cryptex1,GenericDmg": "022-22107-072.dmg",
+        "Cryptex1,GenericTrustCache": "Firmware/022-22107-072.dmg.trustcache",
+        "Cryptex1,CryptexInfoPlist": "Firmware/022-22107-072.dmg.cryptex_info",
+        "Cryptex1,GenericVolume": "Firmware/022-22107-072.dmg.root_hash",
+    },
+    "published": {
+        "Cryptex1,GenericDmg": "Image.dmg",
+        "Cryptex1,GenericTrustCache": "Image.dmg.trustcache",
+        "Cryptex1,CryptexInfoPlist": "Image.dmg.cryptex_info",
+        "Cryptex1,GenericVolume": "Image.dmg.root_hash",
+    },
+}
+
+
+@pytest.mark.parametrize("layout", sorted(BUNDLE_LAYOUTS))
+def test_assets_are_located_through_the_build_manifest(tmp_path: Path, layout: str) -> None:
+    _write_cryptex_bundle(tmp_path, LATEST_DDI_BUILD_ID, BUNDLE_LAYOUTS[layout])
+
+    assets = load_cryptex1_assets(tmp_path)
+
+    assert assets.image == b"Cryptex1,GenericDmg"
+    assert assets.trustcache == b"Cryptex1,GenericTrustCache"
+    assert assets.info == b"Cryptex1,CryptexInfoPlist"
+    assert assets.volumehash == b"Cryptex1,GenericVolume"
+    assert assets.nonce_domain == 4
+
+
+def test_a_mismatched_ddi_build_id_warns(tmp_path: Path, caplog) -> None:
+    _write_cryptex_bundle(tmp_path, "27A0000a", BUNDLE_LAYOUTS["published"])
+
+    with caplog.at_level(logging.WARNING):
+        load_cryptex1_assets(tmp_path)
+
+    assert "27A0000a" in caplog.text
+    assert LATEST_DDI_BUILD_ID in caplog.text
+
+
+def test_a_matching_ddi_build_id_is_quiet(tmp_path: Path, caplog) -> None:
+    _write_cryptex_bundle(tmp_path, LATEST_DDI_BUILD_ID, BUNDLE_LAYOUTS["published"])
+
+    with caplog.at_level(logging.WARNING):
+        load_cryptex1_assets(tmp_path)
+
+    assert not caplog.text
+
+
+class FakeCryptexImage:
+    """Duck-types developer_disk_image's CryptexImage, so the tests do not pin its version."""
+
+    def __init__(self, build_manifest: bytes) -> None:
+        self.build_manifest = build_manifest
+        self.image = b"Cryptex1,GenericDmg"
+        self.trustcache = b"Cryptex1,GenericTrustCache"
+        self.cryptex_info = b"Cryptex1,CryptexInfoPlist"
+        self.root_hash = b"Cryptex1,GenericVolume"
+
+
+def _fake_repository(tmp_path: Path, monkeypatch, build_id: str = LATEST_DDI_BUILD_ID) -> list[int]:
+    """Point the cache at `tmp_path` and serve a canned download; returns a download counter."""
+    bundle = tmp_path / "source"
+    bundle.mkdir()
+    _write_cryptex_bundle(bundle, build_id, BUNDLE_LAYOUTS["published"])
+    downloads: list[int] = []
+
+    class FakeRepository:
+        @classmethod
+        def create(cls) -> "FakeRepository":
+            return cls()
+
+        def get_cryptex_disk_image(self) -> FakeCryptexImage:
+            downloads.append(1)
+            return FakeCryptexImage((bundle / "BuildManifest.plist").read_bytes())
+
+    monkeypatch.setattr(cryptexd, "DeveloperDiskImageRepository", FakeRepository)
+    monkeypatch.setattr(cryptexd, "get_home_folder", lambda: tmp_path / "home")
+    return downloads
+
+
+def test_fetch_cryptex_ddi_downloads_into_a_readable_restore_directory(tmp_path: Path, monkeypatch) -> None:
+    downloads = _fake_repository(tmp_path, monkeypatch)
+
+    restore = cryptexd.fetch_cryptex_ddi()
+
+    assert len(downloads) == 1
+    # Payloads land where the downloaded manifest says they do, so this is a usable Restore dir.
+    assets = load_cryptex1_assets(restore)
+    assert assets.image == b"Cryptex1,GenericDmg"
+    assert assets.info == b"Cryptex1,CryptexInfoPlist"
+    assert assets.volumehash == b"Cryptex1,GenericVolume"
+
+
+def test_fetch_cryptex_ddi_reuses_the_cache(tmp_path: Path, monkeypatch) -> None:
+    downloads = _fake_repository(tmp_path, monkeypatch)
+
+    first = cryptexd.fetch_cryptex_ddi()
+    second = cryptexd.fetch_cryptex_ddi()
+
+    assert first == second
+    assert len(downloads) == 1, "a cached DDI of the expected build must not be downloaded again"
+
+
+def test_fetch_cryptex_ddi_replaces_a_cache_of_the_wrong_build(tmp_path: Path, monkeypatch) -> None:
+    # A cache left by an older pymobiledevice3 must not be served to a release expecting another
+    # build; the mounter's fetch_personalized_ddi refreshes on the same condition.
+    downloads = _fake_repository(tmp_path, monkeypatch, build_id="27A0000a")
+
+    cryptexd.fetch_cryptex_ddi()
+    cryptexd.fetch_cryptex_ddi()
+
+    assert len(downloads) == 2
 
 
 def test_unwrap_nonce_extracts_the_nonce_from_the_daemon_structure() -> None:

--- a/tests/test_tss_cryptex1.py
+++ b/tests/test_tss_cryptex1.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from pymobiledevice3.restore.tss import TSSRequest
+from pymobiledevice3.restore.tss import TSSRequest, cryptex1_udid
 
 XCODE_DDI = Path("/Library/Developer/DeveloperDiskImages/iOS_DDI/Restore/BuildManifest.plist")
 
@@ -70,11 +70,23 @@ def test_nonce_is_sent_raw() -> None:
     assert _request()["Cryptex1,Nonce"] == NONCE
 
 
-def test_device_identity_comes_from_the_chip_instance() -> None:
+def test_device_identity_is_carried_solely_by_the_udid() -> None:
+    # Captured from Xcode: a Cryptex1 request names the device only through Cryptex1,UDID —
+    # sending the Ap* tags an AP request uses makes TSS answer "An internal error occurred."
     request = _request()
-    assert request["ApECID"] == CHIP_INSTANCE["img4_chip_ecid"]
-    assert request["ApChipID"] == CHIP_INSTANCE["img4_chip_chip"]
-    assert request["ApProductionMode"] is True
+    assert request["Cryptex1,UDID"] == cryptex1_udid(CHIP_INSTANCE)
+    assert request["Cryptex1,ProductionMode"] is True
+    assert not [key for key in request if key.startswith("Ap")]
+
+
+def test_udid_is_the_chip_id_and_ecid_big_endian() -> None:
+    # Ends up verbatim as the ticket's UDID tag: 0000000000008030000215140a9a802e.
+    assert cryptex1_udid(CHIP_INSTANCE).hex() == "0000000000008030000215140a9a802e"
+
+
+def test_unique_tag_list_is_sent_empty() -> None:
+    # TSS fills the ticket's uniq tag in itself; the request carries an empty placeholder.
+    assert _request()["Cryptex1,UniqueTagList"] == b""
 
 
 def test_only_personalized_components_are_included() -> None:
@@ -83,7 +95,9 @@ def test_only_personalized_components_are_included() -> None:
     assert "Cryptex1,GenericDmg" not in request
     for key in ("Cryptex1,CryptexInfoPlist", "Cryptex1,GenericTrustCache", "Cryptex1,GenericVolume"):
         assert key in request
-        assert "Info" not in request[key]
+        # Xcode sends the digest alone -- no Info, and none of the EPRO/ESEC/Trusted decoration
+        # an AP request picks up from RestoreRequestRules.
+        assert list(request[key]) == ["Digest"]
 
 
 @pytest.mark.skipif(not XCODE_DDI.exists(), reason="Xcode DDI bundle not installed")


### PR DESCRIPTION
Adds `pymobiledevice3 cryptex auto-install`: the DeveloperDiskImage installed as a **cryptex**, through `cryptexd` alone, with no image mounter involved. It is the counterpart of `mounter auto-mount` — named for the fact that a cryptex is *installed* rather than mounted — and the end result is indistinguishable: `mounter list` reports it as a `Personalized` image at `/System/Developer`.

```console
$ pymobiledevice3 cryptex auto-install
INFO Downloading the Cryptex1 DeveloperDiskImage
INFO Installed com.apple.MobileAsset.DDI 27.1.5228.8
```

Like `mounter auto-mount` it downloads what it needs and caches it under `~/.pymobiledevice3`, so **no Xcode installation is required** and it works on any host. `--restore-dir` still accepts a local bundle.

## The two bugs this had to fix

**The TSS request shape.** Apple rejected every Cryptex1 request with a bare "An internal error occurred." The fix came from comparing against what Xcode actually sends: `CoreDeviceService` logs the dictionary it is about to sign under the `com.apple.libcryptex:scrivener` subsystem, so a `devicectl` DDI install can be read straight out of the unified log — no network capture needed (`gs.apple.com` is pinned, and CoreDevice reuses a cached ticket anyway).

Three things were wrong: a Cryptex1 request identifies the device solely by `Cryptex1,UDID` (chip ID ‖ ECID, big-endian) and must not carry the six `Ap*` tags an AP request uses; each personalized component contributes nothing but its `Digest`, with no `EPRO`/`ESEC`/`Trusted` decoration; and `Cryptex1,ProductionMode` and `Cryptex1,UniqueTagList` were missing. The resulting ticket now decodes identically to Xcode's, tag for tag, except `srvn` — the nonce TSS generates per request.

**The nonce domain.** `Cryptex1,NonceDomain` is a nonce domain *handle*, but it was being passed as an *index*. The two tables disagree: on an iPhone 11 the DDI cryptex is handle 4 == index 10, while index 4 is an unrelated domain. The ticket committed to the wrong nonce and the device rejected it while importing the first asset — surfaced as `invalid asset: ginf`, and narrated in the device's own log as `Manifest no longer valid [70: Stale NFS file handle]`.

## Also

- `LATEST_DDI_BUILD_ID` bumped to `27A5228h`, and now checked on the cryptex path too, so a stale bundle warns up front instead of failing obscurely during import.
- `developer_disk_image>=0.3.0`, which publishes the Cryptex1 assets.
- `auto_install_ddi` raises `AlreadyMountedError` when the DDI cryptex is already installed, instead of spending a TSS round-trip to have cryptexd answer EEXIST.

## Verification

Exercised repeatedly against a physical iPhone 11 on iOS 27: uninstall → auto-install → `DeviceInfo.proclist()` over DVT returns 560 processes, so the mounted DDI genuinely works. Cold cache downloads and installs in ~6s; a warm cache skips the download. Also verified installing from a ticket issued 30 minutes earlier with TSS hard-failed, confirming host-side ticket caching is viable (cryptexd has no `QueryPersonalizationManifest` equivalent — that asymmetry with the mounter is documented in the guide).

Each commit is independently ruff-clean and passes the cryptex tests; pyright reports nothing on the touched files.