### PR TITLE
tunneld: support binding and querying over a unix domain socket

### DIFF
--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -84,6 +84,15 @@ pass a UDID):
 python3 -m pymobiledevice3 developer dvt ls / --tunnel ''
 ```
 
+`tunneld` binds `127.0.0.1:49151` by default. To relocate it, pass `--host`/`--port`, or `--uds` to
+bind a unix domain socket instead of TCP. The `--tunnel` value accepts the matching suffix —
+`UDID:PORT` or `UDID:UDS_PATH` (the UDID part may be empty):
+
+```shell
+sudo python3 -m pymobiledevice3 remote tunneld --uds /var/run/tunneld.sock
+python3 -m pymobiledevice3 developer dvt ls / --tunnel ':/var/run/tunneld.sock'
+```
+
 To make `tunneld` the **default** fallback again — so commands route to it automatically without
 passing `--tunnel`, restoring the pre-userspace-default behavior — set the
 `PYMOBILEDEVICE3_PREFER_TUNNELD` environment variable (any non-empty value):

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -32,7 +32,7 @@ from pymobiledevice3.lockdown import LockdownClient, TcpLockdownClient, create_u
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.osu.os_utils import get_os_utils
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
-from pymobiledevice3.tunneld.api import TUNNELD_DEFAULT_ADDRESS, get_tunneld_devices
+from pymobiledevice3.tunneld.api import TUNNELD_DEFAULT_ADDRESS, TunneldAddress, get_tunneld_devices
 from pymobiledevice3.utils import ask_prompt, get_asyncio_loop
 
 UDID_ENV_VAR = "PYMOBILEDEVICE3_UDID"
@@ -276,16 +276,24 @@ async def get_mobdev2_devices(udid: Optional[str] = None) -> list[TcpLockdownCli
     return [lockdown async for _, lockdown in get_mobdev2_lockdowns(udid=udid)]
 
 
+def _parse_tunnel_spec(tunnel: str) -> tuple[str, TunneldAddress]:
+    """Split a --tunnel value (``UDID``, ``UDID:PORT`` or ``UDID:UDS_PATH``) into
+    (udid, tunneld address). A numeric suffix is a TCP port on the default host;
+    anything else after the ``:`` is a unix domain socket path."""
+    udid, sep, address = tunnel.strip().partition(":")
+    if not sep:
+        return udid, TUNNELD_DEFAULT_ADDRESS
+    if address.isdigit():
+        return udid, (TUNNELD_DEFAULT_ADDRESS[0], int(address))
+    return udid, address
+
+
 async def _tunneld(udid: Optional[str] = None) -> Optional[RemoteServiceDiscoveryService]:
     if udid is None:
         return
 
-    udid = udid.strip()
-    port = TUNNELD_DEFAULT_ADDRESS[1]
-    if ":" in udid:
-        udid, port = udid.split(":")
-
-    rsds = await get_tunneld_devices((TUNNELD_DEFAULT_ADDRESS[0], int(port)))
+    udid, tunneld_address = _parse_tunnel_spec(udid)
+    rsds = await get_tunneld_devices(tunneld_address)
     if len(rsds) == 0:
         raise NoDeviceConnectedError()
 
@@ -406,8 +414,9 @@ def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteSer
             typer.Option(
                 envvar=TUNNEL_ENV_VAR,
                 help=dedent("""\
-                    Use a device discovered via tunneld. Provide a UDID (optionally with :PORT) or leave empty to pick
-                    interactively. Mutually exclusive with --rsd.
+                    Use a device discovered via tunneld. Provide a UDID (optionally with :PORT or :UDS_PATH for a
+                    tunneld bound to a unix domain socket) or leave empty to pick interactively. Mutually exclusive
+                    with --rsd.
                 """),
                 rich_help_panel=DEVICE_OPTIONS_PANEL_TITLE,
             ),

--- a/pymobiledevice3/cli/remote.py
+++ b/pymobiledevice3/cli/remote.py
@@ -93,6 +93,12 @@ cli = InjectingTyper(
 def cli_tunneld(
     host: Annotated[str, typer.Option(help="Address to bind the tunneld server to.")] = TUNNELD_DEFAULT_ADDRESS[0],
     port: Annotated[int, typer.Option(help="Port to bind the tunneld server to.")] = TUNNELD_DEFAULT_ADDRESS[1],
+    uds: Annotated[
+        Optional[str],
+        typer.Option(
+            "--uds", help="Unix domain socket path to bind the tunneld server to (instead of TCP --host/--port)."
+        ),
+    ] = None,
     daemonize: Annotated[bool, typer.Option("--daemonize", "-d", help="Run tunneld in the background.")] = False,
     protocol: Annotated[
         TunnelProtocol,
@@ -120,6 +126,7 @@ def cli_tunneld(
         host,
         port,
         protocol=protocol,
+        uds=uds,
         usb_monitor=usb,
         wifi_monitor=wifi,
         usbmux_monitor=usbmux,
@@ -131,9 +138,10 @@ def cli_tunneld(
             from daemonize import Daemonize
         except ImportError as e:
             raise NotImplementedError("daemonizing is only supported on unix platforms") from e
+        bind = uds if uds is not None else f"{host}:{port}"
         with tempfile.NamedTemporaryFile("wt") as pid_file:
-            daemon = Daemonize(app=f"Tunneld {host}:{port}", pid=pid_file.name, action=tunneld_runner)
-            logger.info(f"starting Tunneld {host}:{port}")
+            daemon = Daemonize(app=f"Tunneld {bind}", pid=pid_file.name, action=tunneld_runner)
+            logger.info(f"starting Tunneld {bind}")
             daemon.start()
     else:
         tunneld_runner()

--- a/pymobiledevice3/tunneld/api.py
+++ b/pymobiledevice3/tunneld/api.py
@@ -1,4 +1,7 @@
-from typing import Any, Optional
+import json
+import socket
+from http.client import HTTPConnection
+from typing import Any, Optional, Union
 
 import requests
 
@@ -7,14 +10,35 @@ from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscove
 
 TUNNELD_DEFAULT_ADDRESS = ("127.0.0.1", 49151)
 
+# Address of a running ``tunneld`` HTTP server: either a ``(host, port)`` TCP address
+# or a ``str`` path to a unix domain socket.
+TunneldAddress = Union[tuple[str, int], str]
+
+
+class _UnixHTTPConnection(HTTPConnection):
+    """HTTPConnection over a unix domain socket."""
+
+    def __init__(self, path: str) -> None:
+        super().__init__("localhost")
+        self._path = path
+
+    def connect(self) -> None:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.connect(self._path)
+        except OSError:
+            sock.close()
+            raise
+        self.sock = sock
+
 
 async def get_tunneld_devices(
-    tunneld_address: tuple[str, int] = TUNNELD_DEFAULT_ADDRESS,
+    tunneld_address: TunneldAddress = TUNNELD_DEFAULT_ADDRESS,
 ) -> list[RemoteServiceDiscoveryService]:
     """
     Query a running ``tunneld`` instance over HTTP for all active tunnels and connect to each.
 
-    :param tunneld_address: ``(host, port)`` of the ``tunneld`` HTTP server.
+    :param tunneld_address: ``(host, port)`` of the ``tunneld`` HTTP server, or a unix domain socket path.
     :returns: a connected `RemoteServiceDiscoveryService`
         for every tunnel that could be reached; tunnels that fail to connect are skipped.
     :raises TunneldConnectionError: if the ``tunneld`` instance cannot be reached.
@@ -24,13 +48,13 @@ async def get_tunneld_devices(
 
 
 async def get_tunneld_device_by_udid(
-    udid: str, tunneld_address: tuple[str, int] = TUNNELD_DEFAULT_ADDRESS
+    udid: str, tunneld_address: TunneldAddress = TUNNELD_DEFAULT_ADDRESS
 ) -> Optional[RemoteServiceDiscoveryService]:
     """
     Query a running ``tunneld`` instance over HTTP for the tunnel matching a given UDID and connect.
 
     :param udid: UDID of the target device.
-    :param tunneld_address: ``(host, port)`` of the ``tunneld`` HTTP server.
+    :param tunneld_address: ``(host, port)`` of the ``tunneld`` HTTP server, or a unix domain socket path.
     :returns: a connected
         `RemoteServiceDiscoveryService` for
         the device, or ``None`` if ``tunneld`` reports no tunnel for the UDID.
@@ -43,12 +67,21 @@ async def get_tunneld_device_by_udid(
     return rsds[0]
 
 
-def _list_tunnels(tunneld_address: tuple[str, int] = TUNNELD_DEFAULT_ADDRESS) -> dict[str, list[dict[str, Any]]]:
+def _list_tunnels(tunneld_address: TunneldAddress = TUNNELD_DEFAULT_ADDRESS) -> dict[str, list[dict[str, Any]]]:
     try:
-        # Get the list of tunnels from the specified address
-        resp = requests.get(f"http://{tunneld_address[0]}:{tunneld_address[1]}")
-        tunnels = resp.json()
-    except requests.exceptions.ConnectionError as e:
+        if isinstance(tunneld_address, str):
+            # Get the list of tunnels over a unix domain socket
+            conn = _UnixHTTPConnection(tunneld_address)
+            try:
+                conn.request("GET", "/")
+                tunnels = json.loads(conn.getresponse().read())
+            finally:
+                conn.close()
+        else:
+            # Get the list of tunnels from the specified address
+            resp = requests.get(f"http://{tunneld_address[0]}:{tunneld_address[1]}")
+            tunnels = resp.json()
+    except (requests.exceptions.ConnectionError, OSError) as e:
         raise TunneldConnectionError() from e
     return tunnels
 

--- a/pymobiledevice3/tunneld/server.py
+++ b/pymobiledevice3/tunneld/server.py
@@ -510,11 +510,13 @@ class TunneldRunner:
         usbmux_monitor: bool = True,
         usbmux_address: Optional[str] = None,
         mobdev2_monitor: bool = True,
+        uds: Optional[str] = None,
     ) -> None:
         cls(
             host,
             port,
             protocol=protocol,
+            uds=uds,
             usb_monitor=usb_monitor,
             wifi_monitor=wifi_monitor,
             usbmux_monitor=usbmux_monitor,
@@ -532,6 +534,7 @@ class TunneldRunner:
         usbmux_monitor: bool = True,
         usbmux_address: Optional[str] = None,
         mobdev2_monitor: bool = True,
+        uds: Optional[str] = None,
     ):
         @asynccontextmanager
         async def lifespan(app: FastAPI):
@@ -542,6 +545,7 @@ class TunneldRunner:
 
         self.host = host
         self.port = port
+        self.uds = uds
         self.protocol = protocol
         self._app = FastAPI(lifespan=lifespan)
         self._tunneld_core = TunneldCore(
@@ -737,4 +741,7 @@ class TunneldRunner:
                 )
 
     def _run_app(self) -> None:
-        uvicorn.run(self._app, host=self.host, port=self.port, loop="asyncio")
+        if self.uds is not None:
+            uvicorn.run(self._app, uds=self.uds, loop="asyncio")
+        else:
+            uvicorn.run(self._app, host=self.host, port=self.port, loop="asyncio")

--- a/tests/test_tunneld_uds.py
+++ b/tests/test_tunneld_uds.py
@@ -1,0 +1,68 @@
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from pymobiledevice3.cli.cli_common import _parse_tunnel_spec
+from pymobiledevice3.exceptions import TunneldConnectionError
+from pymobiledevice3.tunneld.api import TUNNELD_DEFAULT_ADDRESS, _list_tunnels, get_tunneld_devices
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="unix domain sockets are not supported on Windows")
+
+
+def test_parse_tunnel_spec_bare_udid() -> None:
+    assert _parse_tunnel_spec("abc123") == ("abc123", TUNNELD_DEFAULT_ADDRESS)
+
+
+def test_parse_tunnel_spec_empty() -> None:
+    assert _parse_tunnel_spec("") == ("", TUNNELD_DEFAULT_ADDRESS)
+
+
+def test_parse_tunnel_spec_port() -> None:
+    assert _parse_tunnel_spec("abc123:1234") == ("abc123", (TUNNELD_DEFAULT_ADDRESS[0], 1234))
+
+
+def test_parse_tunnel_spec_uds_path() -> None:
+    assert _parse_tunnel_spec("abc123:/tmp/tunneld.sock") == ("abc123", "/tmp/tunneld.sock")
+
+
+def test_parse_tunnel_spec_uds_path_no_udid() -> None:
+    assert _parse_tunnel_spec(":/tmp/tunneld.sock") == ("", "/tmp/tunneld.sock")
+
+
+def test_list_tunnels_missing_socket_raises_tunneld_connection_error() -> None:
+    with pytest.raises(TunneldConnectionError):
+        _list_tunnels(str(Path(tempfile.mkdtemp()) / "missing.sock"))
+
+
+async def test_tunneld_server_over_unix_socket() -> None:
+    """End-to-end: TunneldRunner bound to a unix socket, queried through the UDS client path."""
+    uds = str(Path(tempfile.mkdtemp()) / "tunneld.sock")
+    script = (
+        "import sys\n"
+        "from pymobiledevice3.tunneld.server import TunneldRunner\n"
+        "TunneldRunner.create('127.0.0.1', 0, uds=sys.argv[1], usb_monitor=False, wifi_monitor=False, "
+        "usbmux_monitor=False, mobdev2_monitor=False)\n"
+    )
+    proc = subprocess.Popen([sys.executable, "-c", script, uds], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        deadline = time.monotonic() + 30
+        while True:
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                    sock.connect(uds)
+                break
+            except (FileNotFoundError, ConnectionRefusedError):
+                assert proc.poll() is None, "tunneld server exited prematurely"
+                assert time.monotonic() < deadline, "tunneld server did not come up on the unix socket"
+                time.sleep(0.1)
+
+        assert _list_tunnels(uds) == {}
+        assert await get_tunneld_devices(uds) == []
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)


### PR DESCRIPTION
## What

Just like tunneld can be relocated to another TCP host/port, it can now live on a unix domain socket:

- **Server**: `pymobiledevice3 remote tunneld --uds /path/tunneld.sock` binds a unix socket instead of TCP (uvicorn's native `uds=` bind).
- **Client API**: the tunneld address is now `Union[tuple[str, int], str]` — a `str` means a UDS path. The UDS request path uses a small `http.client.HTTPConnection` subclass over `AF_UNIX`, so no new dependency; unreachable sockets still raise `TunneldConnectionError`.
- **`--tunnel`**: the spec now accepts `UDID:PORT` or `UDID:UDS_PATH` (numeric suffix = port, anything else = socket path; the UDID part may be empty), so `--tunnel ':/var/run/tunneld.sock'` works, including via `PYMOBILEDEVICE3_TUNNEL`.

## Testing

New `tests/test_tunneld_uds.py` (skipped on Windows): spec parsing, missing-socket error mapping, and an end-to-end test that boots a real `TunneldRunner` on a UDS in a subprocess with all monitors disabled and queries it through `_list_tunnels` / `get_tunneld_devices`.

Docs: `docs/guides/ios17-tunnels.md` documents `--uds` and the `--tunnel` suffix; the API reference picks up the updated docstrings.