### PR TITLE
requests: Add timeout to outbound HTTP requests to prevent hang

### DIFF
--- a/pymobiledevice3/cli/restore.py
+++ b/pymobiledevice3/cli/restore.py
@@ -169,7 +169,7 @@ BehaviorOption = Annotated[
 
 
 def query_ipswme(identifier: str) -> str:
-    resp = requests.get(IPSWME_API + identifier, headers={"Accept": "application/json"})
+    resp = requests.get(IPSWME_API + identifier, headers={"Accept": "application/json"}, timeout=30)
     firmwares = resp.json()["firmwares"]
     display_list = [f"{entry['version']}: {entry['buildid']}" for entry in firmwares if entry["signed"]]
     idx = prompt_selection(display_list, "Choose version", idx=True)

--- a/pymobiledevice3/services/mobile_activation.py
+++ b/pymobiledevice3/services/mobile_activation.py
@@ -353,5 +353,5 @@ class MobileActivationService:
         if headers is None:
             headers = DEFAULT_HEADERS
 
-        resp = requests.post(url, data=data, headers=headers)
+        resp = requests.post(url, data=data, headers=headers, timeout=30)
         return resp.content, resp.headers

--- a/pymobiledevice3/utils.py
+++ b/pymobiledevice3/utils.py
@@ -113,7 +113,7 @@ def start_ipython_shell(*, user_ns: Optional[dict[str, Any]] = None, header: Opt
 
 
 def file_download(url: str, outfile: Path, chunk_size: int = 1024) -> None:
-    resp = requests.get(url, stream=True)
+    resp = requests.get(url, stream=True, timeout=30)
     total = int(resp.headers.get("content-length", 0))
     with (
         outfile.open("wb") as file,


### PR DESCRIPTION
Several outbound requests - the streaming file download in utils.py, the Apple activation POST in mobile_activation.py, and the ipsw.me lookup in the restore CLI - have no timeout set. A slow or unresponsive server will hang the calling thread indefinitely.

Added a 30-second timeout to each call so they fail fast instead of blocking forever.

AI Assistance: none