### PR TITLE
dtx: Register NSKeyedArchive classes explicitly for lazy imports

### DIFF
--- a/pymobiledevice3/dtx/message.py
+++ b/pymobiledevice3/dtx/message.py
@@ -23,7 +23,7 @@ from typing import Any, Optional, Union, cast
 
 from bpylist2 import archiver
 
-from . import ns_types as _ns_types  # noqa: F401 - registers common NSKeyedArchive classes
+from . import ns_types as _ns_types
 from .exceptions import DTXNSCodingError, DTXProtocolError
 from .fragment import DTXFragment, DTXTransportFlags
 from .message_aux import MessageAux
@@ -34,6 +34,13 @@ from .structs import (
     DTXMessageType,
     dtx_fragment_payload_header,
 )
+
+# Register the NSKeyedArchive proxy classes eagerly. This must be an explicit call,
+# not a bare import relied upon for its side effect: under PEP 810 lazy imports
+# (Python 3.15+) ns_types' body would not run until one of its names is used,
+# leaving archiver.unarchive() in this module with an empty class map (observed as
+# DTSysmonTapMessage/DTTapHeartbeatMessage decode failures during e.g. `sysmon`).
+_ns_types.register_ns_keyed_classes()
 
 logger = logging.getLogger(__name__)
 

--- a/pymobiledevice3/dtx/message_aux.py
+++ b/pymobiledevice3/dtx/message_aux.py
@@ -5,8 +5,13 @@ from typing import Any, Union, cast
 from bpylist2 import archiver
 from construct import Bytes, ConstructError, Peek
 
-from . import ns_types as _ns_types  # noqa: F401 - registers common NSKeyedArchive classes
+from . import ns_types as _ns_types
 from .primitives import PNULL, PBuf, PDict, _primitive_value_con, _PrimitiveBase
+
+# Register the NSKeyedArchive proxy classes eagerly (see the identical call in dtx/message.py):
+# a bare side-effect import is unsafe under PEP 810 lazy imports, and archiver.unarchive() is
+# reached from this module's own aux-arg decoding.
+_ns_types.register_ns_keyed_classes()
 
 logger = logging.getLogger(__name__)
 _test_eof = Peek(Bytes(1))

--- a/pymobiledevice3/dtx/ns_types.py
+++ b/pymobiledevice3/dtx/ns_types.py
@@ -2,9 +2,9 @@
 
 This module defines the Python proxy classes that :mod:`bpylist2.archiver`
 uses when deserialising NSKeyedArchive payloads received from a DTX peer.
-All classes are registered with the archiver at import time via
-``archiver.update_class_map(...)`` so no explicit registration call is
-needed by callers.
+The classes are registered with the archiver by :func:`register_ns_keyed_classes`,
+which runs eagerly at import for direct importers but must be called explicitly
+from any lazy-imported decode path (see the call in :mod:`pymobiledevice3.dtx.message`).
 
 Exported classes
 ----------------
@@ -219,27 +219,46 @@ class NSDate:
 
 
 # ---------------------------------------------------------------------------
-# Archiver registration  (runs at import time)
+# Archiver registration
 # ---------------------------------------------------------------------------
 
-archiver.update_class_map({
-    "DTSysmonTapMessage": DTTapMessage,
-    "DTTapHeartbeatMessage": DTTapMessage,
-    "DTTapStatusMessage": DTTapMessage,
-    "DTKTraceTapMessage": DTTapMessage,
-    "DTActivityTraceTapMessage": DTTapMessage,
-    "DTTapMessage": DTTapMessage,
-    "NSNull": NSNull,
-    "NSError": NSError,
-    "NSUUID": NSUUID,
-    "NSURL": NSURL,
-    "NSValue": NSValue,
-    "NSMutableArray": NSMutableArray,
-    "NSMutableData": NSMutableData,
-    "NSMutableString": NSMutableString,
-    "NSDate": NSDate,
-})
 
