### PR TITLE
feat(syslog): add --subsystem/--category filters to `syslog live`

### DIFF
--- a/pymobiledevice3/cli/syslog.py
+++ b/pymobiledevice3/cli/syslog.py
@@ -1,3 +1,4 @@
+import fnmatch
 import json
 import logging
 import os
@@ -24,6 +25,7 @@ from pymobiledevice3.services.os_trace import (
     OsActivityStreamFlag,
     OsTraceService,
     SyslogEntry,
+    SyslogLabel,
     SyslogLogLevel,
 )
 from pymobiledevice3.services.syslog import SyslogService
@@ -139,6 +141,28 @@ def _should_skip_line(line: str, invert_match: list[str], invert_match_insensiti
     return any(m.lower() in line_lower for m in invert_match_insensitive)
 
 
+def _matches_any_glob(value: str, patterns: list[str]) -> bool:
+    lowered = value.lower()
+    return any(fnmatch.fnmatchcase(lowered, pattern.lower()) for pattern in patterns)
+
+
+def _should_keep_label(label: Optional[SyslogLabel], subsystem: list[str], category: list[str]) -> bool:
+    """Keep an entry based on its os_log subsystem/category label.
+
+    ``subsystem``/``category`` are case-insensitive glob patterns. Within a single option
+    the patterns are OR-ed (match any); the two options are AND-ed (subsystem AND category
+    must each match when both are given). An entry with no label is dropped as soon as any
+    label filter is active, since it has no subsystem/category to match against.
+    """
+    if not subsystem and not category:
+        return True
+    if label is None:
+        return False
+    subsystem_ok = not subsystem or _matches_any_glob(label.subsystem, subsystem)
+    category_ok = not category or _matches_any_glob(label.category, category)
+    return subsystem_ok and category_ok
+
+
 def _should_keep_line(
     line: str, match: list[str], match_insensitive: list[str], match_regex: list[re.Pattern[str]]
 ) -> bool:
@@ -206,6 +230,8 @@ async def syslog_live(
     include_label: bool,
     regex: list[str],
     insensitive_regex: list[str],
+    subsystem: list[str],
+    category: list[str],
     no_debug: bool = False,
     no_info: bool = False,
     image_offset: bool = False,
@@ -239,6 +265,9 @@ async def syslog_live(
         if no_info and syslog_entry.level == SyslogLogLevel.INFO:
             # I don't really understand why INFO is retrieved when not requested, but this is imitating
             # Console.app behavior
+            continue
+
+        if not _should_keep_label(syslog_entry.label, subsystem, category):
             continue
 
         # Filters always run against the plain rendered line, so a given set of flags
@@ -369,6 +398,26 @@ async def cli_syslog_live(
             "(repeatable; any match includes - disjunction).",
         ),
     ] = None,
+    subsystem: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            "--subsystem",
+            "-s",
+            help="keep only entries whose os_log subsystem matches this case-insensitive glob "
+            "(e.g. 'com.apple.WebKit*'). Repeatable; an entry is kept if it matches any "
+            "(disjunction). Entries with no subsystem/category label are dropped when set.",
+        ),
+    ] = None,
+    category: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            "--category",
+            "-c",
+            help="keep only entries whose os_log category matches this case-insensitive glob "
+            "(e.g. 'Network'). Repeatable; an entry is kept if it matches any (disjunction). "
+            "Combined with --subsystem as a conjunction (both must match).",
+        ),
+    ] = None,
     image_offset: Annotated[
         bool,
         typer.Option(
@@ -423,6 +472,8 @@ async def cli_syslog_live(
             include_label,
             regex or [],
             insensitive_regex or [],
+            subsystem or [],
+            category or [],
             no_debug,
             no_info,
             image_offset,

--- a/tests/cli/test_syslog.py
+++ b/tests/cli/test_syslog.py
@@ -75,6 +75,8 @@ async def _run_syslog_live(
         "include_label": False,
         "regex": [],
         "insensitive_regex": [],
+        "subsystem": [],
+        "category": [],
         "no_debug": False,
         "no_info": False,
     }
@@ -507,3 +509,122 @@ async def test_syslog_live_json_suppresses_start_after_banner(monkeypatch, capsy
     assert len(printed_lines) == 1
     # The single line must parse as valid JSON — no banner contamination.
     assert json.loads(printed_lines[0])["message"] == "one"
+
+
+def _labeled_entry(message: str, subsystem: str, category: str) -> SyslogEntry:
+    entry = _create_syslog_entry(message)
+    entry.label = SyslogLabel(subsystem=subsystem, category=category)
+    return entry
+
+
+@pytest.mark.parametrize(
+    ("subsystem", "category", "label", "expected"),
+    [
+        # no filters -> keep everything, labeled or not
+        ([], [], None, True),
+        ([], [], SyslogLabel(subsystem="com.apple.WebKit", category="session"), True),
+        # a filter is active but the entry has no label -> drop
+        (["com.apple.WebKit"], [], None, False),
+        ([], ["session"], None, False),
+        # exact subsystem
+        (
+            ["com.apple.WebKit.Network"],
+            [],
+            SyslogLabel(subsystem="com.apple.WebKit.Network", category="net"),
+            True,
+        ),
+        (["com.apple.CoreFoundation"], [], SyslogLabel(subsystem="com.apple.WebKit.Network", category="net"), False),
+        # glob subsystem (matches every WebKit sub-subsystem)
+        (
+            ["com.apple.WebKit*"],
+            [],
+            SyslogLabel(subsystem="com.apple.WebKit.Process", category="cache"),
+            True,
+        ),
+        (["com.apple.WebKit*"], [], SyslogLabel(subsystem="com.apple.CoreFoundation", category="io"), False),
+        # case-insensitive
+        (["COM.APPLE.corefoundation"], [], SyslogLabel(subsystem="com.apple.CoreFoundation", category="io"), True),
+        # disjunction within subsystem list
+        (
+            ["com.apple.CoreFoundation", "com.apple.WebKit*"],
+            [],
+            SyslogLabel(subsystem="com.apple.WebKit.Network", category="net"),
+            True,
+        ),
+        # category glob
+        ([], ["net"], SyslogLabel(subsystem="com.apple.WebKit.Network", category="net"), True),
+        ([], ["cach*"], SyslogLabel(subsystem="com.apple.WebKit.Process", category="cache"), True),
+        ([], ["io"], SyslogLabel(subsystem="com.apple.WebKit.Network", category="net"), False),
+        # conjunction across subsystem AND category
+        (
+            ["com.apple.WebKit*"],
+            ["net"],
+            SyslogLabel(subsystem="com.apple.WebKit.Network", category="net"),
+            True,
+        ),
+        (
+            ["com.apple.WebKit*"],
+            ["io"],
+            SyslogLabel(subsystem="com.apple.WebKit.Network", category="net"),
+            False,
+        ),
+    ],
+)
+def test_should_keep_label(subsystem, category, label, expected):
+    assert syslog_module._should_keep_label(label, subsystem, category) == expected
+
+
+@pytest.mark.asyncio
+async def test_syslog_live_subsystem_filter(monkeypatch, capsys):
+    entries = [
+        _labeled_entry("network event", "com.apple.WebKit.Network", "net"),
+        _labeled_entry("cf thing", "com.apple.CoreFoundation", "Loading"),
+        _create_syslog_entry("no label here"),
+    ]
+    printed_lines, _ = await _run_syslog_live(monkeypatch, capsys, entries, subsystem=["com.apple.WebKit*"])
+    assert len(printed_lines) == 1
+    assert printed_lines[0].endswith("network event")
+
+
+@pytest.mark.asyncio
+async def test_syslog_live_category_filter(monkeypatch, capsys):
+    entries = [
+        _labeled_entry("cached", "com.apple.WebKit.Process", "cache"),
+        _labeled_entry("networked", "com.apple.WebKit.Network", "net"),
+    ]
+    printed_lines, _ = await _run_syslog_live(monkeypatch, capsys, entries, category=["cache"])
+    assert len(printed_lines) == 1
+    assert printed_lines[0].endswith("cached")
+
+
+@pytest.mark.asyncio
+async def test_syslog_live_subsystem_and_category_conjunction(monkeypatch, capsys):
+    entries = [
+        _labeled_entry("net on webkit", "com.apple.WebKit.Network", "net"),
+        _labeled_entry("net on other", "com.apple.CoreFoundation", "net"),
+        _labeled_entry("io on webkit", "com.apple.WebKit.Network", "io"),
+    ]
+    printed_lines, _ = await _run_syslog_live(
+        monkeypatch, capsys, entries, subsystem=["com.apple.WebKit*"], category=["net"]
+    )
+    assert len(printed_lines) == 1
+    assert printed_lines[0].endswith("net on webkit")
+
+
+@pytest.mark.asyncio
+async def test_syslog_live_subsystem_filter_json(monkeypatch, capsys):
+    entries = [
+        _labeled_entry("keep", "com.apple.WebKit.Network", "net"),
+        _labeled_entry("drop", "com.apple.CoreFoundation", "Loading"),
+    ]
+    printed_lines, _ = await _run_syslog_live(
+        monkeypatch,
+        capsys,
+        entries,
+        subsystem=["com.apple.WebKit*"],
+        output_format=syslog_module.SyslogFormat.JSON,
+    )
+    assert len(printed_lines) == 1
+    obj = json.loads(printed_lines[0])
+    assert obj["message"] == "keep"
+    assert obj["label"]["subsystem"] == "com.apple.WebKit.Network"


### PR DESCRIPTION
## What

Adds first-class `-s/--subsystem` and `-c/--category` filters to `pymobiledevice3 syslog live`.

Until now, filtering only ran against the rendered text line, so selecting by os_log subsystem/category meant passing `--label` and then a brittle `--match` on the `[subsystem][category]` substring (which also matches those strings anywhere else in the line). These options match on the parsed `SyslogEntry.label` directly.

## Behavior

- **case-insensitive glob** patterns, e.g. `-s 'com.apple.WebKit*'`, `-c 'Network'`
- **repeatable**: OR within an option, AND across the two (`-s A -s B -c C` ⇒ `(A|B) & C`)
- entries with **no** subsystem/category label are dropped once either filter is set
- works in both `--format text` and `--format json`
- independent of `--label` (which only controls rendering)

## Examples

```bash
# only WebKit subsystems, all sub-subsystems
pymobiledevice3 syslog live -s 'com.apple.WebKit*'

# a specific subsystem + category
pymobiledevice3 syslog live -s 'com.apple.WebKit.Network' -c Network
```

## Tests

`tests/cli/test_syslog.py`: parametrized unit tests for the new `_should_keep_label` helper (exact/glob/case-insensitivity/disjunction/conjunction/unlabeled) plus text- and JSON-mode integration tests. Full file passes (77). `ruff check`, `ruff format`, and `pyright` pre-commit hooks pass.