### PR TITLE
cli: adopt PEP 810 lazy imports on Python 3.15+ (no-op on older versions)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,7 +30,9 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        # 3.15 is a prerelease (uv resolves it to the latest beta): it exercises the PEP 810
+        # lazy-imports path enabled by pymobiledevice3/_lazy_imports.py, which is a no-op below 3.15.
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15" ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,12 @@ Guidance for AI coding agents and automation contributors working in this reposi
 - The repository must stay pyright-clean: `pyright --venvpath .` (pinned to 1.1.411 in CI) must
   report 0 errors after any change. Suppressions must be rule-specific
   (`# pyright: ignore[ruleName]`) and reserved for inherently dynamic APIs.
+- On Python 3.15+ the CLI and the test suite run with PEP 810 lazy imports, scoped so
+  that only imports performed by pymobiledevice3's own modules are deferred
+  (`pymobiledevice3/_lazy_imports.py`; `__main__` and `tests/conftest.py` import it first
+  in their first-party block — isort keeps it there). A module-level import may not
+  execute until first use, so never rely on another module's import-time side effects;
+  anything that must run eagerly belongs in an explicit call. No-op on Python <= 3.14.
 - CLI commands are Typer-based and typically use dependency injection via
   `ServiceProviderDep` from `pymobiledevice3/cli/cli_common.py`.
 - Never import `click` or `typer._click` in package code. Typer (>= 0.20) vendors click

--- a/docs/guides/python-api.md
+++ b/docs/guides/python-api.md
@@ -180,3 +180,29 @@ There are ~30 services under `pymobiledevice3/services/`. A few common ones:
 For the full surface, see the [API reference](../api/index.md) and the
 [Writing CLI commands](writing-commands-with-service-provider.md) guide, which shows how the CLI
 wires service providers into commands.
