### PR TITLE
feat(afc): mount AFC filesystems in Finder over WebDAV

### DIFF
--- a/docs/guides/webdav-mounting.md
+++ b/docs/guides/webdav-mounting.md
@@ -1,0 +1,50 @@
+---
+search:
+  boost: 2
+---
+
+# Mounting AFC in Finder (WebDAV)
+
+Any AFC-backed service can be exposed as a local **WebDAV** volume, so macOS Finder (or any
+WebDAV client) can browse and edit the device's filesystem read-write as if it were mounted.
+
+A small async WebDAV server runs inside the `pymobiledevice3` process; every WebDAV request is
+translated into `AfcService` calls. There is a `webdav` subcommand under each AFC-backed group:
+
+```shell
+# media AFC (/var/mobile/Media)
+pymobiledevice3 afc webdav [PATH] [--mount]
+
+# an app's container (pass --documents for Documents-only)
+pymobiledevice3 apps webdav BUNDLE_ID [PATH] [--documents] [--mount]
+
+# crash reports
+pymobiledevice3 crash webdav [PATH] [--mount]
+```
+
+`PATH` defaults to the service root. Press `Ctrl-C` to unmount and stop the server.
+
+## Mounting
+
+With `--mount`, the volume is mounted and revealed using the host's native mechanism —
+`mount_webdav` on macOS, `net use` on Windows, `gio mount` on Linux. If no such tool is
+available, the server instead prints its `http://127.0.0.1:PORT` URL for you to open manually
+(Finder's **Go → Connect to Server**, or your file manager's equivalent).
+
+WebDAV is used rather than FTP because macOS Finder mounts FTP read-only; WebDAV mounts
+read-write.
+
+## Notes and limitations
+
+- **Freshness / stale views.** A mounted WebDAV volume is a *client-cached network filesystem*.
+  Changes you make through the mount are immediate, but changes made on the device out-of-band
+  (an app writing to its container, say) may appear stale until the client revalidates. WebDAV has
+  no live-reload mechanism, and macOS's WebDAV client caches directory listings and attributes at
+  the kernel level regardless of server hints. To force a refresh, navigate out of the folder and
+  back (or reopen the window).
+- **Read-write** browse, read, create, edit, `mkdir`, rename/move, and delete all propagate to the
+  device.
+- **Finder metadata** (`.DS_Store`, AppleDouble `._*`) writes are swallowed — reported as success
+  but never written to the device.
+- **Permissions/ownership** cannot be changed over WebDAV (no `chmod`/`chown`); AFC exposes none.
+- **Python 3.10+** is required for the WebDAV feature (the `asgiwebdav` dependency).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
   - Installation: installation.md
   - Guides:
       - CLI recipes: guides/cli-recipes.md
+      - Mounting AFC in Finder (WebDAV): guides/webdav-mounting.md
       - iOS 17+ tunnels: guides/ios17-tunnels.md
       - WebView debugging: guides/webview-debugging.md
       - Machine-readable output: guides/machine-readable-output.md

--- a/pymobiledevice3/cli/afc.py
+++ b/pymobiledevice3/cli/afc.py
@@ -4,7 +4,16 @@ from typing import Annotated
 import typer
 from typer_injector import InjectingTyper
 
