### PR TITLE
syslog: Apply line filters in JSON output mode

### DIFF
--- a/pymobiledevice3/cli/syslog.py
+++ b/pymobiledevice3/cli/syslog.py
@@ -241,30 +241,31 @@ async def syslog_live(
             # Console.app behavior
             continue
 
+        # Filters always run against the plain rendered line, so a given set of flags
+        # selects the same entries regardless of output format.
+        line = format_line(
+            syslog_entry,
+            include_label=include_label,
+            image_offset=image_offset,
+            color=False,
+        )
+
+        if not started:
+            assert start_after is not None  # started is initialized True when start_after is None
+            if start_after not in line:
+                continue
+            started = True
+
+        if _should_skip_line(line, invert_match, invert_match_insensitive):
+            continue
+
+        if not _should_keep_line(line, match, match_insensitive, match_regex):
+            continue
+
         if output_format is SyslogFormat.JSON:
-            json_line = format_json_line(syslog_entry)
-            _emit_line(json_line, out)
+            _emit_line(format_json_line(syslog_entry), out)
 
         elif output_format is SyslogFormat.TEXT:
-            line = format_line(
-                syslog_entry,
-                include_label=include_label,
-                image_offset=image_offset,
-                color=False,
-            )
-
-            if not started:
-                assert start_after is not None  # started is initialized True when start_after is None
-                if start_after not in line:
-                    continue
-                started = True
-
-            if _should_skip_line(line, invert_match, invert_match_insensitive):
-                continue
-
-            if not _should_keep_line(line, match, match_insensitive, match_regex):
-                continue
-
             if should_color_output:
                 styled_line = format_line(
                     syslog_entry,
@@ -314,8 +315,7 @@ async def cli_syslog_live(
         typer.Option(
             "--match",
             "-m",
-            help="filter only logs matching this expression "
-            "(repeatable; all must match - conjunction). Text mode only.",
+            help="filter only logs matching this expression (repeatable; all must match - conjunction).",
         ),
     ] = None,
     invert_match: Annotated[
@@ -323,8 +323,7 @@ async def cli_syslog_live(
         typer.Option(
             "--invert-match",
             "-v",
-            help="filter only logs not matching this expression "
-            "(repeatable; any match excludes - disjunction). Text mode only.",
+            help="filter only logs not matching this expression (repeatable; any match excludes - disjunction).",
         ),
     ] = None,
     match_insensitive: Annotated[
@@ -333,7 +332,7 @@ async def cli_syslog_live(
             "--match-insensitive",
             "-mi",
             help="filter only logs matching this expression, case-insensitively "
-            "(repeatable; all must match - conjunction). Text mode only.",
+            "(repeatable; all must match - conjunction).",
         ),
     ] = None,
     invert_match_insensitive: Annotated[
@@ -342,14 +341,14 @@ async def cli_syslog_live(
             "--invert-match-insensitive",
             "-vi",
             help="filter only logs not matching this expression, case-insensitively "
-            "(repeatable; any match excludes - disjunction). Text mode only.",
+            "(repeatable; any match excludes - disjunction).",
         ),
     ] = None,
     include_label: Annotated[
         bool,
         typer.Option(
             "--label",
-            help="should include label (text mode only; JSON always emits the label field).",
+            help="Include the [subsystem][category] label in the rendered line (JSON output always emits the label field).",
         ),
     ] = False,
     regex: Annotated[
@@ -357,8 +356,7 @@ async def cli_syslog_live(
         typer.Option(
             "--regex",
             "-e",
-            help="filter only lines matching given regex "
-            "(repeatable; any match includes - disjunction). Text mode only.",
+            help="filter only lines matching given regex (repeatable; any match includes - disjunction).",
         ),
     ] = None,
     insensitive_regex: Annotated[
@@ -367,7 +365,7 @@ async def cli_syslog_live(
             "--insensitive-regex",
             "-ei",
             help="filter only lines matching given regex, case-insensitively "
-            "(repeatable; any match includes - disjunction). Text mode only.",
+            "(repeatable; any match includes - disjunction).",
         ),
     ] = None,
     image_offset: Annotated[
@@ -396,15 +394,15 @@ async def cli_syslog_live(
         Optional[str],
         typer.Option(
             "--start-after",
-            help="Start printing only after this string is seen. Text mode only.",
+            help="Start printing only after this string is seen.",
         ),
     ] = None,
     output_format: Annotated[
         SyslogFormat,
         typer.Option(
             "--format",
-            help="Output format. 'json' emits one JSON per line (NDJSON); only --pid and --process-name "
-            "apply, other filters are ignored.",
+            help="Output format. 'json' emits one JSON object per line (NDJSON). Filters match against "
+            "the rendered text line in both formats.",
             case_sensitive=False,
         ),
     ] = SyslogFormat.TEXT,

--- a/tests/cli/test_syslog.py
+++ b/tests/cli/test_syslog.py
@@ -385,27 +385,47 @@ async def test_syslog_live_json_emits_valid_ndjson(monkeypatch, capsys):
 
 
 @pytest.mark.asyncio
-async def test_syslog_live_json_ignores_text_filters(monkeypatch, capsys):
-    # Every text-mode filter flag must be ignored in JSON mode.
+async def test_syslog_live_json_applies_text_filters(monkeypatch, capsys):
+    # The line filters select the same entries in JSON mode as in text mode.
     printed_lines, _ = await _run_syslog_live(
         monkeypatch,
         capsys,
-        _create_syslog_entries(["keep this", "skip this"]),
+        _create_syslog_entries(["keep this", "skip this", "keep but drop"]),
         output_format=syslog_module.SyslogFormat.JSON,
         match=["keep"],
-        invert_match=["skip"],
+        invert_match=["drop"],
         match_insensitive=["KEEP"],
         invert_match_insensitive=["SKIP"],
         regex=["keep"],
-        insensitive_regex=["KEEP"],
-        start_after="never-appears",
-        include_label=True,
-        image_offset=True,
+        insensitive_regex=["THIS"],
     )
-    # All entries emitted; none are filtered out.
-    assert len(printed_lines) == 2
-    messages = [json.loads(line)["message"] for line in printed_lines]
-    assert messages == ["keep this", "skip this"]
+    assert [json.loads(line)["message"] for line in printed_lines] == ["keep this"]
+
+
+@pytest.mark.asyncio
+async def test_syslog_live_json_applies_start_after(monkeypatch, capsys):
+    printed_lines, _ = await _run_syslog_live(
+        monkeypatch,
+        capsys,
+        _create_syslog_entries(["before", "MARKER hit", "after"]),
+        output_format=syslog_module.SyslogFormat.JSON,
+        start_after="MARKER",
+    )
+    assert [json.loads(line)["message"] for line in printed_lines] == ["MARKER hit", "after"]
+
+
+@pytest.mark.asyncio
+async def test_syslog_live_json_filters_see_rendered_line_not_only_message(monkeypatch, capsys):
+    # Filters run against the same rendered text line as text mode, so metadata
+    # (process name, level, ...) is matchable even when absent from the message.
+    printed_lines, _ = await _run_syslog_live(
+        monkeypatch,
+        capsys,
+        _create_syslog_entries(["plain message"]),
+        output_format=syslog_module.SyslogFormat.JSON,
+        match=["test-process"],
+    )
+    assert [json.loads(line)["message"] for line in printed_lines] == ["plain message"]
 
 
 @pytest.mark.asyncio
@@ -482,7 +502,7 @@ async def test_syslog_live_json_suppresses_start_after_banner(monkeypatch, capsy
         capsys,
         _create_syslog_entries(["one"]),
         output_format=syslog_module.SyslogFormat.JSON,
-        start_after="anything",
+        start_after="one",
     )
     assert len(printed_lines) == 1
     # The single line must parse as valid JSON — no banner contamination.


### PR DESCRIPTION
`syslog live --format json` silently ignored `--match`/`--invert-match`, their case-insensitive variants, the regex filters, and `--start-after` — only `--pid` and `--process-name` applied, and the help text documented the limitation instead of fixing it.

## Change

Filters now always run against the same plain rendered text line that text mode uses, so a given set of flags selects the identical entries in both formats — the output format only changes serialization. Implementation hoists the plain `format_line()` + start-after/skip/keep checks above the format branch; color, match highlighting, and the `Waiting for "..."` banner stay text-only so stdout remains pure NDJSON. Help texts drop the "Text mode only" caveats.

Note this also means `--label`/`--image-offset` affect what filters see (they change the rendered line), consistently with text mode.

## Verified

- New tests (failing on master): filters select/exclude in JSON mode, `--start-after` applies, and filters see the rendered line (process-name matchable), plus the inverted old-contract test
- Live on device: `syslog live --format json -m kernel` emits only `/kernel` entries, every line valid JSON
- Full device-free suite (393 passed) both plain and with `GITHUB_ACTIONS=true`; pyright clean