### PR TITLE
device_link: Make discarded-file bookkeeping O(1) for non-directories

### DIFF
--- a/pymobiledevice3/services/device_link.py
+++ b/pymobiledevice3/services/device_link.py
@@ -291,7 +291,8 @@ class DeviceLink:
             dest = self.root_path / dst
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(source, dest)
-            self._move_discarded_files(Path(src), Path(dst))
+            # the source is gone after the move; the destination mirrors its kind
+            self._move_discarded_files(Path(src), Path(dst), is_dir=dest.is_dir())
             if self.post_file_receive is not None:
                 self.post_file_receive(dst, src)
         await self.status_response(0)
@@ -303,11 +304,12 @@ class DeviceLink:
             return
         dest = self.root_path / cast(str, message[2])
         dest.parent.mkdir(parents=True, exist_ok=True)
-        if src.is_dir():
+        is_dir = src.is_dir()
+        if is_dir:
             shutil.copytree(src, dest)
         else:
             shutil.copy(src, dest)
-        self._copy_discarded_files(Path(cast(str, message[1])), Path(cast(str, message[2])))
+        self._copy_discarded_files(Path(cast(str, message[1])), Path(cast(str, message[2])), is_dir=is_dir)
         if self.post_file_receive is not None:
             self.post_file_receive(cast(str, message[2]), cast(str, message[1]))
         await self.status_response(0)
@@ -318,28 +320,40 @@ class DeviceLink:
     async def remove_items(self, message: DLMessage) -> None:
         for path in cast(Iterable[str], message[1]):
             rm_path = self.root_path / path
-            if rm_path.is_dir():
+            is_dir = rm_path.is_dir()
+            if is_dir:
                 shutil.rmtree(rm_path)
             else:
                 rm_path.unlink(missing_ok=True)
-            self._forget_discarded_files(Path(path))
+            self._forget_discarded_files(Path(path), is_dir=is_dir)
         await self.status_response(0)
 
-    def _discarded_files_below(self, path: Path) -> set[Path]:
+    def _discarded_files_below(self, path: Path, is_dir: bool) -> set[Path]:
+        """Return the discarded-placeholder entries at or below ``path``.
+
+        The set only ever contains file paths (one placeholder per rejected
+        payload), so unless ``path`` is a directory the only possible match is
+        ``path`` itself — an O(1) lookup. Reserving the full scan for directories
+        keeps bulk per-file operations linear instead of quadratic; a filtered
+        whole-device backup issues one move per sent file against a set holding
+        every rejected file (https://github.com/doronz88/pymobiledevice3/issues/1833).
+        """
+        if not is_dir:
+            return {path} if path in self._discarded_files else set()
         return {candidate for candidate in self._discarded_files if candidate == path or path in candidate.parents}
 
-    def _move_discarded_files(self, source: Path, destination: Path) -> None:
-        discarded_files = self._discarded_files_below(source)
+    def _move_discarded_files(self, source: Path, destination: Path, is_dir: bool) -> None:
+        discarded_files = self._discarded_files_below(source, is_dir)
         self._discarded_files.difference_update(discarded_files)
         self._discarded_files.update(destination / path.relative_to(source) for path in discarded_files)
 
-    def _copy_discarded_files(self, source: Path, destination: Path) -> None:
+    def _copy_discarded_files(self, source: Path, destination: Path, is_dir: bool) -> None:
         self._discarded_files.update(
-            destination / path.relative_to(source) for path in self._discarded_files_below(source)
+            destination / path.relative_to(source) for path in self._discarded_files_below(source, is_dir)
         )
 
-    def _forget_discarded_files(self, path: Path) -> None:
-        self._discarded_files.difference_update(self._discarded_files_below(path))
+    def _forget_discarded_files(self, path: Path, is_dir: bool) -> None:
+        self._discarded_files.difference_update(self._discarded_files_below(path, is_dir))
 
     def cleanup_discarded_files(self) -> None:
         """Remove temporary placeholders created for payloads rejected by a backup filter."""

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -1,6 +1,7 @@
 import sqlite3
 import struct
 import time
+from collections.abc import Iterable, Iterator
 from contextlib import closing
 from pathlib import Path
 from ssl import SSLEOFError
@@ -398,10 +399,109 @@ def test_device_link_tracks_filtered_placeholders_when_directory_is_copied_or_re
     copied_file = Path("device/Copy") / "aa" / "hash"
     device_link._discarded_files.add(discarded_file)
 
-    device_link._copy_discarded_files(source, Path("device/Copy"))
-    device_link._forget_discarded_files(source)
+    device_link._copy_discarded_files(source, Path("device/Copy"), is_dir=True)
+    device_link._forget_discarded_files(source, is_dir=True)
 
     assert device_link._discarded_files == {copied_file}
