### PR TITLE
sysmon: Extend --human to durations and add cpuUsageLifetime

### DIFF
--- a/pymobiledevice3/cli/developer/dvt/sysmon/process.py
+++ b/pymobiledevice3/cli/developer/dvt/sysmon/process.py
@@ -41,12 +41,25 @@ _BYTE_FIELDS = {
     "diskBytesRead",
     "diskBytesWritten",
     "memAnon",
+    "memAnonPeak",
     "memCompressed",
+    "memPurgeable",
+    "memRPrvt",
+    "memRShrd",
     "memResidentSize",
     "memVirtualSize",
     "physFootprint",
     "purgeableMemory",
     "wiredMemory",
+    "wiredSize",
+}
+
+_NANOSECOND_FIELDS = {
+    "cpuTotalSystem",
+    "cpuTotalUser",
+    "procAge",
+    "threadsSystem",
+    "threadsUser",
 }
 
 _PROCESS_FILTER_PATTERN = re.compile(r"(?P<key>[^=]+)=(?P<value>.*)")
@@ -89,7 +102,10 @@ HumanReadableProcessValues = Annotated[
     bool,
     typer.Option(
         "--human",
-        help="Format known byte-count fields such as physFootprint using human-readable units.",
+        help=(
+            "Format known byte-count fields such as physFootprint using human-readable units, "
+            "and nanosecond fields such as cpuTotalUser as durations."
+        ),
     ),
 ]
 
@@ -150,12 +166,45 @@ def _format_byte_count(value: int) -> str:
     return f"{size:.1f}{suffixes[suffix_index]}" if size < 10 else f"{size:.0f}{suffixes[suffix_index]}"
 
 
+def _format_duration_ns(value: int) -> str:
+    total_seconds, ns_remainder = divmod(value, 1_000_000_000)
+    if total_seconds == 0:
+        return f"{ns_remainder // 1_000_000}ms"
+    parts: list[str] = []
+    for suffix, unit_seconds in (("d", 86400), ("h", 3600), ("m", 60), ("s", 1)):
+        unit_value, total_seconds = divmod(total_seconds, unit_seconds)
+        if unit_value:
+            parts.append(f"{unit_value}{suffix}")
+    return " ".join(parts)
+
+
 def _humanize_process_values(process: dict[str, Any]) -> dict[str, Any]:
     humanized = dict(process)
     for key, value in humanized.items():
-        if key in _BYTE_FIELDS and isinstance(value, int):
+        if not isinstance(value, int):
+            continue
+        if key in _BYTE_FIELDS:
             humanized[key] = _format_byte_count(value)
+        elif key in _NANOSECOND_FIELDS:
+            humanized[key] = _format_duration_ns(value)
     return humanized
