### PR TITLE
webinspector: js-shell console fixes and quality-of-life improvements

### DIFF
--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -426,6 +426,9 @@ pymobiledevice3 webinspector js-shell --bundle-id com.example.MyApp
 # JavaScript shell without inspector console events
 pymobiledevice3 webinspector js-shell --no-console-enable
 
+# JavaScript shell without the console history the page replays on attach
+pymobiledevice3 webinspector js-shell --no-replayed-log
+
 # List opened tabs
 pymobiledevice3 webinspector opened-tabs
 

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -349,6 +349,13 @@ async def js_shell(
         bool,
         typer.Option(help="Open Safari before selecting a page."),
     ] = False,
+    no_replayed_log: Annotated[
+        bool,
+        typer.Option(
+            "--no-replayed-log",
+            help="Don't print the console history the page replays on attach (webinspector.console.replay).",
+        ),
+    ] = False,
 ) -> None:
     """
     Create a javascript shell. This interpreter runs on your local machine,
@@ -366,6 +373,9 @@ async def js_shell(
 
     if automation and console_enable is not None:
         raise typer.BadParameter("--console-enable/--no-console-enable cannot be combined with --automation.")
+
+    if no_replayed_log:
+        logging.getLogger("webinspector.console.replay").setLevel(logging.CRITICAL + 1)
 
     js_shell_class = AutomationJsShell if automation else InspectorJsShell
     create_kwargs = {}

--- a/pymobiledevice3/services/notification_proxy.py
+++ b/pymobiledevice3/services/notification_proxy.py
@@ -72,7 +72,7 @@ class NotificationProxyService(LockdownService):
 
         :param name: notification name to observe.
         """
-        self.logger.info(f"Observing {name}")
+        self.logger.debug(f"Observing {name}")
         await self.service.send_plist({"Command": "ObserveNotification", "Name": name})
 
     async def receive_notification(self) -> AsyncGenerator[dict[str, Any], None]:
