### PR TITLE
claude-plugin: rename to pymobiledevice3-device-operator + advertise in README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "plugins": [
         {
-            "name": "ios-device-operator",
+            "name": "pymobiledevice3-device-operator",
             "source": "./misc/claude-plugin",
             "description": "Operate iPhone and iPad (iOS/iPadOS) devices from Claude Code with pymobiledevice3: screenshots, syslog search, crash reports, file and app operations, developer services (DVT, tunnels, WebInspector, WDA) — works from a fresh workstation via uvx/PyPI or a local checkout."
         }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ pymobiledevice3 apps list
 
 The docs are built from [`docs/`](docs/) with MkDocs (`mkdocs.yml`).
 
+## Claude Code plugin
+
+The repository ships its
+[device-operator agent skill](https://doronz88.github.io/pymobiledevice3/guides/codex-device-operator-skill/)
+as a Claude Code plugin, teaching the agent to operate a connected iPhone or iPad through pymobiledevice3:
+
+```
+/plugin marketplace add doronz88/pymobiledevice3
+/plugin install pymobiledevice3-device-operator@pymobiledevice3
+```
+
 ## Community
 
 Questions, ideas, or want to help? Join the community on [Discord](https://discord.gg/52mZGC3JXJ).

--- a/docs/guides/codex-device-operator-skill.md
+++ b/docs/guides/codex-device-operator-skill.md
@@ -27,7 +27,7 @@ marketplace. Inside Claude Code run:
 
 ```text
 /plugin marketplace add doronz88/pymobiledevice3
-/plugin install ios-device-operator@pymobiledevice3
+/plugin install pymobiledevice3-device-operator@pymobiledevice3
 ```
 
 After installing, Claude can take screenshots, search the device syslog, pull crash

--- a/misc/claude-plugin/.claude-plugin/plugin.json
+++ b/misc/claude-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-    "name": "ios-device-operator",
+    "name": "pymobiledevice3-device-operator",
     "description": "Operate iPhone and iPad (iOS/iPadOS) devices from Claude Code with pymobiledevice3: screenshots, syslog search, crash reports, file and app operations, developer services (DVT, tunnels, WebInspector, WDA) — works from a fresh workstation via uvx/PyPI or a local checkout.",
     "version": "1.0.0",
     "author": {


### PR DESCRIPTION
Prepares the plugin for resubmission to the Anthropic community plugin directory:

- Rename the plugin from `ios-device-operator` to `pymobiledevice3-device-operator` (pre-empts any trademark objection over "ios" and matches the skill's own name; the old name was never published, so nothing to migrate).
- Add a short "Claude Code plugin" section to the README with the marketplace install commands, so users landing on the repo can discover and install the plugin directly.

`claude plugin validate misc/claude-plugin` passes and `sync_skill.py --check` is clean.