### PR TITLE
device_link: chunk download_files at 32 KiB to avoid BackupAgent2 OOM

### DIFF
--- a/pymobiledevice3/services/device_link.py
+++ b/pymobiledevice3/services/device_link.py
@@ -172,9 +172,20 @@ class DeviceLink:
             try:
                 file_path = self.root_path / file
 
-                # split into chunks, otherwise we may crash BackupAgent2 by OOM
-                # https://github.com/doronz88/pymobiledevice3/issues/1165#issuecomment-2376815692
-                chunk_size = 128 * 1024 * 1024  # 128 MB
+                # Split each file into small protocol frames. BackupAgent2 buffers a whole
+                # frame in memory before flushing it to disk, so large frames drive its RSS
+                # up: on an incremental backup the host sends the previous Manifest.db back
+                # (via DLMessageDownloadFiles) for the device to diff, and a big Manifest.db
+                # (issues #1165, #1857) pushes BackupAgent2 past its jetsam memory limit --
+                # the process is killed mid-transfer and the backup hangs at 0%.
+                #
+                # Apple's own DeviceLink.framework (the host side Finder uses) sends file
+                # data in 32 KiB frames by default (the "BufferSize" preference under
+                # com.apple.DeviceLink; _DLSendFileForBulkOperation reads BufferSize-1 bytes
+                # per frame), so match that. Measured against a 1.55 GB Manifest.db: 128 MiB
+                # frames breach the device memory limit and crawl at ~8.5 MB/s, while 32 KiB
+                # frames stay under it and run ~4.6x faster (same ~40 MB/s as 1 MiB).
+                chunk_size = 32 * 1024  # 32 KiB, matching Apple's DeviceLink BufferSize default
 
                 with file_path.open("rb") as file_handle:
                     while True:


### PR DESCRIPTION
Fixes #1857 (and the same root cause behind #1165).

## Problem

On an **incremental** `backup2`, the device asks the host to send the previous
`Manifest.db` back (`DLMessageDownloadFiles`) so `BackupAgent2` can diff it.
`BackupAgent2` buffers a whole protocol frame in memory before flushing it to
disk, so the old **128 MiB** frame size drives its RSS up. With a large
`Manifest.db` (the reporter's is ~1.55 GB / 1.31M rows) this pushes `BackupAgent2`
past its jetsam memory limit; the kernel kills it mid-transfer and the backup
hangs at **0%**.

The earlier note that "even 32 KiB chunks did not help" (#1165) referred to the
*old* code, which declared a single whole-file frame (`len(data)+1`) and only
split the **socket writes** — so the device always saw one giant frame. With the
current per-frame framing, the frame size is exactly what bounds the device's
memory use.

## Fix

Send `download_files` data in **32 KiB** frames.

This is what Apple's own `DeviceLink.framework` (the host side Finder uses) does
by default: the frame size is the `BufferSize` preference under
`com.apple.DeviceLink`, defaulting to `0x8001`, and `_DLSendFileForBulkOperation`
sends `BufferSize - 1` = 32768 data bytes per frame — with the identical wire
framing (4-byte big-endian length + `0x0C` code byte) this code already uses.

## Measurements

Reproduced on a physical iPhone by inflating a real `Manifest.db` to 1.55 GB and
sending it through the incremental `download_files` path, watching `BackupAgent2`
via `memorystatus` in device syslog. Only the frame size was varied:

| frame size | send time (1.55 GB) | throughput | memory-limit breaches |
|---|---|---|---|
| 32 KiB (this PR / Apple default) | 38.8 s | 39.9 MB/s | 0 |
| 1 MiB | 39.0 s | 39.8 MB/s | 0 |
| 32 MiB | 56.0 s | 27.7 MB/s | 1 |
| 128 MiB (before) | 180.8 s | 8.5 MB/s | 2 |

Smaller frames keep `BackupAgent2` under its memory limit and are ~4.6x faster;
32 KiB has no throughput penalty vs. larger frames. (The test device has more RAM
than the reporter's iPhone 16, so here 128 MiB only *soft*-breached rather than
being killed — but the mechanism, and that 32 KiB avoids the breach entirely, are
the same.)

## Please verify

@OiCkilL — since I can't reproduce the actual jetsam kill on the hardware I have,
could you check this branch against your device with the ~1.55 GB `Manifest.db`?
The incremental should now complete instead of hanging at 0%. If it still stalls,
`pymobiledevice3 syslog live -mi backup` (and grepping for
`memorystatus`/`BackupAgent2`) during the run would confirm whether it's still the
memory limit or something else.