+
+
+class _ScanCountingSet(set[Path]):
+    """A path set that counts full iterations, to prove per-file bookkeeping is O(1)."""
+
+    def __init__(self, iterable: Iterable[Path] = ()) -> None:
+        super().__init__(iterable)
+        self.scans = 0
+
+    def __iter__(self) -> Iterator[Path]:
+        self.scans += 1
+        return super().__iter__()
+
+
+def _device_link_with_large_discarded_set(tmp_path: Path, on_disk: Path) -> tuple[DeviceLink, _ScanCountingSet]:
+    device_link = DeviceLink(AsyncMock(), tmp_path, preserve_file=lambda _file_name, _device_name: False)
+    discarded = _ScanCountingSet(Path("tmp") / f"{index:04x}" for index in range(1000))
+    device_link._discarded_files = discarded
+    path = tmp_path / on_disk
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+    discarded.scans = 0
+    return device_link, discarded
+
+
+@pytest.mark.asyncio
+async def test_device_link_move_items_does_not_scan_discarded_set_for_file_moves(tmp_path: Path) -> None:
+    device_link, discarded = _device_link_with_large_discarded_set(tmp_path, Path("tmp/0000"))
+    preserved = tmp_path / "tmp" / "preserved"
+    preserved.touch()
+
+    await device_link.move_items(["DLMessageMoveItems", {"tmp/0000": "aa/hash", "tmp/preserved": "bb/hash"}])
+
+    assert discarded.scans == 0
+    assert Path("aa/hash") in discarded
+    assert Path("tmp/0000") not in discarded
+
+
+@pytest.mark.asyncio
+async def test_device_link_remove_items_does_not_scan_discarded_set_for_files(tmp_path: Path) -> None:
+    device_link, discarded = _device_link_with_large_discarded_set(tmp_path, Path("tmp/0000"))
+
+    await device_link.remove_items(["DLMessageRemoveItems", ["tmp/0000", "tmp/not-tracked"]])
+
+    assert discarded.scans == 0
+    assert Path("tmp/0000") not in discarded
+
+
+@pytest.mark.asyncio
+async def test_device_link_copy_item_does_not_scan_discarded_set_for_files(tmp_path: Path) -> None:
+    device_link, discarded = _device_link_with_large_discarded_set(tmp_path, Path("tmp/0000"))
+
+    await device_link.copy_item(["DLMessageCopyItem", "tmp/0000", "copy/0000"])
+
+    assert discarded.scans == 0
+    assert Path("copy/0000") in discarded
+    assert Path("tmp/0000") in discarded
+
+
+@pytest.mark.asyncio
+async def test_device_link_move_items_retargets_placeholders_below_moved_directory(tmp_path: Path) -> None:
+    device_link = DeviceLink(AsyncMock(), tmp_path, preserve_file=lambda _file_name, _device_name: False)
+    placeholder = tmp_path / "device/Snapshot/aa/hash"
+    placeholder.parent.mkdir(parents=True)
+    placeholder.touch()
+    device_link._discarded_files.add(Path("device/Snapshot/aa/hash"))
+
+    await device_link.move_items(["DLMessageMoveItems", {"device/Snapshot/aa": "device/aa"}])
+
+    assert device_link._discarded_files == {Path("device/aa/hash")}
+
+
+@pytest.mark.asyncio
+async def test_device_link_remove_items_forgets_placeholders_below_removed_directory(tmp_path: Path) -> None:
+    device_link = DeviceLink(AsyncMock(), tmp_path, preserve_file=lambda _file_name, _device_name: False)
+    placeholder = tmp_path / "device/Snapshot/aa/hash"
+    placeholder.parent.mkdir(parents=True)
+    placeholder.touch()
+    device_link._discarded_files.add(Path("device/Snapshot/aa/hash"))
+
+    await device_link.remove_items(["DLMessageRemoveItems", ["device/Snapshot"]])
+
+    assert device_link._discarded_files == set()
+
+
+@pytest.mark.asyncio
+async def test_device_link_copy_item_duplicates_placeholders_below_copied_directory(tmp_path: Path) -> None:
+    device_link = DeviceLink(AsyncMock(), tmp_path, preserve_file=lambda _file_name, _device_name: False)
+    placeholder = tmp_path / "device/Snapshot/aa/hash"
+    placeholder.parent.mkdir(parents=True)
+    placeholder.touch()
+    device_link._discarded_files.add(Path("device/Snapshot/aa/hash"))
+
+    await device_link.copy_item(["DLMessageCopyItem", "device/Snapshot", "device/Copy"])
+
+    assert device_link._discarded_files == {
+        Path("device/Snapshot/aa/hash"),
+        Path("device/Copy/aa/hash"),
+    }
 
 
 def test_device_link_does_not_remove_directory_tracked_as_discarded_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #1833.

`backup2 backup` with `--only`/`--only-regex` tracks one placeholder per rejected payload in `DeviceLink._discarded_files`, and the device's finalize issues a move per sent file. `_discarded_files_below` scanned the entire set (constructing each candidate's `parents` chain) for every move/copy/remove, making the finalize O(moves × discarded) — at the reported scale (~76k moves × ~74.5k placeholders) that projects to ~3 hours pegged at ~97%, exactly as measured in the issue.

## Fix

The set only ever contains file paths (one placeholder per rejected file, added in `upload_files`), so unless the operated-on path is a directory the only entry that can match is the path itself — an O(1) membership test. The callers already know whether they operated on a directory, so the fix threads that through:

- `move_items`: the source is gone after `shutil.move`, so the destination's kind is checked (it mirrors what was moved)
- `copy_item` / `remove_items`: `is_dir()` was already being computed; it's now captured (before deletion, in the remove case) and passed down

Only genuine directory operations still take the subtree scan.

## Measured

Benchmark at the issue's scale (74.5k-entry set, 76k file moves, macOS arm64):

| | per move | whole move phase |
|---|---|---|
| before | ~155 ms | ~3.3 h (projected) |
| after | O(1) | 0.35 s |

## Tests

- Three tests prove file-level `move_items`/`remove_items`/`copy_item` never iterate the discarded set (via a counting `set` subclass), against a 1000-entry set — these fail on `master`
- Three tests exercise directory move/copy/remove through the public handlers and assert placeholders below are retargeted/duplicated/forgotten — these guard the `is_dir` threading, notably the move case where the source no longer exists on disk

`pytest tests/services/test_backup2.py` (28 passed) and `pyright --venvpath .` (0 errors) are clean.