### PR TITLE
docs: CLI reference, troubleshooting guide, and complete API docstring coverage

### DIFF
--- a/docs/_hooks/gen_cli_reference.py
+++ b/docs/_hooks/gen_cli_reference.py
@@ -1,0 +1,240 @@
+"""MkDocs hook that generates a full CLI reference from the Typer command tree.
+
+At build time the hook imports every CLI group registered in
+``pymobiledevice3.__main__.CLI_GROUPS``, walks the resulting command tree, and emits one
+generated page per group under ``cli/`` plus an index page. The pages are produced from the
+same objects that power ``--help``, so the reference can never drift from the code.
+
+The connection options injected into every device-facing command (``--rsd``, ``--tunnel``,
+``--userspace``, ...) are documented once on the index page; each command lists which of them
+it accepts instead of repeating the full descriptions.
+
+The click command objects are introspected through their public attributes only
+(``commands``, ``params``, ``get_help_record``, ...) — no ``click``/``typer._click`` import,
+per the repository convention.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Optional
+
+from mkdocs.exceptions import PluginError
+from mkdocs.structure.files import File
+
+# Long-form flags of the options injected by cli_common's service-provider dependencies.
+# They are shared by (nearly) every device-facing command, so their full descriptions live
+# once on the index page and each command only lists which of them it accepts.
+CONNECTION_FLAGS = ("--rsd", "--tunnel", "--userspace", "--mobdev2", "--usbmux", "--udid")
+
+INDEX_URI = "cli/index.md"
+
+
+def _escape_cell(text: str) -> str:
+    """Make an arbitrary help string safe inside a one-line Markdown table cell."""
+    return " ".join(text.split()).replace("|", "\\|")
+
+
+def _connection_flag(param: Any) -> Optional[str]:
+    """Return the connection flag this option represents, or None for regular params."""
+    for opt in getattr(param, "opts", []):
+        if opt in CONNECTION_FLAGS:
+            return opt
+    return None
+
+
+def _help_records(cmd: Any, ctx: Any) -> tuple[list[tuple[str, str]], list[tuple[str, str]], list[str]]:
+    """Split a command's params into (argument records, option records, connection flags)."""
+    arguments: list[tuple[str, str]] = []
+    options: list[tuple[str, str]] = []
+    connection: list[str] = []
+    for param in cmd.params:
+        if getattr(param, "hidden", False):
+            continue
+        flag = _connection_flag(param)
+        if flag is not None:
+            connection.append(flag)
+            continue
+        record = param.get_help_record(ctx)
+        if record is None:
+            continue
+        if param.param_type_name == "argument":
+            arguments.append(record)
+        else:
+            options.append(record)
+    return arguments, options, connection
+
+
+def _records_table(title: str, records: list[tuple[str, str]]) -> list[str]:
+    if not records:
+        return []
+    lines = [f"**{title}:**", "", f"| {title[:-1]} | Description |", "| --- | --- |"]
+    for name, help_text in records:
+        lines.append(f"| `{_escape_cell(name)}` | {_escape_cell(help_text)} |")
+    lines.append("")
+    return lines
+
+
+def _usage_line(cmd: Any, ctx: Any) -> str:
+    pieces = " ".join(cmd.collect_usage_pieces(ctx))
+    return f"{ctx.command_path} {pieces}".rstrip()
+
+
+def _walk(cmd: Any, ctx: Any, group_name: str, out: list[str]) -> None:
+    """Emit the section for ``cmd`` and recurse into its subcommands."""
+    # Heading: the command path relative to the group page's H1.
+    relative = ctx.command_path.replace(f"pymobiledevice3 {group_name}", "").strip()
+    if relative:
+        deprecated = " *(deprecated)*" if getattr(cmd, "deprecated", False) else ""
+        out.append(f"## `{relative}`{deprecated}")
+        out.append("")
+
+    help_text = (cmd.help or cmd.short_help or "").strip()
+    if help_text:
+        out.append(help_text)
+        out.append("")
+
+    subcommands = getattr(cmd, "commands", None)
+    if subcommands is None:
+        out.append("```text")
+        out.append(_usage_line(cmd, ctx))
+        out.append("```")
+        out.append("")
+        arguments, options, connection = _help_records(cmd, ctx)
+        out.extend(_records_table("Arguments", arguments))
+        out.extend(_records_table("Options", options))
+        if connection:
+            flags = ", ".join(f"`{f}`" for f in connection)
+            out.append(f"Accepts the [connection options](index.md#connection-options): {flags}.")
+            out.append("")
+        return
+
+    for sub in subcommands.values():
+        if getattr(sub, "hidden", False):
+            continue
+        sub_ctx = sub.context_class(sub, info_name=sub.name, parent=ctx)
+        _walk(sub, sub_ctx, group_name, out)
+
+
+def _summary(cmd: Any) -> str:
+    text = (cmd.short_help or cmd.help or "").strip()
+    return text.splitlines()[0] if text else ""
+
+
+def _load_group_commands() -> dict[str, Any]:
+    import typer
+
+    from pymobiledevice3.__main__ import CLI_GROUPS
+
+    groups: dict[str, Any] = {}
+    for name, module_name in CLI_GROUPS.items():
+        mod = importlib.import_module(f"pymobiledevice3.cli.{module_name}")
+        groups[name] = typer.main.get_command(mod.cli)
+    return groups
+
+
+def _connection_records(groups: dict[str, Any]) -> list[tuple[str, str]]:
+    """Harvest one help record per connection flag from the first command carrying it."""
+    records: dict[str, tuple[str, str]] = {}
+    stack = list(groups.values())
+    while stack and len(records) < len(CONNECTION_FLAGS):
+        cmd = stack.pop()
+        stack.extend(getattr(cmd, "commands", {}).values())
+        ctx = cmd.context_class(cmd, info_name=cmd.name)
+        for param in cmd.params:
+            flag = _connection_flag(param)
+            if flag is None or flag in records:
+                continue
+            record = param.get_help_record(ctx)
+            if record is not None:
+                records[flag] = record
+    return [records[flag] for flag in CONNECTION_FLAGS if flag in records]
+
+
+def _index_page(groups: dict[str, Any]) -> str:
+    out = [
+        "---",
+        "search:",
+        "  boost: 0.5",
+        "---",
+        "",
+        "# CLI Reference",
+        "",
+        "Complete reference for every `pymobiledevice3` command, generated from the CLI itself",
+        "at build time. For task-oriented examples see the",
+        "[CLI recipes](../guides/cli-recipes.md).",
+        "",
+        "## Command groups",
+        "",
+        "| Group | Description |",
+        "| --- | --- |",
+    ]
+    for name, cmd in groups.items():
+        out.append(f"| [`{name}`]({name}.md) | {_escape_cell(_summary(cmd))} |")
+    out += [
+        "",
+        "## Connection options",
+        "",
+        "Device-facing commands accept a shared set of options selecting the target device and",
+        "transport. Each command's page lists which of them it accepts.",
+        "",
+        "| Option | Description |",
+        "| --- | --- |",
+    ]
+    for name, help_text in _connection_records(groups):
+        out.append(f"| `{_escape_cell(name)}` | {_escape_cell(help_text)} |")
+    out += [
+        "",
+        "See [iOS 17+ tunnels](../guides/ios17-tunnels.md) for when a tunnel (`--rsd`/`--tunnel`/",
+        "`--userspace`) is required and how the no-root userspace default works.",
+        "",
+    ]
+    return "\n".join(out)
+
+
+def _group_page(name: str, cmd: Any) -> str:
+    out = [
+        "---",
+        "search:",
+        "  boost: 0.5",
+        "---",
+        "",
+        f"# `pymobiledevice3 {name}`",
+        "",
+    ]
+    ctx = cmd.context_class(cmd, info_name=f"pymobiledevice3 {name}")
+    _walk(cmd, ctx, name, out)
+    return "\n".join(out)
+
+
+def _nav_uris(nav: Any) -> set[str]:
+    """Collect every page URI referenced by the (raw, pre-resolution) nav config."""
+    uris: set[str] = set()
+    items = list(nav or [])
+    while items:
+        item = items.pop()
+        if isinstance(item, str):
+            uris.add(item)
+        elif isinstance(item, dict):
+            items.extend(item.values())
+        elif isinstance(item, list):
+            items.extend(item)
+    return uris
+
+
+def on_files(files, config):
+    groups = _load_group_commands()
+
+    nav_uris = _nav_uris(config["nav"])
+    missing = [name for name in groups if f"cli/{name}.md" not in nav_uris]
+    if missing or INDEX_URI not in nav_uris:
+        raise PluginError(
+            "mkdocs.yml nav is missing CLI reference pages for: "
+            f"{missing or [INDEX_URI]}. Update the 'CLI Reference' nav section to match "
+            "CLI_GROUPS in pymobiledevice3/__main__.py."
+        )
+
+    files.append(File.generated(config, INDEX_URI, content=_index_page(groups)))
+    for name, cmd in groups.items():
+        files.append(File.generated(config, f"cli/{name}.md", content=_group_page(name, cmd)))
+    return files

