### PR TITLE
cli: Machine-readable output contract ($hex bytes, ISO dates, NDJSON streams)

### DIFF
--- a/.codex/skills/pymobiledevice3-device-operator/SKILL.md
+++ b/.codex/skills/pymobiledevice3-device-operator/SKILL.md
@@ -43,6 +43,20 @@ Prefer existing CLI commands first. Prefer reading local docs and CLI source ove
 6. For long-lived streams or interactive shells, keep the process attached instead of replacing it with one-shot polling.
 7. If the CLI is missing a path that clearly exists in services, add a thin command using `ServiceProviderDep`, `@async_command`, and a service class under `pymobiledevice3/services/` — commands live on an `InjectingTyper` app (from `typer_injector`). Read `docs/guides/writing-commands-with-service-provider.md`.
 
+## Parsing Command Output
+
+Prefer machine-readable output over scraping human text — the contract is documented in
+`docs/guides/machine-readable-output.md` (published on the docs site):
+
+- Data goes to stdout; logging and diagnostics go to stderr. Parse stdout only.
+- Most query commands print JSON unconditionally. Binary values appear as single-key
+  `{"$hex": "..."}` objects (decode with `bytes.fromhex`); timestamps are ISO 8601.
+- Streaming commands emit NDJSON (one JSON object per line): dict-record streams
+  (`dvt energy`/`notifications`/`graphics`, `diagnostics battery monitor`,
+  `notification observe`/`observe-all`) always; human-rendered streams (`syslog live`,
+  `dvt oslog`, `dvt netstat`, `accessibility notifications`, `crash watch`) with
+  `--format json`.
+
 ## Safety Rules
 
 Require explicit user intent before any command that changes device state, including:

--- a/docs/guides/machine-readable-output.md
+++ b/docs/guides/machine-readable-output.md
@@ -1,0 +1,72 @@
+# Machine-readable output
+
+Most query-style `pymobiledevice3` commands print JSON on stdout, ready for `jq` or any JSON
+parser. This page documents the conventions that output follows so scripts can rely on them.
+
+## Streams
+
+- **stdout carries data.** JSON documents, NDJSON records, and text-mode data lines all go to
+  stdout.
+- **stderr carries diagnostics.** Logging, progress, and warnings never mix into the data
+  stream. Redirect stderr away (`2>/dev/null`) without losing any data.
+
+## Binary values
+
+JSON has no binary type. Values that are `bytes` on the device (nonces, digests, keys,
+certificates) are encoded as a single-key object tagged `$hex`:
+
+```json
+{
+    "ApNonce": {
+        "$hex": "a1b2c3d4"
+    }
+}
+```
+
+Decode with `bytes.fromhex` in Python, or in `jq` keep the hex string with `.ApNonce["$hex"]`.
+A `$hex` object never has additional keys, so `isinstance(value, dict) and value.keys() == {"$hex"}`
+is a reliable detector when round-tripping arbitrary output:
+
+```python
+def decode(obj):
+    if isinstance(obj, dict):
+        if obj.keys() == {"$hex"}:
+            return bytes.fromhex(obj["$hex"])
+        return {k: decode(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [decode(v) for v in obj]
+    return obj
+```
+
+## Timestamps
+
+Datetimes are ISO 8601 (`datetime.isoformat()`), e.g. `2026-08-08T12:00:00+03:00`. Values
+without an explicit timezone are naive device- or host-local times.
+
+## Streaming commands: NDJSON
+
+Streaming commands print one compact JSON object per line (NDJSON) on stdout — nothing else
+is written to stdout, so the stream can be piped directly:
+
+```shell
+pymobiledevice3 syslog live --format json -m kernel | jq .message
+pymobiledevice3 diagnostics battery monitor | jq .CurrentCapacity
+```
+
+Streams whose records are structured data emit NDJSON always:
+
+- `developer dvt graphics`
+- `developer dvt energy`
+- `developer dvt notifications`
+- `developer dvt sysmon process monitor` (JSONL, optionally to a file via `--output`)
+- `diagnostics battery monitor`
+- `notification observe` / `notification observe-all`
+
+Streams that also have a human-readable text rendering default to it and accept
+`--format json`:
+
+- `syslog live`
+- `developer dvt oslog`
+- `developer dvt netstat`
+- `developer accessibility notifications`
+- `crash watch`

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/SKILL.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/SKILL.md
@@ -43,6 +43,20 @@ Prefer existing CLI commands first. Prefer reading local docs and CLI source ove
 6. For long-lived streams or interactive shells, keep the process attached instead of replacing it with one-shot polling.
 7. If the CLI is missing a path that clearly exists in services, add a thin command using `ServiceProviderDep`, `@async_command`, and a service class under `pymobiledevice3/services/` — commands live on an `InjectingTyper` app (from `typer_injector`). Read `docs/guides/writing-commands-with-service-provider.md`.
 