-from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command
+from pymobiledevice3.cli.cli_common import (
+    ServiceProviderDep,
+    WebDavBindPortOption,
+    WebDavHostOption,
+    WebDavMountOption,
+    WebDavPathArgument,
+    WebDavReadonlyOption,
+    async_command,
+    run_afc_webdav_cli,
+)
 from pymobiledevice3.services.afc import AfcService, AfcShell
 
 cli = InjectingTyper(
@@ -18,6 +27,24 @@ cli = InjectingTyper(
 def afc_shell(service_provider: ServiceProviderDep) -> None:
     """Open an interactive AFC shell rooted at /var/mobile/Media."""
     AfcShell.create(service_provider)
+
+
+@cli.command("webdav")
+@async_command
+async def afc_webdav(
+    service_provider: ServiceProviderDep,
+    path: WebDavPathArgument = "/",
+    mount: WebDavMountOption = False,
+    host: WebDavHostOption = "127.0.0.1",
+    bind_port: WebDavBindPortOption = 0,
+    readonly: WebDavReadonlyOption = False,
+) -> None:
+    """Serve /var/mobile/Media over WebDAV for local mounting (e.g. in Finder)."""
+    async with AfcService(lockdown=service_provider) as afc:
+        label = f"pmd-{service_provider.udid or 'device'}-afc"
+        await run_afc_webdav_cli(
+            afc, path=path, mount=mount, host=host, bind_port=bind_port, readonly=readonly, label=label
+        )
 
 
 @cli.command("pull")

--- a/pymobiledevice3/cli/apps.py
+++ b/pymobiledevice3/cli/apps.py
@@ -8,9 +8,15 @@ from typer_injector import InjectingTyper
 from pymobiledevice3.cli.cli_common import (
     RSDServiceProviderDep,
     ServiceProviderDep,
+    WebDavBindPortOption,
+    WebDavHostOption,
+    WebDavMountOption,
+    WebDavPathArgument,
+    WebDavReadonlyOption,
     async_command,
     cli_loop,
     print_json,
+    run_afc_webdav_cli,
 )
 from pymobiledevice3.services.house_arrest import HouseArrestService
 from pymobiledevice3.services.install_coordination_proxy import InstallCoordinationProxyService
@@ -108,6 +114,28 @@ def afc(
         service.shell()
     finally:
         cli_loop.run_until_complete(service.close())
+
+
+@cli.command("webdav")
+@async_command
+async def apps_webdav(
+    service_provider: ServiceProviderDep,
+    bundle_id: str,
+    path: WebDavPathArgument = "/",
+    documents: Annotated[bool, typer.Option()] = False,
+    mount: WebDavMountOption = False,
+    host: WebDavHostOption = "127.0.0.1",
+    bind_port: WebDavBindPortOption = 0,
+    readonly: WebDavReadonlyOption = False,
+) -> None:
+    """Serve an app container over WebDAV for local mounting; pass --documents for Documents-only."""
+    async with await HouseArrestService.create(
+        lockdown=service_provider, bundle_id=bundle_id, documents_only=documents
+    ) as service:
+        label = f"pmd-{service_provider.udid or 'device'}-{bundle_id}"
+        await run_afc_webdav_cli(
+            service, path=path, mount=mount, host=host, bind_port=bind_port, readonly=readonly, label=label
+        )
 
 
 @cli.command("pull")

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -213,6 +213,46 @@ def async_command(func: Callable[P, Coroutine[Any, Any, R]]) -> Callable[P, R]:
     return wrapper
 
 
+def require_webdav_mount_tool(mount: bool) -> None:
+    """Fail early if ``--mount`` was requested but no WebDAV mount tool is available on this host."""
+    from pymobiledevice3.services.webdav_mount import webdav_mount_supported
+
+    if mount and not webdav_mount_supported():
+        typer.secho(
+            "--mount is unavailable: no supported WebDAV mount tool found "
+            "(mount_webdav on macOS, net on Windows, gio on Linux)",
+            fg="red",
+            err=True,
+        )
+        raise typer.Exit(2)
+
+
+async def run_afc_webdav_cli(
+    afc: Any, *, path: str, mount: bool, host: str, bind_port: int, readonly: bool, label: str
+) -> None:
+    """Serve an open AFC service over WebDAV from a CLI command, and block until interrupted.
+
+    The WebDAV dependencies require Python >= 3.10; on older interpreters a clear error is emitted.
+    """
+    require_webdav_mount_tool(mount)
+    try:
+        from pymobiledevice3.services.webdav import run_afc_webdav
+    except ImportError as e:
+        typer.secho("WebDAV support requires Python >= 3.10", fg="red", err=True)
+        raise typer.Exit(1) from e
+    await run_afc_webdav(afc, path=path, mount=mount, host=host, port=bind_port, readonly=readonly, label=label)
+
+
+# Shared options for the `webdav` subcommands across the AFC-backed CLI groups.
+WebDavPathArgument = Annotated[str, typer.Argument(help="AFC path to serve as the volume root (default: /)")]
+WebDavMountOption = Annotated[
+    bool, typer.Option("--mount", help="mount the served path locally and reveal it in your file manager")
+]
+WebDavHostOption = Annotated[str, typer.Option("--host", help="local interface to bind")]
+WebDavBindPortOption = Annotated[int, typer.Option("--bind-port", help="local TCP port (0 picks a free port)")]
+WebDavReadonlyOption = Annotated[bool, typer.Option("--readonly", help="expose the path read-only")]
+
+
 async def get_mobdev2_devices(udid: Optional[str] = None) -> list[TcpLockdownClient]:
     return [lockdown async for _, lockdown in get_mobdev2_lockdowns(udid=udid)]
 

--- a/pymobiledevice3/cli/crash.py
+++ b/pymobiledevice3/cli/crash.py
@@ -8,8 +8,14 @@ from pymobiledevice3.cli.cli_common import (
     OutputFormat,
     OutputFormatOption,
     ServiceProviderDep,
+    WebDavBindPortOption,
+    WebDavHostOption,
+    WebDavMountOption,
+    WebDavPathArgument,
+    WebDavReadonlyOption,
     async_command,
     print_json_line,
+    run_afc_webdav_cli,
 )
 from pymobiledevice3.services.crash_reports import CrashReportsManager, CrashReportsShell
 
@@ -126,6 +132,24 @@ async def crash_pull(
 def crash_shell(service_provider: ServiceProviderDep) -> None:
     """start an afc shell"""
     CrashReportsShell.create(service_provider)
+
+
+@cli.command("webdav")
+@async_command
+async def crash_webdav(
+    service_provider: ServiceProviderDep,
+    path: WebDavPathArgument = "/",
+    mount: WebDavMountOption = False,
+    host: WebDavHostOption = "127.0.0.1",
+    bind_port: WebDavBindPortOption = 0,
+    readonly: WebDavReadonlyOption = False,
+) -> None:
+    """Serve the crash reports directory over WebDAV for local mounting."""
+    async with CrashReportsManager(service_provider) as crash_manager:
+        label = f"pmd-{service_provider.udid or 'device'}-crash"
+        await run_afc_webdav_cli(
+            crash_manager.afc, path=path, mount=mount, host=host, bind_port=bind_port, readonly=readonly, label=label
+        )
 
 
 @cli.command("ls")

--- a/pymobiledevice3/services/webdav.py
+++ b/pymobiledevice3/services/webdav.py
@@ -1,0 +1,386 @@
+"""Serve an AFC filesystem over a local WebDAV server.
+
+Runs an async WebDAV server (ASGIWebDAV) in-process; every WebDAV request is
+translated into ``AfcService`` calls, so a local WebDAV client (e.g. macOS Finder)
+can browse and edit the device's AFC filesystem read-write as a mounted volume.
+
+ASGIWebDAV requires Python >= 3.10, so this module must be imported lazily by
+callers that still need to run on older interpreters (they should catch
+``ImportError`` and surface a friendly message).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import posixpath
+from stat import S_ISDIR, S_ISREG
+from typing import Any, Optional
+
+import uvicorn
+from asgi_webdav.config import Config, generate_config_from_dict, reinit_global_config
+from asgi_webdav.constants import (
+    RESPONSE_DATA_BLOCK_SIZE,
+    DAVDepth,
+    DAVPath,
+    DAVResponseBodyGenerator,
+    DAVResponseContentRange,
+    DAVTime,
+)
+from asgi_webdav.helpers import generate_etag, guess_type
+from asgi_webdav.property import DAVProperty, DAVPropertyBasicData
+from asgi_webdav.provider.common import DAVProvider, DAVProviderFeature
+from asgi_webdav.request import DAVRequest
+from asgi_webdav.server import DAVApp
+from asgi_webdav.web_dav import PrefixProviderInfo
+
+from pymobiledevice3.exceptions import AfcException
+from pymobiledevice3.services.webdav_mount import (
+    mount_webdav_volume,
+    reveal_in_file_manager,
+    unmount_webdav_volume,
+)
+
+logger = logging.getLogger(__name__)
+
+_APPLE_METADATA_NAMES = frozenset({
+    ".DS_Store",
+    ".localized",
+    ".hidden",
+    ".Trashes",
+    ".apdisk",
+    ".metadata_never_index",
+    ".VolumeIcon.icns",
+})
+
+
+def _is_apple_metadata(name: str) -> bool:
+    """Whether a basename is macOS Finder metadata (``.DS_Store`` / AppleDouble ``._*`` / friends)."""
+    return name.startswith("._") or name in _APPLE_METADATA_NAMES
+
+
+async def _drain(request: DAVRequest) -> None:
+    """Consume and discard a request body."""
+    more_body = True
+    while more_body:
+        event = await request.receive()
+        more_body = event.get("more_body")
+
+
+class AfcDavProvider(DAVProvider):
+    """A WebDAV provider whose backing store is a device's AFC filesystem."""
+
+    type = "afc"
+    feature = DAVProviderFeature(content_range=False, home_dir=False)
+
+    def __init__(self, afc: Any, root: str, config: Config, prefix: DAVPath, read_only: bool) -> None:
+        super().__init__(
+            config=config,
+            prefix=prefix,
+            uri=f"afc://{root}",
+            home_dir=False,
+            read_only=read_only,
+            ignore_property_extra=True,
+        )
+        self._afc = afc
+        self._root = "/" + root.strip("/")
+
+    def __repr__(self) -> str:
+        return f"afc://{self._root}"
+
+    def _afc_path(self, path: DAVPath) -> str:
+        return posixpath.join(self._root, *path.parts)
+
+    async def _create_dav_property_obj(self, href_path: DAVPath, stat_result: Any) -> DAVProperty:
+        is_collection = S_ISDIR(stat_result.st_mode)
+        created = getattr(stat_result, "st_birthtime", stat_result.st_mtime)
+        if is_collection:
+            basic_data = DAVPropertyBasicData(
+                is_collection=is_collection,
+                display_name=href_path.name,
+                creation_date=DAVTime(created),
+                last_modified=DAVTime(stat_result.st_mtime),
+            )
+        else:
+            content_type, content_encoding = guess_type(self.config, href_path.name)
+            basic_data = DAVPropertyBasicData(
+                is_collection=is_collection,
+                display_name=href_path.name,
+                creation_date=DAVTime(created),
+                last_modified=DAVTime(stat_result.st_mtime),
+                content_type="" if content_type is None else content_type,
+                content_charset=None,
+                content_length=stat_result.st_size,
+                content_encoding=content_encoding,
+            )
+        return DAVProperty(href_path=href_path, is_collection=is_collection, basic_data=basic_data)
+
+    async def _get_res_etag(self, request: DAVRequest) -> str:
+        stat_result = await self._afc.os_stat(self._afc_path(request.dist_src_path))
+        return generate_etag(stat_result.st_size, stat_result.st_mtime)
+
+    async def _do_propfind(self, request: DAVRequest) -> dict[DAVPath, DAVProperty]:
+        dav_properties: dict[DAVPath, DAVProperty] = {}
+        try:
+            base_stat = await self._afc.os_stat(self._afc_path(request.dist_src_path))
+        except AfcException:
+            return dav_properties
+
+        dav_properties[request.src_path] = await self._create_dav_property_obj(request.src_path, base_stat)
+        if request.depth != DAVDepth.ZERO and S_ISDIR(base_stat.st_mode):
+            await self._propfind_children(dav_properties, request.src_path, infinity=request.depth == DAVDepth.INFINITY)
+        return dav_properties
+
+    async def _propfind_children(
+        self, dav_properties: dict[DAVPath, DAVProperty], href_base: DAVPath, infinity: bool, depth_limit: int = 99
+    ) -> None:
+        sub_dir_names: list[str] = []
+        for name in await self._afc.listdir(self._afc_path(href_base)):
+            if _is_apple_metadata(name):
+                continue
+            href_path = href_base.add_child(name)
+            try:
+                stat_result = await self._afc.os_stat(self._afc_path(href_path))
+            except AfcException:
+                continue
+            dav_properties[href_path] = await self._create_dav_property_obj(href_path, stat_result)
+            if S_ISDIR(stat_result.st_mode) and infinity:
+                sub_dir_names.append(name)
+
+        if not infinity or depth_limit <= 0:
+            return
+        for name in sub_dir_names:
+            await self._propfind_children(dav_properties, href_base.add_child(name), infinity, depth_limit - 1)
+
+    async def _do_get(
+        self, request: DAVRequest
+    ) -> tuple[
+        int,
+        Optional[DAVPropertyBasicData],
+        Optional[DAVResponseBodyGenerator],
+        Optional[DAVResponseContentRange],
+    ]:
+        if _is_apple_metadata(request.dist_src_path.name):
+            return 404, None, None, None
+        afc_path = self._afc_path(request.dist_src_path)
+        try:
+            stat_result = await self._afc.os_stat(afc_path)
+        except AfcException:
+            return 404, None, None, None
+
+        if S_ISDIR(stat_result.st_mode):
+            dav_property = await self._create_dav_property_obj(request.src_path, stat_result)
+            return 200, dav_property.basic_data, None, None
+        if not S_ISREG(stat_result.st_mode):
+            # refuse fifos / devices / sockets: reading them can block the AFC channel
+            return 403, None, None, None
+
+        dav_property = await self._create_dav_property_obj(request.src_path, stat_result)
+        return 200, dav_property.basic_data, self._body_generator(afc_path), None
+
+    async def _do_head(self, request: DAVRequest) -> tuple[int, Optional[DAVPropertyBasicData]]:
+        if _is_apple_metadata(request.dist_src_path.name):
+            return 404, None
+        try:
+            stat_result = await self._afc.os_stat(self._afc_path(request.dist_src_path))
+        except AfcException:
+            return 404, None
+        if not (S_ISDIR(stat_result.st_mode) or S_ISREG(stat_result.st_mode)):
+            return 403, None
+        dav_property = await self._create_dav_property_obj(request.src_path, stat_result)
+        return 200, dav_property.basic_data
+
+    async def _body_generator(self, afc_path: str) -> DAVResponseBodyGenerator:
+        handle = await self._afc.fopen(afc_path, "r")
+        try:
+            more_body = True
+            while more_body:
+                data = await self._afc.fread(handle, RESPONSE_DATA_BLOCK_SIZE)
+                more_body = len(data) == RESPONSE_DATA_BLOCK_SIZE
+                yield data, more_body
+        finally:
+            await self._afc.fclose(handle)
+
+    async def _do_put(self, request: DAVRequest) -> int:
+        if _is_apple_metadata(request.dist_src_path.name):
+            # swallow Finder metadata writes: report success without touching the device
+            await _drain(request)
+            return 201
+        afc_path = self._afc_path(request.dist_src_path)
+        try:
+            stat_result = await self._afc.os_stat(afc_path)
+        except AfcException:
+            stat_result = None
+        if stat_result is not None and not S_ISREG(stat_result.st_mode):
+            return 405
+
+        try:
+            handle = await self._afc.fopen(afc_path, "w")
+            try:
+                more_body = True
+                while more_body:
+                    event = await request.receive()
+                    more_body = event.get("more_body")
+                    data = event.get("body", b"")
+                    if data:
+                        await self._afc.fwrite(handle, data)
+            finally:
+                await self._afc.fclose(handle)
+        except AfcException:
+            return 403
+        return 201
+
+    async def _do_delete(self, request: DAVRequest) -> int:
+        if _is_apple_metadata(request.dist_src_path.name):
+            return 204
+        afc_path = self._afc_path(request.dist_src_path)
+        if not await self._afc.exists(afc_path):
+            return 404
+        try:
+            await self._afc.rm(afc_path, force=False)
+        except AfcException:
+            return 403
+        return 204
+
+    async def _do_mkcol(self, request: DAVRequest) -> int:
+        afc_path = self._afc_path(request.dist_src_path)
+        if await self._afc.exists(afc_path):
+            return 405
+        parent = posixpath.dirname(afc_path.rstrip("/"))
+        if not await self._afc.exists(parent):
+            return 409
+        try:
+            await self._afc.makedirs(afc_path)
+        except AfcException:
+            return 403
+        return 201
+
+    async def _do_move(self, request: DAVRequest) -> int:
+        src = self._afc_path(request.dist_src_path)
+        dst = self._afc_path(request.dist_dst_path)
+        if not await self._afc.exists(src):
+            return 403
+        if not await self._afc.exists(posixpath.dirname(dst.rstrip("/"))):
+            return 409
+        dst_exists = await self._afc.exists(dst)
+        if not request.overwrite and dst_exists:
+            return 412
+        try:
+            if dst_exists:
+                await self._afc.rm(dst, force=True)
+            await self._afc.rename(src, dst)
+        except AfcException:
+            return 403
+        return 204 if request.overwrite else 201
+
+
+class WebDavServer:
+    """Handle for a running WebDAV server."""
+
+    def __init__(self, uvicorn_server: Any, task: Any, host: str, port: int) -> None:
+        self._server = uvicorn_server
+        self._task = task
+        self.host = host
+        self.port = port
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}/"
+
+    async def stop(self) -> None:
+        self._server.should_exit = True
+        await self._task
+
+
+async def serve_afc_webdav(
+    afc: Any, *, path: str = "/", host: str = "127.0.0.1", port: int = 0, readonly: bool = False
+) -> WebDavServer:
+    """Start a WebDAV server exposing ``afc`` (an :class:`AfcService`).
+
+    :param afc: an open AFC service to bridge.
+    :param path: AFC path to serve as the volume root (default: /).
+    :param host: local interface to bind (default: loopback).
+    :param port: local TCP port; 0 picks a free port.
+    :param readonly: expose the filesystem read-only.
+    :return: a running-server handle with ``url`` and ``stop()``.
+    """
+    for name in ("asgi_webdav", "uvicorn", "uvicorn.error", "uvicorn.access"):
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+    config = generate_config_from_dict({
+        "account_mapping": [{"username": "anonymous", "password": "", "permissions": ["+"]}],
+        "anonymous": {
+            "enable": True,
+            "user": {"username": "anonymous", "password": "", "permissions": ["+"]},
+            "allow_missing_auth_header": True,
+        },
+        "provider_mapping": [],
+        "logging": {"enable": False},
+    })
+    reinit_global_config(config)
+
+    app = DAVApp(config)
+    provider = AfcDavProvider(afc=afc, root=path, config=config, prefix=DAVPath("/"), read_only=readonly)
+    app.web_dav.prefix_provider_mapping = [
+        PrefixProviderInfo(
+            prefix=DAVPath("/"),
+            prefix_weight=1,
+            provider=provider,
+            home_dir=False,
+            read_only=readonly,
+            ignore_property_extra=True,
+        )
+    ]
+
+    uv_config = uvicorn.Config(app, host=host, port=port, log_level="warning", lifespan="off")
+    server = uvicorn.Server(uv_config)
+    task = asyncio.ensure_future(server.serve())
+    while not server.started:
+        await asyncio.sleep(0.02)
+    bound_port = server.servers[0].sockets[0].getsockname()[1]
+    return WebDavServer(server, task, host, bound_port)
+
+
+async def run_afc_webdav(
+    afc: Any,
+    *,
+    path: str = "/",
+    mount: bool = False,
+    host: str = "127.0.0.1",
+    port: int = 0,
+    readonly: bool = False,
+    label: str = "pmd-webdav",
+) -> None:
+    """Serve ``afc`` over WebDAV, optionally mount it locally, and block until interrupted.
+
+    :param afc: an open AFC service to bridge.
+    :param path: AFC path to serve (default: /).
+    :param mount: mount the volume locally and reveal it in the OS file manager.
+    :param host: local interface to bind.
+    :param port: local TCP port; 0 picks a free port.
+    :param readonly: expose the filesystem read-only.
+    :param label: descriptive name for the local mount point, so it is easy to spot in Finder.
+    """
+    server = await serve_afc_webdav(afc, path=path, host=host, port=port, readonly=readonly)
+    print(f"WebDAV server serving {path!r} at {server.url}")
+
+    mounted = None
+    if mount:
+        mounted = await mount_webdav_volume(server.url, label=label)
+        if mounted is None:
+            print("Automatic mount is unavailable on this host; open the URL below in your file manager.")
+
+    if mounted is not None:
+        await reveal_in_file_manager(mounted.reveal_target)
+        print(f"Mounted; revealed {mounted.reveal_target}")
+    else:
+        print(f"Open this WebDAV URL in your file manager: {server.url}")
+    print("Press Ctrl-C to stop.")
+
+    try:
+        await asyncio.Event().wait()
+    finally:
+        if mounted is not None:
+            await unmount_webdav_volume(mounted)
+        await server.stop()
+        print("stopped.")

--- a/pymobiledevice3/services/webdav_mount.py
+++ b/pymobiledevice3/services/webdav_mount.py
@@ -1,0 +1,136 @@
+"""Cross-platform helpers for mounting a WebDAV URL locally and revealing it.
+
+Pure stdlib (no ASGIWebDAV), so it is importable on every supported Python version and
+can be used by the CLI's ``--mount`` precheck as well as by the serving code.
+
+Per host:
+- macOS:   ``mount_webdav`` mounts to a temp dir; ``open`` reveals it.
+- Windows: ``net use`` maps a drive letter; ``explorer`` reveals it.
+- Linux:   ``gio mount`` mounts the ``dav(s)://`` URL; ``xdg-open`` reveals it.
+
+Everything is best-effort: if the host's tool is missing or the mount fails, the caller
+falls back to printing the URL for the user to open manually.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import shutil
+import sys
+import tempfile
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class MountedVolume:
+    """A mounted WebDAV volume: what to reveal, and how to unmount it."""
+
+    reveal_target: str  # a local path or a URL to open in the file manager
+    unmount_command: Optional[list[str]]
+
+
+def webdav_mount_supported() -> bool:
+    """Whether this host has a tool to auto-mount a WebDAV volume."""
+    if sys.platform == "darwin":
+        return shutil.which("mount_webdav") is not None
+    if sys.platform == "win32":
+        return shutil.which("net") is not None
+    return shutil.which("gio") is not None
+
+
+def _sanitize_label(label: str) -> str:
+    """Make ``label`` safe as a single filesystem path component."""
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", label)
+    cleaned = re.sub(r"-{2,}", "-", cleaned).strip("-._")
+    return (cleaned or "webdav")[:100]
+
+
+def _dav_url(http_url: str) -> str:
+    """Convert an http(s) URL to the dav(s) scheme understood by ``gio``."""
+    if http_url.startswith("https://"):
+        return "davs://" + http_url[len("https://") :]
+    if http_url.startswith("http://"):
+        return "dav://" + http_url[len("http://") :]
+    return http_url
+
+
+async def _run(command: list[str]) -> tuple[int, str]:
+    proc = await asyncio.create_subprocess_exec(
+        *command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT
+    )
+    out, _ = await proc.communicate()
+    return (proc.returncode or 0), out.decode(errors="replace")
+
+
+async def mount_webdav_volume(url: str, *, label: str = "pmd-webdav") -> Optional[MountedVolume]:
+    """Mount ``url`` locally using the host's native mechanism.
+
+    :param url: the WebDAV URL to mount.
+    :param label: a descriptive name for the mount point (macOS), so it is easy to spot in Finder;
+        a random suffix is always appended.
+    :return: a :class:`MountedVolume` on success, or ``None`` if unsupported or the mount failed.
+    """
+    try:
+        if sys.platform == "darwin":
+            if shutil.which("mount_webdav") is None:
+                return None
+            mount_point = tempfile.mkdtemp(prefix=_sanitize_label(label) + "-")
+            rc, _ = await _run(["mount_webdav", "-S", url, mount_point])
+            if rc != 0:
+                return None
+            return MountedVolume(mount_point, ["umount", mount_point])
+
+        if sys.platform == "win32":
+            if shutil.which("net") is None:
+                return None
+            rc, out = await _run(["net", "use", "*", url])
+            if rc != 0:
+                return None
+            match = re.search(r"\b([A-Za-z]):", out)
+            if match is None:
+                return None
+            drive = match.group(1) + ":"
+            return MountedVolume(drive, ["net", "use", drive, "/delete", "/y"])
+
+        # linux / other unixes
+        if shutil.which("gio") is None:
+            return None
+        dav = _dav_url(url)
+        rc, _ = await _run(["gio", "mount", dav])
+        if rc != 0:
+            return None
+        return MountedVolume(dav, ["gio", "mount", "-u", dav])
+    except OSError:
+        return None
+
+
+async def unmount_webdav_volume(mounted: MountedVolume) -> None:
+    """Unmount a previously mounted volume, best-effort."""
+    if mounted.unmount_command is not None:
+        with suppress(OSError):
+            await _run(mounted.unmount_command)
+
+
+def _opener_command(target: str) -> Optional[list[str]]:
+    """Command to open ``target`` (a path or URL) in the OS file manager, or ``None``."""
+    if sys.platform == "darwin":
+        return ["open", target]
+    if sys.platform == "win32":
+        return ["explorer", target]
+    if shutil.which("xdg-open") is not None:
+        return ["xdg-open", target]
+    if shutil.which("gio") is not None:
+        return ["gio", "open", target]
+    return None
+
+
+async def reveal_in_file_manager(target: str) -> None:
+    """Open ``target`` in the OS file manager, best-effort (never raises)."""
+    command = _opener_command(target)
+    if command is None:
+        return
+    with suppress(OSError):
+        await _run(command)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,10 +106,15 @@ dependencies = [
     # unconditionally — no capability probing — so the floor IS the compatibility contract.
     # (0.1.0 introduced the pure-asyncio stack the module is written against.)
     "pmd-pytcp>=0.3.7; python_version >= '3.9'",
+    # WebDAV mounting of AFC services (`<group> webdav`). ASGIWebDAV requires Python >= 3.10, so it
+    # is gated accordingly; the CLI surfaces a clear message on 3.9. backports.zstd supplies the zstd
+    # module ASGIWebDAV imports on 3.10-3.13 (stdlib on 3.14+); uvicorn is already a dependency above.
+    "asgiwebdav>=2.0.1; python_version >= '3.10'",
+    "backports.zstd; python_version >= '3.10' and python_version < '3.14'",
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-asyncio"]
+test = ["pytest", "pytest-asyncio", "httpx"]
 # Docs tooling targets Python >= 3.10 (mkdocs-llmstxt / recent mkdocstrings); markers keep the
 # project's 3.9 floor resolvable since uv resolves all extras universally.
 docs = [

--- a/tests/test_afc_webdav.py
+++ b/tests/test_afc_webdav.py
@@ -1,0 +1,288 @@
+"""Device-independent tests for the AFC WebDAV bridge.
+
+The bridge only depends on a small async AFC method surface, so these tests drive
+it against a local-filesystem-backed AFC stub instead of a real device.
+"""
+
+import os
+import shutil
+from typing import Any
+
+import httpx
+import pytest
+
+pytest.importorskip("asgi_webdav")  # WebDAV support requires Python >= 3.10
+
+from pymobiledevice3.exceptions import AfcFileNotFoundError
+from pymobiledevice3.services.webdav import serve_afc_webdav
+
+
+class LocalAfc:
+    """A minimal AFC stand-in backed by a local directory.
+
+    Implements the exact async method surface the WebDAV provider uses, so the same
+    provider works unchanged against a real ``AfcService``.
+    """
+
+    def __init__(self, root: str) -> None:
+        self._root = str(root)
+        self._handles: dict[int, Any] = {}
+        self._next_handle = 1
+
+    def _local(self, path: str) -> str:
+        return os.path.join(self._root, path.lstrip("/"))
+
+    async def os_stat(self, path: str):
+        try:
+            return os.stat(self._local(path))
+        except FileNotFoundError as e:
+            raise AfcFileNotFoundError(str(e), None) from e
+
+    async def exists(self, path: str) -> bool:
+        return os.path.exists(self._local(path))
+
+    async def isdir(self, path: str) -> bool:
+        return os.path.isdir(self._local(path))
+
+    async def listdir(self, path: str) -> list[str]:
+        return os.listdir(self._local(path))
+
+    async def makedirs(self, path: str) -> None:
+        os.makedirs(self._local(path))
+
+    async def rename(self, source: str, target: str) -> None:
+        os.rename(self._local(source), self._local(target))
+
+    async def rm(self, path: str, match=None, force: bool = False) -> list[str]:
+        local = self._local(path)
+        if os.path.isdir(local):
+            shutil.rmtree(local)
+        else:
+            os.remove(local)
+        return []
+
+    async def fopen(self, path: str, mode: str = "r") -> int:
+        handle = self._next_handle
+        self._next_handle += 1
+        self._handles[handle] = open(self._local(path), mode + "b")  # noqa: SIM115 - handle held like AFC fopen
+        return handle
+
+    async def fread(self, handle: int, sz: int) -> bytes:
+        return self._handles[handle].read(sz)
+
+    async def fwrite(self, handle: int, data: bytes, chunk_size: int = 1 << 30) -> None:
+        self._handles[handle].write(data)
+
+    async def fclose(self, handle: int) -> None:
+        self._handles.pop(handle).close()
+
+
+@pytest.mark.asyncio
+async def test_get_serves_existing_file(tmp_path) -> None:
+    (tmp_path / "hello.txt").write_bytes(b"hi from afc")
+    afc = LocalAfc(str(tmp_path))
+
+    server = await serve_afc_webdav(afc, port=0)
+    try:
+        async with httpx.AsyncClient() as http:
+            response = await http.get(f"{server.url}hello.txt")
+        assert response.status_code == 200
+        assert response.content == b"hi from afc"
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_propfind_lists_directory(tmp_path) -> None:
+    (tmp_path / "a.txt").write_bytes(b"a")
+    (tmp_path / "sub").mkdir()
+    afc = LocalAfc(str(tmp_path))
+
+    server = await serve_afc_webdav(afc, port=0)
+    try:
+        async with httpx.AsyncClient() as http:
+            response = await http.request("PROPFIND", server.url, headers={"Depth": "1"})
+        assert response.status_code == 207
+        assert "a.txt" in response.text
+        assert "sub" in response.text
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_put_writes_file(tmp_path) -> None:
+    afc = LocalAfc(str(tmp_path))
+    server = await serve_afc_webdav(afc, port=0)
+    try:
+        async with httpx.AsyncClient() as http:
+            response = await http.put(f"{server.url}created.txt", content=b"payload")
+        assert response.status_code in (200, 201, 204)
+    finally:
+        await server.stop()
+
+    assert (tmp_path / "created.txt").read_bytes() == b"payload"
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_file(tmp_path) -> None:
+    (tmp_path / "doomed.txt").write_bytes(b"bye")
+    afc = LocalAfc(str(tmp_path))
+
+    server = await serve_afc_webdav(afc, port=0)
+    try:
+        async with httpx.AsyncClient() as http:
+            response = await http.delete(f"{server.url}doomed.txt")
+        assert response.status_code in (200, 204)
+    finally:
+        await server.stop()
+
+    assert not (tmp_path / "doomed.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_mkcol_creates_directory(tmp_path) -> None:
+    afc = LocalAfc(str(tmp_path))
+    server = await serve_afc_webdav(afc, port=0)
+    try:
+        async with httpx.AsyncClient() as http:
+            response = await http.request("MKCOL", f"{server.url}newdir")
+        assert response.status_code == 201
+    finally:
+        await server.stop()
+
+    assert (tmp_path / "newdir").is_dir()
+
+
+@pytest.mark.asyncio
+async def test_move_renames_file(tmp_path) -> None:
+    (tmp_path / "before.txt").write_bytes(b"content")
+    afc = LocalAfc(str(tmp_path))
+
+    server = await serve_afc_webdav(afc, port=0)
+    try:
+        async with httpx.AsyncClient() as http:
+            response = await http.request(
+                "MOVE", f"{server.url}before.txt", headers={"Destination": f"{server.url}after.txt"}
+            )
+        assert response.status_code in (201, 204)
+    finally:
+        await server.stop()
+
+    assert not (tmp_path / "before.txt").exists()
+    assert (tmp_path / "after.txt").read_bytes() == b"content"
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires os.mkfifo (POSIX only)")
+@pytest.mark.asyncio
+async def test_get_special_file_returns_403(tmp_path) -> None:
+    os.mkfifo(str(tmp_path / "afifo"))
+    (tmp_path / "after.txt").write_bytes(b"still alive")
+    afc = LocalAfc(str(tmp_path))
+
+    server = await serve_afc_webdav(afc, port=0)
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as http:
+            response = await http.get(f"{server.url}afifo")
+            assert response.status_code == 403
+            alive = await http.get(f"{server.url}after.txt")
+            assert alive.status_code == 200
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_put_ds_store_is_swallowed(tmp_path) -> None:
+    afc = LocalAfc(str(tmp_path))
+    server = await serve_afc_webdav(afc, port=0)
+    try:
+        async with httpx.AsyncClient() as http:
+            response = await http.put(f"{server.url}.DS_Store", content=b"\x00\x01mac")
+        assert response.status_code in (200, 201, 204)
+    finally:
+        await server.stop()
+
+    assert not (tmp_path / ".DS_Store").exists()
+
+
+def test_mount_requires_mount_tool(monkeypatch) -> None:
+    import shutil
+
+    import typer
+
+    from pymobiledevice3.cli.cli_common import require_webdav_mount_tool
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    with pytest.raises(typer.Exit):
+        require_webdav_mount_tool(mount=True)
+    require_webdav_mount_tool(mount=False)  # no tool needed when not mounting
+
+
+@pytest.mark.parametrize(
+    "platform, tool, expected",
+    [("darwin", "mount_webdav", True), ("win32", "net", True), ("linux", "gio", True)],
+)
+def test_webdav_mount_supported_per_platform(monkeypatch, platform, tool, expected) -> None:
+    import shutil
+
+    from pymobiledevice3.services import webdav_mount
+
+    monkeypatch.setattr(webdav_mount.sys, "platform", platform)
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/" + name if name == tool else None)
+    assert webdav_mount.webdav_mount_supported() is expected
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    assert webdav_mount.webdav_mount_supported() is False
+
+
+@pytest.mark.parametrize(
+    "platform, target, expected_prefix",
+    [("darwin", "/mnt", ["open", "/mnt"]), ("win32", "Z:", ["explorer", "Z:"])],
+)
+def test_opener_command_per_platform(monkeypatch, platform, target, expected_prefix) -> None:
+    from pymobiledevice3.services import webdav_mount
+
+    monkeypatch.setattr(webdav_mount.sys, "platform", platform)
+    assert webdav_mount._opener_command(target) == expected_prefix
+
+
+def test_opener_command_linux_uses_xdg_open(monkeypatch) -> None:
+    import shutil
+
+    from pymobiledevice3.services import webdav_mount
+
+    monkeypatch.setattr(webdav_mount.sys, "platform", "linux")
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/xdg-open" if name == "xdg-open" else None)
+    assert webdav_mount._opener_command("dav://x/") == ["xdg-open", "dav://x/"]
+
+
+@pytest.mark.asyncio
+async def test_mount_returns_none_when_tool_absent(monkeypatch) -> None:
+    import shutil
+
+    from pymobiledevice3.services import webdav_mount
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    assert await webdav_mount.mount_webdav_volume("http://127.0.0.1:1234/") is None
+
+
+@pytest.mark.parametrize(
+    "label, expected",
+    [
+        ("pmd-00008030-000-afc", "pmd-00008030-000-afc"),
+        ("pmd-UDID-crash", "pmd-UDID-crash"),
+        ("pmd-UDID-com.foo.bar", "pmd-UDID-com.foo.bar"),
+        ("", "webdav"),
+    ],
+)
+def test_sanitize_label(label, expected) -> None:
+    from pymobiledevice3.services import webdav_mount
+
+    assert webdav_mount._sanitize_label(label) == expected
+
+
+def test_webdav_command_registered_on_afc_groups() -> None:
+    from pymobiledevice3.cli import afc, apps, crash
+
+    for group in (afc.cli, apps.cli, crash.cli):
+        names = {command.name for command in group.registered_commands if command.name}
+        assert "webdav" in names


### PR DESCRIPTION
## What

Adds a `webdav` subcommand to each AFC-backed CLI group, serving the device's AFC filesystem over a local async WebDAV server so macOS Finder (or any WebDAV client) can browse and edit it **read-write** as a mounted volume.

```
pymobiledevice3 afc   webdav [PATH] [--mount]
pymobiledevice3 apps  webdav BUNDLE_ID [PATH] [--documents] [--mount]
pymobiledevice3 crash webdav [PATH] [--mount]
```

`--mount` mounts the volume locally via `mount_webdav` and reveals it (macOS host); otherwise the `http://127.0.0.1:PORT` URL is printed for Finder's **Go → Connect to Server**. Options: `--host`, `--bind-port`, `--readonly`. Programmatic: `await serve_afc_webdav(afc, ...)` / `await run_afc_webdav(afc, ...)`.

WebDAV is used rather than FTP because macOS Finder mounts FTP read-only; WebDAV mounts read-write. AFC and the whole stack are already async (and `uvicorn` is already a dependency), so `AfcDavProvider` `await`s `AfcService` directly — AFC's response demuxing makes concurrent requests over one connection safe.

## Details

- New module `pymobiledevice3/services/webdav.py`: `AfcDavProvider` maps `PROPFIND/GET/HEAD/PUT/DELETE/MKCOL/MOVE` → `AfcService` (`os_stat`, `listdir`, `fopen/fread/fwrite/fclose`, `makedirs`, `rename`, `rm`).
- **Robustness**: swallows Finder metadata writes (`.DS_Store`, AppleDouble `._*`) so they never hit the device; refuses to open non-regular files (fifo/device/socket); translates AFC errors into clean WebDAV statuses instead of 500s.
- **Python 3.9**: ASGIWebDAV requires ≥3.10, so the dependency is gated (`asgiwebdav; python_version >= '3.10'`, plus `backports.zstd` on 3.10–3.13). The module is imported lazily by the CLI, which surfaces a clear "requires Python 3.10+" message on 3.9 — CLI startup is unaffected.

## Testing

- `tests/test_afc_webdav.py`: 10 device-independent tests driving the provider against a local-filesystem-backed AFC stub (each WebDAV op round-trips), plus the `.DS_Store`-swallow, non-regular-file guard, `--mount` precheck, and command-registration cases. Runs under CI's `pytest -m "not device"`.
- ruff + pyright (1.1.411) clean; full test suite collects without import regressions.

Note: I don't have a physical device here, so the end-to-end mount was validated by design parity with the AfcService API surface (method names/signatures verified against the source) and full provider coverage via the stub; a quick `pymobiledevice3 afc webdav --mount` against a real device is worth a sanity check before merge.