### PR TITLE
webinspector: Full object listings and better completions in js-shell

### DIFF
--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -47,8 +47,13 @@ function inspectedPage_evalResult_getCompletions(primitiveType) {
     for (let o = object; o; o = o.__proto__) {
         try {
             let names = Object.getOwnPropertyNames(o);
-            for (let i = 0; i < names.length; ++i)
-                resultSet[names[i]] = true;
+            for (let i = 0; i < names.length; ++i) {
+                if (names[i] in resultSet)
+                    continue;
+                // read the kind from the descriptor - accessing the value could invoke getters
+                let d = Object.getOwnPropertyDescriptor(o, names[i]);
+                resultSet[names[i]] = d && 'value' in d ? typeof d.value : 'accessor';
+            }
         } catch(e) {}
     }
     return resultSet;
@@ -436,10 +441,16 @@ async def get_js_completions(jsshell: "JsShell", obj: str, prefix: str) -> Async
         return
 
     try:
-        for key in await jsshell.evaluate_expression(SCRIPT.substitute(object=obj), return_by_value=True):
+        completions = await jsshell.evaluate_expression(SCRIPT.substitute(object=obj), return_by_value=True)
+        for key in sorted(completions, key=str.lower):
             if not key.startswith(prefix):
                 continue
-            yield Completion(key.removeprefix(prefix), display=key)
+            kind = completions[key]
+            yield Completion(
+                key.removeprefix(prefix),
+                display=key,
+                display_meta="ƒ" if kind == "function" else "",
+            )
     except (Exception, CancelledError):
         # ignore every possible exception
         pass
@@ -457,8 +468,8 @@ class JsShellCompleter(Completer):
         # Build the JS expression we want to inspect
         text = f"globalThis.{document.text_before_cursor}"
 
-        # Extract identifiers / dotted paths
-        matches = re.findall(r"[a-zA-Z_][a-zA-Z_0-9.]+", text)
+        # Extract identifiers / dotted paths ($ is a legal JS identifier character)
+        matches = re.findall(r"[a-zA-Z_$][a-zA-Z_$0-9.]+", text)
         if not matches:
             # async *generator*: just end, don't return a list
             return

--- a/pymobiledevice3/services/web_protocol/inspector_session.py
+++ b/pymobiledevice3/services/web_protocol/inspector_session.py
@@ -28,6 +28,35 @@ webinspector_logger_handlers = _console_logger_handlers(console_logger)
 webinspector_replay_logger_handlers = _console_logger_handlers(console_replay_logger)
 
 
+_MAX_PROPERTY_VALUE_LENGTH = 80
+
+
+def _shorten(text: str) -> str:
+    first_line, *rest = text.split("\n", 1)
+    shortened = first_line[:_MAX_PROPERTY_VALUE_LENGTH]
+    if rest or len(first_line) > _MAX_PROPERTY_VALUE_LENGTH:
+        shortened += "…"
+    return shortened
+
+
+def _shorten_remote_object(remote_object: dict[str, Any]) -> str:
+    """One-line, JS-style rendering of a RemoteObject property value."""
+    if remote_object.get("type") == "string":
+        return _shorten(json.dumps(remote_object["value"]))
+    if remote_object.get("type") == "function":
+        return "ƒ"
+    if remote_object.get("subtype") == "null":
+        return "null"
+    if remote_object.get("type") == "object":
+        return remote_object.get("className") or remote_object.get("description") or "Object"
+    if "description" in remote_object:
+        return _shorten(remote_object["description"])
+    if "value" in remote_object:
+        # json.dumps renders JS-style primitives (true/false) rather than Python's
+        return json.dumps(remote_object["value"])
+    return remote_object.get("type", "")
+
+
 class JSObjectPreview(UserDict[str, Any]):
     def __init__(self, properties: list[dict[str, Any]]):
         super().__init__()
@@ -236,21 +265,44 @@ class InspectorSession:
             value = result.get("value")
             if value is not None:
                 return value
-
-            # TODO: JSObjectProperties()
-            preview = result["preview"]
-            preview_buf = "{\n"
-            for p in result["preview"]["properties"]:
-                value = p.get("value", "NOT_SUPPORTED_FOR_PREVIEW")
-                preview_buf += f"\t{p['name']}: {value}, // {p['type']}\n"
-            if preview.get("overflow"):
-                preview_buf += "\t// ...\n"
-            preview_buf += "}"
-            return f"[object {result['className']}]\n{preview_buf}"
+            return await self._describe_object(result)
         elif result["type"] == "function":
             return result["description"]
         else:
             return result["value"]
+
+    async def _describe_object(self, result: dict[str, Any]) -> str:
+        """Render an object result with all its top-level properties, one shortened line each,
+        the way a browser console prints an evaluated object:
+
+            Window {
+              window: Window
+              document: Document
+              ...
+            }
+
+        Falls back to the bare class name when the object is not addressable or its
+        properties cannot be fetched (released object, navigated page).
+        """
+        class_name = result.get("className") or result.get("description") or "Object"
+        object_id = result.get("objectId")
+        if object_id is None:
+            return class_name
+        try:
+            descriptors = await self.get_properties_raw(object_id)
+        except Exception:
+            return class_name
+        lines: list[str] = []
+        for descriptor in descriptors:
+            if descriptor["name"] == "__proto__":
+                continue
+            remote_object = descriptor.get("value", descriptor.get("get", descriptor.get("set")))
+            if remote_object is None:
+                continue
+            lines.append(f"  {descriptor['name']}: {_shorten_remote_object(remote_object)}")
+        if not lines:
+            return f"{class_name} {{}}"
+        return "\n".join([f"{class_name} {{", *lines, "}"])
 
     # response methods
     def _target_dispatch_message_from_target(self, response: dict[str, Any]):

--- a/pymobiledevice3/services/web_protocol/inspector_session.py
+++ b/pymobiledevice3/services/web_protocol/inspector_session.py
@@ -232,12 +232,20 @@ class InspectorSession:
 
     async def get_properties_raw(self, object_id: str) -> list[dict[str, Any]]:
         """Raw ``Runtime.getProperties`` descriptors, preserving RemoteObject dicts (objectIds)."""
-        message = cast(
-            dict[str, Any],
-            await self.send_command(
-                "Runtime.getProperties", objectId=object_id, ownProperties=True, generatePreview=True
-            ),
+        return await self._fetch_properties(
+            "Runtime.getProperties", objectId=object_id, ownProperties=True, generatePreview=True
         )
+
+    async def get_displayable_properties_raw(self, object_id: str) -> list[dict[str, Any]]:
+        """Raw ``Runtime.getDisplayableProperties`` descriptors - the property set Safari's Web
+        Inspector shows for an object: own properties plus the displayable native accessors
+        (which is where most DOM element attributes live)."""
+        return await self._fetch_properties(
+            "Runtime.getDisplayableProperties", objectId=object_id, generatePreview=True
+        )
+
+    async def _fetch_properties(self, method: str, **kwargs: Any) -> list[dict[str, Any]]:
+        message = cast(dict[str, Any], await self.send_command(method, **kwargs))
         if self.target_id is not None:
             message = json.loads(message["params"]["message"])["result"]
         return message["properties"]
@@ -289,9 +297,13 @@ class InspectorSession:
         if object_id is None:
             return class_name
         try:
-            descriptors = await self.get_properties_raw(object_id)
+            # what Safari's Web Inspector shows: own properties + displayable native accessors
+            descriptors = await self.get_displayable_properties_raw(object_id)
         except Exception:
-            return class_name
+            try:
+                descriptors = await self.get_properties_raw(object_id)
+            except Exception:
+                return class_name
         lines: list[str] = []
         for descriptor in descriptors:
             if descriptor["name"] == "__proto__":

--- a/pymobiledevice3/services/web_protocol/inspector_session.py
+++ b/pymobiledevice3/services/web_protocol/inspector_session.py
@@ -201,7 +201,8 @@ class InspectorSession:
                 return self._dispatch_message_responses.pop(message_id)
             await asyncio.sleep(0)
 
-    async def get_properties(self, object_id: str) -> JSObjectProperties:
+    async def get_properties_raw(self, object_id: str) -> list[dict[str, Any]]:
+        """Raw ``Runtime.getProperties`` descriptors, preserving RemoteObject dicts (objectIds)."""
         message = cast(
             dict[str, Any],
             await self.send_command(
@@ -210,7 +211,10 @@ class InspectorSession:
         )
         if self.target_id is not None:
             message = json.loads(message["params"]["message"])["result"]
-        return JSObjectProperties(message["properties"])
+        return message["properties"]
+
+    async def get_properties(self, object_id: str) -> JSObjectProperties:
+        return JSObjectProperties(await self.get_properties_raw(object_id))
 
     async def _parse_runtime_evaluate(self, response: dict[str, Any]):
         message = response if self.target_id is None else json.loads(response["params"]["message"])

--- a/tests/cli/test_webinspector_completion.py
+++ b/tests/cli/test_webinspector_completion.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from prompt_toolkit.completion import CompleteEvent, Completion
+from prompt_toolkit.document import Document
+
+from pymobiledevice3.cli.webinspector import JsShellCompleter
+
+pytestmark = [pytest.mark.cli]
+
+
+def _completer(names: dict[str, str]) -> "tuple[JsShellCompleter, dict[str, Any]]":
+    captured: dict[str, Any] = {}
+
+    async def evaluate_expression(exp: str, return_by_value: bool = False) -> dict[str, str]:
+        captured["exp"] = exp
+        return names
+
+    shell = SimpleNamespace(evaluate_expression=evaluate_expression)
+    return JsShellCompleter(cast(Any, shell)), captured
+
+
+async def _collect(completer: JsShellCompleter, text: str) -> list[Completion]:
+    document = Document(text, cursor_position=len(text))
+    return [completion async for completion in completer.get_completions_async(document, CompleteEvent())]
+
+
+async def test_completions_sorted_prefix_filtered_with_function_marker() -> None:
+    completer, _ = _completer({
+        "normalize": "function",
+        "name": "string",
+        "navigator": "object",
+        "location": "object",
+    })
+    completions = await _collect(completer, "window.n")
+    assert [completion.display_text for completion in completions] == ["name", "navigator", "normalize"]
+    assert [completion.display_meta_text for completion in completions] == ["", "", "ƒ"]
+    # the prefix is stripped from the inserted text
+    assert [completion.text for completion in completions] == ["ame", "avigator", "ormalize"]
+
+
+async def test_dollar_identifiers_are_completed() -> None:
+    completer, captured = _completer({"$refresh": "function"})
+    completions = await _collect(completer, "$x.")
+    assert "globalThis.$x" in captured["exp"]
+    assert [completion.display_text for completion in completions] == ["$refresh"]
+
+
+async def test_reserved_words_are_not_evaluated() -> None:
+    completer, captured = _completer({"anything": "object"})
+    completions = await _collect(completer, "x = await.")
+    assert completions == []
+    assert "exp" not in captured

--- a/tests/services/test_inspector_session.py
+++ b/tests/services/test_inspector_session.py
@@ -142,3 +142,75 @@ async def test_get_properties_raw_returns_descriptors(session: InspectorSession)
     session.send_command = send_command  # pyright: ignore[reportAttributeAccessIssue]
     properties = await session.get_properties_raw("obj-1")
     assert properties == [{"name": "a", "value": {"type": "number", "value": 1}}]
+
+
+def _object_result(inner_result: dict[str, Any]) -> dict[str, Any]:
+    return {"params": {"message": json.dumps({"result": {"result": inner_result}})}}
+
+
+async def test_object_result_lists_all_top_level_properties(session: InspectorSession) -> None:
+    async def get_properties_raw(object_id: str) -> list[dict[str, Any]]:
+        assert object_id == "win-1"
+        return [
+            {"name": "window", "value": {"type": "object", "className": "Window", "objectId": "win-1"}},
+            {"name": "count", "value": {"type": "number", "value": 4, "description": "4"}},
+            {"name": "flag", "value": {"type": "boolean", "value": True}},
+            {"name": "nothing", "value": {"type": "object", "subtype": "null", "value": None}},
+            {"name": "missing", "value": {"type": "undefined"}},
+            {
+                "name": "greet",
+                "value": {"type": "function", "className": "Function", "description": "function greet() {\n}"},
+            },
+            {"name": "title", "value": {"type": "string", "value": "x" * 100}},
+            {
+                "name": "computed",
+                "get": {"type": "function", "className": "Function", "description": "function get computed() {}"},
+            },
+            {"name": "skipme"},
+            {"name": "__proto__", "value": {"type": "object", "className": "Object", "objectId": "proto-1"}},
+        ]
+
+    session.get_properties_raw = get_properties_raw  # pyright: ignore[reportAttributeAccessIssue]
+    rendered = await session._parse_runtime_evaluate(
+        _object_result({"type": "object", "className": "Window", "objectId": "win-1"})
+    )
+    quoted_title = '"' + "x" * 79 + "…"
+    assert rendered == (
+        "Window {\n"
+        "  window: Window\n"
+        "  count: 4\n"
+        "  flag: true\n"
+        "  nothing: null\n"
+        "  missing: undefined\n"
+        "  greet: ƒ\n"
+        f"  title: {quoted_title}\n"
+        "  computed: ƒ\n"
+        "}"
+    )
+
+
+async def test_object_result_without_properties_renders_class_only(session: InspectorSession) -> None:
+    async def get_properties_raw(object_id: str) -> list[dict[str, Any]]:
+        return []
+
+    session.get_properties_raw = get_properties_raw  # pyright: ignore[reportAttributeAccessIssue]
+    rendered = await session._parse_runtime_evaluate(
+        _object_result({"type": "object", "className": "Blob", "objectId": "blob-1"})
+    )
+    assert rendered == "Blob {}"
+
+
+async def test_object_result_property_fetch_failure_falls_back_to_class_name(session: InspectorSession) -> None:
+    async def get_properties_raw(object_id: str) -> list[dict[str, Any]]:
+        raise RuntimeError("released")
+
+    session.get_properties_raw = get_properties_raw  # pyright: ignore[reportAttributeAccessIssue]
+    rendered = await session._parse_runtime_evaluate(
+        _object_result({"type": "object", "className": "Blob", "objectId": "blob-1"})
+    )
+    assert rendered == "Blob"
+
+
+async def test_object_result_without_object_id_renders_class_only(session: InspectorSession) -> None:
+    rendered = await session._parse_runtime_evaluate(_object_result({"type": "object", "className": "Blob"}))
+    assert rendered == "Blob"

--- a/tests/services/test_inspector_session.py
+++ b/tests/services/test_inspector_session.py
@@ -130,3 +130,15 @@ async def test_console_enable_completion_switches_to_live_output(
     record = _console_record(session, caplog, event, force_live=False)
     assert record.name == "webinspector.console"
     assert record.getMessage() == "4"
+
+
+async def test_get_properties_raw_returns_descriptors(session: InspectorSession) -> None:
+    async def send_command(method: str, **kwargs: Any) -> dict[str, Any]:
+        assert method == "Runtime.getProperties"
+        assert kwargs == {"objectId": "obj-1", "ownProperties": True, "generatePreview": True}
+        inner = {"result": {"properties": [{"name": "a", "value": {"type": "number", "value": 1}}]}}
+        return {"params": {"message": json.dumps(inner)}}
+
+    session.send_command = send_command  # pyright: ignore[reportAttributeAccessIssue]
+    properties = await session.get_properties_raw("obj-1")
+    assert properties == [{"name": "a", "value": {"type": "number", "value": 1}}]

--- a/tests/services/test_inspector_session.py
+++ b/tests/services/test_inspector_session.py
@@ -149,7 +149,7 @@ def _object_result(inner_result: dict[str, Any]) -> dict[str, Any]:
 
 
 async def test_object_result_lists_all_top_level_properties(session: InspectorSession) -> None:
-    async def get_properties_raw(object_id: str) -> list[dict[str, Any]]:
+    async def get_displayable_properties_raw(object_id: str) -> list[dict[str, Any]]:
         assert object_id == "win-1"
         return [
             {"name": "window", "value": {"type": "object", "className": "Window", "objectId": "win-1"}},
@@ -170,7 +170,7 @@ async def test_object_result_lists_all_top_level_properties(session: InspectorSe
             {"name": "__proto__", "value": {"type": "object", "className": "Object", "objectId": "proto-1"}},
         ]
 
-    session.get_properties_raw = get_properties_raw  # pyright: ignore[reportAttributeAccessIssue]
+    session.get_displayable_properties_raw = get_displayable_properties_raw  # pyright: ignore[reportAttributeAccessIssue]
     rendered = await session._parse_runtime_evaluate(
         _object_result({"type": "object", "className": "Window", "objectId": "win-1"})
     )
@@ -214,3 +214,45 @@ async def test_object_result_property_fetch_failure_falls_back_to_class_name(ses
 async def test_object_result_without_object_id_renders_class_only(session: InspectorSession) -> None:
     rendered = await session._parse_runtime_evaluate(_object_result({"type": "object", "className": "Blob"}))
     assert rendered == "Blob"
+
+
+async def test_get_displayable_properties_raw_returns_descriptors(session: InspectorSession) -> None:
+    async def send_command(method: str, **kwargs: Any) -> dict[str, Any]:
+        assert method == "Runtime.getDisplayableProperties"
+        assert kwargs == {"objectId": "obj-1", "generatePreview": True}
+        inner = {"result": {"properties": [{"name": "a", "value": {"type": "number", "value": 1}}]}}
+        return {"params": {"message": json.dumps(inner)}}
+
+    session.send_command = send_command  # pyright: ignore[reportAttributeAccessIssue]
+    properties = await session.get_displayable_properties_raw("obj-1")
+    assert properties == [{"name": "a", "value": {"type": "number", "value": 1}}]
+
+
+async def test_object_listing_prefers_displayable_properties(session: InspectorSession) -> None:
+    async def get_displayable_properties_raw(object_id: str) -> list[dict[str, Any]]:
+        return [{"name": "id", "get": {"type": "function", "className": "Function", "description": "function id()"}}]
+
+    async def get_properties_raw(object_id: str) -> list[dict[str, Any]]:
+        raise AssertionError("must not fall back when displayable properties succeed")
+
+    session.get_displayable_properties_raw = get_displayable_properties_raw  # pyright: ignore[reportAttributeAccessIssue]
+    session.get_properties_raw = get_properties_raw  # pyright: ignore[reportAttributeAccessIssue]
+    rendered = await session._parse_runtime_evaluate(
+        _object_result({"type": "object", "className": "HTMLBodyElement", "objectId": "body-1"})
+    )
+    assert rendered == "HTMLBodyElement {\n  id: ƒ\n}"
+
+
+async def test_object_listing_falls_back_to_own_properties(session: InspectorSession) -> None:
+    async def get_displayable_properties_raw(object_id: str) -> list[dict[str, Any]]:
+        raise RuntimeError("method not supported")
+
+    async def get_properties_raw(object_id: str) -> list[dict[str, Any]]:
+        return [{"name": "a", "value": {"type": "number", "value": 1, "description": "1"}}]
+
+    session.get_displayable_properties_raw = get_displayable_properties_raw  # pyright: ignore[reportAttributeAccessIssue]
+    session.get_properties_raw = get_properties_raw  # pyright: ignore[reportAttributeAccessIssue]
+    rendered = await session._parse_runtime_evaluate(
+        _object_result({"type": "object", "className": "Blob", "objectId": "blob-1"})
+    )
+    assert rendered == "Blob {\n  a: 1\n}"


### PR DESCRIPTION
## What

Four commits making the js-shell REPL output more complete:

1. **Expose raw `Runtime.getProperties` descriptors** on `InspectorSession` (`get_properties_raw`), preserving RemoteObject dicts; `get_properties` now delegates to it.

2. **List all top-level properties for object results.** Object evaluations previously printed WebKit's capped preview (a handful of properties plus `// ...`). They now fetch the object's properties and render every top-level property on its own line in shortened form — strings quoted and truncated at 80 chars, functions as `ƒ`, nested objects by class name, `null`/`undefined`/booleans JS-style:

   ```
   Window {
     window: Window
     document: Document
     location: Location
     ...
   }
   ```

   Values are read from property descriptors without invoking getters; released/unaddressable objects fall back to the bare class name.

3. **Better completions**: sorted alphabetically (case-insensitive) instead of prototype-chain order, functions marked `ƒ` in the completion menu (descriptor-based, getter-safe), and `$` identifiers (`$x.<TAB>`) now complete. Deliberately no caching — every list is fetched fresh so completions can never go stale.

4. **Fetch listings via `Runtime.getDisplayableProperties`** — the RPC Safari's own Web Inspector uses: own properties plus displayable native accessors, so DOM elements list their real attributes instead of rendering nearly empty (`HTMLBodyElement {}`). Falls back to `Runtime.getProperties`, then to the bare class name, if unsupported.

## Verification

- Each commit verified independently in a clean worktree with CI's literal commands (`pre-commit run --all-files`, `pytest -m "not device"`, pinned pyright hook) — all pass per commit.
- Device-free unit tests cover the rendering (mixed value kinds, truncation, getter descriptors, `__proto__` skip, displayable→own→class-name fallback chain) and completion behavior (sorting, `ƒ` markers, prefix stripping, `$` identifiers, reserved words).
- Live end-to-end on a device pending: webinspectord refused new sessions while the test device was locked; the first real `js-shell` run is the remaining check.