+## Parsing Command Output
+
+Prefer machine-readable output over scraping human text — the contract is documented in
+`docs/guides/machine-readable-output.md` (published on the docs site):
+
+- Data goes to stdout; logging and diagnostics go to stderr. Parse stdout only.
+- Most query commands print JSON unconditionally. Binary values appear as single-key
+  `{"$hex": "..."}` objects (decode with `bytes.fromhex`); timestamps are ISO 8601.
+- Streaming commands emit NDJSON (one JSON object per line): dict-record streams
+  (`dvt energy`/`notifications`/`graphics`, `diagnostics battery monitor`,
+  `notification observe`/`observe-all`) always; human-rendered streams (`syslog live`,
+  `dvt oslog`, `dvt netstat`, `accessibility notifications`, `crash watch`) with
+  `--format json`.
+
 ## Safety Rules
 
 Require explicit user intent before any command that changes device state, including:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ plugins:
           - guides/cli-recipes.md
           - guides/ios17-tunnels.md
           - guides/webview-debugging.md
+          - guides/machine-readable-output.md
           - guides/python-api.md
           - guides/writing-commands-with-service-provider.md
           - guides/troubleshooting.md
@@ -117,6 +118,7 @@ nav:
       - CLI recipes: guides/cli-recipes.md
       - iOS 17+ tunnels: guides/ios17-tunnels.md
       - WebView debugging: guides/webview-debugging.md
+      - Machine-readable output: guides/machine-readable-output.md
       - Python API: guides/python-api.md
       - Writing CLI commands: guides/writing-commands-with-service-provider.md
       - Device operator skill: guides/codex-device-operator-skill.md

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -7,6 +7,7 @@ import sys
 import uuid
 from collections.abc import Coroutine
 from contextlib import suppress
+from enum import Enum
 from functools import wraps
 from textwrap import dedent
 from typing import Annotated, Any, Callable, Optional, TypeVar, cast
