### PR TITLE
ci: Run the full device-free test suite instead of only -m cli

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - '.github/workflows/python-app.yml'
       - 'pymobiledevice3/**'
+      - 'tests/**'
+      - 'pytest.ini'
       - 'pyproject.toml'
   release:
     types: [ created ]
@@ -47,8 +49,8 @@ jobs:
         env:
           SKIP: pyright
         run: uvx pre-commit run --all-files
-      - name: Test show usage
-        run: uv run --extra test pytest -m cli
+      - name: Run device-free tests
+        run: uv run --extra test pytest -m "not device"
 
   pyright:
     if: '! github.event.pull_request.draft'

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ filterwarnings =
     error::ResourceWarning
 markers =
     cli: tests for cli interface
+    device: requires a physical device (auto-applied to tests using the device-backed fixtures)

--- a/tests/cli/test_backup_cli.py
+++ b/tests/cli/test_backup_cli.py
@@ -1,9 +1,24 @@
+import re
+
 import pytest
 import typer
 from typer.testing import CliRunner
 
 from pymobiledevice3 import __main__
 from pymobiledevice3.cli.backup import validate_backup_filter_options
+
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def plain_cli_output(output: str) -> str:
+    """Return CLI output as plain text suitable for substring assertions.
+
+    On GitHub Actions typer forces rich terminal rendering, which interleaves ANSI
+    style codes even inside option names (``--password`` renders as ``-`` and
+    ``-password`` in separate style spans), and rich wraps text inside panel borders.
+    Strip the styling and borders and collapse whitespace so assertions see the words.
+    """
+    return " ".join(ANSI_ESCAPE.sub("", output).replace("│", " ").split())
 
 
 def test_backup_only_regex_invalid_pattern(tmp_path):
@@ -12,8 +27,9 @@ def test_backup_only_regex_invalid_pattern(tmp_path):
     result = runner.invoke(__main__.app, ["backup2", "backup", "--only-regex", "[", str(tmp_path)])
 
     assert result.exit_code != 0
-    assert "Invalid value for '--only-regex'" in result.output
-    assert "Invalid regex pattern '['" in result.output
+    output = plain_cli_output(result.output)
+    assert "Invalid value for '--only-regex'" in output
+    assert "Invalid regex pattern '['" in output
 
 
 def test_backup_command_has_password_option():
@@ -22,7 +38,7 @@ def test_backup_command_has_password_option():
     result = runner.invoke(__main__.app, ["backup2", "backup", "--help"])
 
     assert result.exit_code == 0
-    assert "--password" in result.output
+    assert "--password" in plain_cli_output(result.output)
 
 
 def test_backup_command_has_unback_option():
@@ -31,7 +47,7 @@ def test_backup_command_has_unback_option():
     result = runner.invoke(__main__.app, ["backup2", "backup", "--help"])
 
     assert result.exit_code == 0
-    assert "--unback" in result.output
+    assert "--unback" in plain_cli_output(result.output)
 
 
 def test_backup_command_has_patch_manifest_option():
@@ -40,7 +56,7 @@ def test_backup_command_has_patch_manifest_option():
     result = runner.invoke(__main__.app, ["backup2", "backup", "--help"])
 
     assert result.exit_code == 0
-    assert "--patch-manifest" in result.output
+    assert "--patch-manifest" in plain_cli_output(result.output)
 
 
 def test_filtered_unback_requires_patched_manifest():
@@ -59,7 +75,7 @@ def test_backup_command_offers_messages_selection():
     result = runner.invoke(__main__.app, ["backup2", "backup", "--help"])
 
     assert result.exit_code == 0
-    assert "messages" in result.output
+    assert "messages" in plain_cli_output(result.output)
 
 
 def test_encryption_mode_without_password_fails_with_usage_error():
@@ -68,7 +84,7 @@ def test_encryption_mode_without_password_fails_with_usage_error():
     result = runner.invoke(__main__.app, ["backup2", "encryption", "on"])
 
     assert result.exit_code != 0
-    assert "PASSWORD is required" in result.output
+    assert "PASSWORD is required" in plain_cli_output(result.output)
 
 
 def test_encryption_help_documents_no_args_state_query():
@@ -77,8 +93,7 @@ def test_encryption_help_documents_no_args_state_query():
     result = runner.invoke(__main__.app, ["backup2", "encryption", "--help"])
 
     assert result.exit_code == 0
-    normalized_output = " ".join(result.output.replace("│", " ").split())
-    assert "current encryption state" in normalized_output
+    assert "current encryption state" in plain_cli_output(result.output)
 
 
 def test_backup_full_help_describes_conditional_default():
@@ -87,9 +102,7 @@ def test_backup_full_help_describes_conditional_default():
     result = runner.invoke(__main__.app, ["backup2", "backup", "--help"])
 
     assert result.exit_code == 0
-    # Rich wraps the help text inside panel borders, so strip the box-drawing
-    # characters before joining lines back into a single string
-    normalized_output = " ".join(result.output.replace("│", " ").split())
+    normalized_output = plain_cli_output(result.output)
     assert "incremental" in normalized_output
     assert "valid local metadata exists" in normalized_output
     assert "full for an" in normalized_output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,23 @@ def pytest_addoption(parser):
 
 NO_DEVICE_SKIP_REASON = "No test device is available through usbmuxd"
 
+# Fixtures that open a connection to a physical device. Tests reaching a device any
+# other way must carry an explicit ``@pytest.mark.device``.
+DEVICE_FIXTURES = frozenset({"lockdown", "service_provider", "dvt", "xcuitest_service"})
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Auto-mark every test whose fixture closure reaches a physical device.
+
+    CI runs ``pytest -m "not device"``, so the device-free portion of the suite is
+    exercised on every merge without test authors having to remember a marker: using
+    one of the device-backed fixtures (directly or through a derived fixture) is what
+    makes a test a device test.
+    """
+    for item in items:
+        if DEVICE_FIXTURES.intersection(getattr(item, "fixturenames", ())):
+            item.add_marker(pytest.mark.device)
+
 
 def _skip_unless_tunneled(item: pytest.Item, e: InvalidServiceError) -> None:
     funcargs = item.funcargs if isinstance(item, pytest.Function) else {}


### PR DESCRIPTION
CI previously ran only `pytest -m cli` (122 tests), leaving the other ~260 device-free tests unexercised on merges.

## Approach

Device-ness is now **derived, not declared**: a collection hook in `tests/conftest.py` auto-applies a `device` marker to every test whose fixture closure includes one of the device-backed fixtures (`lockdown`, `service_provider`, `dvt`, `xcuitest_service`). Derived fixtures are covered transitively (e.g. `webdriver` builds on `lockdown`), so test authors never have to remember a marker — using a device fixture is what makes a device test. An explicit `@pytest.mark.device` remains available for any future test that reaches a device without the shared fixtures; today none do (audited the suite for direct `usbmux`/tunnel connections — everything funnels through the fixtures or mocks).

CI now runs `pytest -m "not device"`: **385 tests** (vs 122), with 160 device tests deselected. The workflow's path filter also gains `tests/**` and `pytest.ini`, since test changes now affect CI outcomes.

## Verified

- `pytest -m "not device"` with a device attached (deselection proves the partition): 383 passed, 2 environment skips, ~18 s
- Same via CI's literal harness on the 3.9 floor: `uv run --python 3.9 --isolated --extra test pytest -m "not device"` — identical results
- `pyright --venvpath .` clean

Windows/Linux legs run for real on this PR since the workflow change itself is exercised here.