-archiver.ARCHIVE_CLASS_MAP[NSMutableArray] = "NSMutableArray"  # type: ignore[index]
-_archive_cls: Any = archiver.Archive
-_archive_cls.inline_types = list({*_archive_cls.inline_types, bytes})
+def register_ns_keyed_classes() -> None:
+    """Register this module's NSKeyedArchive proxy classes with bpylist2.
+
+    Callers that decode via ``archiver.unarchive`` MUST invoke this explicitly
+    rather than relying on it running as an import-time side effect. Under PEP
+    810 lazy imports (Python 3.15+, enabled for the CLI and test suite) importing
+    this module does not execute its body until one of its names is first used,
+    so a decode path that only touches ``archiver`` would otherwise see an
+    unpopulated ``UNARCHIVE_CLASS_MAP`` and fail on every ``DT*TapMessage``.
+
+    Idempotent: safe to call more than once.
+    """
+    archiver.update_class_map({
+        "DTSysmonTapMessage": DTTapMessage,
+        "DTTapHeartbeatMessage": DTTapMessage,
+        "DTTapStatusMessage": DTTapMessage,
+        "DTKTraceTapMessage": DTTapMessage,
+        "DTActivityTraceTapMessage": DTTapMessage,
+        "DTTapMessage": DTTapMessage,
+        "NSNull": NSNull,
+        "NSError": NSError,
+        "NSUUID": NSUUID,
+        "NSURL": NSURL,
+        "NSValue": NSValue,
+        "NSMutableArray": NSMutableArray,
+        "NSMutableData": NSMutableData,
+        "NSMutableString": NSMutableString,
+        "NSDate": NSDate,
+    })
+
+    archiver.ARCHIVE_CLASS_MAP[NSMutableArray] = "NSMutableArray"  # type: ignore[index]
+    _archive_cls: Any = archiver.Archive
+    _archive_cls.inline_types = list({*_archive_cls.inline_types, bytes})
+
+
+# Eager registration for direct importers of this module and for Python <= 3.14,
+# where module-level imports are not lazy. The explicit call in dtx/message.py
+# covers the lazy-import (3.15+) decode paths.
+register_ns_keyed_classes()

--- a/pymobiledevice3/services/dvt/testmanaged/dtx_services.py
+++ b/pymobiledevice3/services/dvt/testmanaged/dtx_services.py
@@ -25,7 +25,15 @@ from pymobiledevice3.services.dvt.testmanaged.xctest_types import (
     XCTestConfiguration,
     XCTIssue,
     XCTTestIdentifier,
+    register_xctest_classes,
 )
+
+# Register the XCTest NSKeyedArchive proxy classes eagerly. This must be an explicit call,
+# not a bare import relied upon for its side effect: under PEP 810 lazy imports (Python 3.15+)
+# xctest_types' body would not run until one of its names is used, but the XCTest result types
+# (XCTIssue, XCActivityRecord, ...) are decoded by the DTX machinery -- which never touches an
+# xctest_types name -- leaving them undecodable (raw plist dict fallback).
+register_xctest_classes()
 
 logger = logging.getLogger(__name__)
 

--- a/pymobiledevice3/services/dvt/testmanaged/xctest_types.py
+++ b/pymobiledevice3/services/dvt/testmanaged/xctest_types.py
@@ -116,13 +116,6 @@ class XCTestConfiguration:
         return archive_obj.object
 
 
-# Register with bpylist2 archiver so incoming payloads are decoded correctly.
-archiver.update_class_map({
-    "XCTestConfiguration": XCTestConfiguration,
-    "XCTCapabilities": XCTCapabilities,
-})
-
-
 # ---------------------------------------------------------------------------
 # XCTest runtime types — decoded from NSKeyedArchive payloads during test runs
 # ---------------------------------------------------------------------------
@@ -376,19 +369,40 @@ class XCTestCaseRunConfiguration:
         )
 
 
