### PR TITLE
webdav: serve Range requests to prevent large-file corruption

### DIFF
--- a/pymobiledevice3/services/afc.py
+++ b/pymobiledevice3/services/afc.py
@@ -33,7 +33,7 @@ import parameter_decorators
 import xonsh.cli_utils
 import xonsh.main
 import xonsh.tools
-from construct import Bytes, CString, GreedyRange, Int64ul, Tell
+from construct import Bytes, CString, GreedyRange, Int64sl, Int64ul, Tell
 from construct_typed import DataclassMixin, EnumBase, TEnum, TStruct, csfield
 from pygments import formatters, highlight, lexers
 
@@ -273,6 +273,13 @@ class AfcLockRequest(DataclassMixin):
     op: int = csfield(Int64ul)
 
 
+@dataclass
+class AfcFileSeekRequest(DataclassMixin):
+    handle: int = csfield(Int64ul)
+    whence: int = csfield(Int64ul)
+    offset: int = csfield(Int64sl)
+
+
 afc_header_t = TStruct(AfcHeader)
 afc_read_dir_req_t = TStruct(AfcReadDirRequest)
 afc_read_dir_resp_t = TStruct(AfcReadDirResponse)
@@ -286,6 +293,7 @@ afc_rm_req_t = TStruct(AfcRmRequest)
 afc_rename_req_t = TStruct(AfcRenameRequest)
 afc_fread_req_t = TStruct(AfcFreadRequest)
 afc_lock_t = TStruct(AfcLockRequest)
+afc_fseek_req_t = TStruct(AfcFileSeekRequest)
 
 
 def list_to_dict(raw: bytes) -> dict[str, str]:
@@ -970,6 +978,20 @@ class AfcService(LockdownService):
             sz -= to_read
             data += chunk
         return data
+
+    async def fseek(self, handle: int, offset: int, whence: int = os.SEEK_SET) -> None:
+        """
+        Seek within an open file handle.
+
+        :param handle: Handle returned by `fopen`.
+        :param offset: Byte offset relative to ``whence``.
+        :param whence: One of ``os.SEEK_SET`` (0), ``os.SEEK_CUR`` (1), ``os.SEEK_END`` (2).
+        :raises AfcException: if the seek operation fails.
+        """
+        await self._do_operation(
+            AfcOpcode.FILE_SEEK,
+            afc_fseek_req_t.build(AfcFileSeekRequest(handle=handle, whence=whence, offset=offset)),
+        )
 
     async def fwrite(self, handle: int, data: bytes, chunk_size: int = MAXIMUM_WRITE_SIZE) -> None:
         """

--- a/pymobiledevice3/services/webdav.py
+++ b/pymobiledevice3/services/webdav.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import posixpath
 from stat import S_ISDIR, S_ISREG
 from typing import Any, Optional
@@ -29,7 +30,7 @@ from asgi_webdav.constants import (
 )
 from asgi_webdav.helpers import generate_etag, guess_type
 from asgi_webdav.property import DAVProperty, DAVPropertyBasicData
-from asgi_webdav.provider.common import DAVProvider, DAVProviderFeature
+from asgi_webdav.provider.common import DAVProvider, DAVProviderFeature, get_response_content_range
 from asgi_webdav.request import DAVRequest
 from asgi_webdav.server import DAVApp
 from asgi_webdav.web_dav import PrefixProviderInfo
@@ -71,7 +72,7 @@ class AfcDavProvider(DAVProvider):
     """A WebDAV provider whose backing store is a device's AFC filesystem."""
 
     type = "afc"
