### PR TITLE
file_service: Verify advertised fileservice capabilities before use

### DIFF
--- a/pymobiledevice3/remote/core_device/file_service.py
+++ b/pymobiledevice3/remote/core_device/file_service.py
@@ -11,6 +11,13 @@ from pymobiledevice3.remote.core_device.core_device_service import CoreDeviceSer
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
 from pymobiledevice3.remote.xpc_message import XpcInt64Type, XpcUInt64Type
 
+# Capability tags the control service advertises in the RSD handshake. These are NOT invoke()
+# feature identifiers: the control service rejects the CoreDevice.featureIdentifier envelope with
+# "The command provided by the client is not valid" (com.apple.dt.remoteservices.error 11014,
+# verified on-device) and only speaks its Cmd-keyed session protocol below.
+FEATURE_LIST_FILES = "com.apple.coredevice.feature.listFiles"
+FEATURE_TRANSFER_FILES = "com.apple.coredevice.feature.transferFiles"
+
 
 class Domain(IntEnum):
     APP_DATA_CONTAINER = 1
@@ -57,6 +64,7 @@ class FileServiceService(CoreDeviceService):
         self.session = response["NewSessionID"]
 
     async def retrieve_directory_list(self, path: str = ".") -> AsyncGenerator[list[str], None]:
+        self.rsd.require_feature(self.CTRL_SERVICE_NAME, FEATURE_LIST_FILES)
         return (
             await self.send_receive_request({
                 "Cmd": "RetrieveDirectoryList",
@@ -67,6 +75,7 @@ class FileServiceService(CoreDeviceService):
         )["FileList"]
 
     async def retrieve_file(self, path: str = ".") -> bytes:
+        self.rsd.require_feature(self.CTRL_SERVICE_NAME, FEATURE_TRANSFER_FILES)
         response = await self.send_receive_request({"Cmd": "RetrieveFile", "Path": path, "SessionID": self.session})
         data_service = self.rsd.get_service_port("com.apple.coredevice.fileservice.data")
         # Route through the RSD's dialer (set by the userspace tunnel to relay through its
@@ -88,6 +97,8 @@ class FileServiceService(CoreDeviceService):
         last_modification_time: float = time.time(),
     ) -> None:
         """Request to write an empty file at given path."""
+        # Proposing a file is the write direction of the file-transfer flow.
+        self.rsd.require_feature(self.CTRL_SERVICE_NAME, FEATURE_TRANSFER_FILES)
         await self.send_receive_request({
             "Cmd": "ProposeEmptyFile",
             "FileCreationTime": XpcInt64Type(creation_time),

--- a/tests/remote/core_device/test_file_service.py
+++ b/tests/remote/core_device/test_file_service.py
@@ -1,0 +1,74 @@
+from typing import Any, cast
+
+import pytest
+
+from pymobiledevice3.exceptions import DeviceFeatureNotSupportedError
+from pymobiledevice3.remote.core_device.file_service import (
+    FEATURE_LIST_FILES,
+    FEATURE_TRANSFER_FILES,
+    Domain,
+    FileServiceService,
+)
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+from pymobiledevice3.remote.remotexpc import RemoteXPCConnection
+
+
+class FakeConnection:
+    def __init__(self, response: dict[str, Any]) -> None:
+        self._response = response
+        self.sent: list[dict[str, Any]] = []
+
+    async def send_receive_request(self, request: dict[str, Any]) -> dict[str, Any]:
+        self.sent.append(request)
+        return self._response
+
+
+def make_file_service(features: list[str], response: dict[str, Any]) -> tuple[FileServiceService, FakeConnection]:
+    rsd = RemoteServiceDiscoveryService(("127.0.0.1", 0))
+    rsd.peer_info = {
+        "Properties": {"OSVersion": "26.0"},
+        "Services": {FileServiceService.CTRL_SERVICE_NAME: {"Port": "1024", "Properties": {"Features": features}}},
+    }
+    rsd.udid = "udid"
+    service = FileServiceService(rsd, Domain.TEMPORARY)
+    service.session = "session-id"
+    connection = FakeConnection(response)
+    service._service = cast(RemoteXPCConnection, connection)
+    return service, connection
+
+
+@pytest.mark.asyncio
+async def test_retrieve_directory_list_requires_the_listfiles_capability() -> None:
+    service, connection = make_file_service([FEATURE_TRANSFER_FILES], {"FileList": []})
+
+    with pytest.raises(DeviceFeatureNotSupportedError, match="listFiles"):
+        await service.retrieve_directory_list(".")
+    assert connection.sent == []
+
+
+@pytest.mark.asyncio
+async def test_retrieve_directory_list_sends_the_cmd_when_advertised() -> None:
+    service, connection = make_file_service([FEATURE_LIST_FILES], {"FileList": ["a", "b"]})
+
+    assert await service.retrieve_directory_list(".") == ["a", "b"]
+
+    (request,) = connection.sent
+    assert request["Cmd"] == "RetrieveDirectoryList"
+
+
+@pytest.mark.asyncio
+async def test_retrieve_file_requires_the_transferfiles_capability() -> None:
+    service, connection = make_file_service([FEATURE_LIST_FILES], {})
+
+    with pytest.raises(DeviceFeatureNotSupportedError, match="transferFiles"):
+        await service.retrieve_file(".")
+    assert connection.sent == []
+
+
+@pytest.mark.asyncio
+async def test_propose_empty_file_requires_the_transferfiles_capability() -> None:
+    service, connection = make_file_service([FEATURE_LIST_FILES], {})
+
+    with pytest.raises(DeviceFeatureNotSupportedError, match="transferFiles"):
+        await service.propose_empty_file("file.txt")
+    assert connection.sent == []


### PR DESCRIPTION
## What

Answers "can we use the advertised `com.apple.coredevice.feature.listFiles`?" — yes, but not through `invoke()`.

Verified on-device (iPhone12,1, iOS 27.0 beta): `com.apple.coredevice.fileservice.control` **rejects** the `CoreDevice.featureIdentifier` invoke envelope with `com.apple.dt.remoteservices.error 11014: "The command provided by the client is not valid"`. Its advertised features (`listFiles`, `transferFiles`, `filesystemoperation`, `monitorfilechanges`) are capability tags for its own `Cmd`-keyed session protocol, so the right place to consult them is inside `FileServiceService` — the same pattern as cryptexd's capability tags (#1829).

- `retrieve_directory_list` requires `listFiles`
- `retrieve_file` and `propose_empty_file` (the two transfer directions) require `transferFiles`
- `filesystemoperation`/`monitorfilechanges` have no corresponding methods yet, so nothing gates on them

## Testing

- Unit tests for both deny paths (raise before anything is sent) and the allowed `RetrieveDirectoryList` path.
- Live on iOS 27.0: `developer core-device list-directory temporary .` round-trips through the gate.
- pre-commit (ruff + pyright 1.1.411) clean.