### PR TITLE
backup2: Report encryption state when encryption is run without arguments

### DIFF
--- a/pymobiledevice3/cli/backup.py
+++ b/pymobiledevice3/cli/backup.py
@@ -286,6 +286,12 @@ async def extract(
         )
 
 
+def _validate_encryption_password(ctx: typer.Context, _param: typer.CallbackParam, value: str) -> str:
+    if ctx.params.get("mode") is not None and not value:
+        raise typer.BadParameter("PASSWORD is required when setting encryption on or off.")
+    return value
+
+
 @cli.command()
 @async_command
 async def encryption(
@@ -293,20 +299,24 @@ async def encryption(
     *,
     backup_directory: BackupDirectoryOption = Path("."),
     mode: Annotated[
-        Literal["on", "off"],
+        Optional[Literal["on", "off"]],
         typer.Argument(case_sensitive=False),
-    ],
-    password: str,
+    ] = None,
+    password: Annotated[str, typer.Argument(callback=_validate_encryption_password)] = "",
 ) -> None:
     """
-    Set backup encryption on / off.
+    Set backup encryption on / off, or report the current encryption state when run without arguments.
 
     When on, PASSWORD will be the new backup password.
     When off, PASSWORD is the current backup password.
     """
     async with Mobilebackup2Service(service_provider) as backup_client:
+        will_encrypt = await backup_client.get_will_encrypt()
+        if mode is None:
+            typer.echo("on" if will_encrypt else "off")
+            return
         should_encrypt = mode.lower() == "on"
-        if should_encrypt == await backup_client.get_will_encrypt():
+        if should_encrypt == will_encrypt:
             logger.error("Encryption already " + ("on!" if should_encrypt else "off!"))
             return
         if should_encrypt:

--- a/tests/cli/test_backup_cli.py
+++ b/tests/cli/test_backup_cli.py
@@ -62,6 +62,25 @@ def test_backup_command_offers_messages_selection():
     assert "messages" in result.output
 
 
+def test_encryption_mode_without_password_fails_with_usage_error():
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["backup2", "encryption", "on"])
+
+    assert result.exit_code != 0
+    assert "PASSWORD is required" in result.output
+
+
+def test_encryption_help_documents_no_args_state_query():
+    runner = CliRunner()
+
+    result = runner.invoke(__main__.app, ["backup2", "encryption", "--help"])
+
+    assert result.exit_code == 0
+    normalized_output = " ".join(result.output.replace("│", " ").split())
+    assert "current encryption state" in normalized_output
+
+
 def test_backup_full_help_describes_conditional_default():
     runner = CliRunner()
 


### PR DESCRIPTION
`backup2 encryption` previously required a mode and password even to learn whether backup encryption is enabled. Both arguments are now optional:

- `pymobiledevice3 backup2 encryption` → prints the current state (`on`/`off`), read from the `WillEncrypt` lockdown value via the existing `get_will_encrypt()`
- `pymobiledevice3 backup2 encryption on|off PASSWORD` → unchanged behavior
- `pymobiledevice3 backup2 encryption on` (mode without password) → parse-time usage error ("PASSWORD is required when setting encryption on or off."), raised by an argument callback so it surfaces before any device connection is attempted

Verified against a connected device (iPhone12,1): the no-args query prints `on` matching the device's actual state, and the missing-password case fails fast with the usage error. `pytest tests/cli/` (182 passed) and `pyright --venvpath .` (0 errors) are clean. The CLI reference docs are generated from the CLI at build time, so the updated help text flows through automatically.