### PR TITLE
userspace-tunnel: fully close abandoned relay sockets; consume pmd-pytcp 0.3.4

### DIFF
--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -45,7 +45,7 @@ from pmd_net_addr import Ip6Address, Ip6IfAddr, MacAddress
 from pmd_pytcp import stack
 from pmd_pytcp.lib.interface_layer import InterfaceLayer
 from pmd_pytcp.lib.io_backend import register_interface_fd, unregister_interface_fd
-from pmd_pytcp.socket import AF_INET6, SHUT_RDWR, SHUT_WR, SOCK_DGRAM, SOCK_STREAM
+from pmd_pytcp.socket import AF_INET6, SHUT_RDWR, SOCK_DGRAM, SOCK_STREAM
 from pmd_pytcp.socket import socket as pytcp_socket
 
 import pymobiledevice3.remote.tunnel_service as tunnel_service
@@ -346,9 +346,12 @@ class UserspaceTun:
         # thread-wakeup gymnastics remain — the pure-asyncio stack has nothing parked off-loop.
         try:
             await stack.stop()  # pyright: ignore[reportGeneralTypeIssues]  # pmd-pytcp types stop() as sync; it is a coroutine at runtime
-            stack._pmd3_inited = False  # type: ignore[attr-defined]
         except Exception:
             logger.debug("error stopping pytcp stack", exc_info=True)
+        finally:
+            # Clear the init marker even when stop() raised: a later open->close->open cycle
+            # must re-run stack.init() rather than reuse a half-stopped stack.
+            stack._pmd3_inited = False  # type: ignore[attr-defined]
         unregister_interface_fd(self._pend)
         for s in (self._peer, self._pend):
             with suppress(Exception):
@@ -418,12 +421,20 @@ class UserspaceDialPlane:
             except Exception:
                 pass
             finally:
-                # Propagate the client's EOF to the device as a FIN (half-close). The device
-                # then finishes its side and its FIN ends device_to_client with b"", letting
-                # the whole handler complete. Without this the handler waits on device
-                # traffic forever after the client is gone (#1756).
+                # The client is gone — nothing in pymobiledevice3 half-closes its side
+                # (every ServiceConnection teardown is a full close), so no device byte can
+                # ever be delivered again. Fully close the pytcp socket: the FIN still goes
+                # out (services that treat EOF as "finish and close" behave exactly as with
+                # the previous SHUT_WR half-close), but the session is now ORPHANED, so a
+                # device that neither answers nor FINs is reaped by pmd-pytcp's FIN_WAIT_2
+                # orphan timer instead of pinning the session — and this handler — forever.
+                # A mere half-close kept the socket open (a reader existed: device_to_client)
+                # and the reaper is deliberately orphan-only, so abandoned relays accumulated
+                # for the tunnel's lifetime (measured: 24 of 30 abandoned service connections
+                # parked at psock.recv() until teardown). pmd-pytcp >= 0.3.4 wakes the pending
+                # recv() on the session's death, letting the whole handler finish promptly.
                 with suppress(Exception):