-    feature = DAVProviderFeature(content_range=False, home_dir=False)
+    feature = DAVProviderFeature(content_range=True, home_dir=False)
 
     def __init__(self, afc: Any, root: str, config: Config, prefix: DAVPath, read_only: bool) -> None:
         super().__init__(
@@ -176,7 +177,25 @@ class AfcDavProvider(DAVProvider):
             return 403, None, None, None
 
         dav_property = await self._create_dav_property_obj(request.src_path, stat_result)
-        return 200, dav_property.basic_data, self._body_generator(afc_path), None
+
+        if not request.ranges:
+            return 200, dav_property.basic_data, self._body_generator(afc_path), None
+
+        # a Range request: macOS Finder / webdavfs reads large files as a series of byte ranges.
+        # Answering those with 200 + the whole file makes the client write the full body at the
+        # range's offset, corrupting the result. Serve the requested bytes as 206 Partial Content.
+        content_range = get_response_content_range(
+            request_ranges=request.ranges,
+            file_size=dav_property.basic_data.content_length,
+        )
+        if content_range is None:
+            return 200, dav_property.basic_data, self._body_generator(afc_path), None
+        if request.if_range and not request.if_range.match(
+            etag=dav_property.basic_data.etag,
+            last_modified=dav_property.basic_data.last_modified.http_date,
+        ):
+            return 416, dav_property.basic_data, None, content_range
+        return 206, dav_property.basic_data, self._body_generator(afc_path, content_range), content_range
 
     async def _do_head(self, request: DAVRequest) -> tuple[int, Optional[DAVPropertyBasicData]]:
         if _is_apple_metadata(request.dist_src_path.name):
@@ -190,14 +209,27 @@ class AfcDavProvider(DAVProvider):
         dav_property = await self._create_dav_property_obj(request.src_path, stat_result)
         return 200, dav_property.basic_data
 
-    async def _body_generator(self, afc_path: str) -> DAVResponseBodyGenerator:
+    async def _body_generator(
+        self, afc_path: str, content_range: Optional[DAVResponseContentRange] = None
+    ) -> DAVResponseBodyGenerator:
         handle = await self._afc.fopen(afc_path, "r")
         try:
-            more_body = True
-            while more_body:
-                data = await self._afc.fread(handle, RESPONSE_DATA_BLOCK_SIZE)
-                more_body = len(data) == RESPONSE_DATA_BLOCK_SIZE
-                yield data, more_body
+            if content_range is None:
+                more_body = True
+                while more_body:
+                    data = await self._afc.fread(handle, RESPONSE_DATA_BLOCK_SIZE)
+                    more_body = len(data) == RESPONSE_DATA_BLOCK_SIZE
+                    yield data, more_body
+                return
+
+            await self._afc.fseek(handle, content_range.content_start, os.SEEK_SET)
+            remaining = content_range.content_end - content_range.content_start + 1
+            while remaining > 0:
+                data = await self._afc.fread(handle, min(remaining, RESPONSE_DATA_BLOCK_SIZE))
+                if not data:
+                    break
+                remaining -= len(data)
+                yield data, remaining > 0
         finally:
             await self._afc.fclose(handle)
 

--- a/tests/services/test_afc.py
+++ b/tests/services/test_afc.py
@@ -193,6 +193,24 @@ async def test_stat_file(afc: AfcService) -> None:
     assert stat["st_mtime"] >= timestamp
 
 
+async def test_fseek_reads_from_offset(afc: AfcService) -> None:
+    import os
+
+    data = bytes(range(256)) * 8  # 2 KiB with distinct byte values
+    await afc.set_file_contents(TEST_FILENAME, data)
+    try:
+        handle = await afc.fopen(TEST_FILENAME)
+        try:
+            await afc.fseek(handle, 300, os.SEEK_SET)
+            assert await afc.fread(handle, 100) == data[300:400]
+            await afc.fseek(handle, -10, os.SEEK_END)
+            assert await afc.fread(handle, 10) == data[-10:]
+        finally:
+            await afc.fclose(handle)
+    finally:
+        await afc.rm(TEST_FILENAME)
+
+
 async def test_stat_folder(afc: AfcService) -> None:
     timestamp = datetime.fromtimestamp(await afc.lockdown.get_value(key="TimeIntervalSince1970"))
     timestamp = timestamp.replace(microsecond=0)  # stat resolution might not include microseconds

--- a/tests/test_afc_webdav.py
+++ b/tests/test_afc_webdav.py
@@ -76,6 +76,9 @@ class LocalAfc:
     async def fread(self, handle: int, sz: int) -> bytes:
         return self._handles[handle].read(sz)
 
+    async def fseek(self, handle: int, offset: int, whence: int = os.SEEK_SET) -> None:
+        self._handles[handle].seek(offset, whence)
+
     async def fwrite(self, handle: int, data: bytes, chunk_size: int = 1 << 30) -> None:
         self._handles[handle].write(data)
 
@@ -94,6 +97,41 @@ async def test_get_serves_existing_file(tmp_path) -> None:
             response = await http.get(f"{server.url}hello.txt")
         assert response.status_code == 200
         assert response.content == b"hi from afc"
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_get_honors_range_request(tmp_path) -> None:
+    # macOS Finder / webdavfs reads large files as a series of byte ranges. Answering a Range
+    # request with 200 + the whole file makes the client write the full body at the range's
+    # offset, corrupting the result. The server must reply 206 with exactly the requested bytes.
+    payload = bytes((i * 131 + 7) % 256 for i in range(4096)) * 64  # 256 KiB, spans many blocks
+    (tmp_path / "big.bin").write_bytes(payload)
+    afc = LocalAfc(str(tmp_path))
+
+    server = await serve_afc_webdav(afc, port=0)
+    try:
+        async with httpx.AsyncClient() as http:
+            head = await http.head(f"{server.url}big.bin")
+            assert head.headers.get("accept-ranges") == "bytes"
+
+            start, end = 100_000, 200_000
+            response = await http.get(f"{server.url}big.bin", headers={"Range": f"bytes={start}-{end}"})
+            assert response.status_code == 206
+            assert response.headers["content-range"] == f"bytes {start}-{end}/{len(payload)}"
+            assert response.content == payload[start : end + 1]
+
+            # reassembling sequential ranges must reproduce the file byte-for-byte
+            buf = bytearray()
+            off = 0
+            while off < len(payload):
+                stop = min(off + 40_000 - 1, len(payload) - 1)
+                part = await http.get(f"{server.url}big.bin", headers={"Range": f"bytes={off}-{stop}"})
+                assert part.status_code == 206
+                buf += part.content
+                off = stop + 1
+            assert bytes(buf) == payload
     finally:
         await server.stop()
 


### PR DESCRIPTION
## Problem

Copying large files off a device over a mounted AFC WebDAV volume produced **corrupted files**.

`AfcDavProvider` declared `content_range=False` and ignored the HTTP `Range` header, answering **every** `GET` with `200 OK` and the *entire* file body. macOS Finder / `webdavfs` reads large files as a series of byte-range requests (`Range: bytes=X-Y`); when the server returns the whole file with status `200` instead of `206` + the requested slice, the client writes the full body at offset `X` — corrupting the result.

(Same class of bug and fix as the one applied to the sibling `rpc-project` WebDAV bridge, which was ported from this provider.)

## Fix

Honor `Range` requests, mirroring asgi_webdav's own `FileSystemProvider`:

- `feature = DAVProviderFeature(content_range=True, ...)` → advertises `Accept-Ranges: bytes`.
- `_do_get` computes the response content-range and returns **206 Partial Content** (with `416` on a failed `If-Range`), falling back to `200` full-body when there's no range.
- `_body_generator` seeks to the range start and streams only the requested bytes.

Serving a range requires seeking within an open AFC handle, so this adds `AfcService.fseek(handle, offset, whence)` using the existing `FILE_SEEK` opcode (`AfcFileSeekRequest`: `handle` u64, `whence` u64, `offset` i64 — signed for `SEEK_END`/`SEEK_CUR`). Cross-platform; no OS-specific assumptions.

## Verification

- New device-independent test `test_get_honors_range_request` in `tests/test_afc_webdav.py` (drives the provider against the `LocalAfc` filesystem stub): asserts `Accept-Ranges`, a `206` with the exact requested bytes and correct `Content-Range`, and that reassembling sequential ranges reproduces the file byte-for-byte. Full `tests/test_afc_webdav.py` passes (23 passed).
- New device-backed test `test_fseek_reads_from_offset` in `tests/services/test_afc.py`.
- `AfcService.fseek` verified against a real device (iOS 26.6.1): mid-file `SEEK_SET` slice and negative `SEEK_END` reads match; and the full WebDAV range flow (206 ranges, sequential reassembly, suffix range) verified end-to-end over httpx against the device.
- `ruff check`, `ruff format`, and `pyright` (1.1.411) all clean.