### PR TITLE
cli: Fix help listing and suggestions for collapsed single-command groups

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -242,7 +242,11 @@ class Pmd3TyperGroup(TyperGroup):
             module_name = f"pymobiledevice3.cli.{CLI_GROUPS[key]}"
             mod = importlib.import_module(module_name)
             if isinstance(mod.cli, typer.Typer):
-                cmd = Pmd3TyperGroup.collect_commands(typer.main.get_group(mod.cli))
+                # Resolve like import_and_get_command does: a single-command module
+                # with no callback collapses into one command invoked by the group key.
+                cmd = Pmd3TyperGroup.collect_commands(typer.main.get_command(mod.cli))
+                if not isinstance(cmd, list):
+                    cmd = key
             else:
                 cmd = Pmd3TyperGroup.collect_commands(mod.cli.commands[key])
             if isinstance(cmd, list):

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -206,7 +206,12 @@ class Pmd3TyperGroup(TyperGroup):
         mod = importlib.import_module(module_name)
         # submodules expose a Typer Group named "cli"
         cli: typer.Typer = mod.cli
-        return typer.main.get_command(cli)
+        command = typer.main.get_command(cli)
+        # A collapsed single-command module keeps its inner command's click name
+        # (e.g. btlogger's "capture"), but help and suggestions render that name
+        # while dispatch goes by the CLI_GROUPS key — so align it.
+        command.name = name
+        return command
 
     @staticmethod
     def highlight_keyword(text: str, keyword: str) -> str:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -3,6 +3,8 @@ import subprocess
 import sys
 
 import pytest
+import typer
+from typer.core import TyperGroup
 from typer.testing import CliRunner
 
 from pymobiledevice3 import __main__
@@ -141,6 +143,29 @@ def test_cli_suggestions(keyword, suggestions):
     )
     for suggestion in suggestions:
         assert suggestion in output.stderr
+
+
+def test_suggestion_index_matches_runtime_command_tree():
+    """Every "Did you mean" suggestion must be invocable exactly as printed.
+
+    Single-command groups without a callback (btlogger, pcap, power-assertion,
+    version) are collapsed by Typer at runtime, so they must be indexed under
+    their group name alone — not as phantom paths like "btlogger capture".
+    """
+    root = typer.main.get_command(__main__.app)
+    suggestions = __main__.Pmd3TyperGroup.load_all_commands()
+
+    for collapsed in ("btlogger", "pcap", "power-assertion", "version"):
+        assert collapsed in suggestions
+
+    for suggestion in suggestions:
+        tokens = suggestion.split(" ")
+        assert tokens[0] in __main__.CLI_GROUPS, f"{suggestion!r} does not start with a top-level command"
+        command = root
+        for token in tokens:
+            assert isinstance(command, TyperGroup), f"{suggestion!r}: {token!r} is not reachable at runtime"
+            command = command.get_command(None, token)  # pyright: ignore[reportArgumentType]
+            assert command is not None, f"{suggestion!r}: {token!r} is not reachable at runtime"
 
 
 @pytest.mark.parametrize("group", __main__.CLI_GROUPS.keys())

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -169,6 +169,19 @@ def test_suggestion_index_matches_runtime_command_tree():
 
 
 @pytest.mark.parametrize("group", __main__.CLI_GROUPS.keys())
+def test_top_level_command_is_named_after_its_dispatch_key(group):
+    """The rich help panel shows each resolved command's click name, so it must
+    match the CLI_GROUPS key it is dispatched by. A collapsed single-command
+    module would otherwise be listed under its inner command name (e.g.
+    "capture"), which `pymobiledevice3 capture` cannot actually invoke."""
+    root = typer.main.get_command(__main__.app)
+    assert isinstance(root, TyperGroup)
+    command = root.get_command(None, group)  # pyright: ignore[reportArgumentType]
+    assert command is not None
+    assert command.name == group
+
+
+@pytest.mark.parametrize("group", __main__.CLI_GROUPS.keys())
 def test_cli_groups(group):
     runner = CliRunner()
     group_help_result = runner.invoke(__main__.app, [group, "--help"])


### PR DESCRIPTION
## Summary

Typer collapses a single-command module with no callback (`btlogger`, `pcap`, `power-assertion`, `version`) into one command invoked directly by its group key — but two places disagreed with that runtime resolution:

- **"Did you mean" suggestions** built the index with `typer.main.get_group()`, which never collapses, advertising phantom paths like `btlogger capture` (where `capture` would be parsed as the *output filename*), `pcap pcap`, and `power-assertion power-assertion`. The index is now built with the same `get_command()` resolution used for dispatch, recording collapsed modules under their group key.
- **The top-level help panel** renders each resolved command's click name, so btlogger was listed as `capture` — a name the root group cannot dispatch. `import_and_get_command` now renames the resolved command to its `CLI_GROUPS` key so help, suggestions, and dispatch agree.

No runtime CLI shape changes: `pymobiledevice3 btlogger trace.pklg` works exactly as documented.

## Tests

- `test_suggestion_index_matches_runtime_command_tree` — walks every suggestion through the actual runtime command tree and asserts it is invocable exactly as printed.
- `test_top_level_command_is_named_after_its_dispatch_key` — parametrized over every `CLI_GROUPS` key; failed only for `btlogger` before the fix.

`tests/cli/` passes (213 passed, 5 skipped), pyright 1.1.411 and ruff clean on touched files.