### PR TITLE
skill: Route the cryptex group in the task map, enforce coverage in CI

### DIFF
--- a/.codex/skills/pymobiledevice3-device-operator/references/task-map.md
+++ b/.codex/skills/pymobiledevice3-device-operator/references/task-map.md
@@ -68,6 +68,9 @@ Use WebInspector for Safari/WebView automation and WDA for device UI automation.
 ## Developer Services And Instrumentation
 
 - `mounter`: mount developer images.
+- `cryptex`: manage personalized cryptexes via cryptexd (iOS 17+, requires an RSD tunnel) —
+  list, auto-install a DDI from unpacked Restore assets, personalization identifiers,
+  nonce inspection/rolling, uninstall.
 - `developer dvt`: screenshot, sysmon, process control, oslog, device info, netstat, HAR, energy, location simulation, xcuitest, profiling.
 - `developer core-device`: file/process/app/device-info operations through CoreDevice flows.
 - `developer debugserver`: debugserver launch and LLDB bridging.

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/task-map.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/task-map.md
@@ -68,6 +68,9 @@ Use WebInspector for Safari/WebView automation and WDA for device UI automation.
 ## Developer Services And Instrumentation
 
 - `mounter`: mount developer images.
+- `cryptex`: manage personalized cryptexes via cryptexd (iOS 17+, requires an RSD tunnel) —
+  list, auto-install a DDI from unpacked Restore assets, personalization identifiers,
+  nonce inspection/rolling, uninstall.
 - `developer dvt`: screenshot, sysmon, process control, oslog, device info, netstat, HAR, energy, location simulation, xcuitest, profiling.
 - `developer core-device`: file/process/app/device-info operations through CoreDevice flows.
 - `developer debugserver`: debugserver launch and LLDB bridging.

--- a/tests/test_device_operator_skill.py
+++ b/tests/test_device_operator_skill.py
@@ -1,0 +1,32 @@
+"""Drift checks for the device-operator skill's task map.
+
+The skill routes agent intent to CLI command groups. New top-level groups must be
+reflected there, or agents fall through to source-scanning to discover them.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from pymobiledevice3.__main__ import CLI_GROUPS
+
+pytestmark = [pytest.mark.cli]
+
+TASK_MAP = Path(__file__).parent.parent / ".codex/skills/pymobiledevice3-device-operator/references/task-map.md"
+
+# Groups deliberately absent from the task map: no on-device task routes to them.
+TASK_MAP_EXEMPT = {"version"}
+
+
+def test_task_map_mentions_every_cli_group():
+    task_map = TASK_MAP.read_text()
+    missing = [group for group in CLI_GROUPS if group not in TASK_MAP_EXEMPT and f"`{group}" not in task_map]
+    assert not missing, (
+        f"CLI groups missing from the device-operator task map: {missing}. "
+        f"Add them to {TASK_MAP} (the sync hook refreshes the plugin copy)."
+    )
+
+
+def test_task_map_exemptions_are_still_real_groups():
+    stale = TASK_MAP_EXEMPT - CLI_GROUPS.keys()
+    assert not stale, f"TASK_MAP_EXEMPT entries no longer exist in CLI_GROUPS: {stale}"


### PR DESCRIPTION
Follow-up from auditing whether the device-operator skill covers the CLI: the task map routed 26 of 28 top-level groups — `cryptex` was missing entirely (only `version` is also absent, deliberately). An agent asked to install a DDI cryptex had to fall through to the `CLI_GROUPS` escape hatch.

Two changes:

- Add the `cryptex` routing line to the task map's Developer Services section (list, auto-install from unpacked Restore assets, personalization identifiers, nonce inspection/rolling, uninstall — RSD required). Vendored plugin copy refreshed by the sync hook.
- Add `tests/test_device_operator_skill.py`: a drift test asserting every `CLI_GROUPS` key (minus an explicit `TASK_MAP_EXEMPT` allowlist) appears in the task map, plus a guard that the exemption list itself doesn't go stale. Written test-first — it failed with exactly `['cryptex']` before the map fix. New top-level groups now cannot merge without the skill learning about them.

445 device-free tests pass, pyright clean, all hooks pass.