-archiver.update_class_map({
-    "XCTTestIdentifier": XCTTestIdentifier,
-    "XCTTestIdentifierSet": XCTTestIdentifierSet,
-    "XCTSourceCodeLocation": XCTSourceCodeLocation,
-    "XCTSourceCodeContext": XCTSourceCodeContext,
-    "XCTIssue": XCTIssue,
-    "XCTMutableIssue": XCTIssue,
-    "XCActivityRecord": XCActivityRecord,
-    "XCTAttachment": XCTAttachment,
-    "XCTestCaseRunConfiguration": XCTestCaseRunConfiguration,
-})
+def register_xctest_classes() -> None:
+    """Register this module's XCTest NSKeyedArchive proxy classes with bpylist2.
 
-# Register XCTTestIdentifier and XCTTestIdentifierSet in the encoding map so
-# bpylist2 can archive them (used when building XCTestConfiguration).
-archiver.ARCHIVE_CLASS_MAP[XCTTestIdentifier] = "XCTTestIdentifier"  # type: ignore[index]
-archiver.ARCHIVE_CLASS_MAP[XCTTestIdentifierSet] = "XCTTestIdentifierSet"  # type: ignore[index]
+    Callers that decode XCTest payloads via ``archiver.unarchive`` MUST invoke this
+    explicitly rather than relying on it running as an import-time side effect. Under
+    PEP 810 lazy imports (Python 3.15+) importing this module does not execute its
+    body until one of its names is first used, and the XCTest result types
+    (XCTIssue, XCActivityRecord, ...) are decoded by the DTX machinery without any
+    such name being touched -- leaving archiver.unarchive() with an unpopulated class
+    map and every XCTest payload falling back to a raw plist dict.
+
+    Idempotent: safe to call more than once.
+    """
+    archiver.update_class_map({
+        "XCTestConfiguration": XCTestConfiguration,
+        "XCTCapabilities": XCTCapabilities,
+        "XCTTestIdentifier": XCTTestIdentifier,
+        "XCTTestIdentifierSet": XCTTestIdentifierSet,
+        "XCTSourceCodeLocation": XCTSourceCodeLocation,
+        "XCTSourceCodeContext": XCTSourceCodeContext,
+        "XCTIssue": XCTIssue,
+        "XCTMutableIssue": XCTIssue,
+        "XCActivityRecord": XCActivityRecord,
+        "XCTAttachment": XCTAttachment,
+        "XCTestCaseRunConfiguration": XCTestCaseRunConfiguration,
+    })
+
+    # Register XCTTestIdentifier and XCTTestIdentifierSet in the encoding map so
+    # bpylist2 can archive them (used when building XCTestConfiguration).
+    archiver.ARCHIVE_CLASS_MAP[XCTTestIdentifier] = "XCTTestIdentifier"  # type: ignore[index]
+    archiver.ARCHIVE_CLASS_MAP[XCTTestIdentifierSet] = "XCTTestIdentifierSet"  # type: ignore[index]
+
+
+# Eager registration for direct importers of this module and for Python <= 3.14,
+# where module-level imports are not lazy. The explicit call in dtx_services.py
+# covers the lazy-import (3.15+) XCTest decode paths.
+register_xctest_classes()

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -61,3 +61,29 @@ def test_dtx_decode_registers_ns_classes_under_lazy_imports() -> None:
         "assert msg.payload == {'k': 0, 'tv': 65536}, msg.payload\n"
     )
     subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_xctest_decode_registers_classes_under_lazy_imports() -> None:
