### PR TITLE
userspace-tunnel: right-size the tun socketpair buffers to 6 MiB

### DIFF
--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -147,7 +147,7 @@ def throughput_sysctls() -> dict[str, int]:
 
 
 #: Datagram socketpair buffer, sized to hold a burst of a full receive window of packets.
-SOCKET_BUFFER_SIZE = 8 * 1024 * 1024
+SOCKET_BUFFER_SIZE = 6 * 1024 * 1024
 
 #: Read/relay chunk size for the dial-plane bridge.
 _CHUNK = 65536


### PR DESCRIPTION
The datagram socketpair buffers exist to absorb a burst of one full receive window of packets (`tcp.rcv_wnd_max` = 4 MiB); 8 MiB was double that for no measurable benefit. 6 MiB keeps 1.5x headroom over the window while trimming 8 MiB of kernel socket-buffer reservation per tunnel (2 sockets x SNDBUF+RCVBUF x 2 MiB).

Verified on a real device (iOS 26.6.1 over USB): a DSC fetch over the userspace tunnel sustains ~103 MB/s at both 6 MiB and 8 MiB (4.74 GB vs 4.73 GB transferred in identical 45 s windows), and interactive DVT commands (`dvt ls`) work unchanged. `tests/test_userspace_tunnel.py` passes and pyright reports 0 errors.