### PR TITLE
cli: Migrate interactive prompts to questionary and fail fast without a TTY

### DIFF
--- a/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -15,6 +15,9 @@ Read this file when the request touches transport selection, iOS 17+ developer s
   equivalent); it is mutually exclusive with `--rsd`/`--tunnel`.
 - `--rsd HOST PORT` is for a specific RemoteServiceDiscovery endpoint.
 - `--tunnel ''` or `--tunnel <UDID>` targets a device already exposed by `tunneld`.
+- With multiple devices attached, always pass `--udid <UDID>` (or set
+  `PYMOBILEDEVICE3_UDID`). Without a TTY the interactive device chooser does not prompt —
+  it exits 1 and prints the candidate devices on stderr.
 
 Use `uvx --from . pymobiledevice3 usbmux list` first for direct USB discovery.
 

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -15,6 +15,9 @@ Read this file when the request touches transport selection, iOS 17+ developer s
   equivalent); it is mutually exclusive with `--rsd`/`--tunnel`.
 - `--rsd HOST PORT` is for a specific RemoteServiceDiscovery endpoint.
 - `--tunnel ''` or `--tunnel <UDID>` targets a device already exposed by `tunneld`.
+- With multiple devices attached, always pass `--udid <UDID>` (or set
+  `PYMOBILEDEVICE3_UDID`). Without a TTY the interactive device chooser does not prompt —
+  it exits 1 and prints the candidate devices on stderr.
 
 Use `uvx --from . pymobiledevice3 usbmux list` first for direct USB discovery.
 

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -159,7 +159,16 @@ def sudo_required(func: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
-def prompt_selection(choices: list[Any], message: str, idx: bool = False) -> Any:
+def prompt_selection(choices: list[Any], message: str, idx: bool = False, hint: Optional[str] = None) -> Any:
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        # Scripts, CI, and agents cannot answer an interactive prompt — fail fast with the
+        # candidates instead of garbling the output stream (or hanging) with escape sequences.
+        typer.secho(f"{message}: interactive selection requires a terminal. Candidates:", err=True, fg="red")
+        for choice in choices:
+            typer.echo(f"  {choice}", err=True)
+        if hint is not None:
+            typer.echo(hint, err=True)
+        raise typer.Exit(code=1)
     question = questionary.select(
         message, choices=[questionary.Choice(title=str(choice), value=i) for i, choice in enumerate(choices)]
     )
@@ -172,7 +181,11 @@ def prompt_selection(choices: list[Any], message: str, idx: bool = False) -> Any
 
 
 def prompt_device_list(device_list: list[Any]) -> Any:
-    return prompt_selection(device_list, "Choose device")
+    return prompt_selection(
+        device_list,
+        "Choose device",
+        hint=f"Pass --udid or set {UDID_ENV_VAR} to choose a device non-interactively.",
+    )
 
 
 def is_invoked_for_completion() -> bool:

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -14,9 +14,8 @@ from typing import Annotated, Any, Callable, Optional, TypeVar, cast
 
 import coloredlogs
 import hexdump
-import inquirer3
+import questionary
 import typer
-from inquirer3.themes import GreenPassion
 from packaging.version import Version
 from pygments import formatters, highlight, lexers
 from typer_injector import Depends
@@ -34,7 +33,7 @@ from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.osu.os_utils import get_os_utils
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
 from pymobiledevice3.tunneld.api import TUNNELD_DEFAULT_ADDRESS, get_tunneld_devices
-from pymobiledevice3.utils import get_asyncio_loop
+from pymobiledevice3.utils import ask_prompt, get_asyncio_loop
 
 UDID_ENV_VAR = "PYMOBILEDEVICE3_UDID"
 TUNNEL_ENV_VAR = "PYMOBILEDEVICE3_TUNNEL"
@@ -161,15 +160,15 @@ def sudo_required(func: Callable[..., Any]) -> Callable[..., Any]:
 
 
 def prompt_selection(choices: list[Any], message: str, idx: bool = False) -> Any:
-    question = [inquirer3.List("selection", message=message, choices=choices, carousel=True)]
+    question = questionary.select(
+        message, choices=[questionary.Choice(title=str(choice), value=i) for i, choice in enumerate(choices)]
+    )
     try:
-        result = cast(
-            dict[str, Any], cast(Any, inquirer3).prompt(question, theme=GreenPassion(), raise_keyboard_interrupt=True)
-        )
+        selection = cast(int, ask_prompt(question))
     except KeyboardInterrupt:
         typer.echo(typer.style("No selection was made", fg="red"))
         raise typer.Exit(code=1) from None
-    return result["selection"] if not idx else choices.index(result["selection"])
+    return selection if idx else choices[selection]
 
 
 def prompt_device_list(device_list: list[Any]) -> Any:

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -9,10 +9,8 @@ from functools import update_wrapper
 from string import Template
 from typing import Annotated, Any, Optional, cast
 
-import inquirer3
 import typer
 import uvicorn
-from inquirer3.themes import GreenPassion
 from prompt_toolkit import HTML, PromptSession
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion.base import CompleteEvent, Completer, Completion
@@ -25,7 +23,7 @@ from pygments import formatters, highlight, lexers
 from pygments import styles as _pygments_styles
 from typer_injector import InjectingTyper
 
-from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command
+from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command, prompt_selection
 from pymobiledevice3.common import get_home_folder
 from pymobiledevice3.exceptions import (
     InspectorEvaluateError,
@@ -634,11 +632,7 @@ class InspectorJsShell(JsShell):
         if len(available_pages) == 1:
             return available_pages[0]
 
-        page_query = [inquirer3.List("page", message="choose page", choices=available_pages, carousel=True)]
-        page = cast(
-            dict[str, Any], cast(Any, inquirer3).prompt(page_query, theme=GreenPassion(), raise_keyboard_interrupt=True)
-        )["page"]
-        return page
+        return prompt_selection(available_pages, "choose page")
 
 
 async def run_js_shell(

--- a/pymobiledevice3/services/mobile_activation.py
+++ b/pymobiledevice3/services/mobile_activation.py
@@ -5,9 +5,9 @@ import plistlib
 import xml.etree.ElementTree as ET
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
-import inquirer3
+import questionary
 import requests
 import typer
 from requests.structures import CaseInsensitiveDict
@@ -15,6 +15,7 @@ from requests.structures import CaseInsensitiveDict
 from pymobiledevice3.exceptions import MobileActivationException
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+from pymobiledevice3.utils import ask_prompt
 
 ACTIVATION_USER_AGENT_IOS = "iOS Device Activator (MobileActivation-20 built on Jan 15 2012 at 19:07:28)"
 ACTIVATION_DEFAULT_URL = "https://albert.apple.com/deviceservices/deviceActivation"
@@ -212,13 +213,13 @@ class MobileActivationService:
             else:
                 typer.secho(activation_form.title, bold=True)
                 typer.secho(activation_form.description)
-                fields: list[Any] = []
+                data: dict[str, Any] = {}
                 for field in activation_form.fields:
-                    if field.secure:
-                        fields.append(inquirer3.Password(name=field.id, message=f"{field.label}"))
-                    else:
-                        fields.append(inquirer3.Text(name=field.id, message=f"{field.label}"))
-                data: dict[str, Any] = cast(Any, inquirer3).prompt(fields)
+                    if field.id is None:
+                        # an id-less field cannot be submitted as form data
+                        continue
+                    prompt = questionary.password if field.secure else questionary.text
+                    data[field.id] = ask_prompt(prompt(f"{field.label}"))
                 data.update(activation_form.server_info)
                 content, headers = self.post(ACTIVATION_DEFAULT_URL, data=data)
                 content_type = headers["Content-Type"]

--- a/pymobiledevice3/utils.py
+++ b/pymobiledevice3/utils.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional, Union, cast, overload
 
 import IPython
+import questionary
 import requests
 from construct import Int8ul, Int16ul, Int32ul, Int64ul, Select
 from tqdm import tqdm
@@ -100,6 +101,23 @@ def get_asyncio_loop() -> asyncio.AbstractEventLoop:
 
 def run_in_loop(coro: Coroutine[Any, Any, Any]):
     return get_asyncio_loop().run_until_complete(coro)
+
+
+def ask_prompt(question: questionary.Question) -> Any:
+    """Ask a questionary prompt from either a sync or an async calling context.
+
+    prompt_toolkit refuses ``Application.run()`` while an asyncio loop is already running in
+    the current thread, and prompts are regularly reached from ``@async_command`` handlers.
+    In that case run the prompt on a worker thread, blocking the loop for the prompt's
+    duration — the same terminal-owning behavior a plain blocking read would have.
+
+    Raises ``KeyboardInterrupt`` on Ctrl-C (questionary's ``unsafe_ask`` contract).
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return question.unsafe_ask()
+    return question.application.run(in_thread=True)
 
 
 def start_ipython_shell(*, user_ns: Optional[dict[str, Any]] = None, header: Optional[str] = None) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "uvicorn>=0.15.0",
     "wsproto",
     "Pillow",
-    "inquirer3>=0.6.0",
+    "questionary>=2.0.0",
     "ipsw_parser>=1.6.0",
     "ifaddr",
     "hyperframe",

--- a/tests/cli/test_device_selection.py
+++ b/tests/cli/test_device_selection.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+
+import pytest
+import typer
+
+from pymobiledevice3.cli.cli_common import prompt_device_list
+
+pytestmark = [pytest.mark.cli]
+
+
+def test_prompt_without_tty_fails_fast_with_candidates(capsys: pytest.CaptureFixture[str]) -> None:
+    # pytest runs without a TTY on stdin/stdout, which is exactly the guarded scenario
+    devices = [SimpleNamespace(udid="udid-a"), SimpleNamespace(udid="udid-b")]
+    with pytest.raises(typer.Exit) as exc_info:
+        prompt_device_list(devices)
+    assert exc_info.value.exit_code == 1
+    err = capsys.readouterr().err
+    assert "interactive selection requires a terminal" in err
+    assert "udid-a" in err
+    assert "udid-b" in err
+    assert "PYMOBILEDEVICE3_UDID" in err


### PR DESCRIPTION
## What

Two commits modernizing the interactive selection prompts (device chooser, webinspector page picker, activation forms):

1. **Migrate inquirer3 → questionary.** questionary is a thin wrapper over prompt_toolkit, which is already a direct dependency — this drops the blessed/readchar/editor stack entirely and moves terminal input onto prompt_toolkit's first-class Windows console handling. Prompts reached from `@async_command` handlers now route through `utils.ask_prompt()` (`Application.run(in_thread=True)`), fixing an `asyncio.run() cannot be called from a running event loop` crash that the naive `unsafe_ask()` path hits (reproduced live via `webinspector js-shell`). Also fixes activation-form fields without an id being submitted under a literal `None` key.

2. **Non-TTY guard.** Without a terminal, selection prompts no longer emit escape sequences into pipes — they exit 1 and print the candidates on stderr, with a `--udid` / `PYMOBILEDEVICE3_UDID` hint for the device chooser. Documented in the device-operator skill's transport guidance (vendored plugin copy synced).

Prompt entries keep the existing `repr()` rendering — deliberately no display-side formatting layer.

## Verification

- Each commit verified independently in a clean worktree with CI's literal commands: `pre-commit run --all-files`, `pytest -m "not device"`, and the pinned pyright hook — all pass per commit.
- Tip additionally verified on Python 3.9.
- Interactive behavior exercised through a pty (arrow-key selection, Ctrl-C in sync and async contexts) and against a real connected device.