-                    psock.shutdown(SHUT_WR)
+                    psock.close()
 
         async def device_to_client() -> None:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,14 +88,19 @@ dependencies = [
     # (https://github.com/doronz88/pmd-pytcp). Pulls its pmd-net-addr / pmd-net-proto siblings in
     # transitively. Supported on Python 3.9+ (the whole pymobiledevice3 range); if the import or
     # stack init fails the tunnel transparently falls back to the kernel path (see cli_common).
-    # 0.3.0 floor: the 'net.rx_cksum_validate' software RX-checksum-offload sysctl (skips the
-    # RFC 1071 checksum on the AEAD-authenticated tunnel; ~+35% bulk download). 0.2.0 added
-    # dynamic send-MSS via working RFC 4821/8899 PLPMTUD (probing sysctls tcp.mtu_probing /
-    # tcp.base_mss / tcp.plpmtud.probe_timer_ms, the tcp.rto.min_ms floor, and the runtime
-    # 'log.enabled' hot-path gate). userspace_tunnel.py sets these knobs unconditionally — no
-    # capability probing — so the floor IS the compatibility contract. (0.1.0 introduced the
-    # pure-asyncio stack the module is written against.)
-    "pmd-pytcp>=0.3.0; python_version >= '3.9'",
+    # 0.3.4 floor: session death (RST / FIN / reaper / 2MSL) wakes blocked recv() waiters —
+    # the relay handler in userspace_tunnel.py relies on this to finish promptly once it fully
+    # closes an abandoned connection's pytcp socket (a parked waiter used to leak the handler
+    # task for the tunnel's lifetime); also fixes the NUD FAILED black-hole (a device asleep
+    # ~3 s could kill the tunnel until process restart) and the per-session post-close 1 kHz
+    # timer spin. 0.3.0 added the 'net.rx_cksum_validate' software RX-checksum-offload sysctl
+    # (skips the RFC 1071 checksum on the AEAD-authenticated tunnel; ~+35% bulk download).
+    # 0.2.0 added dynamic send-MSS via working RFC 4821/8899 PLPMTUD (probing sysctls
+    # tcp.mtu_probing / tcp.base_mss / tcp.plpmtud.probe_timer_ms, the tcp.rto.min_ms floor,
+    # and the runtime 'log.enabled' hot-path gate). userspace_tunnel.py sets these knobs
+    # unconditionally — no capability probing — so the floor IS the compatibility contract.
+    # (0.1.0 introduced the pure-asyncio stack the module is written against.)
+    "pmd-pytcp>=0.3.4; python_version >= '3.9'",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_userspace_tunnel.py
+++ b/tests/test_userspace_tunnel.py
@@ -107,6 +107,10 @@ class FakePyTcpSocket:
 
     def close(self) -> None:
         self.closed.set()
+        # pmd-pytcp >= 0.3.4: the session's death (close/RST/reap) wakes a
+        # parked recv(), which then reports EOF or a connection error
+        # instead of sleeping forever.
+        self.feed_eof()
 
 
 class FakeTun:
@@ -132,9 +136,10 @@ async def _poll_until(predicate, timeout: float = 5.0):
 
 
 async def test_relay_full_conversation_and_clean_completion():
-    # ping/pong through the relay, then a client-initiated close: the client EOF must reach
-    # the device as a half-close (SHUT_WR), and once the device answers with its own EOF the
-    # handler must finish on its own — with the pytcp socket closed and no task left behind.
+    # ping/pong through the relay, then a client-initiated close: the client's EOF must fully
+    # close the pytcp socket (the FIN still reaches the device; the session becomes an orphan
+    # the stack's FIN_WAIT_2 reaper owns) and the handler must finish on its own — with no
+    # task left behind and WITHOUT requiring any further device action.
     tun = FakeTun()
     async with UserspaceDialPlane(cast(UserspaceTun, tun), DEVICE_ADDR) as dial_plane:
         reader, writer = await dial_plane.dial(DEVICE_ADDR, 1234)
@@ -147,11 +152,26 @@ async def test_relay_full_conversation_and_clean_completion():
         assert await reader.readexactly(4) == b"pong"
 
         writer.close()
-        # client EOF -> device half-close (SHUT_WR=1 or SHUT_RDWR=2)
-        await _poll_until(lambda: any(how in (1, 2) for how in psock.shutdown_calls))
-        psock.feed_eof()  # the device finishes its side
-        await _poll_until(lambda: not dial_plane._relay_tasks)  # handler completed unaided
         await asyncio.wait_for(psock.closed.wait(), timeout=5)
+        await _poll_until(lambda: not dial_plane._relay_tasks)  # handler completed unaided
+
+
+async def test_abandoned_client_with_silent_device_leaks_nothing():
+    # The dominant real-world leak (measured live: 24 of 30 abandoned service connections):
+    # the client vanishes while the device neither sends a byte nor FINs. A half-close kept
+    # the pytcp socket open — a reader existed — so the stack's orphan-only FIN_WAIT_2 reaper
+    # never armed and the handler parked at recv() until tunnel teardown. The relay must fully
+    # close the socket on client EOF so the session is orphaned (reaper territory) and the
+    # handler finishes promptly.
+    tun = FakeTun()
+    async with UserspaceDialPlane(cast(UserspaceTun, tun), DEVICE_ADDR) as dial_plane:
+        _reader, writer = await dial_plane.dial(DEVICE_ADDR, 4321)
+        psock = (await _poll_until(lambda: tun.socks))[0]
+
+        writer.close()  # the client is gone; the device stays silent
+
+        await asyncio.wait_for(psock.closed.wait(), timeout=5)
+        await _poll_until(lambda: not dial_plane._relay_tasks)
 
 
 async def test_device_eof_reaches_client():


### PR DESCRIPTION
## What

Fixes the dominant resource leak in the userspace tunnel and moves the pmd-pytcp floor to 0.3.4 (the stability release produced by this audit cycle).

### The leak

The relay handler propagated a client's EOF to the device as a **half-close** (`shutdown(SHUT_WR)`) and kept reading. Nothing in pymobiledevice3 ever half-closes deliberately — every `ServiceConnection` teardown is a full close — so the pattern being protected doesn't exist, while the cost was real: the pytcp socket stayed open, the session was never *orphaned*, pmd-pytcp's FIN_WAIT_2 reaper (deliberately orphan-only) never armed, and against a device that neither sent a byte nor FINed, the handler parked at `psock.recv()` forever.

**Measured live** (USB iPhone, iOS 27.0): 24 of 30 abandoned service connections leaked their handler task + pytcp socket + session until tunnel teardown. The CLI keeps its tunnel for the process lifetime, so these accumulated without bound.

### The fix

Client EOF now **fully closes** the pytcp socket. The FIN still goes out (services treating EOF as "finish and close" behave identically), but a silent device leaves an orphan the reaper frees — and with pmd-pytcp ≥ 0.3.4, the session's death wakes the parked `recv()` so the handler finishes promptly. Re-measured: **0 of 30** abandoned connections leave anything behind.

### The 0.3.4 floor

[pmd-pytcp 0.3.4](https://github.com/doronz88/pmd-pytcp/releases/tag/v0.3.4) ships the stack-side half of this fix plus the audit's other tunnel-killers: death-wakes-receivers + RST as `ConnectionResetError`, the NUD FAILED black-hole (a device asleep ~3 s could kill the tunnel until process restart), the CLOSING dead-end, datagram close()-wakes-recv (`UserspaceUdp` readers no longer hang), and the post-close 1 kHz timer spin.

Also hardens `UserspaceTun.close()`: the stack-init marker is cleared in a `finally`, so an open→close→open cycle re-runs `stack.init()` even when `stop()` raised.

## Verification

- `tests/test_userspace_tunnel.py`: conversation test updated to pin full-close completion; new abandoned-client/silent-device regression (fails against the old half-close code); fake socket mirrors 0.3.4 semantics. 9/9 pass.
- pyright 1.1.411: 0 errors.
- Live device: stuck-task census 48 → 0 across 30 abandoned relays + churn (100× connect/close, 30× refused, 20× cancelled) drains to baseline; teardown leaves 0 sockets / 0 timers.
- Perf unchanged: `dvt ls /` 0.79–0.82 s (baseline 0.80–0.81), 30 MB afc push/pull within run variance.