### PR TITLE
Set Expect header to '100-continue' in TSS request

### DIFF
--- a/pymobiledevice3/restore/tss.py
+++ b/pymobiledevice3/restore/tss.py
@@ -1186,7 +1186,7 @@ class TSSRequest:
             "Cache-Control": "no-cache",
             "Content-type": 'text/xml; charset="utf-8"',
             "User-Agent": "InetURL/1.0",
-            "Expect": "",
+            "Expect": "100-continue",
         }
 
         logger.info("Sending TSS request...")


### PR DESCRIPTION
## Summary

My corp proxy went crazy over empty Expect header so I changed it to the only possible value `100-continue`

## Testing

I did restore vm via vphone-cli

## AI Assistance

`none`
