### PR TITLE
webdav: Close the server when the device disconnects

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -30,8 +30,10 @@ from pymobiledevice3.cli.cli_common import (
     TUNNEL_ENV_VAR,
     UDID_ENV_VAR,
     USERSPACE_ENV_VAR,
+    _cli_udid,
     isatty,
     requires_kernel_tunnel,
+    resolved_udid,
     set_color_flag,
     set_verbosity,
 )
@@ -421,6 +423,9 @@ def invoke_cli_with_error_handling() -> bool:
         )
     except DeviceNotFoundError as e:
         logger.error(f"Device not found: {e.udid}")
+        # Reconnectable: after a disconnect the target device may still be re-enumerating
+        # while other devices are attached, making re-invocation fail with this error.
+        return True
     except NotEnoughDiskSpaceError:
         logger.error("Not enough disk space")
     except DeprecationError:
@@ -471,7 +476,15 @@ def main() -> None:
             break
         try:
             logger.info("Waiting for the device to be available again")
-            lockdown = asyncio.run(retry_create_using_usbmux())
+            # Wait for the device the command targeted, not just any device. The target is the
+            # explicit --udid / env value, or whichever device the command's dependency resolved
+            # to (auto-pick or interactive prompt).
+            serial = _cli_udid() or resolved_udid()
+            lockdown = asyncio.run(retry_create_using_usbmux(serial=serial))
+            if serial is not None and not os.getenv(UDID_ENV_VAR):
+                # Stamp the target so the re-invocation resolves the same device instead of
+                # prompting again (or silently auto-picking another attached device).
+                os.environ[UDID_ENV_VAR] = serial
             logger.info("Device connected")
             asyncio.run(lockdown.close())
         except KeyboardInterrupt:

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -193,6 +193,25 @@ def is_invoked_for_completion() -> bool:
     return any(env.startswith("_") and env.endswith("_COMPLETE") for env in os.environ)
 
 
+# UDID of the device the running command actually resolved to (explicit --udid, auto-pick, or
+# interactive prompt). The global --reconnect machinery in __main__ reads it to wait for and
+# re-target that same device — the selection would otherwise be lost when it came from a prompt.
+_resolved_udid: Optional[str] = None
+
+
+def resolved_udid() -> Optional[str]:
+    """The UDID the current command's device dependency resolved to, if any."""
+    return _resolved_udid
+
+
+def _record_resolved(provider: LockdownServiceProvider) -> LockdownServiceProvider:
+    """Remember which device a service-provider dependency picked (see ``resolved_udid``)."""
+    global _resolved_udid
+    if provider.udid is not None:
+        _resolved_udid = provider.udid
+    return provider
+
+
 cli_loop = get_asyncio_loop()
 
 
