### PR TITLE
syslog: Reword --label help so the generated docs build again

### DIFF
--- a/pymobiledevice3/cli/syslog.py
+++ b/pymobiledevice3/cli/syslog.py
@@ -348,7 +348,8 @@ async def cli_syslog_live(
         bool,
         typer.Option(
             "--label",
-            help="Include the [subsystem][category] label in the rendered line (JSON output always emits the label field).",
+            help="Include the subsystem/category label in the rendered line "
+            "(JSON output always emits the label field).",
         ),
     ] = False,
     regex: Annotated[


### PR DESCRIPTION
The docs deploy on master broke with #1837: the new `--label` help text contained `[subsystem][category]`, which Markdown parses as a reference-style link when `gen_cli_reference` renders help text into `cli/syslog.md`. mkdocs strict mode aborts on the unresolved autoref target ("Could not find cross-reference target 'category'"), so the Pages deploy stopped (the site kept serving the previous build).

Reworded to prose without brackets. Verified with CI's literal command: `python -m mkdocs build --strict` completes cleanly.