--- a/docs/api/apps-files.md
+++ b/docs/api/apps-files.md
@@ -15,3 +15,12 @@ App-container file access, configuration profiles, and provisioning profiles.
 ::: pymobiledevice3.services.misagent.MisagentService
 
 ::: pymobiledevice3.services.file_relay.FileRelayService
+
+## Install records (iOS 17+)
+
+`InstallCoordinationProxyService` is a RemoteXPC service: construct it with a
+`RemoteServiceDiscoveryService` (it requires an RSD tunnel), not a lockdown client.
+
+::: pymobiledevice3.services.install_coordination_proxy.InstallCoordinationProxyService
+
+::: pymobiledevice3.services.install_coordination_proxy.InstallRecord

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -18,7 +18,3 @@ connect → service pattern with runnable examples. This section is the detailed
 - **[Capture, logging &amp; automation](capture.md)** — screenshots, pcap, syslog, WebInspector, WDA.
 - **[Backup, symbols &amp; location](backup-symbols.md)** — backup/restore, symbol fetching, GPS simulation.
 - **[Developer / DVT](dvt.md)** — the DVT provider and instruments (iOS 17+, over a tunnel).
-
-!!! tip "Docstring coverage is a work in progress"
-    Some methods are not yet documented. The generated pages reflect the current source; missing
-    prose means the docstring hasn't been written yet, not that the method is private.