@@ -505,7 +524,7 @@ def any_service_provider_dependency(
         return  # type: ignore[return-value]
 
     if rsd_service_provider is not None:
-        return rsd_service_provider
+        return _record_resolved(rsd_service_provider)
 
     if mobdev2:
         devices = cli_loop.run_until_complete(get_mobdev2_devices(udid=udid))
@@ -513,24 +532,24 @@ def any_service_provider_dependency(
             raise NoDeviceConnectedError()
 
         if len(devices) == 1:
-            return devices[0]
+            return _record_resolved(devices[0])
 
-        return prompt_device_list(devices)
+        return _record_resolved(prompt_device_list(devices))
 
     if udid is not None:
-        return cli_loop.run_until_complete(create_using_usbmux(serial=udid, usbmux_address=usbmux))
+        return _record_resolved(cli_loop.run_until_complete(create_using_usbmux(serial=udid, usbmux_address=usbmux)))
 
     devices = cli_loop.run_until_complete(
         usbmuxd.select_devices_by_connection_type(connection_type="USB", usbmux_address=usbmux)
     )
     if len(devices) <= 1:
-        return cli_loop.run_until_complete(create_using_usbmux(usbmux_address=usbmux))
+        return _record_resolved(cli_loop.run_until_complete(create_using_usbmux(usbmux_address=usbmux)))
 
     lockdownds = [
         cli_loop.run_until_complete(create_using_usbmux(serial=device.serial, usbmux_address=usbmux))
         for device in devices
     ]
-    return prompt_device_list(lockdownds)
+    return _record_resolved(prompt_device_list(lockdownds))
 
 
 def no_autopair_service_provider_dependency(
@@ -552,9 +571,9 @@ def no_autopair_service_provider_dependency(
         return  # type: ignore[return-value]
 
     if rsd_service_provider is not None:
-        return rsd_service_provider
+        return _record_resolved(rsd_service_provider)
 
-    return cli_loop.run_until_complete(create_using_usbmux(serial=udid, autopair=False))
+    return _record_resolved(cli_loop.run_until_complete(create_using_usbmux(serial=udid, autopair=False)))
 
 
 def _narrow_to_lockdown_client(ctx: typer.Context, service_provider: LockdownServiceProvider) -> LockdownClient:

--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -339,6 +339,9 @@ class AfcService(LockdownService):
         self._afc_pending: dict[int, asyncio.Future[Any]] = {}
         self._afc_write_lock = asyncio.Lock()
         self._afc_reader_task: Optional[asyncio.Task[None]] = None
+        # Set (and never cleared) once the connection terminates; the reader task handle
+        # itself is not a stable signal because _send_and_wait restarts exited readers.
+        self._afc_terminated = asyncio.Event()
 
     async def __aenter__(self):
         await super().__aenter__()
@@ -366,6 +369,18 @@ class AfcService(LockdownService):
         exc_tb: Optional[TracebackType],
     ):
         await self.aclose()
+
+    async def wait_terminated(self) -> None:
+        """Block until the AFC connection terminates (e.g. the device disconnects).
+
+        Ensures the background reader is running so termination is detected even when no
+        AFC operation is in flight. Returns immediately if the connection already died.
+        """
+        if not self._afc_terminated.is_set():
+            await self.connect()
+            if self._afc_reader_task is None or self._afc_reader_task.done():
+                self._afc_reader_task = asyncio.create_task(self._afc_reader_loop(), name="afc-reader")
+        await self._afc_terminated.wait()
 
     async def _afc_reader_loop(self) -> None:
         """Background task: read AFC response packets and route them to waiting callers."""
@@ -400,6 +415,8 @@ class AfcService(LockdownService):
                 if not fut.done():
                     fut.set_exception(e)
             self._afc_pending.clear()
+        finally:
+            self._afc_terminated.set()
 
     async def pull(
         self,

--- a/pymobiledevice3/services/webdav.py
+++ b/pymobiledevice3/services/webdav.py
@@ -34,7 +34,7 @@ from asgi_webdav.request import DAVRequest
 from asgi_webdav.server import DAVApp
 from asgi_webdav.web_dav import PrefixProviderInfo
 
-from pymobiledevice3.exceptions import AfcException
+from pymobiledevice3.exceptions import AfcException, ConnectionTerminatedError
 from pymobiledevice3.services.webdav_mount import (
     mount_webdav_volume,
     reveal_in_file_manager,
@@ -360,6 +360,8 @@ async def run_afc_webdav(
     :param port: local TCP port; 0 picks a free port.
     :param readonly: expose the filesystem read-only.
     :param label: descriptive name for the local mount point, so it is easy to spot in Finder.
+    :raises ConnectionTerminatedError: when the device disconnects (after unmounting and
+        stopping the local server), so CLI-level reconnect logic can re-serve.
     """
     server = await serve_afc_webdav(afc, path=path, host=host, port=port, readonly=readonly)
     print(f"WebDAV server serving {path!r} at {server.url}")
@@ -378,7 +380,11 @@ async def run_afc_webdav(
     print("Press Ctrl-C to stop.")
 
     try:
-        await asyncio.Event().wait()
+        await afc.wait_terminated()
+        print("Device disconnected; stopping.")
+        # Propagate as a connection error (after the finally-cleanup below) so the CLI's
+        # global --reconnect machinery can wait for the device and re-serve.
+        raise ConnectionTerminatedError()
     finally:
         if mounted is not None:
             await unmount_webdav_volume(mounted)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -191,3 +191,113 @@ def test_cli_groups(group):
 @pytest.mark.parametrize("group", __main__.CLI_GROUPS.keys())
 def test_cli_from_python_m_flag(group):
     subprocess.run([sys.executable, "-m", "pymobiledevice3", group, "--help"], check=True)
+
+
+def _patch_isolated_asyncio_run(monkeypatch):
+    """``main()`` uses ``asyncio.run``, whose cleanup unsets the main-thread event loop and breaks
+    later sync tests on Python 3.9 (``asyncio.Lock()`` there binds ``get_event_loop()`` at creation).
+    Run coroutines on a private loop instead, leaving global loop state untouched."""
+    import asyncio
+
+    def isolated_run(coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    monkeypatch.setattr(asyncio, "run", isolated_run)
+
+
+def test_reconnect_waits_for_the_target_device(monkeypatch):
+    """`--reconnect` must wait for the device the command targeted (--udid), not just any device."""
+    _patch_isolated_asyncio_run(monkeypatch)
+    captured: dict[str, str] = {}
+
+    async def fake_retry_create_using_usbmux(*args, **kwargs):
+        captured.update(kwargs)
+
+        class _FakeLockdown:
+            async def close(self) -> None:
+                pass
+
+        return _FakeLockdown()
+
+    invocations = iter([True, False])
+    monkeypatch.setattr(__main__, "invoke_cli_with_error_handling", lambda: next(invocations))
+    monkeypatch.setattr(__main__, "RECONNECT", True)
+    monkeypatch.setattr(__main__, "retry_create_using_usbmux", fake_retry_create_using_usbmux)
+    monkeypatch.setattr(sys, "argv", ["pymobiledevice3", "--reconnect", "afc", "webdav", "--udid", "TARGET-UDID"])
+
+    __main__.main()
+
+    assert captured.get("serial") == "TARGET-UDID"
+
+
+def test_device_not_found_is_a_reconnectable_failure(monkeypatch):
+    """A device-not-found failure must keep the `--reconnect` retry loop alive: after a disconnect,
+    the target device may still be enumerating while other devices are attached."""
+    from pymobiledevice3.exceptions import DeviceNotFoundError
+
+    def raise_not_found(*args, **kwargs):
+        raise DeviceNotFoundError("TARGET-UDID")
+
+    monkeypatch.setattr(__main__, "app", raise_not_found)
+    assert __main__.invoke_cli_with_error_handling() is True
+
+
+def test_reconnect_reuses_interactively_selected_device(monkeypatch):
+    """When the device was chosen at the interactive prompt (no --udid on argv/env), `--reconnect`
+    must wait for and re-target that same device, not whichever device appears first."""
+    import os
+
+    from pymobiledevice3.cli import cli_common
+
+    _patch_isolated_asyncio_run(monkeypatch)
+
+    captured: dict[str, str] = {}
+
+    async def fake_retry_create_using_usbmux(*args, **kwargs):
+        captured.update(kwargs)
+
+        class _FakeLockdown:
+            async def close(self) -> None:
+                pass
+
+        return _FakeLockdown()
+
+    invocations = iter([True, False])
+    monkeypatch.setattr(__main__, "invoke_cli_with_error_handling", lambda: next(invocations))
+    monkeypatch.setattr(__main__, "RECONNECT", True)
+    monkeypatch.setattr(__main__, "retry_create_using_usbmux", fake_retry_create_using_usbmux)
+    monkeypatch.setattr(sys, "argv", ["pymobiledevice3", "--reconnect", "afc", "webdav"])
+    monkeypatch.setattr(os, "environ", dict(os.environ))  # isolate env mutations done by main()
+    os.environ.pop(cli_common.UDID_ENV_VAR, None)
+    monkeypatch.setattr(cli_common, "_resolved_udid", "PROMPTED-UDID")  # as recorded on dependency resolution
+
+    __main__.main()
+
+    assert captured.get("serial") == "PROMPTED-UDID"
+    # Stamped so the re-invocation resolves the same device instead of prompting/auto-picking.
+    assert os.environ[cli_common.UDID_ENV_VAR] == "PROMPTED-UDID"
+
+
+def test_service_provider_dependency_records_resolved_udid(monkeypatch):
+    """Dependency resolution must record which device it picked, for `--reconnect` to reuse."""
+    from pymobiledevice3.cli import cli_common
+
+    class _FakeProvider:
+        udid = "RESOLVED-UDID"
+
+    async def fake_create_using_usbmux(*args, **kwargs):
+        return _FakeProvider()
+
+    monkeypatch.setattr(cli_common, "create_using_usbmux", fake_create_using_usbmux)
+    monkeypatch.setattr(cli_common, "_resolved_udid", None)
+
+    provider = cli_common.any_service_provider_dependency(
+        rsd_service_provider=None, mobdev2=False, usbmux=None, udid="RESOLVED-UDID"
+    )
+
+    assert provider is not None
+    assert cli_common.resolved_udid() == "RESOLVED-UDID"

--- a/tests/services/test_afc.py
+++ b/tests/services/test_afc.py
@@ -1,12 +1,15 @@
 import asyncio
 import pathlib
 from datetime import datetime
+from typing import cast
 
 import pytest
 import pytest_asyncio
 
-from pymobiledevice3.exceptions import AfcException, AfcFileNotFoundError
+from pymobiledevice3.exceptions import AfcException, AfcFileNotFoundError, ConnectionTerminatedError
 from pymobiledevice3.lockdown import LockdownClient
+from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+from pymobiledevice3.service_connection import ServiceConnection
 from pymobiledevice3.services.afc import MAXIMUM_READ_SIZE, AfcError, AfcService
 
 TEST_FILENAME = "test"
@@ -387,3 +390,30 @@ async def test_concurrent_operations(lockdown: LockdownClient) -> None:
         assert all(sorted(r) == sorted(listings[0]) for r in listings), (
             f"Expected all concurrent listdir results to be identical, got {listings}"
         )
+
+
+class _DisconnectingConnection:
+    """A fake service connection: ``recvall`` blocks until ``dropped``, then dies."""
+
+    def __init__(self) -> None:
+        self.dropped = asyncio.Event()
+
+    async def recvall(self, size: int) -> bytes:
+        await self.dropped.wait()
+        raise ConnectionTerminatedError()
+
+    async def close(self) -> None:
+        pass
+
+
+async def test_wait_terminated_unblocks_on_connection_drop() -> None:
+    """``wait_terminated`` must return once the underlying connection dies (device disconnect)."""
+    afc = AfcService(cast(LockdownServiceProvider, object()), service_name="com.apple.afc")
+    connection = _DisconnectingConnection()
+    afc._service = cast(ServiceConnection, connection)  # pre-injected connection: no real device needed
+    waiter = asyncio.create_task(afc.wait_terminated())
+    await asyncio.sleep(0.05)
+    assert not waiter.done()
+
+    connection.dropped.set()
+    await asyncio.wait_for(waiter, timeout=5)

--- a/tests/test_afc_webdav.py
+++ b/tests/test_afc_webdav.py
@@ -4,7 +4,9 @@ The bridge only depends on a small async AFC method surface, so these tests driv
 it against a local-filesystem-backed AFC stub instead of a real device.
 """
 
+import asyncio
 import os
+import re
 import shutil
 from typing import Any
 
@@ -13,8 +15,8 @@ import pytest
 
 pytest.importorskip("asgi_webdav")  # WebDAV support requires Python >= 3.10
 
-from pymobiledevice3.exceptions import AfcFileNotFoundError
-from pymobiledevice3.services.webdav import serve_afc_webdav
+from pymobiledevice3.exceptions import AfcFileNotFoundError, ConnectionTerminatedError
+from pymobiledevice3.services.webdav import run_afc_webdav, serve_afc_webdav
 
 
 class LocalAfc:
@@ -28,6 +30,10 @@ class LocalAfc:
         self._root = str(root)
         self._handles: dict[int, Any] = {}
         self._next_handle = 1
+        self._terminated = asyncio.Event()
+
+    async def wait_terminated(self) -> None:
+        await self._terminated.wait()
 
     def _local(self, path: str) -> str:
         return os.path.join(self._root, path.lstrip("/"))
@@ -202,6 +208,37 @@ async def test_put_ds_store_is_swallowed(tmp_path) -> None:
         await server.stop()
 
     assert not (tmp_path / ".DS_Store").exists()
+
+
+@pytest.mark.asyncio
+async def test_server_closes_when_device_disconnects(tmp_path, capsys) -> None:
+    (tmp_path / "hello.txt").write_bytes(b"hi")
+    afc = LocalAfc(str(tmp_path))
+    task = asyncio.create_task(run_afc_webdav(afc, mount=False))
+
+    output = ""
+    for _ in range(250):
+        output += capsys.readouterr().out
+        if "http://" in output:
+            break
+        assert not task.done(), f"server task exited early: {task.exception()!r}"
+        await asyncio.sleep(0.02)
+    match = re.search(r"http://\S+/", output)
+    assert match is not None, f"server URL not printed; output was: {output!r}"
+    url = match.group(0)
+
+    async with httpx.AsyncClient() as http:
+        response = await http.get(f"{url}hello.txt")
+        assert response.status_code == 200  # serving while the device is connected
+
+        afc._terminated.set()  # simulate the device disconnecting
+        # The disconnect must propagate as ConnectionTerminatedError so the global
+        # `--reconnect` machinery in __main__ can re-invoke the command.
+        with pytest.raises(ConnectionTerminatedError):
+            await asyncio.wait_for(task, timeout=5)
+
+        with pytest.raises(httpx.ConnectError):
+            await http.get(f"{url}hello.txt")
 
 
 def test_mount_requires_mount_tool(monkeypatch) -> None:


### PR DESCRIPTION
## Problem

When the device disconnects while `afc`/`apps`/`crash webdav` is serving, the server, the local mount, and the process all remain open (serving 500s) until Ctrl-C. The runner blocked on a fresh `asyncio.Event().wait()` that nothing ever set, and nothing observed the death of the AFC connection.

## Fix

- `AfcService` now exposes `wait_terminated()`, backed by a sticky `asyncio.Event` set whenever the background reader loop exits (the reader task handle itself is not a stable signal, since `_send_and_wait` restarts exited readers). `wait_terminated()` also lazily starts the reader so a disconnect is detected even with no operation in flight.
- `run_afc_webdav` waits on it instead of the never-set event, prints `Device disconnected; stopping.`, tears down (unmount, server stop), and then raises `ConnectionTerminatedError` so the global `--reconnect` machinery can wait for the device and re-serve. Ctrl-C behavior is unchanged.

## `--reconnect` cooperation

Verifying against physical devices (two attached) surfaced three gaps in the global retry loop in `__main__`:

- it waited for *any* device instead of the one the command targeted, so the other attached device satisfied the wait instantly; it now targets the right serial.
- the resulting `DeviceNotFoundError` on re-invocation was not treated as a reconnectable failure, killing the retry loop; it now is.
- a device selected at the interactive prompt was forgotten: the wait accepted any device and the re-invocation silently auto-picked another attached device while the target was still rebooting. The service-provider dependencies now record which device they resolved to (explicit `--udid`, auto-pick, or prompt); the reconnect loop waits for that device and stamps `PYMOBILEDEVICE3_UDID` before re-invoking so the same device is deterministically re-targeted without a second prompt.

## Testing

- New device-independent tests: `wait_terminated()` unblocks on `ConnectionTerminatedError`; a simulated disconnect makes `run_afc_webdav` tear down, close the port, and raise `ConnectionTerminatedError`; the retry loop passes the target serial (explicit and prompt-recorded) and stamps the env var; `DeviceNotFoundError` keeps the retry loop alive; dependency resolution records the resolved udid.
- Verified end-to-end against physical devices: rebooting the served device without `--reconnect` prints the disconnect message and exits within seconds; with `--reconnect` it tears down, waits for that specific device, and re-serves on the same port. The interactive-prompt scenario was verified through a pty with two devices attached: selecting the second device, rebooting it, and confirming the re-served volume is the same device (via a marker file only it has) with no second prompt.
- `pytest tests/test_afc_webdav.py tests/cli/test_cli.py tests/services/test_afc.py::test_wait_terminated_unblocks_on_connection_drop` (121 passed) and pyright 1.1.411 clean on all touched files.