+
+## 5. Faster imports on Python 3.15+
+
+On Python 3.15+ the CLI enables [PEP 810 lazy imports](https://peps.python.org/pep-0810/) for
+itself, scoped so that only pymobiledevice3's own imports are deferred — roughly halving its
+startup time. As a library, pymobiledevice3 never changes your process's import semantics:
+importing `pymobiledevice3.*` from your application stays eager.
+
+If you own the process, you can opt in to the same behavior. It saves ~0.2-0.3s on the heaviest
+entry points (e.g. `pymobiledevice3.remote.userspace_tunnel`), and the filter keeps every other
+package eager — process-wide laziness is known to break some import hooks:
+
+```python
+import sys
+
+
+def _lazy_filter(importing: str, imported: str, fromlist: object = None) -> bool:
+    return importing.partition(".")[0] == "pymobiledevice3"
+
+
+if hasattr(sys, "set_lazy_imports"):  # Python 3.15+
+    sys.set_lazy_imports("all")
+    sys.set_lazy_imports_filter(_lazy_filter)
+```
+
+Run this before importing any pymobiledevice3 module. On older Pythons it is a no-op.

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -22,6 +22,9 @@ try:
 except ImportError:  # pragma: no cover
     shellingham = None
 
+# Must precede the other first-party imports (isort keeps it first) so their dependency
+# chains are lazy on Python 3.15+; see the module docstring.
+import pymobiledevice3._lazy_imports  # noqa: F401
 from pymobiledevice3.cli.cli_common import (
     PREFER_TUNNELD_ENV_VAR,
     TUNNEL_ENV_VAR,

--- a/pymobiledevice3/_lazy_imports.py
+++ b/pymobiledevice3/_lazy_imports.py
@@ -1,0 +1,34 @@
+"""
+Opt the current process into PEP 810 lazy imports, scoped to pymobiledevice3's own imports.
+
+Importing this module is a deliberate side effect: on Python 3.15+ every module-level import
+performed *by a pymobiledevice3 module* becomes potentially lazy, so heavy dependency chains
+(pykdebugparser, fastapi, IPython, qh3, ...) load on first use instead of at CLI startup
+(roughly 2x faster command dispatch and ``--help``). The filter below keeps third-party
+modules' own imports eager: process-wide laziness is known to break import hooks in other
+packages (e.g. pytest's assertion rewriter trips over a lazy ``fnmatch`` proxy).
+
+On Python < 3.15 importing this module is a no-op. Only process entry points should import it
+(``pymobiledevice3.__main__``, ``tests/conftest.py``) -- library consumers are never affected.
+"""
+
+import sys
+from typing import Callable, Optional
+
+_LAZY_TOP_LEVEL_MODULES = ("pymobiledevice3", "__main__")
+
+
+def _lazy_filter(importing: str, imported: str, fromlist: object = None) -> bool:
+    """Keep an import lazy only when a pymobiledevice3 module (or the CLI ``__main__``) performs it."""
+    return importing.partition(".")[0] in _LAZY_TOP_LEVEL_MODULES
+
+
+# getattr keeps pyright (pinned to the 3.9 floor) away from attributes typeshed gates on 3.15.
+_set_lazy_imports: Optional[Callable[[str], None]] = getattr(sys, "set_lazy_imports", None)
+_set_lazy_imports_filter: Optional[Callable[[Callable[[str, str, object], bool]], None]] = getattr(
+    sys, "set_lazy_imports_filter", None
+)
+
+if _set_lazy_imports is not None and _set_lazy_imports_filter is not None:  # Python 3.15+ (PEP 810)
+    _set_lazy_imports("all")
+    _set_lazy_imports_filter(_lazy_filter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
 ]
 dynamic = ["version"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,9 @@ from typing import Any, Union
 import pytest
 import pytest_asyncio
 
+# Must precede the other first-party imports (isort keeps it first): on Python 3.15+ this makes
+# pymobiledevice3-internal imports lazy for the whole test run, exercising the mode the CLI ships.
+import pymobiledevice3._lazy_imports  # noqa: F401
 from pymobiledevice3.exceptions import (
     ConnectionFailedToUsbmuxdError,
     DeviceNotFoundError,

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,32 @@
+import subprocess
+import sys
+
+from pymobiledevice3._lazy_imports import _lazy_filter
+
+LAZY_IMPORTS_SUPPORTED = hasattr(sys, "set_lazy_imports")  # Python 3.15+ (PEP 810)
+
+
+def test_lazy_filter_keeps_pymobiledevice3_imports_lazy() -> None:
+    assert _lazy_filter("pymobiledevice3", "typer")
+    assert _lazy_filter("pymobiledevice3.cli.developer.dvt.core_profile_session", "pykdebugparser.pykdebugparser")
+    # `python -m pymobiledevice3` executes __main__.py under the module name "__main__"
+    assert _lazy_filter("__main__", "pymobiledevice3.cli.cli_common")
+
+
+def test_lazy_filter_leaves_foreign_imports_eager() -> None:
+    # Laziness inside arbitrary packages breaks import hooks (e.g. pytest's assertion rewriter)
+    assert not _lazy_filter("_pytest.assertion.rewrite", "fnmatch")
+    assert not _lazy_filter("conftest", "pymobiledevice3.lockdown")
+    # Only a whole leading component counts, not a name prefix
+    assert not _lazy_filter("pymobiledevice3_fork.module", "os")
+
+
+def test_cli_entry_enables_scoped_lazy_imports() -> None:
+    """Importing the CLI entry module must flip the process to filtered lazy mode on 3.15+."""
+    # Subprocess because sys.set_lazy_imports() is process-global state
+    if LAZY_IMPORTS_SUPPORTED:
+        checks = "assert sys.get_lazy_imports() == 'all'; assert sys.get_lazy_imports_filter() is not None"
+    else:
+        checks = "assert not hasattr(sys, 'get_lazy_imports')"
+    code = f"import sys; import pymobiledevice3.__main__; {checks}"
+    subprocess.run([sys.executable, "-c", code], check=True)


### PR DESCRIPTION
## What

Opt the CLI process into [PEP 810](https://peps.python.org/pep-0810/) lazy imports on Python 3.15+, scoped via `sys.set_lazy_imports_filter()` so **only imports performed by pymobiledevice3's own modules** become lazy. Third-party packages' internals stay eager — unscoped process-wide laziness is known to break import hooks (pytest's assertion rewriter raises `ImportCycleError` over a lazy `fnmatch` proxy).

On Python <= 3.14 the shim is a `getattr`-guarded no-op: no new syntax, the 3.9 floor is untouched, and library consumers are never affected (only `__main__` and `tests/conftest.py` import the shim).

## Why

CLI startup is dominated by eagerly importing heavy dependency chains (pykdebugparser, fastapi/pydantic, IPython, qh3, cryptography) that most invocations never use. `__main__` already imports CLI groups on demand, but `--help` renders short-help for all 28 groups and every group eagerly pulls its service modules.

Measured on 3.15.0b3 (macOS arm64, warm cache, device connected):

| scenario | eager | lazy |
|---|---|---|
| `pymobiledevice3 --help` | 0.55s | 0.23s |
| `pymobiledevice3 usbmux list` | 0.53s | 0.39s (rest is device I/O) |

Import self-time for `--help` drops 413ms -> 157ms.

## Validation

- Full test suite against a physical iPhone on 3.15.0b3 with lazy mode active: identical results to eager (603 passed; the 2 failures — `test_afc.py::test_dirlist`, `test_backup2.py::test_encrypted_backup` — are pre-existing device-state issues that fail identically on 3.14 eager).
- `--help` output byte-identical lazy vs eager.
- `tests/conftest.py` imports the shim, so the suite permanently exercises the shipped mode on 3.15+; the CI matrix now includes the 3.15 prerelease.
- pyright (1.1.411) clean without suppressions — the shim uses typed `getattr` lookups since typeshed gates the new `sys` attributes on 3.15 while `pythonVersion` is pinned to the 3.9 floor.

Known residual: Typer resolves parameter-type annotations at registration, so modules whose enums appear in command signatures (e.g. `remote.tunnel_service` via `TunnelProtocol`) still reify during `--help`. Moving such enums into lighter modules could claw back more later; deliberately out of scope here.