+
+
+def _add_derived_fields(process: dict[str, Any]) -> dict[str, Any]:
+    with_derived = dict(process)
+    cpu_total_user = process.get("cpuTotalUser")
+    cpu_total_system = process.get("cpuTotalSystem")
+    proc_age = process.get("procAge")
+    if (
+        isinstance(cpu_total_user, int)
+        and isinstance(cpu_total_system, int)
+        and isinstance(proc_age, int)
+        and proc_age > 0
+    ):
+        # Lifetime average CPU on the same percent-of-core scale as cpuUsage; comparing the two
+        # tells chronic hogs apart from momentary spikes.
+        with_derived["cpuUsageLifetime"] = (cpu_total_user + cpu_total_system) / proc_age * 100
+    return with_derived
 
 
 def _serialize_process(
@@ -219,7 +268,7 @@ async def iter_processes(sysmon: Sysmontap, skip_first_snapshot: bool = False) -
         if should_skip_snapshot:
             should_skip_snapshot = False
             continue
-        yield process_snapshot
+        yield [_add_derived_fields(process) for process in process_snapshot]
 
 
 def _process_sort_key(process: dict[str, Any]) -> tuple[int, int, str]:

--- a/tests/cli/developer/dvt/sysmon/test_process_unit.py
+++ b/tests/cli/developer/dvt/sysmon/test_process_unit.py
@@ -8,10 +8,12 @@ import typer
 from pymobiledevice3.cli.developer.dvt.sysmon import process as process_module
 from pymobiledevice3.cli.developer.dvt.sysmon.process import (
     ProcessSelectionMode,
+    _add_derived_fields,
     _describe_process,
     _describe_processes,
     _duration_elapsed,
     _format_byte_count,
+    _format_duration_ns,
     _get_process_identifier,
     _humanize_process_values,
     _matches_filters,
@@ -109,6 +111,49 @@ def test_select_process_output_keys_filters_selected_keys():
 )
 def test_format_byte_count(value, expected):
     assert _format_byte_count(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (0, "0ms"),
+        (500_000, "0ms"),
+        (74_633_791, "74ms"),
+        (1_000_000_000, "1s"),
+        (61_000_000_000, "1m 1s"),
+        (3_600_000_000_000, "1h"),
+        (227_239_368_467_125, "2d 15h 7m 19s"),
+    ],
+)
+def test_format_duration_ns(value, expected):
+    assert _format_duration_ns(value) == expected
+
+
+def test_humanize_process_values_formats_shared_memory_byte_fields():
+    assert _humanize_process_values({"memRShrd": 2048, "memAnonPeak": 1024, "wiredSize": 512}) == {
+        "memRShrd": "2.0KB",
+        "memAnonPeak": "1.0KB",
+        "wiredSize": "512B",
+    }
+
+
+def test_humanize_process_values_formats_nanosecond_fields():
+    assert _humanize_process_values({"cpuTotalUser": 61_000_000_000, "procAge": 1_000_000_000, "pid": 7}) == {
+        "cpuTotalUser": "1m 1s",
+        "procAge": "1s",
+        "pid": 7,
+    }
+
+
+def test_add_derived_fields_computes_cpu_usage_lifetime():
+    process = {"cpuTotalUser": 150, "cpuTotalSystem": 50, "procAge": 100}
+    assert _add_derived_fields(process)["cpuUsageLifetime"] == 200.0
+    assert "cpuUsageLifetime" not in process
+
+
+def test_add_derived_fields_skips_when_inputs_missing_or_zero():
+    assert "cpuUsageLifetime" not in _add_derived_fields({"pid": 7})
+    assert "cpuUsageLifetime" not in _add_derived_fields({"cpuTotalUser": 1, "cpuTotalSystem": 1, "procAge": 0})
 
 
 def test_humanize_process_values_formats_only_known_byte_fields():
@@ -236,6 +281,16 @@ async def test_iter_processes_skips_first_snapshot_when_requested():
     iterated_snapshots = [snapshot async for snapshot in iter_processes(sysmon, skip_first_snapshot=True)]
 
     assert iterated_snapshots == snapshots[1:]
+
+
+@pytest.mark.asyncio
+async def test_iter_processes_adds_cpu_usage_lifetime():
+    snapshots = [[{"pid": 7, "cpuTotalUser": 150, "cpuTotalSystem": 50, "procAge": 100}]]
+    sysmon = cast(Sysmontap, _FakeSysmontap(snapshots))
+
+    iterated_snapshots = [snapshot async for snapshot in iter_processes(sysmon)]
+
+    assert iterated_snapshots[0][0]["cpuUsageLifetime"] == 200.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

- Complete `_BYTE_FIELDS` with the byte-count process fields real sysmon records carry but the set missed: `memAnonPeak`, `memPurgeable`, `memRPrvt`, `memRShrd`, `wiredSize`.
- Format nanosecond fields (`cpuTotalUser`, `cpuTotalSystem`, `procAge`, `threadsUser`, `threadsSystem`) as human-readable durations under `--human` (e.g. `"2d 16h 4m 22s"`, sub-second values as `"74ms"`).
- Add a derived `cpuUsageLifetime` field: `(cpuTotalUser + cpuTotalSystem) / procAge * 100`, on the same percent-of-core scale as `cpuUsage` — comparing the two tells chronic CPU hogs apart from momentary spikes.

The derived field is injected at the snapshot level (`iter_processes`), so it works with `--filter`/`--key` like native fields and appears in plain JSON output too (it is data, not formatting). Under `--human` it stays numeric, like `cpuUsage`.

## Example

```shell
pymobiledevice3 developer dvt sysmon process single -f name=dtappserviced --human \
  -k name -k cpuUsage -k cpuUsageLifetime -k cpuTotalUser -k procAge
```

```json
{
    "cpuTotalUser": "2d 16h 4m 22s",
    "cpuUsage": 286.3897552160728,
    "cpuUsageLifetime": 297.94016080455026,
    "name": "dtappserviced",
    "procAge": "21h 30m 19s"
}
```

(Real output from an iOS device with a runaway `dtappserviced` — the near-equal instant vs lifetime values expose it as a chronic spinner.)

## Testing

- 12 new unit tests (`_format_duration_ns`, `_humanize_process_values`, `_add_derived_fields`, `iter_processes` integration); all 59 sysmon tests pass.
- pyright 1.1.411 and ruff clean.
- Verified live against a physical device (iPhone 11, iOS 27.0 beta).