### PR TITLE
accessibility-audit: Fix connection establishment via RSD

### DIFF
--- a/pymobiledevice3/dtx_service_provider.py
+++ b/pymobiledevice3/dtx_service_provider.py
@@ -196,6 +196,17 @@ class DtxServiceProvider:
         ``com.apple.instruments.remoteserver`` and similar pre-iOS 14 services.
         """
         lockdown = self.lockdown
+        if isinstance(lockdown, RemoteServiceDiscoveryService) and service_name.endswith(".shim.remote"):
+            # A ".shim.remote" service is a lockdown service shimmed over RSD, and every
+            # such shim requires the RSDCheckin handshake before it will speak — the
+            # accessibility shim, for example, resets the connection otherwise.
+            # start_lockdown_service() performs the check-in and consumes its two framed
+            # plist responses, leaving the stream at the start of the DTX frame.
+            # (Native RemoteXPC-era services like dtservicehub need no check-in.)
+            svc = await lockdown.start_lockdown_service(service_name)
+            reader, writer = await svc._ensure_started()
+            return DTXConnection(reader, writer)
+
         attr = await lockdown.get_service_connection_attributes(service_name, False)
         svc = await lockdown.create_service_connection(attr["Port"])
 


### PR DESCRIPTION
## Summary

`AccessibilityAudit` fails on RSD with `ConnectionTerminatedError` on the first dispatch. `DtxServiceProvider._open_dtx_connection()` connects to the service port and starts DTX immediately, correct for `dtservicehub`, but the `axAuditDaemon.remoteserver.shim.remote` shim resets the connection unless the `RSDCheckin` handshake is performed first.

Adds a `REQUIRES_RSD_CHECKIN` class flag (default `False`, so existing DTX services are unaffected) that routes through `start_lockdown_service()`, which already performs the handshake, and enables it for the accessibility provider.


## Testing

Verified on iOS 27.0 and 26: `capabilities()`, `supported_audits_types()`, `settings()`, `run_audit()`, `move_focus()` and the setters all work; DVT is unchanged.

