### PR TITLE
tss: Fix Yonkers component selection

### DIFF
--- a/pymobiledevice3/restore/tss.py
+++ b/pymobiledevice3/restore/tss.py
@@ -747,15 +747,18 @@ class TSSRequest:
         result_comp_name = None
 
         for comp_name, node in manifest.items():
-            if not comp_name.startswith("Yonkers,"):
+            # Only Yonkers,SysTopPatch* is eligible: other Yonkers,* entries (e.g. the
+            # Yonkers,SepObject added in iOS 27) carry neither EPRO nor FabRevision, so
+            # they'd pass the filters below and shadow the correct component.
+            if not comp_name.startswith("Yonkers,SysTopPatch"):
                 continue
 
             target_node = 1
             sub_node = node.get("EPRO")
-            if sub_node:
+            if sub_node is not None:
                 target_node &= sub_node if isprod else not sub_node
             sub_node = node.get("FabRevision")
-            if sub_node:
+            if sub_node is not None:
                 target_node &= sub_node == fabrevision
 
             if target_node:

--- a/tests/test_tss_yonkers.py
+++ b/tests/test_tss_yonkers.py
@@ -1,0 +1,61 @@
+from typing import Any
+
+import pytest
+
+from pymobiledevice3.exceptions import PyMobileDevice3Exception
+from pymobiledevice3.restore.tss import TSSRequest
+
+# Modeled on the iPhone17,1 iOS 27.0 beta (24A5408d) BuildManifest: SysTopPatch entries
+# come in EPRO=False/True pairs per FabRevision, and Yonkers,SepObject (new in iOS 27)
+# carries neither EPRO nor FabRevision. Keys are listed in plist (alphabetical) order,
+# so SepObject is seen before any SysTopPatch entry.
+MANIFEST: dict[str, Any] = {
+    "SEP": {"Digest": b"\xff", "Info": {}},
+    "Yonkers,SepObject": {"Digest": b"\x00", "Info": {}},
+    "Yonkers,SysTopPatch8": {"Digest": b"\x08", "EPRO": False, "FabRevision": 54529, "Info": {}},
+    "Yonkers,SysTopPatch9": {"Digest": b"\x09", "EPRO": True, "FabRevision": 54529, "Info": {}},
+    "Yonkers,SysTopPatchA": {"Digest": b"\x0a", "EPRO": False, "FabRevision": 56577, "Info": {}},
+    "Yonkers,SysTopPatchB": {"Digest": b"\x0b", "EPRO": True, "FabRevision": 56577, "Info": {}},
+}
+
+
+def _parameters(isprod: bool, fabrevision: int) -> dict[str, Any]:
+    return {
+        "Manifest": MANIFEST,
+        "Yonkers,ProductionMode": isprod,
+        "Yonkers,FabRevision": fabrevision,
+    }
+
+
+def _select(isprod: bool, fabrevision: int) -> str:
+    request = TSSRequest()
+    return request.add_yonkers_tags(_parameters(isprod, fabrevision))
+
+
+def test_sep_object_is_not_selected() -> None:
+    # Yonkers,SepObject has neither EPRO nor FabRevision, so before the SysTopPatch
+    # prefix restriction it passed both filters and shadowed the real component.
+    assert _select(True, 54529) == "Yonkers,SysTopPatch9"
+
+
+def test_production_device_selects_the_epro_true_entry() -> None:
+    # EPRO=False must be treated as a present-and-failing filter, not skipped:
+    # SysTopPatch8 (EPRO=False) precedes SysTopPatch9 (EPRO=True) for the same fab.
+    assert _select(True, 54529) == "Yonkers,SysTopPatch9"
+    assert _select(True, 56577) == "Yonkers,SysTopPatchB"
+
+
+def test_development_device_selects_the_epro_false_entry() -> None:
+    assert _select(False, 54529) == "Yonkers,SysTopPatch8"
+    assert _select(False, 56577) == "Yonkers,SysTopPatchA"
+
+
+def test_selected_component_is_added_to_the_request() -> None:
+    request = TSSRequest()
+    comp_name = request.add_yonkers_tags(_parameters(True, 54529))
+    assert request._request[comp_name] == {"Digest": b"\x09", "EPRO": True, "FabRevision": 54529}
+
+
+def test_unknown_fab_revision_raises() -> None:
+    with pytest.raises(PyMobileDevice3Exception):
+        _select(True, 12345)


### PR DESCRIPTION
## Summary

Two fixes to `add_yonkers_tags`, aligning it with libtatsu's selector (port of the open [libimobiledevice/libtatsu#8](https://github.com/libimobiledevice/libtatsu/pull/8), plus a pymobiledevice3-only bug found while verifying it):

1. **Restrict candidate components to `Yonkers,SysTopPatch*`.** iOS 27 beta manifests introduce a `Yonkers,SepObject` entry that carries neither `EPRO` nor `FabRevision`, so it passed both filters and — sorting before every `SysTopPatch` entry — was always selected. TSS then signs the wrong component and the restore fails.
2. **Check `EPRO`/`FabRevision` by key presence, not truthiness.** libtatsu applies the EPRO filter whenever the key exists (`plist_dict_get_item(...) != NULL`); our port used `if sub_node:`, which skips the filter entirely for `EPRO=False` entries. SysTopPatch entries come in dev/prod pairs per FabRevision with distinct digests, and the `EPRO=False` entry sorts first — so a production device selected the dev-fused component.

## Verification

I surveyed real BuildManifests (range-fetched from Apple's CDN) rather than reasoning from the code alone:

- **No regression surface:** iPhone11,2 / 12,3 / 13,2 / 14,2 / 15,2 / 16,1 / 17,1 / 18,1 across iOS 18.0.1, 18.7.9 and 26.6 — every `Yonkers,*` entry in every build identity is a `Yonkers,SysTopPatch[0-F]` carrying both `EPRO` and `FabRevision`. The prefix restriction is a no-op on all of them.
- **The failure case reproduces:** on the iPhone17,1 27.0 beta 5 (24A5408d) manifest, the old selector picks `Yonkers,SepObject`; the fixed one picks the correct `SysTopPatch` entry for the device's EPRO/FabRevision (e.g. `SysTopPatch9` for a production device with `FabRevision=54529`, matching the on-device result reported in the libtatsu PR).
- That manifest confirms the dev/prod pairing for fix 2, e.g. `SysTopPatch8` = `EPRO=False, FabRevision=54529` vs `SysTopPatch9` = `EPRO=True, FabRevision=54529`, with different digests.

## Testing

- New `tests/test_tss_yonkers.py` unit tests modeled on the 24A5408d manifest shape (SepObject exclusion, prod/dev EPRO pairing, no-match error).
- `pyright@1.1.411 --venvpath .`: 0 errors.