+    """XCTest result payloads must decode once the XCTest DTX service module is in use.
+
+    Same regression as the DTX case, one layer up: xctest_types registered its proxy
+    classes (XCTIssue, XCActivityRecord, ...) only as an import side effect, but those
+    types are decoded by the DTX machinery without any xctest_types name being touched,
+    so under lazy imports they fell back to a raw plist dict. Using a name from the
+    decode-entry module (dtx_services) must be enough to register them.
+    """
+    code = (
+        "import pymobiledevice3._lazy_imports\n"
+        "import plistlib\n"
+        "from pymobiledevice3.services.dvt.testmanaged.dtx_services import XCTestManager_IDEInterface\n"
+        "XCTestManager_IDEInterface  # use the name -> resolve dtx_services body -> register\n"
+        "from pymobiledevice3.dtx.message import DTXMessage, DTXMessageType\n"
+        "U = plistlib.UID\n"
+        "archive = {'$version': 100000, '$archiver': 'NSKeyedArchiver', '$top': {'root': U(1)},\n"
+        "    '$objects': ['$null', {'$class': U(2)},\n"
+        "        {'$classname': 'XCTIssue', '$classes': ['XCTIssue', 'NSObject']}]}\n"
+        "data = plistlib.dumps(archive, fmt=plistlib.FMT_BINARY)\n"
+        "msg = DTXMessage(type=next(iter(DTXMessageType)), payload_data=memoryview(data))\n"
+        "assert type(msg.payload).__name__ == 'XCTIssue', msg.payload\n"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -30,3 +30,34 @@ def test_cli_entry_enables_scoped_lazy_imports() -> None:
         checks = "assert not hasattr(sys, 'get_lazy_imports')"
     code = f"import sys; import pymobiledevice3.__main__; {checks}"
     subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_dtx_decode_registers_ns_classes_under_lazy_imports() -> None:
+    """A DTX payload must decode via NSKeyedUnarchiver without a caller pre-touching ns_types.
+
+    Regression: under PEP 810 lazy imports the NSKeyedArchive class registration in
+    pymobiledevice3.dtx.ns_types ran only as an import side effect, which never fired
+    for decode paths (e.g. `sysmon`) that reach archiver.unarchive without using an
+    ns_types name -- every DT*TapMessage then failed to unarchive and fell back to a raw
+    plist dict. Run in a subprocess so process-global lazy state and the class map are
+    pristine, importing only the decode entry point (dtx.message).
+    """
+    code = (
+        "import pymobiledevice3._lazy_imports\n"  # enable filtered lazy imports on 3.15+ (no-op below)
+        "import plistlib\n"
+        "from pymobiledevice3.dtx.message import DTXMessage, DTXMessageType\n"
+        "U = plistlib.UID\n"
+        "archive = {'$version': 100000, '$archiver': 'NSKeyedArchiver', '$top': {'root': U(1)},\n"
+        "    '$objects': ['$null',\n"
+        "        {'DTTapMessagePlist': U(2), '$class': U(8)},\n"
+        "        {'NS.keys': [U(3), U(4)], 'NS.objects': [U(5), U(6)], '$class': U(7)},\n"
+        "        'k', 'tv', 0, 65536,\n"
+        "        {'$classname': 'NSMutableDictionary',\n"
+        "         '$classes': ['NSMutableDictionary', 'NSDictionary', 'NSObject']},\n"
+        "        {'$classname': 'DTSysmonTapMessage',\n"
+        "         '$classes': ['DTSysmonTapMessage', 'DTTapMessage', 'NSObject']}]}\n"
+        "data = plistlib.dumps(archive, fmt=plistlib.FMT_BINARY)\n"
+        "msg = DTXMessage(type=next(iter(DTXMessageType)), payload_data=memoryview(data))\n"
+        "assert msg.payload == {'k': 0, 'tv': 65536}, msg.payload\n"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)


### PR DESCRIPTION
## Problem

On Python 3.15+ (PEP 810 lazy imports, enabled for the CLI and test suite), DTX developer commands emit a decode warning per message, e.g. `sysmon`:

```
WARNING Failed to decode DTX payload with NSKeyedUnarchiver, but successfully
decoded with plistlib: no mapping for DTSysmonTapMessage in {...default map...}
```

The NSKeyedArchive proxy classes are registered with bpylist2 via `archiver.update_class_map(...)` running **at module-body time**, and consumers relied on that firing as an *import side effect* (bare `from . import ns_types`, etc.). Under lazy imports a module body does not run until one of its names is used, so decode paths that reach `archiver.unarchive()` without touching such a name see an unpopulated class map and fall back to plistlib. This is the exact import-time-side-effect trap called out in `AGENTS.md`.

Two independent instances of this bug were found and fixed:

1. **`pymobiledevice3/dtx/ns_types.py`** — DTX proxy classes (`DTSysmonTapMessage`, `DTTapHeartbeatMessage`, `NSError`, ...). Symptom: warnings on `sysmon` and other DVT tap commands.
2. **`pymobiledevice3/services/dvt/testmanaged/xctest_types.py`** — XCTest proxy classes (`XCTestConfiguration`, `XCTIssue`, `XCActivityRecord`, ...). Symptom: XCUITest result payloads decode to raw plist dicts instead of typed objects.

## Fix

For each module: extract the registration into an explicit, idempotent `register_*` function (still called eagerly at import for direct importers / Python ≤ 3.14), and call it explicitly from the modules that own the `archiver.unarchive` decode sites — `dtx/message.py` and `dtx/message_aux.py` for the DTX types, `dtx_services.py` for the XCTest types — instead of relying on a bare side-effect import. Those modules are always loaded and used before their respective decode paths run, so registration is guaranteed to precede decoding.

## Tests

Added regression tests in `tests/test_lazy_imports.py` that decode a `DTSysmonTapMessage` and an `XCTIssue` payload in isolated subprocesses with lazy imports enabled, importing only the decode entry points. Both fail on the pre-fix source under 3.15 (decode to the raw `$archiver` dict) and pass after the fix.

Verified: pinned `pyright@1.1.411` clean; `tests/dtx tests/services/instruments tests/test_lazy_imports.py` pass. Reproduced the original `sysmon` warning and the XCTest decode failure under the actual 3.15 CLI interpreter and confirmed both are resolved.

## Out of scope (noted separately)

`tunnel_service.py:120` monkeypatches `qh3.quic.packet_builder.PACKET_MAX_SIZE` at module-body time, but `QuicConfiguration.max_datagram_size` freezes the value as a dataclass field default at `qh3.quic.configuration` import — so the patch is already ineffective for that default in **both** eager and lazy modes. It is a separate pre-existing issue, not a lazy-import regression, and is left untouched here.