@@ -56,6 +57,21 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
+class OutputFormat(str, Enum):
+    TEXT = "text"
+    JSON = "json"
+
+
+OutputFormatOption = Annotated[
+    OutputFormat,
+    typer.Option(
+        "--format",
+        help="Output format. 'json' emits one JSON object per line (NDJSON) on stdout.",
+        case_sensitive=False,
+    ),
+]
+
+
 def default_json_encoder(obj: Any) -> Any:
     """Encode the non-JSON-native types found in device responses.
 
@@ -70,6 +86,11 @@ def default_json_encoder(obj: Any) -> Any:
     if isinstance(obj, uuid.UUID):
         return str(obj)
     raise TypeError()
+
+
+def print_json_line(obj: Any) -> None:
+    """Emit one compact NDJSON record on stdout — the streaming counterpart of :func:`print_json`."""
+    print(json.dumps(obj, default=default_json_encoder, ensure_ascii=False), flush=True)
 
 
 def print_json(buf: Any, colored: Optional[bool] = None, default: Callable[[Any], Any] = default_json_encoder) -> str:

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -56,11 +56,17 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def default_json_encoder(obj: Any) -> str:
+def default_json_encoder(obj: Any) -> Any:
+    """Encode the non-JSON-native types found in device responses.
+
+    ``bytes`` become a single-key ``{"$hex": "..."}`` object so consumers can detect
+    and decode binary values unambiguously (``bytes.fromhex``); datetimes are ISO 8601.
+    This is the machine-readable output contract — see docs/guides/machine-readable-output.md.
+    """
     if isinstance(obj, bytes):
-        return f"<{obj.hex()}>"
+        return {"$hex": obj.hex()}
     if isinstance(obj, datetime.datetime):
-        return str(obj)
+        return obj.isoformat()
     if isinstance(obj, uuid.UUID):
         return str(obj)
     raise TypeError()

--- a/pymobiledevice3/cli/crash.py
+++ b/pymobiledevice3/cli/crash.py
@@ -1,10 +1,16 @@
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Optional, cast
 
 import typer
 from typer_injector import InjectingTyper
 
-from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command
+from pymobiledevice3.cli.cli_common import (
+    OutputFormat,
+    OutputFormatOption,
+    ServiceProviderDep,
+    async_command,
+    print_json_line,
+)
 from pymobiledevice3.services.crash_reports import CrashReportsManager, CrashReportsShell
 
 cli = InjectingTyper(
@@ -155,11 +161,28 @@ async def crash_watch(
         bool,
         typer.Option("--raw", "-r"),
     ] = False,
+    output_format: OutputFormatOption = OutputFormat.TEXT,
 ) -> None:
     """watch for crash report generation"""
     async with CrashReportsManager(service_provider) as crash_manager:
         async for crash_report in crash_manager.watch(name=name, raw=raw):
-            print(crash_report)
+            if output_format is OutputFormat.JSON:
+                if isinstance(crash_report, str):
+                    print_json_line({"content": crash_report})
+                else:
+                    print_json_line({
+                        "name": crash_report.name,
+                        "bug_type": crash_report.bug_type,
+                        "bug_type_str": crash_report.bug_type_str,
+                        # pycrashreport's incident_id property is untyped (metadata lookup)
+                        "incident_id": cast(
+                            Optional[str],
+                            crash_report.incident_id,  # pyright: ignore[reportUnknownMemberType]
+                        ),
+                        "timestamp": crash_report.timestamp,
+                    })
+            else:
+                print(crash_report, flush=True)
 
 
 @cli.command("sysdiagnose")

--- a/pymobiledevice3/cli/developer/accessibility/__init__.py
+++ b/pymobiledevice3/cli/developer/accessibility/__init__.py
@@ -3,7 +3,14 @@ from typing import Any
 
 from typer_injector import InjectingTyper
 
-from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command, print_json
+from pymobiledevice3.cli.cli_common import (
+    OutputFormat,
+    OutputFormatOption,
+    ServiceProviderDep,
+    async_command,
+    print_json,
+    print_json_line,
+)
 from pymobiledevice3.cli.developer.accessibility import settings
 from pymobiledevice3.services.accessibilityaudit import AccessibilityAudit
 
@@ -48,7 +55,9 @@ def accessibility_shell(service_provider: ServiceProviderDep) -> None:
 
 @cli.command("notifications")
 @async_command
-async def accessibility_notifications(service_provider: ServiceProviderDep) -> None:
+async def accessibility_notifications(
+    service_provider: ServiceProviderDep, output_format: OutputFormatOption = OutputFormat.TEXT
+) -> None:
     """show notifications"""
     service = AccessibilityAudit(service_provider)
     async for event in service.iter_events():
@@ -57,7 +66,10 @@ async def accessibility_notifications(service_provider: ServiceProviderDep) -> N
             "hostInspectorCurrentElementChanged:",
         ):
             for focus_item in event.data:
-                logger.info(focus_item)
+                if output_format is OutputFormat.JSON:
+                    print_json_line(focus_item.to_dict())
+                else:
+                    print(focus_item, flush=True)
 
 
 @cli.command("list-items")

--- a/pymobiledevice3/cli/developer/dvt/__init__.py
+++ b/pymobiledevice3/cli/developer/dvt/__init__.py
@@ -15,9 +15,12 @@ from typer_injector import InjectingTyper
 
 from pymobiledevice3.cli.cli_common import (
     OSUTILS,
+    OutputFormat,
+    OutputFormatOption,
     ServiceProviderDep,
     async_command,
     print_json,
+    print_json_line,
     user_requested_colored_output,
 )
 from pymobiledevice3.cli.developer.dvt import core_profile_session, simulate_location, sysmon
@@ -386,15 +389,28 @@ async def device_information(service_provider: ServiceProviderDep) -> None:
 
 @cli.command("netstat")
 @async_command
-async def netstat(service_provider: ServiceProviderDep) -> None:
+async def netstat(service_provider: ServiceProviderDep, output_format: OutputFormatOption = OutputFormat.TEXT) -> None:
     """Print information about current network activity."""
     async with DvtProvider(service_provider) as dvt, NetworkMonitor(dvt) as monitor:
         async for event in monitor:
             if isinstance(event, ConnectionDetectionEvent):
-                logger.info(
-                    f"Connection detected: {event.local_address.data.address}:{event.local_address.port} -> "
-                    f"{event.remote_address.data.address}:{event.remote_address.port}"
-                )
+                if output_format is OutputFormat.JSON:
+                    print_json_line({
+                        "event": "connection_detected",
+                        "local": {"address": str(event.local_address.data.address), "port": event.local_address.port},
+                        "remote": {
+                            "address": str(event.remote_address.data.address),
+                            "port": event.remote_address.port,
+                        },
+                        "pid": event.pid,
+                        "interface_index": event.interface_index,
+                    })
+                else:
+                    print(
+                        f"Connection detected: {event.local_address.data.address}:{event.local_address.port} -> "
+                        f"{event.remote_address.data.address}:{event.remote_address.port}",
+                        flush=True,
+                    )
 
 
 @cli.command("screenshot")
@@ -539,7 +555,11 @@ async def dvt_name_for_gid(service_provider: ServiceProviderDep, gid: int) -> No
 
 @cli.command("oslog")
 @async_command
-async def dvt_oslog(service_provider: ServiceProviderDep, pid: Optional[int] = None) -> None:
+async def dvt_oslog(
+    service_provider: ServiceProviderDep,
+    pid: Optional[int] = None,
+    output_format: OutputFormatOption = OutputFormat.TEXT,
+) -> None:
     """Sniff device oslog (not very stable, but includes more data and normal syslog)"""
     async with DvtProvider(service_provider) as dvt, ActivityTraceTap(dvt) as tap:
         async for message in cast(AsyncIterator[Any], tap):
@@ -562,6 +582,18 @@ async def dvt_oslog(service_provider: ServiceProviderDep, pid: Optional[int] = N
                 continue
 
             formatted_message = decode_message_format(message.message) if message.message else message.name
+
+            if output_format is OutputFormat.JSON:
+                print_json_line({
+                    "timestamp": timestamp,
+                    "pid": message_pid,
+                    "message_type": message_type,
+                    "subsystem": subsystem,
+                    "category": category,
+                    "image_name": image_name,
+                    "message": formatted_message,
+                })
+                continue
 
             if user_requested_colored_output():
                 timestamp = typer.style(str(timestamp), bold=True)
@@ -593,7 +625,7 @@ async def dvt_energy(service_provider: ServiceProviderDep, pid_list: list[str]) 
         EnergyMonitor(dvt, pid_int_list) as energy_monitor,
     ):
         async for telemetry in energy_monitor:
-            logger.info(telemetry)
+            print_json_line(telemetry)
 
 
 @cli.command("notifications")
@@ -602,7 +634,7 @@ async def dvt_notifications(service_provider: ServiceProviderDep) -> None:
     """Monitor memory and app notifications"""
     async with DvtProvider(service_provider) as dvt, Notifications(dvt) as notifications:
         async for notification in notifications:
-            logger.info(notification)
+            print_json_line(notification)
 
 
 @cli.command("graphics")
@@ -611,7 +643,7 @@ async def dvt_graphics(service_provider: ServiceProviderDep) -> None:
     """Monitor graphics-related information"""
     async with DvtProvider(service_provider) as dvt, Graphics(dvt) as graphics:
         async for stats in graphics:
-            logger.info(stats)
+            print_json_line(stats)
 
 
 @cli.command("har")

--- a/pymobiledevice3/cli/diagnostics/battery.py
+++ b/pymobiledevice3/cli/diagnostics/battery.py
@@ -3,7 +3,7 @@ import logging
 
 from typer_injector import InjectingTyper
 
-from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command, print_json
+from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command, print_json, print_json_line
 from pymobiledevice3.exceptions import MissingValueError
 from pymobiledevice3.services.diagnostics import DiagnosticsService
 
@@ -44,7 +44,7 @@ async def diagnostics_battery_monitor(service_provider: ServiceProviderDep) -> N
             "IsCharging": raw_info.get("IsCharging"),
             "CurrentCapacity": raw_info.get("CurrentCapacity"),
         }
-        logger.info(info)
+        print_json_line(info)
         await asyncio.sleep(1)
 
 

--- a/pymobiledevice3/cli/notification.py
+++ b/pymobiledevice3/cli/notification.py
@@ -5,7 +5,7 @@ from typing import Annotated, Union
 import typer
 from typer_injector import InjectingTyper
 
-from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command
+from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command, print_json_line
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
 from pymobiledevice3.resources.firmware_notifications import get_notifications
@@ -78,7 +78,7 @@ async def observe(
             await service.notify_register_dispatch(name)
 
         async for event in service.receive_notification():
-            logger.info(event)
+            print_json_line(event)
 
 
 @cli.command("observe-all")
@@ -95,4 +95,4 @@ async def observe_all(
             await service.notify_register_dispatch(notification)
 
         async for event in service.receive_notification():
-            logger.info(event)
+            print_json_line(event)

--- a/pymobiledevice3/cli/processes.py
+++ b/pymobiledevice3/cli/processes.py
@@ -1,12 +1,7 @@
-import logging
-
 from typer_injector import InjectingTyper
 
 from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command, print_json
 from pymobiledevice3.services.os_trace import OsTraceService
-
-logger = logging.getLogger(__name__)
-
 
 cli = InjectingTyper(
     name="processes",
@@ -27,7 +22,9 @@ async def processes_ps(service_provider: ServiceProviderDep) -> None:
 async def processes_pgrep(service_provider: ServiceProviderDep, expression: str) -> None:
     """try to match processes pid by given expression (like pgrep)"""
     processes_list = (await OsTraceService(lockdown=service_provider).get_pid_list()).get("Payload")
-    for pid, process_info in processes_list.items():
-        process_name = process_info.get("ProcessName")
-        if expression in process_name:
-            logger.info(f"{pid} {process_name}")
+    matches = [
+        {"pid": pid, "name": process_info.get("ProcessName")}
+        for pid, process_info in processes_list.items()
+        if expression in process_info.get("ProcessName")
+    ]
+    print_json(matches)

--- a/tests/cli/developer/dvt/test_dvt_streams.py
+++ b/tests/cli/developer/dvt/test_dvt_streams.py
@@ -1,0 +1,159 @@
+import ipaddress
+import json
+from typing import cast
+
+import pytest
+
+from pymobiledevice3.cli.cli_common import OutputFormat
+from pymobiledevice3.cli.developer import dvt as dvt_module
+from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+from pymobiledevice3.services.dvt.instruments.network_monitor import (
+    AddressV4,
+    ConnectionDetectionEvent,
+    SocketAddress,
+)
+
+pytestmark = [pytest.mark.cli]
+
+_FAKE_SERVICE_PROVIDER = cast(LockdownServiceProvider, object())
+
+
+class _FakeDvtProvider:
+    def __init__(self, service_provider):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _fake_stream(items):
+    class _Stream:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def __aiter__(self):
+            return self._generate()
+
+        async def _generate(self):
+            for item in items:
+                yield item
+
+    return _Stream
+
+
+@pytest.fixture(autouse=True)
+def _fake_dvt(monkeypatch):
+    monkeypatch.setattr(dvt_module, "DvtProvider", _FakeDvtProvider)
+
+
+def test_energy_emits_ndjson_records(monkeypatch, capsys):
+    samples = [{"energy.cost": 1.5}, {"energy.cost": 2.5}]
+    monkeypatch.setattr(dvt_module, "EnergyMonitor", _fake_stream(samples))
+
+    dvt_module.dvt_energy(_FAKE_SERVICE_PROVIDER, ["123"])
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert [json.loads(line) for line in lines] == samples
+
+
+def test_notifications_emits_ndjson_records(monkeypatch, capsys):
+    events = [{"execName": "app", "state": 4}]
+    monkeypatch.setattr(dvt_module, "Notifications", _fake_stream(events))
+
+    dvt_module.dvt_notifications(_FAKE_SERVICE_PROVIDER)
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert [json.loads(line) for line in lines] == events
+
+
+def test_graphics_emits_ndjson_records(monkeypatch, capsys):
+    samples = [{"CoreAnimationFramesPerSecond": 60}]
+    monkeypatch.setattr(dvt_module, "Graphics", _fake_stream(samples))
+
+    dvt_module.dvt_graphics(_FAKE_SERVICE_PROVIDER)
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert [json.loads(line) for line in lines] == samples
+
+
+def _connection_event() -> ConnectionDetectionEvent:
+    def address(ip: str, port: int) -> SocketAddress:
+        return SocketAddress(
+            length=0x10,
+            family=2,
+            port=port,
+            data=AddressV4(address=ipaddress.IPv4Address(ip), _zero=b"\x00" * 8),
+        )
+
+    return ConnectionDetectionEvent(
+        local_address=address("10.0.0.1", 5000),
+        remote_address=address("17.0.0.1", 443),
+        interface_index=1,
+        pid=42,
+        recv_buffer_size=0,
+        recv_buffer_used=0,
+        serial_number=7,
+        kind=1,
+    )
+
+
+def test_netstat_json_emits_connection_records(monkeypatch, capsys):
+    monkeypatch.setattr(dvt_module, "NetworkMonitor", _fake_stream([_connection_event()]))
+
+    dvt_module.netstat(_FAKE_SERVICE_PROVIDER, output_format=OutputFormat.JSON)
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert [json.loads(line) for line in lines] == [
+        {
+            "event": "connection_detected",
+            "local": {"address": "10.0.0.1", "port": 5000},
+            "remote": {"address": "17.0.0.1", "port": 443},
+            "pid": 42,
+            "interface_index": 1,
+        }
+    ]
+
+
+def test_netstat_text_prints_connection_line_to_stdout(monkeypatch, capsys):
+    monkeypatch.setattr(dvt_module, "NetworkMonitor", _fake_stream([_connection_event()]))
+
+    dvt_module.netstat(_FAKE_SERVICE_PROVIDER, output_format=OutputFormat.TEXT)
+
+    captured = capsys.readouterr()
+    assert "10.0.0.1:5000 -> 17.0.0.1:443" in captured.out
+
+
+class _FakeOslogMessage:
+    process = 42
+    message_type = "Default"
+    sender_image_path = "/usr/lib/libfoo.dylib"
+    subsystem = "com.apple.test"
+    category = "general"
+    message = None
+    name = "hello world"
+
+
+def test_oslog_json_emits_ndjson_records(monkeypatch, capsys):
+    monkeypatch.setattr(dvt_module, "ActivityTraceTap", _fake_stream([_FakeOslogMessage()]))
+
+    dvt_module.dvt_oslog(_FAKE_SERVICE_PROVIDER, output_format=OutputFormat.JSON)
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["pid"] == 42
+    assert record["message_type"] == "Default"
+    assert record["subsystem"] == "com.apple.test"
+    assert record["category"] == "general"
+    assert record["image_name"] == "libfoo.dylib"
+    assert record["message"] == "hello world"
+    assert "timestamp" in record

--- a/tests/cli/developer/test_accessibility_notifications.py
+++ b/tests/cli/developer/test_accessibility_notifications.py
@@ -1,0 +1,52 @@
+import json
+from typing import ClassVar, cast
+
+import pytest
+
+from pymobiledevice3.cli.cli_common import OutputFormat
+from pymobiledevice3.cli.developer import accessibility as accessibility_module
+from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+
+pytestmark = [pytest.mark.cli]
+
+_FAKE_SERVICE_PROVIDER = cast(LockdownServiceProvider, object())
+
+
+class _FakeFocusItem:
+    def to_dict(self):
+        return {"caption": "Settings", "element": {"$hexish": "irrelevant"}}
+
+    def __str__(self):
+        return "<FocusItem caption=Settings>"
+
+
+class _FakeEvent:
+    name = "hostInspectorCurrentElementChanged:"
+    data: ClassVar[list["_FakeFocusItem"]] = [_FakeFocusItem()]
+
+
+class _FakeAccessibilityAudit:
+    def __init__(self, service_provider):
+        pass
+
+    async def iter_events(self):
+        yield _FakeEvent()
+
+
+@pytest.fixture(autouse=True)
+def _fake_service(monkeypatch):
+    monkeypatch.setattr(accessibility_module, "AccessibilityAudit", _FakeAccessibilityAudit)
+
+
+def test_accessibility_notifications_json_emits_ndjson_records(capsys):
+    accessibility_module.accessibility_notifications(_FAKE_SERVICE_PROVIDER, output_format=OutputFormat.JSON)
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert [json.loads(line) for line in lines] == [{"caption": "Settings", "element": {"$hexish": "irrelevant"}}]
+
+
+def test_accessibility_notifications_text_prints_records_to_stdout(capsys):
+    accessibility_module.accessibility_notifications(_FAKE_SERVICE_PROVIDER, output_format=OutputFormat.TEXT)
+
+    captured = capsys.readouterr()
+    assert "caption=Settings" in captured.out

--- a/tests/cli/test_battery_monitor.py
+++ b/tests/cli/test_battery_monitor.py
@@ -1,0 +1,59 @@
+import json
+from typing import cast
+
+import pytest
+
+from pymobiledevice3.cli.diagnostics import battery as battery_module
+from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+
+pytestmark = [pytest.mark.cli]
+
+_FAKE_SERVICE_PROVIDER = cast(LockdownServiceProvider, object())
+
+_RAW_INFO = {
+    "InstantAmperage": -211,
+    "Temperature": 3010,
+    "Voltage": 4123,
+    "IsCharging": False,
+    "CurrentCapacity": 78,
+    "SomethingElse": "ignored",
+}
+
+
+class _StopMonitor(Exception):
+    """Raised by the fake service to break the endless monitor loop after one sample."""
+
+
+class _FakeDiagnosticsService:
+    def __init__(self, lockdown):
+        self.samples = 0
+
+    async def get_battery(self):
+        if self.samples:
+            raise _StopMonitor
+        self.samples += 1
+        return _RAW_INFO
+
+
+@pytest.fixture(autouse=True)
+def _fake_service(monkeypatch):
+    monkeypatch.setattr(battery_module, "DiagnosticsService", _FakeDiagnosticsService)
+    monkeypatch.setattr(battery_module.asyncio, "sleep", _no_sleep)
+
+
+async def _no_sleep(_duration):
+    return None
+
+
+def test_battery_monitor_emits_ndjson_record(capsys):
+    with pytest.raises(_StopMonitor):
+        battery_module.diagnostics_battery_monitor(_FAKE_SERVICE_PROVIDER)
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert json.loads(lines[0]) == {
+        "InstantAmperage": -211,
+        "Temperature": 3010,
+        "Voltage": 4123,
+        "IsCharging": False,
+        "CurrentCapacity": 78,
+    }

--- a/tests/cli/test_crash_watch.py
+++ b/tests/cli/test_crash_watch.py
@@ -1,0 +1,77 @@
+import datetime
+import json
+from typing import cast
+
+import pytest
+
+from pymobiledevice3.cli import crash as crash_module
+from pymobiledevice3.cli.cli_common import OutputFormat
+from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+
+pytestmark = [pytest.mark.cli]
+
+_FAKE_SERVICE_PROVIDER = cast(LockdownServiceProvider, object())
+
+
+class _FakeReport:
+    name = "MobileSafari"
+    bug_type = 309
+    bug_type_str = "crash"
+    incident_id = "AAAA-BBBB"
+    timestamp = datetime.datetime(2026, 8, 8, 12, 0, 0)
+
+    def __str__(self):
+        return "MobileSafari crash report"
+
+
+def _fake_manager(items):
+    class _Manager:
+        def __init__(self, service_provider):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def watch(self, name=None, raw=False):
+            for item in items:
+                yield item
+
+    return _Manager
+
+
+def test_crash_watch_json_emits_parsed_record(monkeypatch, capsys):
+    monkeypatch.setattr(crash_module, "CrashReportsManager", _fake_manager([_FakeReport()]))
+
+    crash_module.crash_watch(_FAKE_SERVICE_PROVIDER, output_format=OutputFormat.JSON)
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert [json.loads(line) for line in lines] == [
+        {
+            "name": "MobileSafari",
+            "bug_type": 309,
+            "bug_type_str": "crash",
+            "incident_id": "AAAA-BBBB",
+            "timestamp": "2026-08-08T12:00:00",
+        }
+    ]
+
+
+def test_crash_watch_json_emits_raw_record_as_content(monkeypatch, capsys):
+    monkeypatch.setattr(crash_module, "CrashReportsManager", _fake_manager(["raw report text"]))
+
+    crash_module.crash_watch(_FAKE_SERVICE_PROVIDER, raw=True, output_format=OutputFormat.JSON)
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert [json.loads(line) for line in lines] == [{"content": "raw report text"}]
+
+
+def test_crash_watch_text_prints_report(monkeypatch, capsys):
+    monkeypatch.setattr(crash_module, "CrashReportsManager", _fake_manager([_FakeReport()]))
+
+    crash_module.crash_watch(_FAKE_SERVICE_PROVIDER, output_format=OutputFormat.TEXT)
+
+    captured = capsys.readouterr()
+    assert "MobileSafari crash report" in captured.out

--- a/tests/cli/test_json_output.py
+++ b/tests/cli/test_json_output.py
@@ -1,0 +1,37 @@
+import datetime
+import json
+import uuid
+
+import pytest
+
+from pymobiledevice3.cli.cli_common import default_json_encoder
+
+pytestmark = [pytest.mark.cli]
+
+
+def _roundtrip(obj) -> object:
+    return json.loads(json.dumps(obj, default=default_json_encoder))
+
+
+def test_json_encoder_bytes_as_tagged_hex():
+    assert _roundtrip(b"\xa1\xb2\xc3") == {"$hex": "a1b2c3"}
+
+
+def test_json_encoder_empty_bytes():
+    assert _roundtrip(b"") == {"$hex": ""}
+
+
+def test_json_encoder_nested_bytes():
+    assert _roundtrip({"nonce": b"\x00\xff", "name": "ok"}) == {"nonce": {"$hex": "00ff"}, "name": "ok"}
+
+
+def test_json_encoder_datetime_iso8601():
+    aware = datetime.datetime(2024, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)
+    assert _roundtrip(aware) == "2024-01-02T03:04:05+00:00"
+    naive = datetime.datetime(2024, 1, 2, 3, 4, 5, 123456)
+    assert _roundtrip(naive) == "2024-01-02T03:04:05.123456"
+
+
+def test_json_encoder_uuid():
+    value = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    assert _roundtrip(value) == "12345678-1234-5678-1234-567812345678"

--- a/tests/cli/test_notification_cli.py
+++ b/tests/cli/test_notification_cli.py
@@ -1,0 +1,49 @@
+import json
+from typing import cast
+
+import pytest
+
+from pymobiledevice3.cli import notification as notification_module
+from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+
+pytestmark = [pytest.mark.cli]
+
+_FAKE_SERVICE_PROVIDER = cast(LockdownServiceProvider, object())
+
+_EVENTS = [
+    {"Command": "RelayNotification", "Name": "com.apple.mobile.data_sync.domain_changed"},
+    {"Command": "RelayNotification", "Name": "com.apple.springboard.lockstate"},
+]
+
+
+class _FakeNotificationProxyService:
+    def __init__(self, lockdown, insecure=False):
+        pass
+
+    async def notify_register_dispatch(self, name):
+        pass
+
+    async def receive_notification(self):
+        for event in _EVENTS:
+            yield event
+
+
+@pytest.fixture(autouse=True)
+def _fake_service(monkeypatch):
+    monkeypatch.setattr(notification_module, "NotificationProxyService", _FakeNotificationProxyService)
+
+
+def test_observe_emits_ndjson_records(capsys):
+    notification_module.observe(_FAKE_SERVICE_PROVIDER, ["some-name"])
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert [json.loads(line) for line in lines] == _EVENTS
+
+
+def test_observe_all_emits_ndjson_records(monkeypatch, capsys):
+    monkeypatch.setattr(notification_module, "get_notifications", lambda: ["a", "b"])
+
+    notification_module.observe_all(_FAKE_SERVICE_PROVIDER)
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert [json.loads(line) for line in lines] == _EVENTS

--- a/tests/cli/test_processes.py
+++ b/tests/cli/test_processes.py
@@ -1,0 +1,53 @@
+import json
+from typing import cast
+
+import pytest
+
+from pymobiledevice3.cli import cli_common
+from pymobiledevice3.cli import processes as processes_module
+from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+
+pytestmark = [pytest.mark.cli]
+
+_FAKE_SERVICE_PROVIDER = cast(LockdownServiceProvider, object())
+
+
+@pytest.fixture(autouse=True)
+def _no_color(monkeypatch):
+    # capsys' stdout has no fileno(); disable print_json's TTY color autodetection
+    monkeypatch.setattr(cli_common, "user_requested_colored_output", lambda: False)
+
+
+class _FakeOsTraceService:
+    def __init__(self, lockdown):
+        pass
+
+    async def get_pid_list(self):
+        return {
+            "Payload": {
+                1: {"ProcessName": "kernel_task"},
+                42: {"ProcessName": "backboardd"},
+                77: {"ProcessName": "kernelmanagerd"},
+            }
+        }
+
+
+def test_pgrep_prints_matches_as_json_on_stdout(monkeypatch, capsys):
+    monkeypatch.setattr(processes_module, "OsTraceService", _FakeOsTraceService)
+
+    processes_module.processes_pgrep(_FAKE_SERVICE_PROVIDER, "kernel")
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == [
+        {"pid": 1, "name": "kernel_task"},
+        {"pid": 77, "name": "kernelmanagerd"},
+    ]
+
+
+def test_pgrep_no_matches_prints_empty_json_list(monkeypatch, capsys):
+    monkeypatch.setattr(processes_module, "OsTraceService", _FakeOsTraceService)
+
+    processes_module.processes_pgrep(_FAKE_SERVICE_PROVIDER, "no-such-process")
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == []


### PR DESCRIPTION
Implements the output-contract consult (items 1–5): make the CLI's machine-readable output consistent and pipeable.

## Breaking changes (release-notes callout material)

1. **Bytes in JSON output** are now single-key `{"$hex": "..."}` objects instead of the string `"<hexdigits>"` — unambiguous, mechanically round-trippable (`bytes.fromhex`). Affects every `print_json` command via the shared encoder.
2. **Datetimes in JSON output** are ISO 8601 (`isoformat()`), converging with `syslog live --format json`.
3. **Stream discipline** — data now goes to stdout, not stderr:
   - `processes pgrep` prints a `[{"pid", "name"}]` JSON list (was `logger.info` lines on stderr)
   - Streams whose records are plain dictionaries with no designed human rendering are now **JSON-only** (NDJSON, one object per line): `dvt energy`, `dvt notifications`, `dvt graphics`, `diagnostics battery monitor`, `notification observe`/`observe-all`. Their old "text" form was a Python dict repr on stderr — JSON is strictly more predictable.

## New

4. **`--format text|json` on streams that have a real human rendering** (shared `OutputFormat` option + `print_json_line` NDJSON helper): `dvt oslog`, `dvt netstat`, `accessibility notifications`, `crash watch` (joining the existing `syslog live`). Text stays the default and now prints to stdout; JSON mode emits explicit stable record shapes.
5. **Docs**: new `guides/machine-readable-output.md` stating the contract (streams, `$hex` + decode recipe, timestamps, always-NDJSON vs `--format` command lists), added to mkdocs nav.

## Verified

- TDD throughout: encoder unit tests, per-command fake-service tests (414 device-free tests pass, plus `GITHUB_ACTIONS=true` run)
- Live on device: `diagnostics battery monitor` emits valid NDJSON per sample
- `pyright --venvpath .` 0 errors, all pre-commit hooks pass, `mkdocs build --strict` clean

Suggest releasing this as v10.5.0 with the breaking changes called out in Highlights.