### PR TITLE
userspace-tunnel: relay dialed connections over unix domain sockets

### DIFF
--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -167,6 +167,11 @@ What works over the userspace tunnel: the host-initiated developer services (`dv
 `core-device …`), and the device-initiated AV/HID paths — `display serve-web`, `display serve-vnc`,
 `display start-video-stream` / `start-audio-stream`, and the HID gesture commands.
 
+Service connections are handed off in-process over unix-socket relays; on Windows (no `AF_UNIX`)
+the relays use loopback TCP instead. Set `PYMOBILEDEVICE3_USERSPACE_TCP_RELAY` (any non-empty
+value) to force the loopback-TCP relays on any platform — useful for reproducing Windows-specific
+relay behavior elsewhere.
+
 ### Limitation: in-process only
 
 The device's tunnel address lives only inside the pymobiledevice3 process, so it is **not reachable

--- a/pymobiledevice3/osu/os_utils.py
+++ b/pymobiledevice3/osu/os_utils.py
@@ -74,6 +74,11 @@ class OsUtils:
         raise FeatureNotSupportedError(self._os_name, _calling_function_name())
 
     @property
+    def supports_unix_sockets(self) -> bool:
+        """Whether AF_UNIX stream sockets (and asyncio's unix stream APIs) exist on this platform."""
+        raise FeatureNotSupportedError(self._os_name, _calling_function_name())
+
+    @property
     def access_denied_error(self) -> str:
         raise FeatureNotSupportedError(self._os_name, _calling_function_name())
 

--- a/pymobiledevice3/osu/posix_util.py
+++ b/pymobiledevice3/osu/posix_util.py
@@ -22,6 +22,10 @@ class Posix(OsUtils):
         return os.geteuid() == 0
 
     @property
+    def supports_unix_sockets(self) -> bool:
+        return True
+
+    @property
     def usbmux_address(self) -> tuple[Union[str, tuple[str, int]], int]:
         return MuxConnection.USBMUXD_PIPE, socket.AF_UNIX
 

--- a/pymobiledevice3/osu/win_util.py
+++ b/pymobiledevice3/osu/win_util.py
@@ -32,6 +32,11 @@ class Win32(OsUtils):
             return False
 
     @property
+    def supports_unix_sockets(self) -> bool:
+        # CPython on Windows exposes neither socket.AF_UNIX nor asyncio's unix stream APIs.
+        return False
+
+    @property
     def usbmux_address(self) -> tuple[tuple[str, int], int]:
         return MuxConnection.ITUNES_HOST, socket.AF_INET
 

--- a/pymobiledevice3/remote/remotexpc.py
+++ b/pymobiledevice3/remote/remotexpc.py
@@ -22,6 +22,7 @@ from pymobiledevice3.exceptions import (
     ConnectionTerminatedError,
     NotConnectedError,
     ProtocolError,
+    PyMobileDevice3Exception,
     StreamClosedError,
 )
 from pymobiledevice3.remote.xpc_message import (
@@ -148,7 +149,14 @@ class RemoteXPCConnection:
         ``mediastreamstart``. Only valid while the connection is open.
         """
         sockname = self.writer.get_extra_info("sockname")
-        return sockname[0], sockname[1]
+        if not isinstance(sockname, tuple):
+            # e.g. an AF_UNIX sockname ('' or a path) — the userspace tunnel's relay dialer.
+            # This connection has no kernel endpoint the device could ever reach, and the old
+            # loopback-TCP relay's ('127.0.0.1', port) answer was equally unreachable — fail
+            # loudly instead of advertising a dead endpoint.
+            raise PyMobileDevice3Exception("local_address is unavailable over an in-process (userspace) tunnel")
+        address = cast("tuple[str, int]", sockname)
+        return address[0], address[1]
 
     async def close(self) -> None:
         self._pending_window_updates.clear()

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -735,6 +735,7 @@ class UserspaceRsdTunnel:
         self.rsd: Optional[RemoteServiceDiscoveryService] = None
         self.tun: Optional[UserspaceTun] = None
         self._exit_stack: Optional[AsyncExitStack] = None
+        self._transport_watcher: Optional[asyncio.Task[None]] = None
 
     async def aopen(self) -> RemoteServiceDiscoveryService:
         """Establish the tunnel and return the connected RSD. Idempotent on this handle; raises
@@ -785,8 +786,28 @@ class UserspaceRsdTunnel:
         self.rsd = rsd
         _active_tunnel = self
         USERSPACE_ACTIVE = True
+        self._transport_watcher = asyncio.create_task(
+            self._watch_transport_closed(tunnel_result.client),
+            name=f"userspace-tunnel-transport-watcher-{tunnel_result.address}",
+        )
         logger.debug("userspace RSD established (no root): %s rsd_port=%s", tunnel_result.address, tunnel_result.port)
         return rsd
+
+    async def _watch_transport_closed(self, client: tunnel_service.RemotePairingTunnel) -> None:
+        """Tear the tunnel down when its outer transport dies (e.g. the USB cable is pulled:
+        usbmuxd closes the CoreDeviceProxy connection and the transport read task just ends).
+
+        Without this nothing wakes the pytcp sessions or the relay handlers — every in-flight
+        service read parks forever. Keep-alive cannot cover it: a relay's peer is this very
+        process, so loopback probes are always answered no matter what happened to the device.
+        Closing the dial plane cancels the relay handlers, which surfaces EOF/connection errors
+        to all blocked callers."""
+        with suppress(Exception):
+            await client.wait_closed()
+        if self._exit_stack is None:
+            return  # normal aclose() already ran
+        logger.warning("userspace tunnel transport closed (device disconnected?); tearing down")
+        await self.aclose()
 
     async def aclose(self) -> None:
         """Tear down the tunnel and its RSD, releasing every resource in LIFO order and restoring
@@ -798,6 +819,9 @@ class UserspaceRsdTunnel:
         if self._exit_stack is None:
             return
         stack, self._exit_stack = self._exit_stack, None
+        watcher, self._transport_watcher = self._transport_watcher, None
+        if watcher is not None and watcher is not asyncio.current_task():
+            watcher.cancel()
         self.rsd = None
         self.tun = None
         if _active_tunnel is self:

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -117,6 +117,10 @@ MIN_RTO_MS = 200
 #: ACK-every-other-segment rule, not the timer — measured 38-39 MB/s at 1/10/100 ms alike).
 ACK_DELAY_MS = 1
 
+#: Set (to any non-empty value) to force the dial plane's relays onto loopback TCP even where
+#: AF_UNIX exists — reproduces the Windows relay path on any platform for debugging.
+TCP_RELAY_ENV_VAR = "PYMOBILEDEVICE3_USERSPACE_TCP_RELAY"
+
 
 def throughput_sysctls() -> dict[str, int]:
     """The ``stack.init(sysctls=...)`` entries that tune the tunnel for bulk transfer and latency.
@@ -541,8 +545,9 @@ class UserspaceDialPlane:
         A unix socket is preferred: it lives in a 0700 temp directory, so the filesystem —
         not the network stack — decides who may connect, whereas a loopback TCP port is
         connectable by any local process for the tunnel's whole lifetime. TCP remains the
-        fallback where AF_UNIX is unavailable (e.g. Windows)."""
-        if get_os_utils().supports_unix_sockets:
+        fallback where AF_UNIX is unavailable (e.g. Windows), and can be forced anywhere via
+        :data:`TCP_RELAY_ENV_VAR` to debug that path."""
+        if get_os_utils().supports_unix_sockets and not os.getenv(TCP_RELAY_ENV_VAR):
             if self._socket_dir is None:
                 self._socket_dir = tempfile.mkdtemp(prefix="pmd3-")
             path = os.path.join(self._socket_dir, f"{port}.sock")

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -409,9 +409,11 @@ class UserspaceDialPlane:
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self._closing = True
         # A dial's connect completes in the kernel before the server's accept callback runs,
-        # so an accept may already be queued on the loop. Give it one tick to run with
-        # _closing set: it spawns a handler that sees the flag, closes its transport and
-        # bails — otherwise that transport would never be closed by anyone.
+        # so an accept may already be queued on the loop. Give it one tick to run BEFORE the
+        # servers close: the callback then attaches its transport to a still-open Server and
+        # spawns a gate handler that closes it (during wait_closed below). Without the tick
+        # the callback runs against an already-closed Server, dies on an internal assertion
+        # inside asyncio, and the accepted socket is finalized by GC as a ResourceWarning.
         await asyncio.sleep(0)
         for srv in self._servers:
             srv.close()
@@ -421,12 +423,10 @@ class UserspaceDialPlane:
         # caller's timeout (issue #1756). Cancelling here (instead of leaving orphan tasks for
         # the loop's shutdown to cancel) also guarantees each handler's psock cleanup runs
         # while the stack is still up, and that no relay task outlives the dial plane.
-        #
-        # A dial can also race teardown (see the sleep above): a handler spawned during that
-        # tick may register in _relay_tasks only after this loop snapshots it — keep
-        # cancelling until none remain; handlers that start even later see _closing and bail
-        # out on their own.
-        while self._relay_tasks:
+        # One pass suffices: _closing was set before any await in this method and handlers
+        # register in an await-free step after checking it, so nothing can join
+        # _relay_tasks after the snapshot below — late starters see the gate and bail.
+        if self._relay_tasks:
             for task in list(self._relay_tasks):
                 task.cancel()
             await asyncio.gather(*list(self._relay_tasks), return_exceptions=True)
@@ -515,6 +515,8 @@ class UserspaceDialPlane:
                 psock.close()
 
     async def _ensure_relay(self, port: int) -> _RelayOpener:
+        if self._closing:
+            raise ConnectionError("userspace dial plane is closed")
         key = (self._device_addr, port)
         if key in self._relays:
             return self._relays[key]
@@ -553,9 +555,11 @@ class UserspaceDialPlane:
             path = os.path.join(self._socket_dir, f"{port}.sock")
             try:
                 self._servers.append(await asyncio.start_unix_server(handle, path))
-            except OSError:
-                # e.g. sun_path length exceeded by an unusually long TMPDIR
-                logger.debug("unix-socket relay bind failed; falling back to loopback TCP", exc_info=True)
+            except OSError as e:
+                # e.g. sun_path length exceeded by an unusually long TMPDIR. The fallback is a
+                # loopback TCP port any local process can connect to — losing the unix socket's
+                # filesystem access control — so say so visibly.
+                logger.warning("unix-socket relay bind failed (%s); falling back to loopback TCP", e)
             else:
                 logger.debug("userspace relay %s:%s -> %s", self._device_addr, port, path)
                 return partial(asyncio.open_unix_connection, path)
@@ -572,6 +576,10 @@ class UserspaceDialPlane:
         everything else falls through to the stdlib ``asyncio.open_connection`` unchanged."""
         if host is not None and str(host) == self._device_addr:
             assert port is not None
+            if self._closing:
+                # A dial racing (or following) teardown must not re-create relay state that
+                # nothing will ever clean up — and its stream would only yield silent EOF.
+                raise ConnectionError("userspace dial plane is closed")
             opener = await self._ensure_relay(port)
             return await opener(**kwargs)
         return await asyncio.open_connection(host, port, **kwargs)
@@ -807,7 +815,13 @@ class UserspaceRsdTunnel:
         if self._exit_stack is None:
             return  # normal aclose() already ran
         logger.warning("userspace tunnel transport closed (device disconnected?); tearing down")
-        await self.aclose()
+        try:
+            await self.aclose()
+        except Exception:
+            # This task is fire-and-forget and it runs exactly when unwinding is most likely
+            # to raise (the transport just died under the RSD); an unhandled exception here
+            # would only surface as "Task exception was never retrieved" at GC.
+            logger.warning("userspace tunnel teardown after transport death failed", exc_info=True)
 
     async def aclose(self) -> None:
         """Tear down the tunnel and its RSD, releasing every resource in LIFO order and restoring

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -14,9 +14,10 @@ wires together:
   path is L2; its L3/TUN egress is buggy.)
 * :class:`UserspaceDialPlane` — an ``asyncio.open_connection``-compatible dialer (injected into the
   RSD via ``open_connection=``, NOT monkeypatched onto the global) that relays connections to the
-  device's tunnel address through a localhost socket into a PyTCP socket. This covers the RSD HTTP/2
-  handshake and every ``ServiceConnection.create_using_tcp`` while leaving the process-global
-  ``asyncio.open_connection`` untouched for any other code sharing the process.
+  device's tunnel address through a unix socket (loopback TCP where AF_UNIX is unavailable) into a
+  PyTCP socket. This covers the RSD HTTP/2 handshake and every ``ServiceConnection.create_using_tcp``
+  while leaving the process-global ``asyncio.open_connection`` untouched for any other code sharing
+  the process.
 * :class:`UserspaceUdp` — a UDP socket on the stack for device-initiated inbound streams (the
   AV media behind ``display serve-web``): the device pushes RTP to the stack address rather
   than to an unreachable host kernel socket.
@@ -35,11 +36,15 @@ import asyncio
 import atexit
 import logging
 import os
+import shutil
 import socket
 import struct
 import sys
+import tempfile
+from collections.abc import Coroutine
 from contextlib import AsyncExitStack, suppress
-from typing import Any, Optional, Protocol, cast
+from functools import partial
+from typing import Any, Callable, Optional, Protocol, cast
 
 from pmd_net_addr import Ip6Address, Ip6IfAddr, MacAddress
 from pmd_pytcp import stack
@@ -358,28 +363,52 @@ class UserspaceTun:
                 s.close()
 
 
+#: Connects to a relay's listener, yielding the stream pair (`asyncio.open_connection`-shaped,
+#: minus the address arguments — those are baked in when the listener is bound).
+_RelayOpener = Callable[..., Coroutine[Any, Any, tuple[asyncio.StreamReader, asyncio.StreamWriter]]]
+
+#: A relay server's client-connected callback.
+_RelayHandler = Callable[[asyncio.StreamReader, asyncio.StreamWriter], Coroutine[Any, Any, None]]
+
+
 class UserspaceDialPlane:
     """Provides an ``asyncio.open_connection``-compatible :meth:`dial` that bridges device-bound
-    connections to PyTCP sockets via localhost relays.
+    connections to PyTCP sockets via local relays.
+
+    The relays listen on unix sockets wherever AF_UNIX exists, falling back to loopback TCP
+    (e.g. on Windows) — see :meth:`_start_relay_server` for why. Nothing outside this process
+    ever legitimately connects to a relay (external-tool flows such as ``debugserver lldb``
+    refuse userspace tunnels), so nothing is lost by keeping the listeners off the network
+    stack.
 
     Pass :meth:`dial` to ``RemoteServiceDiscoveryService(open_connection=...)`` so ONLY connections
     made through that RSD are relayed. This deliberately does NOT monkeypatch the process-global
     ``asyncio.open_connection``: a library consumer who establishes a userspace tunnel keeps the
     stdlib function untouched, so unrelated connections elsewhere in their process are unaffected.
 
-    Use as an async context manager so the localhost relay servers are torn down on exit."""
+    Use as an async context manager so the relay servers are torn down on exit."""
 
     def __init__(self, tun: UserspaceTun, device_addr: str) -> None:
         self._tun = tun
         self._device_addr = str(device_addr)
-        self._relays: dict[tuple[str, int], int] = {}
+        # per-device-port relay opener: connects to that relay's listener; whether that means a
+        # unix socket or the loopback TCP fallback was decided once, at bind time
+        self._relays: dict[tuple[str, int], _RelayOpener] = {}
         self._servers: list[asyncio.AbstractServer] = []  # kept referenced so relays stay alive
         self._relay_tasks: set[asyncio.Task[None]] = set()  # in-flight handlers, cancelled on exit
+        self._socket_dir: Optional[str] = None  # holds the relay unix sockets, removed on exit
+        self._closing = False  # teardown began; late-spawning handlers must bail out
 
     async def __aenter__(self) -> UserspaceDialPlane:
         return self
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self._closing = True
+        # A dial's connect completes in the kernel before the server's accept callback runs,
+        # so an accept may already be queued on the loop. Give it one tick to run with
+        # _closing set: it spawns a handler that sees the flag, closes its transport and
+        # bails — otherwise that transport would never be closed by anyone.
+        await asyncio.sleep(0)
         for srv in self._servers:
             srv.close()
         # Cancel the in-flight relay handlers BEFORE wait_closed(): since Python 3.12.1
@@ -388,15 +417,25 @@ class UserspaceDialPlane:
         # caller's timeout (issue #1756). Cancelling here (instead of leaving orphan tasks for
         # the loop's shutdown to cancel) also guarantees each handler's psock cleanup runs
         # while the stack is still up, and that no relay task outlives the dial plane.
-        for task in list(self._relay_tasks):
-            task.cancel()
-        if self._relay_tasks:
-            await asyncio.gather(*self._relay_tasks, return_exceptions=True)
+        #
+        # A dial can also race teardown (see the sleep above): a handler spawned during that
+        # tick may register in _relay_tasks only after this loop snapshots it — keep
+        # cancelling until none remain; handlers that start even later see _closing and bail
+        # out on their own.
+        while self._relay_tasks:
+            for task in list(self._relay_tasks):
+                task.cancel()
+            await asyncio.gather(*list(self._relay_tasks), return_exceptions=True)
         for srv in self._servers:
             with suppress(Exception):
                 await srv.wait_closed()
         self._servers.clear()
         self._relays.clear()
+        if self._socket_dir is not None:
+            # asyncio only unlinks unix server sockets on close from Python 3.13; remove the
+            # whole directory so every version leaves nothing behind.
+            shutil.rmtree(self._socket_dir, ignore_errors=True)
+            self._socket_dir = None
 
     async def _relay_handler(self, port: int, creader: asyncio.StreamReader, cwriter: asyncio.StreamWriter) -> None:
         try:
@@ -405,6 +444,12 @@ class UserspaceDialPlane:
             logger.debug("relay connect_tcp(%s:%s) failed", self._device_addr, port, exc_info=True)
             cwriter.close()
             return
+        except BaseException:
+            # Cancellation (dial-plane teardown) while connecting: the accepted transport must
+            # still be closed, or it stays attached to the relay server and __aexit__ hangs in
+            # Server.wait_closed() (which waits for all attached connections since 3.12.1).
+            cwriter.close()
+            raise
 
         # Both pump directions are plain awaits on the same event loop the stack runs on: a
         # cancelled handler cancels the pumps at their await points, so nothing can stay
@@ -465,12 +510,17 @@ class UserspaceDialPlane:
             with suppress(Exception):
                 psock.close()
 
-    async def _ensure_relay(self, port: int) -> int:
+    async def _ensure_relay(self, port: int) -> _RelayOpener:
         key = (self._device_addr, port)
         if key in self._relays:
             return self._relays[key]
 
         async def handle(creader: asyncio.StreamReader, cwriter: asyncio.StreamWriter) -> None:
+            if self._closing:
+                # Accepted just as teardown began (see __aexit__): close the transport so
+                # Server.wait_closed() can complete, and never touch the stack.
+                cwriter.close()
+                return
             # Track the handler task so __aexit__ can cancel any relay still in flight
             # (start_server's own task bookkeeping offers no cross-version cancel API).
             task = asyncio.current_task()
@@ -481,12 +531,34 @@ class UserspaceDialPlane:
             finally:
                 self._relay_tasks.discard(task)
 
+        opener = await self._start_relay_server(port, handle)
+        self._relays[key] = opener
+        return opener
+
+    async def _start_relay_server(self, port: int, handle: _RelayHandler) -> _RelayOpener:
+        """Bind a relay listener and return the opener that connects to it.
+
+        A unix socket is preferred: it lives in a 0700 temp directory, so the filesystem —
+        not the network stack — decides who may connect, whereas a loopback TCP port is
+        connectable by any local process for the tunnel's whole lifetime. TCP remains the
+        fallback where AF_UNIX is unavailable (e.g. Windows)."""
+        if get_os_utils().supports_unix_sockets:
+            if self._socket_dir is None:
+                self._socket_dir = tempfile.mkdtemp(prefix="pmd3-")
+            path = os.path.join(self._socket_dir, f"{port}.sock")
+            try:
+                self._servers.append(await asyncio.start_unix_server(handle, path))
+            except OSError:
+                # e.g. sun_path length exceeded by an unusually long TMPDIR
+                logger.debug("unix-socket relay bind failed; falling back to loopback TCP", exc_info=True)
+            else:
+                logger.debug("userspace relay %s:%s -> %s", self._device_addr, port, path)
+                return partial(asyncio.open_unix_connection, path)
         srv = await asyncio.start_server(handle, "127.0.0.1", 0)
         self._servers.append(srv)
         lport = srv.sockets[0].getsockname()[1]
-        self._relays[key] = lport
         logger.debug("userspace relay %s:%s -> 127.0.0.1:%s", self._device_addr, port, lport)
-        return lport
+        return partial(asyncio.open_connection, "127.0.0.1", lport)
 
     async def dial(self, host: Optional[str] = None, port: Optional[int] = None, **kwargs: Any):
         """``asyncio.open_connection``-compatible dialer passed to the RSD via ``open_connection=``.
@@ -495,8 +567,8 @@ class UserspaceDialPlane:
         everything else falls through to the stdlib ``asyncio.open_connection`` unchanged."""
         if host is not None and str(host) == self._device_addr:
             assert port is not None
-            lport = await self._ensure_relay(port)
-            return await asyncio.open_connection("127.0.0.1", lport, **kwargs)
+            opener = await self._ensure_relay(port)
+            return await opener(**kwargs)
         return await asyncio.open_connection(host, port, **kwargs)
 
 

--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -149,9 +149,8 @@ class ServiceConnection:
         :param create_connection_timeout: The timeout for creating the connection.
         :param open_connection: Optional ``asyncio.open_connection``-compatible dialer. Defaults to
             ``asyncio.open_connection``; the userspace tunnel injects one that relays device-bound
-            connections through its in-process stack (avoiding a global monkeypatch). Keep-alive is
-            skipped for injected dialers — their connection is a process-local relay leg, not the
-            network leg to the device.
+            connections through its in-process stack. Keep-alive is skipped for injected dialers —
+            their connection is a process-local relay leg, not the network leg to the device.
         :return: A ServiceConnection object.
         """
         dialer = open_connection or asyncio.open_connection

--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -149,17 +149,24 @@ class ServiceConnection:
         :param create_connection_timeout: The timeout for creating the connection.
         :param open_connection: Optional ``asyncio.open_connection``-compatible dialer. Defaults to
             ``asyncio.open_connection``; the userspace tunnel injects one that relays device-bound
-            connections through its in-process stack (avoiding a global monkeypatch).
+            connections through its in-process stack (avoiding a global monkeypatch). Keep-alive is
+            skipped for injected dialers — their connection is a process-local relay leg, not the
+            network leg to the device.
         :return: A ServiceConnection object.
         """
-        open_connection = open_connection or asyncio.open_connection
-        reader, writer = await asyncio.wait_for(open_connection(hostname, port), timeout=create_connection_timeout)
-        sock = writer.get_extra_info("socket")
-        if sock is None:
+        dialer = open_connection or asyncio.open_connection
+        reader, writer = await asyncio.wait_for(dialer(hostname, port), timeout=create_connection_timeout)
+        try:
+            sock = writer.get_extra_info("socket")
+            if sock is None:
+                raise ConnectionError(f"failed to get socket from connection to {hostname}:{port}")
+            if keep_alive and open_connection is None:
+                OSUTIL.set_keepalive(sock)
+        except BaseException:
+            # Never leak the established connection: an open writer keeps the userspace
+            # tunnel's relay pumping (and its accepted transport attached) forever.
             await close_stream_writer(writer)
-            raise ConnectionError(f"failed to get socket from connection to {hostname}:{port}")
-        if keep_alive:
-            OSUTIL.set_keepalive(sock)
+            raise
         conn = ServiceConnection(sock)
         conn.reader = reader
         conn.writer = writer

--- a/tests/test_userspace_tunnel.py
+++ b/tests/test_userspace_tunnel.py
@@ -278,6 +278,26 @@ async def test_relay_uses_unix_sockets_and_removes_them_on_exit():
     assert not os.path.exists(socket_dir)
 
 
+async def test_tcp_relay_forced_by_env_var(monkeypatch):
+    # PYMOBILEDEVICE3_USERSPACE_TCP_RELAY reproduces the Windows relay path on any platform:
+    # the relay must bind loopback TCP and never create a socket directory. This also gives the
+    # TCP relay path POSIX CI coverage (it is otherwise exercised only on Windows runners).
+    monkeypatch.setenv(userspace_tunnel.TCP_RELAY_ENV_VAR, "1")
+    tun = FakeTun()
+    async with UserspaceDialPlane(cast(UserspaceTun, tun), DEVICE_ADDR) as dial_plane:
+        reader, writer = await dial_plane.dial(DEVICE_ADDR, 4444)
+        assert writer.get_extra_info("socket").family == socket.AF_INET
+        assert dial_plane._socket_dir is None
+
+        psock = (await _poll_until(lambda: tun.socks))[0]
+        writer.write(b"ping")
+        await writer.drain()
+        await _poll_until(lambda: psock.sent == [b"ping"])
+        psock.feed(b"pong")
+        assert await reader.readexactly(4) == b"pong"
+        writer.close()
+
+
 async def test_tun_address_usable_when_up_returns():
     # The stack installs the interface address from its own tasks shortly AFTER stack.start()
     # returns, so up() must not return before the address is usable: a connect issued right

--- a/tests/test_userspace_tunnel.py
+++ b/tests/test_userspace_tunnel.py
@@ -16,7 +16,7 @@ import asyncio
 import os
 import socket
 import threading
-from contextlib import AsyncExitStack, suppress
+from contextlib import AsyncExitStack
 from typing import Any, cast
 
 import pytest
@@ -29,6 +29,7 @@ from pmd_pytcp.stack import sysctl
 from pymobiledevice3.osu.os_utils import get_os_utils
 from pymobiledevice3.remote import userspace_tunnel
 from pymobiledevice3.remote.userspace_tunnel import UserspaceDialPlane, UserspaceTun
+from pymobiledevice3.service_connection import close_stream_writer
 
 
 def test_throughput_sysctls_only_emits_registered_knobs():
@@ -246,13 +247,26 @@ async def test_dial_plane_exit_completes_when_dial_races_teardown():
     await asyncio.wait_for(dial_plane.__aexit__(None, None, None), timeout=5)
 
     assert not dial_plane._relay_tasks
-    writer.close()
-    with suppress(OSError):
-        await writer.wait_closed()
+    await close_stream_writer(writer)
     # Drain the loop so the gate handler for the raced connection finishes closing its
     # transport; otherwise the accepted socket is finalized by GC and flagged unraisable.
     for _ in range(5):
         await asyncio.sleep(0)
+
+
+async def test_dial_after_close_raises():
+    # A dial racing (or following) teardown must fail loudly: letting it through re-created
+    # the socket dir and registered a live relay server after teardown had cleared both —
+    # leaked until process exit — and handed the caller a stream that only ever yields EOF.
+    # The window is real since the transport watcher runs teardown concurrently with dials.
+    tun = FakeTun()
+    dial_plane = UserspaceDialPlane(cast(UserspaceTun, tun), DEVICE_ADDR)
+    async with dial_plane:
+        pass
+    with pytest.raises(ConnectionError):
+        await dial_plane.dial(DEVICE_ADDR, 5555)
+    assert dial_plane._socket_dir is None
+    assert not dial_plane._servers
 
 
 @pytest.mark.skipif(not get_os_utils().supports_unix_sockets, reason="platform has no AF_UNIX")
@@ -263,18 +277,14 @@ async def test_relay_uses_unix_sockets_and_removes_them_on_exit():
     # unlinks unix server sockets from 3.13, so the dial plane removes its socket directory
     # itself.
     tun = FakeTun()
-    dial_plane = UserspaceDialPlane(cast(UserspaceTun, tun), DEVICE_ADDR)
-    await dial_plane.__aenter__()
-    _reader, writer = await dial_plane.dial(DEVICE_ADDR, 2222)
-    assert writer.get_extra_info("socket").family == socket.AF_UNIX
-    socket_dir = dial_plane._socket_dir
-    assert socket_dir is not None and os.path.isdir(socket_dir)
+    async with UserspaceDialPlane(cast(UserspaceTun, tun), DEVICE_ADDR) as dial_plane:
+        _reader, writer = await dial_plane.dial(DEVICE_ADDR, 2222)
+        assert writer.get_extra_info("socket").family == socket.AF_UNIX
+        socket_dir = dial_plane._socket_dir
+        assert socket_dir is not None and os.path.isdir(socket_dir)
 
-    writer.close()
-    with suppress(OSError):
-        await writer.wait_closed()
-    await _poll_until(lambda: not dial_plane._relay_tasks)
-    await dial_plane.__aexit__(None, None, None)
+        await close_stream_writer(writer)
+        await _poll_until(lambda: not dial_plane._relay_tasks)
     assert not os.path.exists(socket_dir)
 
 

--- a/tests/test_userspace_tunnel.py
+++ b/tests/test_userspace_tunnel.py
@@ -16,7 +16,7 @@ import asyncio
 import os
 import socket
 import threading
-from contextlib import suppress
+from contextlib import AsyncExitStack, suppress
 from typing import Any, cast
 
 import pytest
@@ -296,6 +296,24 @@ async def test_tcp_relay_forced_by_env_var(monkeypatch):
         psock.feed(b"pong")
         assert await reader.readexactly(4) == b"pong"
         writer.close()
+
+
+async def test_transport_watcher_tears_down_on_transport_death():
+    # Device unplug: usbmuxd closes the outer CoreDeviceProxy connection, the transport read
+    # task ends (wait_closed returns) and nothing else wakes blocked service reads — the pytcp
+    # sessions stay ESTABLISHED and relay pumps park forever (keep-alive can't cover it: a
+    # relay's peer is this very process). The watcher must react by running aclose(), whose
+    # relay teardown surfaces EOF/errors to every blocked caller. Reproduced live: `dvt oslog`
+    # parked forever on USB unplug; with the watcher it exits within a second.
+    tunnel = userspace_tunnel.UserspaceRsdTunnel()
+    tunnel._exit_stack = AsyncExitStack()
+
+    class FakeTunnelClient:
+        async def wait_closed(self) -> None:
+            return  # the transport read task has ended
+
+    await asyncio.wait_for(tunnel._watch_transport_closed(cast(Any, FakeTunnelClient())), timeout=5)
+    assert tunnel._exit_stack is None  # aclose() ran
 
 
 async def test_tun_address_usable_when_up_returns():

--- a/tests/test_userspace_tunnel.py
+++ b/tests/test_userspace_tunnel.py
@@ -13,7 +13,10 @@ threads at all — that relaying spawns none.
 """
 
 import asyncio
+import os
+import socket
 import threading
+from contextlib import suppress
 from typing import Any, cast
 
 import pytest
@@ -23,6 +26,7 @@ pytest.importorskip("pmd_pytcp")
 
 from pmd_pytcp.stack import sysctl
 
+from pymobiledevice3.osu.os_utils import get_os_utils
 from pymobiledevice3.remote import userspace_tunnel
 from pymobiledevice3.remote.userspace_tunnel import UserspaceDialPlane, UserspaceTun
 
@@ -219,6 +223,59 @@ async def test_relaying_spawns_no_threads():
         assert set(threading.enumerate()) == baseline
     for writer in writers:
         writer.close()
+
+
+async def test_dial_plane_exit_completes_when_dial_races_teardown():
+    # A dial's connect completes in the kernel before the server's accept callback has
+    # spawned the handler. If teardown then begins — e.g. the dialer's caller raised during
+    # connection setup — __aexit__'s cancel loop snapshots _relay_tasks before that handler
+    # registers, so nothing cancelled it: its pumps parked forever on an abandoned client
+    # connection and __aexit__ hung in Server.wait_closed() (which waits for all attached
+    # connections since Python 3.12.1). Reproduced live against a device; exit must complete
+    # promptly with no relay task left behind.
+    class StallingTun:
+        async def connect_tcp(self, addr: str, port: int) -> FakePyTcpSocket:
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    dial_plane = UserspaceDialPlane(cast(UserspaceTun, StallingTun()), DEVICE_ADDR)
+    await dial_plane.__aenter__()
+    _reader, writer = await dial_plane.dial(DEVICE_ADDR, 3333)
+
+    # No yield to the loop between dial and teardown: the handler must not be registered yet.
+    await asyncio.wait_for(dial_plane.__aexit__(None, None, None), timeout=5)
+
+    assert not dial_plane._relay_tasks
+    writer.close()
+    with suppress(OSError):
+        await writer.wait_closed()
+    # Drain the loop so the gate handler for the raced connection finishes closing its
+    # transport; otherwise the accepted socket is finalized by GC and flagged unraisable.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.skipif(not get_os_utils().supports_unix_sockets, reason="platform has no AF_UNIX")
+async def test_relay_uses_unix_sockets_and_removes_them_on_exit():
+    # Where AF_UNIX exists the relay must listen on unix sockets, not loopback TCP: the
+    # socket dir's 0700 mode decides who may connect, instead of exposing the device's
+    # services on a port any local process can reach. Also pin the cleanup: asyncio only
+    # unlinks unix server sockets from 3.13, so the dial plane removes its socket directory
+    # itself.
+    tun = FakeTun()
+    dial_plane = UserspaceDialPlane(cast(UserspaceTun, tun), DEVICE_ADDR)
+    await dial_plane.__aenter__()
+    _reader, writer = await dial_plane.dial(DEVICE_ADDR, 2222)
+    assert writer.get_extra_info("socket").family == socket.AF_UNIX
+    socket_dir = dial_plane._socket_dir
+    assert socket_dir is not None and os.path.isdir(socket_dir)
+
+    writer.close()
+    with suppress(OSError):
+        await writer.wait_closed()
+    await _poll_until(lambda: not dial_plane._relay_tasks)
+    await dial_plane.__aexit__(None, None, None)
+    assert not os.path.exists(socket_dir)
 
 
 async def test_tun_address_usable_when_up_returns():


### PR DESCRIPTION
## What

The userspace tunnel's dial plane relayed device-bound service connections over loopback TCP: an unauthenticated port through which **any local process** could reach the device's RSD/DVT/lockdown services for the tunnel's whole lifetime. The relays now bind unix sockets in a `0700` temp directory instead, so filesystem permissions decide who may connect. Loopback TCP remains the fallback where `AF_UNIX` is unavailable (e.g. Windows, or a `sun_path`-overflowing `TMPDIR`), and the socket directory is removed on dial-plane exit.

Nothing outside the process ever legitimately connects to a relay (external-tool flows such as `debugserver lldb` already refuse userspace tunnels), so no reachability is lost.

A minor side benefit: the relays ran with keep-alive (idle 3 s / interval 3 s), so every idle service connection had the kernel exchanging probe/ACK pairs on loopback for the tunnel's lifetime. Keep-alive is now keyed off the dialer — an injected `open_connection` means a process-local relay leg (the same fact `is_in_process_tunnel` is defined by), where keep-alive is meaningless — so an idle tunnel is truly silent on both relay flavors, TCP fallback included. (In-kernel and microseconds per probe — hygiene, not measurable performance.)

## Robustness fixes surfaced by the switch (all reachable on the TCP fallback too)

- `create_using_tcp`: skip the TCP keep-alive options for relay-leg connections (on a unix socket they raise `OSError`; on the loopback fallback they were pointless chatter), and close the writer on **any** setup failure instead of leaking the established connection.
- Dial plane teardown: a dial's connect completes in the kernel before the accept callback spawns the relay handler, so a handler could register after `__aexit__` snapshot-cancelled `_relay_tasks` and park forever, hanging `Server.wait_closed()` (which waits for all attached connections since Python 3.12.1). Teardown now drains queued accepts behind a `_closing` gate, keeps cancelling until no handlers remain, and closes the accepted transport when a handler is cancelled mid-connect. Regression-tested (the new test hangs without the fix).

## Transport-death teardown (third commit)

Investigating disconnect handling surfaced a pre-existing hole in the in-process userspace path: when the outer transport dies (USB unplug → usbmuxd closes the CoreDeviceProxy connection), the transport read task just ended and nothing woke the pytcp sessions or relay handlers — `dvt oslog` parked forever, **on both relay flavors** (keep-alive on the loopback relay never fires: its peer is this very process, measured 15 s of active probing with no effect; the kernel-tunnel path is unaffected since the utun interface disappears and connections error out). A watcher on the tunnel client's `wait_closed()` now tears the userspace RSD down, surfacing EOF/errors to every blocked caller — `dvt oslog` exits within a second of the transport dying (verified live via `pkill usbmuxd` as an unplug equivalent).

## Verification

- Live against a physical device (iOS 27 beta, USB): tunnel establishment, RSD handshake, remote lockdown, and AFC all over the unix-socket relays.
- Throughput is unchanged — 16 MiB AFC benchmark, 4 alternating rounds per relay flavor: push ~11.2 vs ~11.1 MiB/s, pull ~26.7 vs ~29.6 MiB/s (differences within run-to-run variance; the pmd-pytcp stack is the bottleneck, not the relay hop).
- `pytest -m 'not device'`: 543 passed; `pre-commit` (ruff + pyright 1.1.411): clean.

## Review findings (fourth commit)

An adversarial multi-verifier review pass over the branch surfaced four functional issues, all fixed and verified: `RemoteXPCConnection.local_address` raised `IndexError` over the relay (AF_UNIX sockname is a string) — now a clear error; a dial racing/following teardown re-created leaked relay state and returned a silent-EOF stream — now `ConnectionError`; the unix-socket-bind fallback to loopback TCP logged only at debug despite trading away the 0700 access control — now a warning; and the transport watcher's fire-and-forget `aclose()` could swallow teardown exceptions — now guarded and logged. Plus comment/teardown-loop corrections and test hygiene (hang-protected writer close, no leak on assertion failure).
