### PR TITLE
remote: Verify RSD-advertised capabilities before performing operations

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -44,6 +44,7 @@ from pymobiledevice3.exceptions import (
     DeprecationError,
     DeveloperModeError,
     DeveloperModeIsNotEnabledError,
+    DeviceFeatureNotSupportedError,
     DeviceHasPasscodeSetError,
     DeviceNotFoundError,
     FeatureNotSupportedError,
@@ -352,6 +353,8 @@ def invoke_cli_with_error_handling() -> bool:
         logger.error(str(e))
     except UserspaceTunnelUnavailableError as e:
         logger.error(str(e))
+    except DeviceFeatureNotSupportedError as e:
+        logger.error(f"{e} (iOS {e.product_version})")
     except (InvalidServiceError, RSDRequiredError) as e:
         reason = ""
         # Both exceptions carry the device's product version (no extra device round-trip needed).

--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -19,6 +19,7 @@ __all__ = [
     "DeveloperModeError",
     "DeveloperModeIsNotEnabledError",
     "DeviceAlreadyInUseError",
+    "DeviceFeatureNotSupportedError",
     "DeviceHasPasscodeSetError",
     "DeviceNotFoundError",
     "DeviceVersionNotSupportedError",
@@ -406,6 +407,17 @@ class MessageNotSupportedError(PyMobileDevice3Exception):
 
 class InvalidServiceError(LockdownError):
     pass
+
+
+class DeviceFeatureNotSupportedError(LockdownError):
+    """The device's RSD handshake does not advertise a feature required for the operation."""
+
+    def __init__(self, service_name: str, feature: str, identifier: Optional[str], product_version: str) -> None:
+        super().__init__(
+            f"device does not support feature {feature!r} (service {service_name!r})", identifier, product_version
+        )
+        self.service_name = service_name
+        self.feature = feature
 
 
 class InspectorEvaluateError(PyMobileDevice3Exception):

--- a/pymobiledevice3/remote/core_device/core_device_service.py
+++ b/pymobiledevice3/remote/core_device/core_device_service.py
@@ -45,6 +45,8 @@ class CoreDeviceService(RemoteService):
         input_: Optional[dict[str, Any]] = None,
         action_identifier: Optional[str] = None,
     ) -> Any:
+        if feature_identifier is not None:
+            self.rsd.require_feature(self.service_name, feature_identifier)
         if input_ is None:
             input_ = {}
         request: dict[str, Any] = {
@@ -76,6 +78,7 @@ class CoreDeviceService(RemoteService):
         pushes ``SideChannelStatus.pushing`` batches over the side channel and ends with
         ``finishStreaming``. Each element is yielded individually.
         """
+        self.rsd.require_feature(self.service_name, feature_identifier)
         if input_ is None:
             input_ = {}
         request: dict[str, Any] = {

--- a/pymobiledevice3/remote/remote_service_discovery.py
+++ b/pymobiledevice3/remote/remote_service_discovery.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Optional, Union, cast
 from pymobiledevice3.bonjour import DEFAULT_BONJOUR_TIMEOUT, browse_remoted
 from pymobiledevice3.common import get_home_folder
 from pymobiledevice3.exceptions import (
+    DeviceFeatureNotSupportedError,
     InvalidServiceError,
     NoDeviceConnectedError,
     NotConnectedError,
@@ -356,10 +357,46 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         :returns: the device-side TCP port for the service.
         :raises InvalidServiceError: if the device does not offer a service with this name.
         """
+        return int(self._get_service_entry(name)["Port"])
+
+    def get_service_features(self, name: str) -> frozenset[str]:
+        """
+        Return the features a service advertises in the RSD handshake ``peer_info``.
+
+        For CoreDevice services these are the ``com.apple.coredevice.feature.*`` identifiers the
+        service accepts in ``CoreDevice.featureIdentifier``; other services advertise plain
+        capability tags (e.g. cryptexd's ``CryptexInstall``).
+
+        :param name: name of the service.
+        :returns: the advertised features, empty if the service advertises none.
+        :raises InvalidServiceError: if the device does not offer a service with this name.
+        """
+        return frozenset(self._get_service_entry(name).get("Properties", {}).get("Features") or ())
+
+    def require_feature(self, service_name: str, feature: str) -> None:
+        """
+        Verify a service advertises a feature in the RSD handshake, raising if it does not.
+
+        A service entry with no ``Features`` list (or an empty one) is never used to deny an
+        operation: absence of capability advertisement is not evidence of a missing capability,
+        so the check is skipped and the device stays the final authority.
+
+        :param service_name: name of the service the feature belongs to.
+        :param feature: the feature identifier to verify.
+        :raises InvalidServiceError: if the device does not offer a service with this name.
+        :raises DeviceFeatureNotSupportedError: if the service advertises a feature list that does
+            not contain ``feature``.
+        """
+        features = self._get_service_entry(service_name).get("Properties", {}).get("Features")
+        if features and feature not in features:
+            raise DeviceFeatureNotSupportedError(service_name, feature, self.udid, self.product_version)
+
+    def _get_service_entry(self, name: str) -> dict[str, Any]:
+        """Return a service's ``peer_info`` entry, raising `InvalidServiceError` if absent."""
         service = self._require_peer_info()["Services"].get(name)
         if service is None:
             raise InvalidServiceError(f"No such service: {name}", self.udid, self.product_version)
-        return int(service["Port"])
+        return service
 
     async def close(self) -> None:
         """Close the lockdown client (if any) and the underlying RemoteXPC connection."""

--- a/pymobiledevice3/services/cryptexd.py
+++ b/pymobiledevice3/services/cryptexd.py
@@ -31,6 +31,11 @@ DDI_PERSISTENCE = 2
 DDI_NONCE_PERSISTENCE = 1
 
 
+#: Capability tags cryptexd advertises in the RSD handshake (``peer_info`` ``Features``).
+FEATURE_CRYPTEX_INSTALL = "CryptexInstall"
+FEATURE_READ_IDENTIFIERS = "ReadIdentifiers"
+
+
 #: Where Xcode unpacks ``CoreDevice/CandidateDDIs/iOS_DDI.dmg``, for hosts that have Xcode.
 XCODE_DDI_RESTORE_DIR = Path("/Library/Developer/DeveloperDiskImages/iOS_DDI/Restore")
 
@@ -301,7 +306,10 @@ class CryptexdService(RemoteService):
         :param nonce_persistence: nonce persistence mode.
         :param auth: authentication mode.
         :raises CryptexdError: if the daemon rejected the request or the install failed.
+        :raises DeviceFeatureNotSupportedError: if the device does not advertise the
+            ``CryptexInstall`` capability.
         """
+        self.rsd.require_feature(self.SERVICE_NAME, FEATURE_CRYPTEX_INSTALL)
         transfers = [
             ("image", image),
             ("trustcache", trustcache),
@@ -415,7 +423,11 @@ class CryptexdService(RemoteService):
 
         The returned mapping uses the daemon's ``img4_chip_*`` key names, e.g. ``img4_chip_chip``
         (ChipID), ``img4_chip_bord`` (BoardID) and ``img4_chip_ecid`` (ECID).
+
+        :raises DeviceFeatureNotSupportedError: if the device does not advertise the
+            ``ReadIdentifiers`` capability.
         """
+        self.rsd.require_feature(self.SERVICE_NAME, FEATURE_READ_IDENTIFIERS)
         return await self.invoke("read-personalization-id", {})
 
     async def copy_installed(self) -> list[InstalledCryptex]:
@@ -483,7 +495,10 @@ class CryptexdService(RemoteService):
                            ``com.apple.MobileAsset.DDI``.
         :param version: optional version to scope the removal to.
         :raises CryptexdError: if no such cryptex is installed (``errno 2``) or removal failed.
+        :raises DeviceFeatureNotSupportedError: if the device does not advertise the
+            ``CryptexInstall`` capability.
         """
+        self.rsd.require_feature(self.SERVICE_NAME, FEATURE_CRYPTEX_INSTALL)
         argv: dict[str, Any] = {"remote-cryptex-identifier": identifier}
         if version is not None:
             argv["remote-cryptex-version"] = version

--- a/pymobiledevice3/services/remote_fetch_symbols.py
+++ b/pymobiledevice3/services/remote_fetch_symbols.py
@@ -11,6 +11,9 @@ from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscove
 
 MAX_CONCURRENT_DOWNLOADS = 4
 
+#: Capability the service advertises in the RSD handshake when DSC fetching is available.
+FEATURE_DSC_FILES = "com.apple.dt.remoteFetchSymbols.dyldSharedCacheFiles"
+
 
 @dataclasses.dataclass
 class DSCFile:
@@ -43,7 +46,10 @@ class RemoteFetchSymbolsService(RemoteService):
 
         :returns: One `DSCFile` per advertised file, each carrying its on-device path and
             expected byte length.
+        :raises DeviceFeatureNotSupportedError: if the device does not advertise the DSC
+            fetching capability.
         """
+        self.rsd.require_feature(self.SERVICE_NAME, FEATURE_DSC_FILES)
         files: list[DSCFile] = []
         response = await self.service.send_receive_request({
             "XPCDictionary_sideChannel": uuid.uuid4(),

--- a/tests/remote/core_device/test_core_device_service.py
+++ b/tests/remote/core_device/test_core_device_service.py
@@ -1,0 +1,69 @@
+from typing import Any, cast
+
+import pytest
+
+from pymobiledevice3.exceptions import DeviceFeatureNotSupportedError
+from pymobiledevice3.remote.core_device.app_service import AppServiceService
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+from pymobiledevice3.remote.remotexpc import RemoteXPCConnection
+
+APP_SERVICE = "com.apple.coredevice.appservice"
+
+
+class FakeConnection:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def send_receive_request(self, request: dict[str, Any]) -> dict[str, Any]:
+        self.sent.append(request)
+        return {"CoreDevice.output": {"ok": True}}
+
+
+def make_app_service(features: list[str]) -> tuple[AppServiceService, FakeConnection]:
+    """An AppServiceService over a handshake advertising *features*, with a recording connection."""
+    rsd = RemoteServiceDiscoveryService(("127.0.0.1", 0))
+    rsd.peer_info = {
+        "Properties": {"OSVersion": "26.0"},
+        "Services": {APP_SERVICE: {"Port": "1024", "Properties": {"Features": features}}},
+    }
+    rsd.udid = "udid"
+    service = AppServiceService(rsd)
+    connection = FakeConnection()
+    service._service = cast(RemoteXPCConnection, connection)
+    return service, connection
+
+
+@pytest.mark.asyncio
+async def test_invoke_unadvertised_feature_raises_without_sending() -> None:
+    service, connection = make_app_service(["com.apple.coredevice.feature.listapps"])
+    with pytest.raises(DeviceFeatureNotSupportedError) as exc_info:
+        await service.invoke("com.apple.coredevice.feature.streamapplist")
+    assert exc_info.value.feature == "com.apple.coredevice.feature.streamapplist"
+    assert connection.sent == []
+
+
+@pytest.mark.asyncio
+async def test_invoke_advertised_feature_sends_request() -> None:
+    service, connection = make_app_service(["com.apple.coredevice.feature.listapps"])
+    output = await service.invoke("com.apple.coredevice.feature.listapps")
+    assert output == {"ok": True}
+    assert len(connection.sent) == 1
+    assert connection.sent[0]["CoreDevice.featureIdentifier"] == "com.apple.coredevice.feature.listapps"
+
+
+@pytest.mark.asyncio
+async def test_invoke_action_only_skips_feature_check() -> None:
+    # Actions are not part of the advertised Features list, so they are never checked against it.
+    service, connection = make_app_service(["com.apple.coredevice.feature.listapps"])
+    output = await service.invoke(action_identifier="com.apple.coredevice.action.getuserinterfacestyle")
+    assert output == {"ok": True}
+    assert len(connection.sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_invoke_unadvertised_feature_raises_without_sending() -> None:
+    service, connection = make_app_service(["com.apple.coredevice.feature.listapps"])
+    stream = service.stream_invoke("com.apple.coredevice.feature.streamapplist")
+    with pytest.raises(DeviceFeatureNotSupportedError):
+        await stream.__anext__()
+    assert connection.sent == []

--- a/tests/remote/core_device/test_icon_service.py
+++ b/tests/remote/core_device/test_icon_service.py
@@ -29,8 +29,17 @@ def _service(response: dict[str, Any]) -> tuple[IconService, list[dict[str, Any]
             sent.append(request)
             return {"CoreDevice.output": response}
 
-    service = object.__new__(IconService)
-    service.rsd = cast(RemoteServiceDiscoveryService, object())
+    rsd = RemoteServiceDiscoveryService(("127.0.0.1", 0))
+    rsd.peer_info = {
+        "Properties": {"OSVersion": "26.0"},
+        "Services": {
+            IconService.SERVICE_NAME: {
+                "Port": "1024",
+                "Properties": {"Features": ["com.apple.coredevice.feature.fetchappicons"]},
+            }
+        },
+    }
+    service = IconService(rsd)
     service._service = cast(RemoteXPCConnection, FakeConnection())
     return service, sent
 

--- a/tests/remote/test_remote_service_discovery.py
+++ b/tests/remote/test_remote_service_discovery.py
@@ -1,0 +1,77 @@
+from typing import Any, Optional
+
+import pytest
+
+from pymobiledevice3.exceptions import DeviceFeatureNotSupportedError, InvalidServiceError, NotConnectedError
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+
+APP_SERVICE = "com.apple.coredevice.appservice"
+APP_FEATURES = [
+    "com.apple.coredevice.feature.listapps",
+    "com.apple.coredevice.feature.launchapplication",
+]
+
+
+def make_rsd(services: dict[str, Any], udid: Optional[str] = "udid") -> RemoteServiceDiscoveryService:
+    """An RSD wired with a handshake response, without any I/O."""
+    rsd = RemoteServiceDiscoveryService(("127.0.0.1", 0))
+    rsd.peer_info = {"Properties": {"OSVersion": "26.0"}, "Services": services}
+    rsd.udid = udid
+    return rsd
+
+
+def test_get_service_features_returns_advertised_features() -> None:
+    rsd = make_rsd({APP_SERVICE: {"Port": "1024", "Properties": {"Features": APP_FEATURES}}})
+    assert rsd.get_service_features(APP_SERVICE) == frozenset(APP_FEATURES)
+
+
+def test_get_service_features_empty_when_service_advertises_none() -> None:
+    rsd = make_rsd({APP_SERVICE: {"Port": "1024", "Properties": {"UsesRemoteXPC": True}}})
+    assert rsd.get_service_features(APP_SERVICE) == frozenset()
+
+
+def test_get_service_features_missing_service_raises() -> None:
+    rsd = make_rsd({})
+    with pytest.raises(InvalidServiceError):
+        rsd.get_service_features(APP_SERVICE)
+
+
+def test_get_service_features_not_connected_raises() -> None:
+    rsd = RemoteServiceDiscoveryService(("127.0.0.1", 0))
+    with pytest.raises(NotConnectedError):
+        rsd.get_service_features(APP_SERVICE)
+
+
+def test_require_feature_passes_when_advertised() -> None:
+    rsd = make_rsd({APP_SERVICE: {"Port": "1024", "Properties": {"Features": APP_FEATURES}}})
+    rsd.require_feature(APP_SERVICE, "com.apple.coredevice.feature.listapps")
+
+
+def test_require_feature_raises_when_not_advertised() -> None:
+    rsd = make_rsd({APP_SERVICE: {"Port": "1024", "Properties": {"Features": APP_FEATURES}}})
+    with pytest.raises(DeviceFeatureNotSupportedError) as exc_info:
+        rsd.require_feature(APP_SERVICE, "com.apple.coredevice.feature.streamapplist")
+    error = exc_info.value
+    assert error.service_name == APP_SERVICE
+    assert error.feature == "com.apple.coredevice.feature.streamapplist"
+    assert error.identifier == "udid"
+    assert error.product_version == "26.0"
+    assert "streamapplist" in str(error)
+
+
+def test_require_feature_noop_when_service_advertises_no_features() -> None:
+    # A handshake without a Features list cannot be used to deny an operation.
+    rsd = make_rsd({APP_SERVICE: {"Port": "1024", "Properties": {"UsesRemoteXPC": True}}})
+    rsd.require_feature(APP_SERVICE, "com.apple.coredevice.feature.streamapplist")
+
+
+def test_require_feature_noop_when_features_list_is_empty() -> None:
+    # An empty list is treated like an absent one: deny-all is never inferred from it.
+    rsd = make_rsd({APP_SERVICE: {"Port": "1024", "Properties": {"Features": []}}})
+    rsd.require_feature(APP_SERVICE, "com.apple.coredevice.feature.streamapplist")
+
+
+def test_require_feature_missing_service_raises_invalid_service() -> None:
+    rsd = make_rsd({})
+    with pytest.raises(InvalidServiceError):
+        rsd.require_feature(APP_SERVICE, "com.apple.coredevice.feature.listapps")

--- a/tests/services/test_cryptexd.py
+++ b/tests/services/test_cryptexd.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 import pytest
 
-from pymobiledevice3.exceptions import AlreadyMountedError, CryptexdError
+from pymobiledevice3.exceptions import AlreadyMountedError, CryptexdError, DeviceFeatureNotSupportedError
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
 from pymobiledevice3.services import cryptexd
 from pymobiledevice3.services.cryptexd import (
@@ -46,6 +46,9 @@ class FakeRsd:
         self._response = response
         self._sent = sent
         self.connections: list[FakeConnection] = []
+
+    def require_feature(self, service_name: str, feature: str) -> None:
+        pass
 
     def start_remote_service(self, name: str) -> Any:
         assert name == CryptexdService.SERVICE_NAME
@@ -265,6 +268,9 @@ def _install_service(response: dict[str, Any]) -> tuple[CryptexdService, Recordi
     connection = RecordingConnection(response)
 
     class Rsd:
+        def require_feature(self, service_name: str, feature: str) -> None:
+            pass
+
         def start_remote_service(self, name: str) -> Any:
             return connection
 
@@ -494,6 +500,40 @@ def test_fetch_cryptex_ddi_replaces_a_cache_of_the_wrong_build(tmp_path: Path, m
     cryptexd.fetch_cryptex_ddi()
 
     assert len(downloads) == 2
+
+
+def _restricted_service(features: list[str]) -> CryptexdService:
+    """A CryptexdService over a handshake advertising only *features* for cryptexd."""
+    rsd = RemoteServiceDiscoveryService(("127.0.0.1", 0))
+    rsd.peer_info = {
+        "Properties": {"OSVersion": "26.0"},
+        "Services": {CryptexdService.SERVICE_NAME: {"Port": "1024", "Properties": {"Features": features}}},
+    }
+    return CryptexdService(rsd)
+
+
+@pytest.mark.asyncio
+async def test_install_requires_the_advertised_cryptexinstall_capability() -> None:
+    service = _restricted_service(["ReadIdentifiers"])
+
+    with pytest.raises(DeviceFeatureNotSupportedError, match="CryptexInstall"):
+        await service.install(b"i", b"t", b"m", b"info", b"vol", {})
+
+
+@pytest.mark.asyncio
+async def test_uninstall_requires_the_advertised_cryptexinstall_capability() -> None:
+    service = _restricted_service(["ReadIdentifiers"])
+
+    with pytest.raises(DeviceFeatureNotSupportedError, match="CryptexInstall"):
+        await service.uninstall("com.apple.MobileAsset.DDI")
+
+
+@pytest.mark.asyncio
+async def test_read_personalization_identifiers_requires_the_readidentifiers_capability() -> None:
+    service = _restricted_service(["CryptexInstall"])
+
+    with pytest.raises(DeviceFeatureNotSupportedError, match="ReadIdentifiers"):
+        await service.read_personalization_identifiers()
 
 
 def test_unwrap_nonce_extracts_the_nonce_from_the_daemon_structure() -> None:

--- a/tests/services/test_remote_fetch_symbols.py
+++ b/tests/services/test_remote_fetch_symbols.py
@@ -4,6 +4,7 @@ from typing import cast
 
 import pytest
 
+from pymobiledevice3.exceptions import DeviceFeatureNotSupportedError
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
 from pymobiledevice3.remote.remotexpc import RemoteXPCConnection
 from pymobiledevice3.services.remote_fetch_symbols import DSCFile, RemoteFetchSymbolsService
@@ -37,3 +38,18 @@ async def test_download_uses_multiple_streams(tmp_path):
     assert max_active_downloads > 1
     for i in range(4):
         assert (tmp_path / f"file{i}").read_bytes() == str(i).encode()
+
+
+@pytest.mark.asyncio
+async def test_get_dsc_file_list_requires_the_advertised_capability():
+    rsd = RemoteServiceDiscoveryService(("127.0.0.1", 0))
+    rsd.peer_info = {
+        "Properties": {"OSVersion": "26.0"},
+        "Services": {
+            RemoteFetchSymbolsService.SERVICE_NAME: {"Port": "1024", "Properties": {"Features": ["something.else"]}}
+        },
+    }
+    fetch_symbols = RemoteFetchSymbolsService(rsd)
+
+    with pytest.raises(DeviceFeatureNotSupportedError, match="dyldSharedCacheFiles"):
+        await fetch_symbols.get_dsc_file_list()


### PR DESCRIPTION
## What

The RSD handshake's `peer_info` lists each service's supported features — for CoreDevice services, the exact `featureIdentifier`s it accepts; for others, capability tags such as cryptexd's `CryptexInstall`. Until now a missing feature only surfaced as an opaque on-device rejection (`CoreDeviceError: Failed to invoke: ... Got error: {...}`), while a missing *service* already raised a clear `InvalidServiceError`.

This PR closes that gap:

- `RemoteServiceDiscoveryService.get_service_features()` / `require_feature()` expose the advertised feature lists, with the new `DeviceFeatureNotSupportedError` (a `LockdownError` carrying `service_name`/`feature`; named to avoid colliding with the existing host-OS `FeatureNotSupportedError`).
- `CoreDeviceService.invoke()`/`stream_invoke()` verify the feature before sending, covering every CoreDevice service with no per-method changes. Action-only invocations are exempt (actions are not part of the advertised list).
- `cryptexd` gates `install`/`uninstall` on `CryptexInstall` and `read-personalization-id` on `ReadIdentifiers`.
- `remote_fetch_symbols` gates DSC fetching on `com.apple.dt.remoteFetchSymbols.dyldSharedCacheFiles`.

A service entry advertising no `Features` list is never used to deny an operation — absence of advertisement is not evidence of a missing capability, so the device stays the final authority there.

## Testing

- New unit tests for the query/guard API, the CoreDevice raise-before-send behavior, and each swept consumer (53 passing in the touched suites).
- Verified live on an iPhone12,1 (iOS 27.0 beta) over the userspace tunnel: all 22 feature identifiers used by the codebase are advertised, `developer core-device list-processes` runs through the new gate, and `cryptex list` is unaffected.
- `pre-commit` (ruff + pyright 1.1.411) clean.

