### PR TITLE
irecv: Don't let unopenable USB devices abort the device scan

### DIFF
--- a/pymobiledevice3/irecv.py
+++ b/pymobiledevice3/irecv.py
@@ -318,23 +318,26 @@ class IRecv:
         end = start + timeout
         while (self._device is None) and (time.time() < end):
             for device in cast(Iterable[Device], find(find_all=True)):
+                usb_device: Any = device
+
+                # Match on the descriptor fields cached at enumeration. Reading string
+                # descriptors (e.g. manufacturer) requires opening the device, which fails
+                # for unrelated devices lacking a libusb-compatible driver (e.g. on Windows).
+                if usb_device.idVendor != APPLE_VENDOR_ID:
+                    continue
+
+                mode = Mode.get_mode_from_value(usb_device.idProduct)
+                if mode is None:
+                    # not one of Apple's special modes
+                    continue
+
+                if is_recovery is not None and mode.is_recovery != is_recovery:
+                    continue
+
+                if self._device is not None:
+                    raise IRecvError("More then one connected device was found connected in recovery mode")
+
                 try:
-                    usb_device: Any = device
-                    if usb_device.manufacturer is None:
-                        continue
-                    if not usb_device.manufacturer.startswith("Apple"):
-                        continue
-
-                    mode = Mode.get_mode_from_value(usb_device.idProduct)
-                    if mode is None:
-                        # not one of Apple's special modes
-                        continue
-
-                    if is_recovery is not None and mode.is_recovery != is_recovery:
-                        continue
-
-                    if self._device is not None:
-                        raise IRecvError("More then one connected device was found connected in recovery mode")
                     self._device = device
                     self._mode = mode
                     self._populate_device_info()
@@ -345,7 +348,10 @@ class IRecv:
                             # wrong device - move on
                             self._device = None
                             continue
-                except ValueError:
+                except (ValueError, NotImplementedError, USBError):
+                    # unreadable device (e.g. missing driver or permissions) - move on
+                    self._device = None
+                    self._mode = None
                     continue
 
     def _populate_device_info(self):


### PR DESCRIPTION
Fixes #1848

`_find()` read `usb_device.manufacturer` on every enumerated USB device, but string descriptors require opening the device. On Windows, devices without a libusb-compatible driver raise `NotImplementedError` from `libusb_open`, which escaped the `ValueError`-only handler and aborted the whole scan — so a connected DFU/Recovery device was never found if an unrelated USB device enumerated first.

Instead of only broadening the `except` (the workaround suggested in the issue), match on `idVendor`/`idProduct` first — these are cached at enumeration and never require opening the device — so unrelated hardware is skipped without being touched at all (same matching strategy as libirecovery). The remaining handler around the serial-number read now also catches `NotImplementedError`/`USBError` and resets `_device`/`_mode`, so an Apple-VID device that cannot be opened (missing driver/permissions) is skipped cleanly instead of crashing or leaking a half-probed device out of the scan.

Verified with a mocked-pyusb simulation of the reporter's exact scenario (hostile devices raising `NotImplementedError` on string-descriptor access enumerating before an Apple recovery device): unpatched master crashes with the traceback from the issue; patched code finds the device. Also exercised ECID match/mismatch, `is_recovery` filtering, and an unopenable Apple-PID device. `pre-commit` (ruff + pyright 1.1.411) passes.