--- a/docs/api/services.md
+++ b/docs/api/services.md
@@ -5,8 +5,8 @@ search:
 
 # Lockdown services
 
-Every service takes a service provider and is used as an async context manager. They all derive
-from `LockdownService`.
+Every service takes a service provider and is used as an async context manager. Unless noted
+otherwise, they derive from `LockdownService`.
 
 ## Base class
 
@@ -27,5 +27,17 @@ from `LockdownService`.
 ::: pymobiledevice3.services.crash_reports.CrashReportsManager
 
 ::: pymobiledevice3.services.mobile_image_mounter.MobileImageMounterService
+
+## DDI over cryptexd (iOS 17+)
+
+`CryptexdService` installs the DeveloperDiskImage as a cryptex without the image mounter. It is a
+RemoteXPC service: construct it with a `RemoteServiceDiscoveryService` (it requires an RSD
+tunnel), not a lockdown client.
+
+::: pymobiledevice3.services.cryptexd.CryptexdService
+
+::: pymobiledevice3.services.cryptexd.fetch_cryptex_ddi
+
+::: pymobiledevice3.services.cryptexd.InstalledCryptex
 
 ::: pymobiledevice3.services.bt_packet_logger.BtPacketLoggerService

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,0 +1,173 @@
+---
+search:
+  boost: 2
+---
+
+# Troubleshooting
+
+Common failures mapped to their causes and fixes. Each section quotes the error message (or
+exception name) the CLI prints, so you can search this page for what you're seeing.
+
+For any problem, running with increased verbosity usually reveals what is going on:
+
+```shell
+pymobiledevice3 -vv <command...>
+```
+
+## Device discovery
+
+### "Device is not connected" (`NoDeviceConnectedError`)
+
+No device was found over usbmux.
+
+- Check the cable and that the device shows up in `pymobiledevice3 usbmux list`.
+- On Linux, make sure [usbmuxd](https://github.com/libimobiledevice/usbmuxd) is installed and
+  running.
+- On Windows, install iTunes from the
+  [Microsoft Store](https://apps.microsoft.com/detail/9pb2mz1zmb1s) — it provides the Apple
+  Mobile Device Support service that pymobiledevice3 relies on.
+- If you passed `--udid`, verify it matches a connected device (see the next section).
+
+### "Failed to connect to usbmuxd socket" (`ConnectionFailedToUsbmuxdError`)
+
+The usbmuxd daemon itself is not reachable.
+
+- On Linux, start it: `sudo systemctl start usbmuxd` (or run `usbmuxd -f` in the foreground to
+  see its logs).
+- On Windows, make sure the *Apple Mobile Device Service* is running.
+- If your daemon listens on a non-default address, point pymobiledevice3 at it with
+  `--usbmux HOST:PORT` (or a unix socket path), or the `PYMOBILEDEVICE3_USBMUX` /
+  `USBMUXD_SOCKET_ADDRESS` environment variables.
+
+### "Device not found: ..." (`DeviceNotFoundError`)
+
+The UDID you passed (via `--udid` or `PYMOBILEDEVICE3_UDID`) doesn't match any connected
+device. List what's actually connected:
+
+```shell
+pymobiledevice3 usbmux list
+```
+
+## Pairing and trust
+
+### "Waiting for user dialog approval" (`PairingDialogResponsePendingError`)
+
+The device is showing the *Trust This Computer?* dialog. Unlock the device, tap **Trust**, and
+run the command again.
+
+### "User refused to trust this computer" (`UserDeniedPairingError`)
+
+**Don't Trust** was tapped. To make the dialog reappear, reset the device's trust decisions:
+*Settings → General → Transfer or Reset iPhone → Reset → Reset Location & Privacy*, then
+reconnect the cable.
+
+### "Device is password protected. Please unlock and retry" (`PasswordRequiredError`)
+
+Pairing (and some lockdown operations) require the device to be unlocked. Unlock it and retry.
+
+### "Device is not paired" (`NotPairedError`)
+
+The host has no valid pair record for this device. Create one:
+
+```shell
+pymobiledevice3 lockdown pair
+```
+
+If pairing keeps failing with an `InvalidHostIDError`, the device holds a stale record for this
+host — unpair first (`pymobiledevice3 lockdown unpair`) or reset trust as described above, then
+pair again.
+
+## Developer services
+
+### "Failed to start service" (`InvalidServiceError`)
+
+The single most common error. A developer service was requested but the device can't provide
+it yet. In order:
+
+1. **Enable Developer Mode** (iOS 15+):
+
+    ```shell
+    pymobiledevice3 amfi enable-developer-mode
+    ```
+
+    This reboots the device. If it fails with *"Cannot enable developer-mode when passcode is
+    set"* (`DeviceHasPasscodeSetError`), remove the device passcode temporarily — iOS refuses
+    to enable Developer Mode automatically while one is set (you can instead enable it manually
+    under *Settings → Privacy & Security → Developer Mode*).
+
+2. **Mount the Developer Disk Image** (once per boot):
+
+    ```shell
+    pymobiledevice3 mounter auto-mount
+    ```
+
+    This downloads the correct image for your iOS version and caches it under
+    `~/.pymobiledevice3` — no Xcode required. On iOS 17+ you can alternatively use
+    `pymobiledevice3 cryptex auto-install` (see the
+    [CLI recipes](cli-recipes.md#cryptexes-ios-17-rsd-tunnel)).
+
+3. On **iOS 17+**, developer commands also need a tunnel — but you normally don't need to do
+   anything: the CLI establishes a no-root userspace tunnel in-process automatically (you'll
+   see a *"Trying again over a no-root userspace tunnel"* warning, which is normal). See
+   [iOS 17+ tunnels](ios17-tunnels.md) for the full picture.
+
+### "Unable to connect to Tunneld" (`TunneldConnectionError`)
+
+You passed `--tunnel` (or the automatic fallback chose tunneld — which happens on
+iOS 17.0–17.3, where the userspace tunnel has no reliable transport), but no tunneld daemon is
+running. Start one with root privileges and leave it running:
+
+```shell
+sudo pymobiledevice3 remote tunneld
+```
+
+### `AccessDeniedError` / "This command requires root/admin"
+
+The requested operation needs elevated privileges — typically creating a kernel tunnel
+(`remote start-tunnel`, `remote tunneld`). Re-run with `sudo` (macOS/Linux) or from an
+Administrator shell (Windows). For developer commands, prefer the default no-root userspace
+tunnel instead — it requires no privileges at all.
+
+### `PskCipherNotSupportedError`
+
+Your Python's SSL backend cannot negotiate the PSK ciphers the TCP tunnel requires — typical
+for interpreters linked against LibreSSL. Use a Python build linked against OpenSSL (e.g. the
+[python.org](https://www.python.org/downloads/) installer, or `brew install python`).
+
+### `QuicProtocolNotSupportedError`
+
+Apple removed QUIC tunnel support in iOS 18.2+. Drop the QUIC protocol selection and use the
+default TCP tunnel.
+
+## WebInspector
+
+### "Web Inspector is not enabled" (`WebInspectorNotEnabledError`)
+
+Enable it on the device: *Settings → Safari → Advanced → Web Inspector*.
+
+### "Remote Automation is not enabled" (`RemoteAutomationNotEnabledError`)
+
+Automation commands (`webinspector launch`, `js-shell --automation`, `shell`) additionally
+require: *Settings → Safari → Advanced → Remote Automation*.
+
+## Backup
+
+### Encrypted backups
+
+If the device has backup encryption enabled, commands that read backup contents need the
+password: pass `--password` to `backup2` subcommands. A
+`BackupFilterPasswordRequiredError` means you combined a filtered backup with
+`--patch-manifest` on an encrypted backup — that also requires `--password`, so the manifest
+can be decrypted and re-encrypted.
+
+### "Not enough disk space" (`NotEnoughDiskSpaceError`)
+
+The host doesn't have room for the backup. Note that the first filtered backup still transfers
+*all* backup bytes from the device (filtering saves disk, not transfer) — budget space
+accordingly or free some up.
+
+## Still stuck?
+
+- Re-run with `-vv` and read the debug logs.
+- Search the [GitHub issues](https://github.com/doronz88/pymobiledevice3/issues).
+- Ask on [Discord](https://discord.gg/52mZGC3JXJ).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ markdown_extensions:
 
 hooks:
   - docs/_hooks/inject_external.py
+  - docs/_hooks/gen_cli_reference.py
 
 nav:
   - Home: index.md
@@ -118,6 +119,36 @@ nav:
       - Python API: guides/python-api.md
       - Writing CLI commands: guides/writing-commands-with-service-provider.md
       - Device operator skill: guides/codex-device-operator-skill.md
+  - CLI Reference:
+      - Overview: cli/index.md
+      - activation: cli/activation.md
+      - afc: cli/afc.md
+      - amfi: cli/amfi.md
+      - apps: cli/apps.md
+      - backup2: cli/backup2.md
+      - btlogger: cli/btlogger.md
+      - bonjour: cli/bonjour.md
+      - companion: cli/companion.md
+      - crash: cli/crash.md
+      - cryptex: cli/cryptex.md
+      - developer: cli/developer.md
+      - diagnostics: cli/diagnostics.md
+      - lockdown: cli/lockdown.md
+      - mounter: cli/mounter.md
+      - notification: cli/notification.md
+      - pcap: cli/pcap.md
+      - power-assertion: cli/power-assertion.md
+      - processes: cli/processes.md
+      - profile: cli/profile.md
+      - provision: cli/provision.md
+      - remote: cli/remote.md
+      - restore: cli/restore.md
+      - springboard: cli/springboard.md
+      - syslog: cli/syslog.md
+      - usbmux: cli/usbmux.md
+      - webinspector: cli/webinspector.md
+      - idam: cli/idam.md
+      - version: cli/version.md
   - Python API Reference:
       - Overview: api/index.md
       - Connecting to a device: api/connection.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ plugins:
           - guides/webview-debugging.md
           - guides/python-api.md
           - guides/writing-commands-with-service-provider.md
+          - guides/troubleshooting.md
         API reference:
           - api/index.md
           - api/connection.md
@@ -119,6 +120,7 @@ nav:
       - Python API: guides/python-api.md
       - Writing CLI commands: guides/writing-commands-with-service-provider.md
       - Device operator skill: guides/codex-device-operator-skill.md
+      - Troubleshooting: guides/troubleshooting.md
   - CLI Reference:
       - Overview: cli/index.md
       - activation: cli/activation.md

--- a/pymobiledevice3/remote/remote_service_discovery.py
+++ b/pymobiledevice3/remote/remote_service_discovery.py
@@ -121,51 +121,78 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         return self.lockdown
 
     async def get_developer_mode_status(self) -> bool:
+        """Get whether Developer Mode is enabled, via the remote lockdown service
+        (see ``LockdownClient.get_developer_mode_status``)."""
         return await self._lockdown.get_developer_mode_status()
 
     async def get_date(self) -> datetime:
+        """Get the device's current date and time, via the remote lockdown service
+        (see ``LockdownClient.get_date``)."""
         return await self._lockdown.get_date()
 
     async def set_language(self, language: str) -> None:
+        """Set the device's language, via the remote lockdown service (see ``LockdownClient.set_language``)."""
         await self._lockdown.set_language(language)
 
     async def get_language(self) -> str:
+        """Get the device's language, via the remote lockdown service (see ``LockdownClient.get_language``)."""
         return await self._lockdown.get_language()
 
     async def set_locale(self, locale: str) -> None:
+        """Set the device's locale, via the remote lockdown service (see ``LockdownClient.set_locale``)."""
         await self._lockdown.set_locale(locale)
 
     async def get_locale(self) -> str:
+        """Get the device's locale, via the remote lockdown service (see ``LockdownClient.get_locale``)."""
         return await self._lockdown.get_locale()
 
     async def set_assistive_touch(self, value: bool) -> None:
+        """Enable or disable AssistiveTouch, via the remote lockdown service
+        (see ``LockdownClient.set_assistive_touch``)."""
         await self._lockdown.set_assistive_touch(value)
 
     async def get_assistive_touch(self) -> bool:
+        """Get whether AssistiveTouch is enabled, via the remote lockdown service
+        (see ``LockdownClient.get_assistive_touch``)."""
         return await self._lockdown.get_assistive_touch()
 
     async def set_voice_over(self, value: bool) -> None:
+        """Enable or disable VoiceOver, via the remote lockdown service
+        (see ``LockdownClient.set_voice_over``)."""
         await self._lockdown.set_voice_over(value)
 
     async def get_voice_over(self) -> bool:
+        """Get whether VoiceOver is enabled, via the remote lockdown service
+        (see ``LockdownClient.get_voice_over``)."""
         return await self._lockdown.get_voice_over()
 
     async def set_invert_display(self, value: bool) -> None:
+        """Enable or disable display color inversion, via the remote lockdown service
+        (see ``LockdownClient.set_invert_display``)."""
         await self._lockdown.set_invert_display(value)
 
     async def get_invert_display(self) -> bool:
+        """Get whether display color inversion is enabled, via the remote lockdown service
+        (see ``LockdownClient.get_invert_display``)."""
         return await self._lockdown.get_invert_display()
 
     async def set_enable_wifi_connections(self, value: bool) -> None:
+        """Enable or disable Wi-Fi lockdown connections, via the remote lockdown service
+        (see ``LockdownClient.set_enable_wifi_connections``)."""
         await self._lockdown.set_enable_wifi_connections(value)
 
     async def get_enable_wifi_connections(self) -> bool:
+        """Get whether Wi-Fi lockdown connections are enabled, via the remote lockdown service
+        (see ``LockdownClient.get_enable_wifi_connections``)."""
         return await self._lockdown.get_enable_wifi_connections()
 
     async def set_timezone(self, timezone: str) -> None:
+        """Set the device's time zone, via the remote lockdown service (see ``LockdownClient.set_timezone``)."""
         await self._lockdown.set_timezone(timezone)
 
     async def set_uses24h_clock(self, value: bool) -> None:
+        """Set whether the device uses the 24-hour clock format, via the remote lockdown service
+        (see ``LockdownClient.set_uses24h_clock``)."""
         await self._lockdown.set_uses24h_clock(value)
 
     async def connect(self) -> None:
@@ -210,12 +237,15 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
             raise
 
     async def get_value(self, domain: Optional[str] = None, key: Optional[str] = None) -> Any:
+        """Read a value from the device, via the remote lockdown service (see ``LockdownClient.get_value``)."""
         return await self._lockdown.get_value(domain, key)
 
     async def set_value(self, value: Any, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
+        """Write a value to the device, via the remote lockdown service (see ``LockdownClient.set_value``)."""
         return await self._lockdown.set_value(value, domain=domain, key=key)
 
     async def remove_value(self, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
+        """Remove a value on the device, via the remote lockdown service (see ``LockdownClient.remove_value``)."""
         return await self._lockdown.remove_value(domain=domain, key=key)
 
     async def start_lockdown_service_without_checkin(self, name: str) -> ServiceConnection:

--- a/pymobiledevice3/remote/remote_service_discovery.py
+++ b/pymobiledevice3/remote/remote_service_discovery.py
@@ -131,7 +131,10 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         return await self._lockdown.get_date()
 
     async def set_language(self, language: str) -> None:
-        """Set the device's language, via the remote lockdown service (see ``LockdownClient.set_language``)."""
+        """Set the device's language, via the remote lockdown service (see ``LockdownClient.set_language``).
+
+        :param language: The language code to set (e.g. ``"en"``).
+        """
         await self._lockdown.set_language(language)
 
     async def get_language(self) -> str:
@@ -139,7 +142,10 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         return await self._lockdown.get_language()
 
     async def set_locale(self, locale: str) -> None:
-        """Set the device's locale, via the remote lockdown service (see ``LockdownClient.set_locale``)."""
+        """Set the device's locale, via the remote lockdown service (see ``LockdownClient.set_locale``).
+
+        :param locale: The locale string to set (e.g. ``"en_US"``).
+        """
         await self._lockdown.set_locale(locale)
 
     async def get_locale(self) -> str:
@@ -148,7 +154,10 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
 
     async def set_assistive_touch(self, value: bool) -> None:
         """Enable or disable AssistiveTouch, via the remote lockdown service
-        (see ``LockdownClient.set_assistive_touch``)."""
+        (see ``LockdownClient.set_assistive_touch``).
+
+        :param value: True to enable, False to disable.
+        """
         await self._lockdown.set_assistive_touch(value)
 
     async def get_assistive_touch(self) -> bool:
@@ -158,7 +167,10 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
 
     async def set_voice_over(self, value: bool) -> None:
         """Enable or disable VoiceOver, via the remote lockdown service
-        (see ``LockdownClient.set_voice_over``)."""
+        (see ``LockdownClient.set_voice_over``).
+
+        :param value: True to enable, False to disable.
+        """
         await self._lockdown.set_voice_over(value)
 
     async def get_voice_over(self) -> bool:
@@ -168,7 +180,10 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
 
     async def set_invert_display(self, value: bool) -> None:
         """Enable or disable display color inversion, via the remote lockdown service
-        (see ``LockdownClient.set_invert_display``)."""
+        (see ``LockdownClient.set_invert_display``).
+
+        :param value: True to enable, False to disable.
+        """
         await self._lockdown.set_invert_display(value)
 
     async def get_invert_display(self) -> bool:
@@ -178,7 +193,10 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
 
     async def set_enable_wifi_connections(self, value: bool) -> None:
         """Enable or disable Wi-Fi lockdown connections, via the remote lockdown service
-        (see ``LockdownClient.set_enable_wifi_connections``)."""
+        (see ``LockdownClient.set_enable_wifi_connections``).
+
+        :param value: True to enable, False to disable.
+        """
         await self._lockdown.set_enable_wifi_connections(value)
 
     async def get_enable_wifi_connections(self) -> bool:
@@ -187,12 +205,18 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         return await self._lockdown.get_enable_wifi_connections()
 
     async def set_timezone(self, timezone: str) -> None:
-        """Set the device's time zone, via the remote lockdown service (see ``LockdownClient.set_timezone``)."""
+        """Set the device's time zone, via the remote lockdown service (see ``LockdownClient.set_timezone``).
+
+        :param timezone: The time zone identifier to set (e.g. ``"America/New_York"``).
+        """
         await self._lockdown.set_timezone(timezone)
 
     async def set_uses24h_clock(self, value: bool) -> None:
         """Set whether the device uses the 24-hour clock format, via the remote lockdown service
-        (see ``LockdownClient.set_uses24h_clock``)."""
+        (see ``LockdownClient.set_uses24h_clock``).
+
+        :param value: True for 24-hour format, False for 12-hour format.
+        """
         await self._lockdown.set_uses24h_clock(value)
 
     async def connect(self) -> None:
@@ -237,15 +261,31 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
             raise
 
     async def get_value(self, domain: Optional[str] = None, key: Optional[str] = None) -> Any:
-        """Read a value from the device, via the remote lockdown service (see ``LockdownClient.get_value``)."""
+        """Read a value from the device, via the remote lockdown service (see ``LockdownClient.get_value``).
+
+        :param domain: Domain to read from, or ``None`` for the default domain.
+        :param key: Key to read, or ``None`` for all keys in the domain.
+        :return: The requested value.
+        """
         return await self._lockdown.get_value(domain, key)
 
     async def set_value(self, value: Any, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
-        """Write a value to the device, via the remote lockdown service (see ``LockdownClient.set_value``)."""
+        """Write a value to the device, via the remote lockdown service (see ``LockdownClient.set_value``).
+
+        :param value: The value to write.
+        :param domain: Domain to write to, or ``None`` for the default domain.
+        :param key: Key to write, or ``None`` for the domain root.
+        :return: The device's response plist.
+        """
         return await self._lockdown.set_value(value, domain=domain, key=key)
 
     async def remove_value(self, domain: Optional[str] = None, key: Optional[str] = None) -> dict[str, Any]:
-        """Remove a value on the device, via the remote lockdown service (see ``LockdownClient.remove_value``)."""
+        """Remove a value on the device, via the remote lockdown service (see ``LockdownClient.remove_value``).
+
+        :param domain: Domain to remove from, or ``None`` for the default domain.
+        :param key: Key to remove, or ``None`` for the domain root.
+        :return: The device's response plist.
+        """
         return await self._lockdown.remove_value(domain=domain, key=key)
 
     async def start_lockdown_service_without_checkin(self, name: str) -> ServiceConnection:

--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -346,6 +346,8 @@ class AfcService(LockdownService):
         return self
 
     async def aclose(self) -> None:
+        """Shut down the service: stop the reader task, fail all in-flight requests with
+        ``ConnectionTerminatedError``, and close the underlying connection."""
         if self._afc_reader_task is not None:
             self._afc_reader_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/pymobiledevice3/services/bt_packet_logger.py
+++ b/pymobiledevice3/services/bt_packet_logger.py
@@ -123,12 +123,24 @@ async def write_pcapng_stream(
 
 
 class BtPacketLoggerService(LockdownService):
+    """Capture live Bluetooth HCI traffic from the device.
+
+    Wraps ``com.apple.bluetooth.BTPacketLogger``, which streams Apple PacketLogger records.
+    Use `watch` to iterate the raw records, and `write_to_packetlogger` /
+    `write_to_pcapng` to persist them in a format PacketLogger.app or Wireshark can open.
+    """
+
     SERVICE_NAME = "com.apple.bluetooth.BTPacketLogger"
 
     def __init__(self, lockdown: LockdownServiceProvider) -> None:
         super().__init__(lockdown, self.SERVICE_NAME)
 
     async def watch(self, packets_count: int = -1) -> AsyncGenerator[bytes, None]:
+        """Yield raw PacketLogger records as they are captured.
+
+        :param packets_count: Stop after this many records, or -1 to stream forever.
+        :return: Generator of raw PacketLogger records (parse with ``parse_packetlogger_record``).
+        """
         packet_index = 0
         while packet_index != packets_count:
             packet_length = unpack("<H", await self.service.recvall(SERVICE_PACKET_SIZE_HEADER))[0]
@@ -138,8 +150,22 @@ class BtPacketLoggerService(LockdownService):
             packet_index += 1
 
     async def write_to_packetlogger(self, out: BinaryIO, packet_generator: AsyncIterable[bytes]) -> None:
+        """Write raw records (e.g. from `watch`) to ``out`` in Apple PacketLogger (.pklg) format.
+
+        :param out: Destination binary stream, flushed after every record.
+        :param packet_generator: Source of raw PacketLogger records.
+        """
         await write_packetlogger_stream(out, packet_generator)
 
     async def write_to_pcapng(self, out: BinaryIO, packet_generator: AsyncIterable[bytes]) -> None:
+        """Write raw records (e.g. from `watch`) to ``out`` as a pcapng capture Wireshark can open.
+
+        Records are converted to HCI H4 frames (link-type 201, with direction pseudo-header); records
+        that don't map to HCI, or are malformed, are skipped. Timestamps are shifted from the device's
+        local wall-clock to UTC using the device-reported timezone offset.
+
+        :param out: Destination binary stream, flushed after every packet.
+        :param packet_generator: Source of raw PacketLogger records.
+        """
         tz_offset_seconds = self.lockdown.all_values.get("TimeZoneOffsetFromUTC") or 0
         await write_pcapng_stream(out, packet_generator, self.lockdown.product_version, tz_offset_seconds)

--- a/pymobiledevice3/services/dvt/instruments/process_control.py
+++ b/pymobiledevice3/services/dvt/instruments/process_control.py
@@ -103,6 +103,7 @@ class ProcessControl(DtxService[ProcessControlService]):
     """
 
     async def connect(self):
+        """Open the instrument's DTX channel and route its message log to this instrument's logger."""
         await super().connect()
         self._provider.dtx.ctx["logger"] = self.logger.getChild("dtx")
 


### PR DESCRIPTION
Three targeted documentation improvements:

## Generated CLI reference

A new mkdocs hook (`docs/_hooks/gen_cli_reference.py`) imports every group in `CLI_GROUPS`, walks the Typer command tree, and emits one reference page per group plus an index — built from the same objects that power `--help`, so it can never drift from the code. The hook fails the strict build with a clear message if `CLI_GROUPS` and the nav ever get out of sync, and it introspects the command objects through public attributes only (no `click`/`typer._click` import, per AGENTS.md).

The connection options injected into every device-facing command (`--rsd`, `--tunnel`, `--userspace`, ...) are documented once on the index page; each command lists which of them it accepts instead of repeating nine boilerplate rows.

## Troubleshooting guide

`docs/guides/troubleshooting.md` maps the failures users actually hit — discovery/usbmuxd, pairing and trust, `InvalidServiceError` and the iOS 17+ tunnel fallbacks, WebInspector toggles, encrypted backups — to causes and fixes. Sections quote the exact CLI error messages and exception names so site search and web searches land on the right entry.

## API reference completeness

- Filled the last 25 missing docstrings among the objects the generated reference renders (RSD lockdown delegation wrappers, `BtPacketLoggerService`, `AfcService.aclose`, `ProcessControl.connect`); the rendered surface is now at 100% docstring coverage, so the "work in progress" admonition is dropped.
- Exposed `CryptexdService` and `InstallCoordinationProxyService` (both fully documented in code but absent from the reference) with notes that they take an RSD provider.

## Verification

- `mkdocs build --strict` passes at every commit (verified in a clean worktree)
- `uvx pre-commit run --all-files` (ruff, pyright, skill-sync) passes
- `pytest -m cli`: 122 passed
- markdownlint passes on the new guide