### PR TITLE
utils: import IPython inside start_ipython_shell

### DIFF
--- a/pymobiledevice3/utils.py
+++ b/pymobiledevice3/utils.py
@@ -6,7 +6,6 @@ from functools import wraps
 from pathlib import Path
 from typing import Any, Callable, Optional, Union, cast, overload
 
-import IPython
 import questionary
 import requests
 from construct import Int8ul, Int16ul, Int32ul, Int64ul, Select
@@ -121,6 +120,12 @@ def ask_prompt(question: questionary.Question) -> Any:
 
 
 def start_ipython_shell(*, user_ns: Optional[dict[str, Any]] = None, header: Optional[str] = None) -> None:
+    # Imported here rather than at module scope. This is IPython's only use
+    # in the package, but `pymobiledevice3.lockdown` imports this module, so
+    # every library consumer that opens a lockdown connection was paying to
+    # import a REPL it never starts.
+    import IPython
+
     # Keep IPython autoawait on the same loop used by CLI async wrappers.
     config = Config()
     config.InteractiveShell.loop_runner = run_in_loop


### PR DESCRIPTION
`pymobiledevice3.lockdown` imports `pymobiledevice3.utils`, and `utils` imports IPython at module scope. IPython is used in exactly one place — `start_ipython_shell` — so every library consumer that opens a lockdown connection pays to import a REPL it never starts.

### Measured

Python 3.13.12, venv installed from `main` (`74faf40`), best of 5:

```python
from pymobiledevice3.lockdown import create_using_usbmux
```

| | import time | IPython loaded |
|---|---|---|
| before | **180.1 ms** | yes |
| after | **125.1 ms** | no |

`-X importtime` on the same import, before: `pymobiledevice3.lockdown` 180.9 ms, of which `pymobiledevice3.utils` 114.5 ms and **IPython 86.1 ms** — about 48% of the total.

### Why this isn't covered by #1855

The PEP 810 work is opted into by `__main__.py`, so it applies to the CLI and not to library consumers; and `sys.set_lazy_imports` requires 3.15+, so it is a no-op on current releases. Deferring this one import helps both audiences on every version, and costs nothing where PEP 810 is active.

### Checks

- `ruff check pymobiledevice3/utils.py` — passes
- every module in the package still imports; the only two failures (`osu.win_util`, `remote.core_device.hevc_av`) reproduce identically on unmodified `main` on macOS
- `python -m pymobiledevice3 version` still works
- `start_ipython_shell` is unchanged in behaviour — it imports IPython on entry, the only moment it needed it

Found while profiling a downstream tool where a device-listing call spent more time importing than talking to the phone.