### PR TITLE
usbmux: don't flip the returned socket back to blocking mode

### DIFF
--- a/pymobiledevice3/cli/developer/wda.py
+++ b/pymobiledevice3/cli/developer/wda.py
@@ -66,10 +66,11 @@ async def wait_for_xctest_app(service_provider: LockdownServiceProvider, xctrunn
             if device is None:
                 raise DeviceNotFoundError(service_provider.udid)
             try:
-                await device.connect(DEFAULT_WDA_PORT)
+                probe_sock = await device.connect(DEFAULT_WDA_PORT)
             except ConnectionFailedError:
                 await asyncio.sleep(0.1)
             else:
+                probe_sock.close()
                 break
     except Exception:
         xctrunner_task.cancel()

--- a/pymobiledevice3/usbmux.py
+++ b/pymobiledevice3/usbmux.py
@@ -246,7 +246,6 @@ class MuxConnection:
     async def connect(self, device: MuxDevice, port: int) -> socket.socket:
         await self._connect(device.devid, socket.htons(port))
         self._connected = True
-        self._sock.setblocking(True)
         return self._sock
 
     async def close(self):


### PR DESCRIPTION
`MuxConnection.connect()` set the socket back to blocking right before handing it to the caller — a leftover from the old sync API contract that was carried over in the asyncio migration (4f12a36c).

No consumer wants a blocking socket:

- `ServiceConnection.__init__` immediately flips it back with `setblocking(False)` (`service_connection.py:125`), covering both usbmux paths (`create_using_usbmux` and `UsbmuxTcpForwarder`).
- The WDA reachability probe (`cli/developer/wda.py`) discards the returned socket entirely.

Beyond being dead weight, it's a footgun: a blocking socket passed to `loop.sock_recv()`/`sock_sendall()` stalls the entire event loop when no data is ready (the selector loop tries an inline `sock.recv()` first), and raises `ValueError: the socket must be non-blocking` in asyncio debug mode. The only reason nothing breaks today is that `ServiceConnection` happens to repair it.

Since `MuxDevice.connect()`/`MuxConnection.connect()` are async APIs, non-blocking is the correct contract for the returned socket. External callers doing synchronous `recv()` on it (if any exist) would need to call `setblocking(True)` themselves.