@@ -131,7 +131,7 @@ class RemoteNotificationProxyService(RemoteService):
 
         :param name: notification name to observe.
         """
-        self.logger.info(f"Observing {name}")
+        self.logger.debug(f"Observing {name}")
         await self.service.send_request({"Command": "ObserveNotification", "Name": name})
 
     async def receive_notification(self) -> AsyncGenerator[dict[str, Any], None]:

--- a/pymobiledevice3/services/web_protocol/inspector_session.py
+++ b/pymobiledevice3/services/web_protocol/inspector_session.py
@@ -71,6 +71,7 @@ class InspectorSession:
             "Console.messagesCleared": lambda _: _,
             "Console.messageRepeatCountUpdated": self._console_message_repeated_count_updated,
             "Heap.garbageCollected": self._heap_garbage_collected,
+            "Runtime.executionContextCreated": self._runtime_execution_context_created,
         }
 
         self._receive_task = asyncio.create_task(self._receive_loop())
@@ -261,6 +262,11 @@ class InspectorSession:
 
     def _heap_garbage_collected(self, message: dict[str, Any]):
         heap_logger.debug(message["params"])
+
+    def _runtime_execution_context_created(self, message: dict[str, Any]):
+        # pushed by the page after Runtime.enable for every JS execution context; evaluation
+        # pins uniqueContextId '0.1' (see runtime_evaluate), so the event is informational only
+        logger.debug(f"executionContextCreated: {message['params']['context']}")
 
     def _target_created(self, response: dict[str, Any]):
         pass

--- a/pymobiledevice3/services/web_protocol/inspector_session.py
+++ b/pymobiledevice3/services/web_protocol/inspector_session.py
@@ -252,10 +252,28 @@ class InspectorSession:
             logger.critical(f"unhandled message: {message}")
 
     def _console_message_added(self, message: dict[str, Any]):
-        log_level = message["params"]["message"]["level"]
-        text = message["params"]["message"]["text"]
+        message_body = message["params"]["message"]
+        log_level = message_body["level"]
+        # console-api messages carry only the first argument in 'text'; all arguments arrive
+        # as RemoteObjects in 'parameters' (e.g. console.log(4,4) -> text '4', parameters [4, 4])
+        parameters = message_body.get("parameters")
+        if parameters:
+            text = " ".join(self._stringify_console_parameter(parameter) for parameter in parameters)
+        else:
+            text = message_body["text"]
         self._last_console_message = message
         webinspector_logger_handlers[log_level](text)
+
+    @staticmethod
+    def _stringify_console_parameter(parameter: dict[str, Any]) -> str:
+        if parameter.get("type") == "string":
+            return cast(str, parameter["value"])
+        if "description" in parameter:
+            return cast(str, parameter["description"])
+        if "value" in parameter:
+            # json.dumps renders JS-style primitives (true/false/null) rather than Python's
+            return json.dumps(parameter["value"])
+        return cast(str, parameter.get("type", ""))
 
     def _console_message_repeated_count_updated(self, message: dict[str, Any]):
         self._console_message_added(self._last_console_message)

--- a/pymobiledevice3/services/web_protocol/inspector_session.py
+++ b/pymobiledevice3/services/web_protocol/inspector_session.py
@@ -9,15 +9,23 @@ from pymobiledevice3.services.web_protocol.session_protocol import SessionProtoc
 
 logger = logging.getLogger(__name__)
 console_logger = logging.getLogger("webinspector.console")
+# console history replayed by the page on attach, distinguishable (and silenceable) by logger name
+console_replay_logger = logging.getLogger("webinspector.console.replay")
 heap_logger = logging.getLogger("webinspector.heap")
 
-webinspector_logger_handlers = {
-    "log": console_logger.info,
-    "info": console_logger.info,
-    "error": console_logger.error,
-    "debug": console_logger.debug,
-    "warning": console_logger.warning,
-}
+
+def _console_logger_handlers(console: logging.Logger) -> "dict[str, Callable[[str], None]]":
+    return {
+        "log": console.info,
+        "info": console.info,
+        "error": console.error,
+        "debug": console.debug,
+        "warning": console.warning,
+    }
+
+
+webinspector_logger_handlers = _console_logger_handlers(console_logger)
+webinspector_replay_logger_handlers = _console_logger_handlers(console_replay_logger)
 
 
 class JSObjectPreview(UserDict[str, Any]):
@@ -61,6 +69,9 @@ class InspectorSession:
         self.message_id = 1
         self._last_console_message: dict[str, Any] = {}
         self._dispatch_message_responses: dict[int, dict[str, Any]] = {}
+        # WebKit replays the page's buffered console history to a newly attached frontend
+        # while Console.enable is being processed; mark those messages as replayed
+        self._console_replay = True
 
         self.response_methods: dict[str, Callable[[dict[str, Any]], Any]] = {
             "Target.targetCreated": self._target_created,
@@ -114,7 +125,9 @@ class InspectorSession:
         return await self.send_command("Heap.enable")
 
     async def console_enable(self):
-        return await self.send_command("Console.enable")
+        result = await self.send_command("Console.enable")
+        self._console_replay = False
+        return result
 
     async def runtime_enable(self):
         return await self.send_command("Runtime.enable")
@@ -262,7 +275,8 @@ class InspectorSession:
         else:
             text = message_body["text"]
         self._last_console_message = message
-        webinspector_logger_handlers[log_level](text)
+        handlers = webinspector_replay_logger_handlers if self._console_replay else webinspector_logger_handlers
+        handlers[log_level](text)
 
     @staticmethod
     def _stringify_console_parameter(parameter: dict[str, Any]) -> str:

--- a/tests/services/test_inspector_session.py
+++ b/tests/services/test_inspector_session.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from types import SimpleNamespace
@@ -52,11 +53,20 @@ def _console_message_added(text: str, parameters: Optional[list[dict[str, Any]]]
     return {"method": "Console.messageAdded", "params": {"message": message}}
 
 
-def _console_output(session: InspectorSession, caplog: pytest.LogCaptureFixture, event: dict[str, Any]) -> str:
+def _console_record(
+    session: InspectorSession, caplog: pytest.LogCaptureFixture, event: dict[str, Any], force_live: bool = True
+) -> logging.LogRecord:
+    if force_live:
+        # formatting tests represent messages logged after Console.enable completed
+        session._console_replay = False
     with caplog.at_level(logging.DEBUG, logger="webinspector.console"):
         session._target_dispatch_message_from_target(_wrap_target_event(event))
     assert len(caplog.records) == 1
-    return caplog.records[0].getMessage()
+    return caplog.records[0]
+
+
+def _console_output(session: InspectorSession, caplog: pytest.LogCaptureFixture, event: dict[str, Any]) -> str:
+    return _console_record(session, caplog, event).getMessage()
 
 
 async def test_console_log_multiple_arguments(session: InspectorSession, caplog: pytest.LogCaptureFixture) -> None:
@@ -91,3 +101,32 @@ async def test_console_message_without_parameters_uses_text(
     # page-originated messages (e.g. resource errors) carry no 'parameters'
     event = _console_message_added("Failed to load resource", None)
     assert _console_output(session, caplog, event) == "Failed to load resource"
+
+
+async def test_console_history_replayed_before_enable_completes_is_marked(
+    session: InspectorSession, caplog: pytest.LogCaptureFixture
+) -> None:
+    # WebKit replays the page's buffered console history while Console.enable is being
+    # processed; those messages are distinguishable (and silenceable) by logger name
+    event = _console_message_added("4", [{"type": "number", "value": 4, "description": "4"}])
+    record = _console_record(session, caplog, event, force_live=False)
+    assert record.name == "webinspector.console.replay"
+    assert record.getMessage() == "4"
+
+
+async def test_console_enable_completion_switches_to_live_output(
+    session: InspectorSession, caplog: pytest.LogCaptureFixture
+) -> None:
+    async def send_command(method: str, **kwargs: Any) -> None:
+        pass
+
+    session.protocol.send_command = send_command  # pyright: ignore[reportAttributeAccessIssue]
+    task = asyncio.create_task(session.console_enable())
+    # deliver the Console.enable response (inner id 1) so console_enable completes
+    session.protocol.inspector.wir_events.append(_wrap_target_event({"id": 1, "result": {}}))
+    await asyncio.wait_for(task, timeout=5)
+    event = _console_message_added("4", [{"type": "number", "value": 4, "description": "4"}])
+    # console_enable itself must have switched the session out of replay state
+    record = _console_record(session, caplog, event, force_live=False)
+    assert record.name == "webinspector.console"
+    assert record.getMessage() == "4"

--- a/tests/services/test_inspector_session.py
+++ b/tests/services/test_inspector_session.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 
@@ -38,10 +38,56 @@ async def test_runtime_execution_context_created_is_not_logged_as_unhandled(
     assert not [record for record in caplog.records if record.levelno >= logging.CRITICAL]
 
 
-async def test_truly_unknown_event_still_logged(
-    session: InspectorSession, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_truly_unknown_event_still_logged(session: InspectorSession, caplog: pytest.LogCaptureFixture) -> None:
     event = {"method": "Bogus.event", "params": {}}
     with caplog.at_level(logging.DEBUG, logger="pymobiledevice3.services.web_protocol.inspector_session"):
         session._target_dispatch_message_from_target(_wrap_target_event(event))
     assert [record for record in caplog.records if record.levelno >= logging.CRITICAL]
+
+
+def _console_message_added(text: str, parameters: Optional[list[dict[str, Any]]]) -> dict[str, Any]:
+    message: dict[str, Any] = {"source": "console-api", "level": "log", "type": "log", "text": text}
+    if parameters is not None:
+        message["parameters"] = parameters
+    return {"method": "Console.messageAdded", "params": {"message": message}}
+
+
+def _console_output(session: InspectorSession, caplog: pytest.LogCaptureFixture, event: dict[str, Any]) -> str:
+    with caplog.at_level(logging.DEBUG, logger="webinspector.console"):
+        session._target_dispatch_message_from_target(_wrap_target_event(event))
+    assert len(caplog.records) == 1
+    return caplog.records[0].getMessage()
+
+
+async def test_console_log_multiple_arguments(session: InspectorSession, caplog: pytest.LogCaptureFixture) -> None:
+    # captured live from console.log(4,4): 'text' carries only the first argument,
+    # 'parameters' carries all of them
+    event = _console_message_added(
+        "4",
+        [
+            {"type": "number", "value": 4, "description": "4"},
+            {"type": "number", "value": 4, "description": "4"},
+        ],
+    )
+    assert _console_output(session, caplog, event) == "4 4"
+
+
+async def test_console_log_mixed_arguments(session: InspectorSession, caplog: pytest.LogCaptureFixture) -> None:
+    event = _console_message_added(
+        "hello",
+        [
+            {"type": "string", "value": "hello"},
+            {"type": "boolean", "value": True},
+            {"type": "undefined"},
+            {"type": "object", "className": "Object", "description": "Object", "objectId": "obj-1"},
+        ],
+    )
+    assert _console_output(session, caplog, event) == "hello true undefined Object"
+
+
+async def test_console_message_without_parameters_uses_text(
+    session: InspectorSession, caplog: pytest.LogCaptureFixture
+) -> None:
+    # page-originated messages (e.g. resource errors) carry no 'parameters'
+    event = _console_message_added("Failed to load resource", None)
+    assert _console_output(session, caplog, event) == "Failed to load resource"

--- a/tests/services/test_inspector_session.py
+++ b/tests/services/test_inspector_session.py
@@ -1,0 +1,47 @@
+import json
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from pymobiledevice3.services.web_protocol.inspector_session import InspectorSession
+
+
+@pytest.fixture()
+async def session():
+    protocol = SimpleNamespace(inspector=SimpleNamespace(wir_events=[]))
+    session = InspectorSession(protocol, target_id="page-1")  # pyright: ignore[reportArgumentType]
+    yield session
+    session._receive_task.cancel()
+
+
+def _wrap_target_event(inner: dict[str, Any]) -> dict[str, Any]:
+    # events pushed by the page arrive wrapped in Target.dispatchMessageFromTarget,
+    # with the inner message JSON-encoded and carrying no 'id'
+    return {
+        "method": "Target.dispatchMessageFromTarget",
+        "params": {"targetId": "page-1", "message": json.dumps(inner)},
+    }
+
+
+async def test_runtime_execution_context_created_is_not_logged_as_unhandled(
+    session: InspectorSession, caplog: pytest.LogCaptureFixture
+) -> None:
+    # observed live: WebKit pushes this right after Runtime.enable
+    event = {
+        "method": "Runtime.executionContextCreated",
+        "params": {"context": {"id": 2, "type": "normal", "name": "", "frameId": "0.1"}},
+    }
+    with caplog.at_level(logging.DEBUG, logger="pymobiledevice3.services.web_protocol.inspector_session"):
+        session._target_dispatch_message_from_target(_wrap_target_event(event))
+    assert not [record for record in caplog.records if record.levelno >= logging.CRITICAL]
+
+
+async def test_truly_unknown_event_still_logged(
+    session: InspectorSession, caplog: pytest.LogCaptureFixture
+) -> None:
+    event = {"method": "Bogus.event", "params": {}}
+    with caplog.at_level(logging.DEBUG, logger="pymobiledevice3.services.web_protocol.inspector_session"):
+        session._target_dispatch_message_from_target(_wrap_target_event(event))
+    assert [record for record in caplog.records if record.levelno >= logging.CRITICAL]


### PR DESCRIPTION
## What

js-shell fixes root-caused from live device sessions, plus follow-up quality-of-life changes:

1. **Handle `Runtime.executionContextCreated`.** js-shell always sends `Runtime.enable`, and the page then pushes this event for each JS execution context. It arrives wrapped in `Target.dispatchMessageFromTarget` with no inner `id`, and the id-less dispatch table only knew `Target.*`/`Console.*`/`Heap.*` — so every session logged a spurious `CRITICAL unhandled message` for normal protocol traffic. Now debug-logged; evaluation pins `uniqueContextId '0.1'`, so no further processing is needed. Truly unknown events still hit the CRITICAL fallback.

2. **Print all console arguments.** WebKit's `Console.messageAdded` sets `text` to the *first* argument only and delivers every argument as a RemoteObject in `parameters` (captured live: `console.log(4,4)` → `text: '4'`, `parameters: [4, 4]`). The handler printed just `text`, silently dropping the rest. Arguments are now stringified and joined (`value` for strings, `description` when present, JSON-rendered value otherwise so booleans/null print JS-style); messages without `parameters` (e.g. page resource errors) keep using `text`.

3. **Distinguish replayed console history.** WebKit replays the page's buffered console history to a newly attached frontend while `Console.enable` is processed; it was indistinguishable from live output. History now logs to `webinspector.console.replay` — visible in the log line and silenceable via standard logging config.

4. **`js-shell --no-replayed-log`** silences that replay logger from the CLI.

5. **notification_proxy:** demote `Observing <name>` INFO logs to debug — transport plumbing that printed on every webinspector command startup.

## Verification

- New unit tests drive the live-captured payloads through the real dispatch path; each fix was red before and green after, with companion tests covering unknown events, mixed argument types, parameter-less messages, and the replay→live transition across `Console.enable`.
- pyright, pre-commit, and the cli+services suites pass.