### PR TITLE
userspace-tunnel: bind one eager relay listener; route the port in-band

### DIFF
--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -21,6 +21,11 @@ shared/persistent tunnel, or iOS 17.0-17.3.1 — see
 Reference protocol details:
 [RemoteXPC](../internals/remotexpc.md)
 
+!!! tip
+    For diagrams of what each transport path looks like under the hood — usbmux, Wi-Fi
+    lockdown, kernel tunnels, and the userspace tunnel — see
+    [Understanding the network stacks](network-stacks.md).
+
 ## The default: a no-root tunnel, automatically
 
 When a developer command needs an RSD tunnel and you passed none of `--rsd` / `--tunnel` /

--- a/docs/guides/network-stacks.md
+++ b/docs/guides/network-stacks.md
@@ -1,0 +1,179 @@
+# Understanding the network stacks
+
+Every pymobiledevice3 command reaches the device through one of four transport paths. This
+guide shows what each path actually looks like — which sockets exist, what needs root, and
+how a device disconnect is detected. For choosing between them day-to-day, see
+[iOS 17+ tunnels](ios17-tunnels.md).
+
+## USB lockdown via usbmuxd
+
+The classic path, used by everything that does not need an RSD tunnel (`afc`, `backup2`,
+`syslog`, `apps`, ...). No TCP on the host at all: the client speaks the usbmux protocol
+over usbmuxd's unix socket, and usbmuxd multiplexes device-port streams over the USB link.
+
+```mermaid
+flowchart LR
+    cli["pymobiledevice3"] -->|"/var/run/usbmuxd<br/>(unix socket)"| mux["usbmuxd"]
+    mux -->|USB| dev["iOS device<br/>lockdownd + services"]
+```
+
+- **Root:** not required.
+- **Disconnect:** usbmuxd owns the link — on unplug it closes your socket immediately
+  (kernel EOF, no probing needed).
+- On Windows usbmuxd's socket is loopback TCP (`127.0.0.1:27015`) instead of a unix socket.
+
+## Wi-Fi lockdown (mobdev2)
+
+The same lockdown protocol, carried over the LAN to port 62078 (`--mobdev2` /
+`get_mobdev2_lockdowns`). Devices are discovered over bonjour.
+
+```mermaid
+flowchart LR
+    cli["pymobiledevice3"] -->|"TCP :62078 over Wi-Fi"| dev["iOS device<br/>lockdownd + services"]
+```
+
+- **Root:** not required.
+- **Disconnect:** a Wi-Fi link can die silently, so these connections run TCP keep-alive
+  (idle 3 s / interval 3 s) — a vanished device errors out within seconds.
+
+## Kernel tunnel (`start-tunnel` / `tunneld`)
+
+iOS 17+ developer services live behind an encrypted tunnel to an RSD endpoint. The kernel
+tunnel terminates that tunnel in a `utun` interface, making the device's tunnel address
+(`fdxx::1`) kernel-routable — reachable by **any process**, including external tools like
+`lldb`.
+
+```mermaid
+flowchart LR
+    subgraph host["host (root required)"]
+        cli["pymobiledevice3<br/>(or any tool)"]
+        utun["utunX<br/>fdxx::/64"]
+        td["start-tunnel / tunneld"]
+    end
+    cli -->|"kernel TCP6 to [fdxx::1]"| utun
+    utun --> td
+    td -->|"encrypted tunnel over<br/>USB (CoreDeviceProxy) or Wi-Fi"| dev["iOS device<br/>RSD + services"]
+```
+
+- **Root:** required (creating `utun` needs it); `tunneld` is the daemon form that shares
+  tunnels across processes, queryable over HTTP (`--tunnel`), optionally on a unix socket
+  (`--uds`).
+- **Disconnect:** the `utun` interface disappears with the tunnel, erroring connections
+  out; service connections also run TCP keep-alive.
+- Highest host→device throughput; the only path external tools can use.
+
+## Userspace tunnel (the no-root default)
+
+The default for RSD-required commands on iOS 17.4+ over USB. The kernel interface is
+replaced by a pure-Python TCP/IP stack ([pmd-pytcp](https://github.com/doronz88/pmd-pytcp))
+running on the process's own event loop — no root anywhere, and no kernel TCP anywhere:
+
+```mermaid
+flowchart TB
+    subgraph proc["pymobiledevice3 process"]
+        svc["Developer services<br/>(DVT, os_trace, AFC, ...)"]
+        rsd["RemoteServiceDiscoveryService<br/><i>open_connection = dial plane</i>"]
+        dp["UserspaceDialPlane<br/>one relay listener (unix socket —<br/>loopback TCP on Windows)"]
+        stack["pmd-pytcp<br/>pure-asyncio TCP/IP stack"]
+        tun["UserspaceTun<br/>L2 bridge: datagram socketpair<br/>+ 14-byte Ethernet shim"]
+        cdp["CoreDeviceProxy transport<br/>(lockdown service connection)"]
+    end
+    usbmuxd["usbmuxd<br/>(unix socket)"]
+    dev["iOS device<br/>RSD + services at fdxx::1"]
+
+    svc --> rsd --> dp
+    dp <-->|"pytcp TCP session<br/>over the tunnel"| stack
+    stack <--> tun
+    tun <-->|"encrypted tunnel frames"| cdp
+    cdp <--> usbmuxd <-->|USB| dev
+```
+
+Key properties that fall out of this shape:
+
+- **No root anywhere** — there is no kernel interface; the "network" to the device lives
+  entirely inside the process.
+- **The tunnel address is in-process only.** `fdxx::1` exists on the pytcp stack, not in
+  the kernel routing table, so external tools cannot reach it — the RSD reports this via
+  `is_in_process_tunnel`.
+- **One tunnel per process.** The pytcp stack is a process-global singleton; every
+  open/close transition serializes on a lifecycle lock, and concurrent
+  `establish_userspace_rsd()` callers share the winning tunnel instead of racing it.
+
+### Dialing a service connection
+
+Services call the RSD's injected `open_connection`, which relays through a single
+pre-bound listener; the target port travels in-band as a 2-byte header, so nothing ever
+binds on the dial path:
+
+```mermaid
+sequenceDiagram
+    participant S as ServiceConnection
+    participant D as dial()
+    participant L as relay listener
+    participant H as handler
+    participant P as pytcp socket
+    participant Dev as device service
+
+    S->>D: open_connection(fdxx::1, port)
+    D->>L: connect (unix socket)
+    D->>L: 2-byte port header
+    D-->>S: (reader, writer)
+    L->>H: spawn per-connection handler
+    H->>H: read port header
+    H->>P: connect_tcp(fdxx::1, port)
+    P->>Dev: SYN ... over the tunnel
+    loop two pump tasks
+        S->>P: bytes (client → device)
+        P->>S: bytes (device → client)
+    end
+    Note over H,P: client EOF fully closes the pytcp socket<br/>(FIN reaches the device — orphan reaper owns the tail)<br/>device EOF reaches the client as write_eof
+```
+
+Why a unix socket for the hand-off: it lives in a `0700` temp directory, so filesystem
+permissions decide who may connect — a loopback TCP port would be connectable by any local
+process for the tunnel's whole lifetime. Loopback TCP remains the fallback where `AF_UNIX`
+does not exist (Windows), and `PYMOBILEDEVICE3_USERSPACE_TCP_RELAY` forces it anywhere for
+debugging. A connection that never sends its port header is shed after a timeout instead
+of pinning a handler.
+
+### Device disconnect and teardown
+
+Nothing on the relay path can detect a vanished device (both relay endpoints are the same
+process, so keep-alive would only probe the local kernel), so the tunnel watches its own
+transport: when the CoreDeviceProxy connection dies — USB unplug makes usbmuxd close it
+immediately — a watcher task tears the whole tunnel down, surfacing errors to every
+blocked service read within about a second:
+
+```mermaid
+sequenceDiagram
+    participant U as usbmuxd
+    participant T as transport read task
+    participant W as transport watcher
+    participant A as aclose()
+    participant DP as dial plane
+    participant S as blocked service reads
+
+    U--xT: connection closed (unplug)
+    T->>W: wait_closed() returns
+    W->>A: tear down (serialized on the lifecycle lock)
+    A->>DP: __aexit__
+    DP->>DP: close listener, cancel relay handlers
+    DP->>S: EOF / connection error
+    Note over S: e.g. `dvt oslog` exits ~1 s after the cable is pulled
+```
+
+Teardown details worth knowing when reading the code:
+
+- The dial plane sets a `_closing` gate, gives already-queued accepts one loop tick to
+  attach (so their transports can be closed properly), cancels every in-flight relay
+  handler, and awaits the listener's `wait_closed()` — this is what keeps
+  `Server.wait_closed()` from hanging on a relay parked on device traffic (issue #1756).
+- `aclose()` returning means the process-global stack is really stopped: an explicit close
+  that races the watcher's teardown waits for it instead of returning early, so
+  close-then-reopen is safe.
+- The one listener bind that exists is shielded against cancellation:
+  `create_server`-style coroutines suspend once *after* the socket is serving, and a
+  cancellation landing there would otherwise orphan a listener the event loop keeps alive
+  forever.
+- The CLI keeps its tunnel for the process lifetime and closes it at interpreter exit
+  (~3 ms), so the device always sees clean FINs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,7 +102,11 @@ markdown_extensions:
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.details
@@ -118,6 +122,7 @@ nav:
       - CLI recipes: guides/cli-recipes.md
       - Mounting AFC in Finder (WebDAV): guides/webdav-mounting.md
       - iOS 17+ tunnels: guides/ios17-tunnels.md
+      - Understanding the network stacks: guides/network-stacks.md
       - WebView debugging: guides/webview-debugging.md
       - Machine-readable output: guides/machine-readable-output.md
       - Python API: guides/python-api.md

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -483,10 +483,14 @@ class UserspaceDialPlane:
         # caller's timeout (issue #1756). Cancelling here (instead of leaving orphan tasks for
         # the loop's shutdown to cancel) also guarantees each handler's psock cleanup runs
         # while the stack is still up, and that no relay task outlives the dial plane.
-        # One pass suffices: _closing was set before any await in this method and handlers
-        # register in an await-free step after checking it, so nothing can join
-        # _relay_tasks after the snapshot below — late starters see the gate and bail.
-        if self._relay_tasks:
+        # Nothing can join _relay_tasks after the first snapshot (_closing was set before any
+        # await in this method and handlers register in an await-free step after checking
+        # it), but repeat the cancel a few times anyway: on Python <= 3.11 a cancellation
+        # racing an inner future's completion can be swallowed (the old wait_for behavior),
+        # and a survivor here would park __aexit__ forever.
+        for _ in range(3):
+            if not self._relay_tasks:
+                break
             for task in list(self._relay_tasks):
                 task.cancel()
             await asyncio.gather(*list(self._relay_tasks), return_exceptions=True)
@@ -519,10 +523,15 @@ class UserspaceDialPlane:
                 # dial() writes the header before returning, so a well-behaved client's header
                 # arrives immediately; the timeout sheds strays that connect and send nothing
                 # (on the TCP fallback any local process can), which would otherwise pin this
-                # handler and its transport until tunnel close.
-                port = int.from_bytes(
-                    await asyncio.wait_for(creader.readexactly(2), timeout=RELAY_HEADER_TIMEOUT), "big"
-                )
+                # handler and its transport until tunnel close. Enforced via call_later rather
+                # than wait_for: on Python <= 3.11 wait_for can swallow an external
+                # cancellation that races the header's arrival, leaving teardown's cancel
+                # lost and __aexit__ waiting on this handler forever (observed on slow CI).
+                shed = asyncio.get_running_loop().call_later(RELAY_HEADER_TIMEOUT, cwriter.close)
+                try:
+                    port = int.from_bytes(await creader.readexactly(2), "big")
+                finally:
+                    shed.cancel()
             except (asyncio.IncompleteReadError, ConnectionError, asyncio.TimeoutError):
                 cwriter.close()
                 return

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -41,6 +41,7 @@ import socket
 import struct
 import sys
 import tempfile
+import weakref
 from collections.abc import Coroutine
 from contextlib import AsyncExitStack, suppress
 from functools import partial
@@ -116,6 +117,11 @@ MIN_RTO_MS = 200
 #: immediately; bulk transfers are unaffected either way (streams are governed by the
 #: ACK-every-other-segment rule, not the timer — measured 38-39 MB/s at 1/10/100 ms alike).
 ACK_DELAY_MS = 1
+
+#: How long :class:`UserspaceDialPlane` waits for a relay connection's 2-byte port header.
+#: dial() writes it before returning, so legitimate headers arrive within one loop tick;
+#: this only sheds stray local connections that send nothing.
+RELAY_HEADER_TIMEOUT = 10
 
 #: Set (to any non-empty value) to force the dial plane's relays onto loopback TCP even where
 #: AF_UNIX exists — reproduces the Windows relay path on any platform for debugging.
@@ -510,8 +516,14 @@ class UserspaceDialPlane:
         self._relay_tasks.add(task)
         try:
             try:
-                port = int.from_bytes(await creader.readexactly(2), "big")
-            except (asyncio.IncompleteReadError, ConnectionError):
+                # dial() writes the header before returning, so a well-behaved client's header
+                # arrives immediately; the timeout sheds strays that connect and send nothing
+                # (on the TCP fallback any local process can), which would otherwise pin this
+                # handler and its transport until tunnel close.
+                port = int.from_bytes(
+                    await asyncio.wait_for(creader.readexactly(2), timeout=RELAY_HEADER_TIMEOUT), "big"
+                )
+            except (asyncio.IncompleteReadError, ConnectionError, asyncio.TimeoutError):
                 cwriter.close()
                 return
             except BaseException:
@@ -789,6 +801,11 @@ class UserspaceRsdTunnel:
         global _active_tunnel, USERSPACE_ACTIVE
         if self.rsd is not None:
             return self.rsd
+        async with _lifecycle_lock():
+            return await self._aopen_locked()
+
+    async def _aopen_locked(self) -> RemoteServiceDiscoveryService:
+        global _active_tunnel, USERSPACE_ACTIVE
         if _active_tunnel is not None:
             raise PyMobileDevice3Exception(
                 "a userspace tunnel is already active in this process (PyTCP's stack is a "
@@ -866,21 +883,29 @@ class UserspaceRsdTunnel:
         the kernel-tunnel factory default. Idempotent.
 
         After this returns, no background thread remains blocked (closing the tun wakes the parked
-        reader), so the process can exit normally — embedders do NOT need :func:`force_exit`."""
+        reader), so the process can exit normally — embedders do NOT need :func:`force_exit`.
+
+        Serialized with the transport watcher's teardown: an explicit aclose() during the
+        watcher's unwind (device just disconnected) waits for that unwind instead of
+        returning while resources are still being released — so aclose() returning means the
+        process-global pytcp stack is really stopped and a new tunnel may be opened."""
         global _active_tunnel, USERSPACE_ACTIVE
-        if self._exit_stack is None:
-            return
-        stack, self._exit_stack = self._exit_stack, None
-        watcher, self._transport_watcher = self._transport_watcher, None
-        if watcher is not None and watcher is not asyncio.current_task():
-            watcher.cancel()
-        self.rsd = None
-        self.tun = None
-        if _active_tunnel is self:
-            _active_tunnel = None
-            USERSPACE_ACTIVE = False
-            tunnel_service.USE_USERSPACE_TUNNEL = False
-        await stack.aclose()
+        async with _lifecycle_lock():
+            if self._exit_stack is None:
+                return
+            stack, self._exit_stack = self._exit_stack, None
+            watcher, self._transport_watcher = self._transport_watcher, None
+            if watcher is not None and watcher is not asyncio.current_task():
+                # The watcher is parked in wait_closed() (it cannot be mid-aclose: that path
+                # holds this lock) — safe to cancel.
+                watcher.cancel()
+            self.rsd = None
+            self.tun = None
+            if _active_tunnel is self:
+                _active_tunnel = None
+                USERSPACE_ACTIVE = False
+                tunnel_service.USE_USERSPACE_TUNNEL = False
+            await stack.aclose()
 
     #: ``open``/``close`` are aliases for :meth:`aopen`/:meth:`aclose` (still awaitable).
     open = aopen
@@ -891,6 +916,27 @@ class UserspaceRsdTunnel:
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         await self.aclose()
+
+
+_lifecycle_locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = weakref.WeakKeyDictionary()
+
+
+def _lifecycle_lock() -> asyncio.Lock:
+    """The lock serializing every open/close transition of the process-global pytcp stack.
+
+    aopen() checks the singleton guard and publishes _active_tunnel on opposite sides of the
+    whole establishment, so without serialization two concurrent aopen() calls both pass the
+    guard and drive the one stack at once (measured live: both handshakes die with
+    IncompleteReadError and pmd-pytcp is left asserting "ARP Cache.start() called while a
+    worker is still running"). It also serializes a new aopen() against a previous handle's
+    still-unwinding teardown. One lock per event loop, created inside the loop (Python 3.9's
+    primitives bind their loop at construction time)."""
+    loop = asyncio.get_running_loop()
+    lock = _lifecycle_locks.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _lifecycle_locks[loop] = lock
+    return lock
 
 
 #: Holds the CLI's tunnel for the process lifetime (the CLI has no teardown hook and hard-exits
@@ -923,7 +969,19 @@ async def establish_userspace_rsd(
     ):
         return _cli_tunnel.rsd
     tunnel = UserspaceRsdTunnel(serial=serial, autopair=autopair, remotepairing_fallback=remotepairing_fallback)
-    rsd = await tunnel.aopen()
+    try:
+        rsd = await tunnel.aopen()
+    except PyMobileDevice3Exception:
+        # Lost an establishment race (aopen serializes on the lifecycle lock, so by now the
+        # winner has published): share its tunnel when it serves the requested device.
+        winner = _cli_tunnel or _active_tunnel
+        if (
+            winner is not None
+            and winner.rsd is not None
+            and (serial is None or serial in (winner.serial, winner.rsd.udid))
+        ):
+            return winner.rsd
+        raise
     _cli_tunnel = tunnel
     # The pure-asyncio stack has no threads to park, so process exit cannot hang anymore. The
     # CLI still never closes its tunnel (it lives for the process lifetime), so hard-exit at

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -39,7 +39,6 @@ import os
 import shutil
 import socket
 import struct
-import sys
 import tempfile
 import weakref
 from collections.abc import Coroutine
@@ -59,6 +58,7 @@ from pymobiledevice3.exceptions import InvalidServiceError, PyMobileDevice3Excep
 from pymobiledevice3.lockdown import create_using_usbmux
 from pymobiledevice3.osu.os_utils import get_os_utils
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+from pymobiledevice3.utils import get_asyncio_loop
 
 logger = logging.getLogger(__name__)
 
@@ -644,8 +644,7 @@ class UserspaceDialPlane:
 _active_tunnel: Optional[UserspaceRsdTunnel] = None
 
 #: True while a userspace tunnel is active in this process. Mirrors ``_active_tunnel is not None``
-#: (kept as a plain flag so callers can read it as an attribute). The CLI also uses it to gate the
-#: hard exit in :func:`force_exit`.
+#: (kept as a plain flag so callers can read it as an attribute).
 USERSPACE_ACTIVE = False
 
 
@@ -883,7 +882,7 @@ class UserspaceRsdTunnel:
         the kernel-tunnel factory default. Idempotent.
 
         After this returns, no background thread remains blocked (closing the tun wakes the parked
-        reader), so the process can exit normally — embedders do NOT need :func:`force_exit`.
+        reader), so the process can exit normally.
 
         Serialized with the transport watcher's teardown: an explicit aclose() during the
         watcher's unwind (device just disconnected) waits for that unwind instead of
@@ -939,8 +938,8 @@ def _lifecycle_lock() -> asyncio.Lock:
     return lock
 
 
-#: Holds the CLI's tunnel for the process lifetime (the CLI has no teardown hook and hard-exits
-#: via force_exit instead of calling aclose). Embedders hold their own UserspaceRsdTunnel.
+#: Holds the CLI's tunnel for the process lifetime (closed at interpreter exit — the CLI has no
+#: earlier teardown hook). Embedders hold their own UserspaceRsdTunnel.
 _cli_tunnel: Optional[UserspaceRsdTunnel] = None
 
 
@@ -951,8 +950,7 @@ async def establish_userspace_rsd(
 
     Embedders should use :class:`UserspaceRsdTunnel` directly — it is a closeable handle / async
     context manager. This wrapper exists for the CLI, which has no teardown hook: it stashes the
-    tunnel for the process lifetime and registers :func:`force_exit` at exit so the CLI exits
-    promptly without awaiting teardown.
+    tunnel for the process lifetime and closes it at interpreter exit (a few ms).
 
     ``remotepairing_fallback=False`` makes a pre-17.4 device (no CoreDeviceProxy) raise
     :class:`UserspaceTunnelUnavailableError` instead of attempting RemotePairing, so the caller can
@@ -983,25 +981,24 @@ async def establish_userspace_rsd(
             return winner.rsd
         raise
     _cli_tunnel = tunnel
-    # The pure-asyncio stack has no threads to park, so process exit cannot hang anymore. The
-    # CLI still never closes its tunnel (it lives for the process lifetime), so hard-exit at
-    # atexit to skip the "Task was destroyed but it is pending!" GC noise from the stack's
-    # still-scheduled loop tasks. Embedders who call aclose() never reach this with
-    # USERSPACE_ACTIVE set.
-    atexit.register(force_exit)
+    atexit.register(_close_cli_tunnel_at_exit)
     return rsd
 
 
-def force_exit(code: int = 0) -> None:
-    """Flush output and hard-exit, skipping userspace tunnel teardown. No-op unless a userspace
-    tunnel is active. Used by the CLI, which keeps its tunnel for the process lifetime instead of
-    closing it; embedders should prefer :meth:`UserspaceRsdTunnel.aclose`, which tears down
-    cleanly and lets the process exit on its own."""
-    if not USERSPACE_ACTIVE:
+def _close_cli_tunnel_at_exit() -> None:
+    """Close the CLI's process-lifetime tunnel at interpreter exit (bounded; measured ~3 ms on
+    a healthy tunnel — the device gets a clean FIN instead of an abandoned session).
+
+    This replaced a hard ``os._exit`` whose reasons no longer exist: the pure-asyncio stack
+    has no threads that could park exit, and the CLI's persistent loop is abandoned rather
+    than closed, so there is no pending-task GC noise to mute either. Registration is
+    idempotent in effect: aclose() is."""
+    if _cli_tunnel is None or _cli_tunnel.rsd is None:
         return
     try:
-        sys.stdout.flush()
-        sys.stderr.flush()
+        loop = get_asyncio_loop()
+        if loop.is_running():
+            return  # exiting from inside the loop; nothing safe to run here
+        loop.run_until_complete(asyncio.wait_for(_cli_tunnel.aclose(), timeout=3))
     except Exception:
-        pass
-    os._exit(code)
+        logger.debug("closing the CLI tunnel at exit failed", exc_info=True)

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -44,7 +44,7 @@ import tempfile
 from collections.abc import Coroutine
 from contextlib import AsyncExitStack, suppress
 from functools import partial
-from typing import Any, Callable, Optional, Protocol, cast
+from typing import Any, Callable, Optional, Protocol, TypeVar, cast
 
 from pmd_net_addr import Ip6Address, Ip6IfAddr, MacAddress
 from pmd_pytcp import stack
@@ -371,8 +371,29 @@ class UserspaceTun:
 #: minus the address arguments — those are baked in when the listener is bound).
 _RelayOpener = Callable[..., Coroutine[Any, Any, tuple[asyncio.StreamReader, asyncio.StreamWriter]]]
 
-#: A relay server's client-connected callback.
-_RelayHandler = Callable[[asyncio.StreamReader, asyncio.StreamWriter], Coroutine[Any, Any, None]]
+
+_ServerT = TypeVar("_ServerT", bound=asyncio.AbstractServer)
+
+
+async def _bind_listener(bind: Coroutine[Any, Any, _ServerT]) -> _ServerT:
+    """Await a ``start_server``-style coroutine without orphaning its listener on cancellation.
+
+    ``create_server``/``create_unix_server`` suspend once AFTER the socket is bound, serving,
+    and registered with the loop's selector (their trailing ``sleep(0)``); a cancellation
+    landing exactly there — e.g. ``create_using_tcp``'s connect timeout cancelling a dial
+    mid-bind — discards the Server object while the selector keeps its socket alive forever.
+    Shield the bind and close the listener when it lands if the awaiter was cancelled."""
+    task = asyncio.ensure_future(bind)
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+
+        def _close_when_done(t: asyncio.Task[asyncio.AbstractServer]) -> None:
+            if not t.cancelled() and t.exception() is None:
+                t.result().close()
+
+        task.add_done_callback(_close_when_done)
+        raise
 
 
 class UserspaceDialPlane:
@@ -380,7 +401,7 @@ class UserspaceDialPlane:
     connections to PyTCP sockets via local relays.
 
     The relays listen on unix sockets wherever AF_UNIX exists, falling back to loopback TCP
-    (e.g. on Windows) — see :meth:`_start_relay_server` for why. Nothing outside this process
+    (e.g. on Windows) — see :meth:`__aenter__` for why. Nothing outside this process
     ever legitimately connects to a relay (external-tool flows such as ``debugserver lldb``
     refuse userspace tunnels), so nothing is lost by keeping the listeners off the network
     stack.
@@ -395,28 +416,61 @@ class UserspaceDialPlane:
     def __init__(self, tun: UserspaceTun, device_addr: str) -> None:
         self._tun = tun
         self._device_addr = str(device_addr)
-        # per-device-port relay opener: connects to that relay's listener; whether that means a
-        # unix socket or the loopback TCP fallback was decided once, at bind time
-        self._relays: dict[tuple[str, int], _RelayOpener] = {}
-        self._servers: list[asyncio.AbstractServer] = []  # kept referenced so relays stay alive
+        self._server: Optional[asyncio.AbstractServer] = None  # the single relay listener
+        self._opener: Optional[_RelayOpener] = None  # connects to it (unix path or TCP port)
         self._relay_tasks: set[asyncio.Task[None]] = set()  # in-flight handlers, cancelled on exit
-        self._socket_dir: Optional[str] = None  # holds the relay unix sockets, removed on exit
+        self._socket_dir: Optional[str] = None  # holds the relay unix socket, removed on exit
         self._closing = False  # teardown began; late-spawning handlers must bail out
+        self._inflight_dials = 0  # connects in progress; __aexit__ lets them land pre-close
 
     async def __aenter__(self) -> UserspaceDialPlane:
+        """Bind the single relay listener. Binding eagerly — before any dial exists — is what
+        keeps this class simple: nothing ever binds on the dial path, so no bind can race a
+        dial timeout, a cancellation, or teardown.
+
+        A unix socket is preferred: it lives in a 0700 temp directory, so the filesystem —
+        not the network stack — decides who may connect, whereas a loopback TCP port is
+        connectable by any local process for the tunnel's whole lifetime. TCP remains the
+        fallback where AF_UNIX is unavailable (e.g. Windows), and can be forced anywhere via
+        :data:`TCP_RELAY_ENV_VAR` to debug that path."""
+        if get_os_utils().supports_unix_sockets and not os.getenv(TCP_RELAY_ENV_VAR):
+            self._socket_dir = tempfile.mkdtemp(prefix="pmd3-")
+            path = os.path.join(self._socket_dir, "relay.sock")
+            try:
+                self._server = await _bind_listener(asyncio.start_unix_server(self._handle, path))
+            except OSError as e:
+                # e.g. sun_path length exceeded by an unusually long TMPDIR. The fallback is a
+                # loopback TCP port any local process can connect to — losing the unix socket's
+                # filesystem access control — so say so visibly.
+                logger.warning("unix-socket relay bind failed (%s); falling back to loopback TCP", e)
+                shutil.rmtree(self._socket_dir, ignore_errors=True)
+                self._socket_dir = None
+            else:
+                self._opener = partial(asyncio.open_unix_connection, path)
+                logger.debug("userspace relay for %s -> %s", self._device_addr, path)
+        if self._server is None:
+            self._server = await _bind_listener(asyncio.start_server(self._handle, "127.0.0.1", 0))
+            lport = self._server.sockets[0].getsockname()[1]
+            self._opener = partial(asyncio.open_connection, "127.0.0.1", lport)
+            logger.debug("userspace relay for %s -> 127.0.0.1:%s", self._device_addr, lport)
         return self
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self._closing = True
-        # A dial's connect completes in the kernel before the server's accept callback runs,
-        # so an accept may already be queued on the loop. Give it one tick to run BEFORE the
-        # servers close: the callback then attaches its transport to a still-open Server and
-        # spawns a gate handler that closes it (during wait_closed below). Without the tick
-        # the callback runs against an already-closed Server, dies on an internal assertion
-        # inside asyncio, and the accepted socket is finalized by GC as a ResourceWarning.
+        # Let every connect that already passed dial()'s gate land against a still-open
+        # Server, and give queued accept callbacks one more tick to attach: an accept
+        # processed after close() dies on an internal assertion inside asyncio and the
+        # accepted socket is abandoned unclosed (GC ResourceWarning). Attached transports
+        # are owned — their gate handlers close them during wait_closed below. In-flight
+        # dials settle within a few ticks (connect + nothing else); the deadline only guards
+        # against a wedged loop.
+        for _ in range(100):
+            await asyncio.sleep(0)
+            if not self._inflight_dials:
+                break
         await asyncio.sleep(0)
-        for srv in self._servers:
-            srv.close()
+        if self._server is not None:
+            self._server.close()
         # Cancel the in-flight relay handlers BEFORE wait_closed(): since Python 3.12.1
         # Server.wait_closed() also waits for every active connection handler, and a relay
         # parked on device traffic never finishes on its own — teardown would hang until the
@@ -430,16 +484,44 @@ class UserspaceDialPlane:
             for task in list(self._relay_tasks):
                 task.cancel()
             await asyncio.gather(*list(self._relay_tasks), return_exceptions=True)
-        for srv in self._servers:
+        if self._server is not None:
             with suppress(Exception):
-                await srv.wait_closed()
-        self._servers.clear()
-        self._relays.clear()
+                await self._server.wait_closed()
+            self._server = None
+        self._opener = None
         if self._socket_dir is not None:
             # asyncio only unlinks unix server sockets on close from Python 3.13; remove the
             # whole directory so every version leaves nothing behind.
             shutil.rmtree(self._socket_dir, ignore_errors=True)
             self._socket_dir = None
+
+    async def _handle(self, creader: asyncio.StreamReader, cwriter: asyncio.StreamWriter) -> None:
+        """Per-connection server callback: read the 2-byte device-port header :meth:`dial`
+        wrote, then bridge the stream to a pytcp socket."""
+        if self._closing:
+            # Accepted just as teardown began (see __aexit__): close the transport so
+            # Server.wait_closed() can complete, and never touch the stack.
+            cwriter.close()
+            return
+        # Track the handler task so __aexit__ can cancel any relay still in flight
+        # (start_server's own task bookkeeping offers no cross-version cancel API).
+        task = asyncio.current_task()
+        assert task is not None
+        self._relay_tasks.add(task)
+        try:
+            try:
+                port = int.from_bytes(await creader.readexactly(2), "big")
+            except (asyncio.IncompleteReadError, ConnectionError):
+                cwriter.close()
+                return
+            except BaseException:
+                # Cancellation (teardown) while reading the header: still close the accepted
+                # transport, or it stays attached and __aexit__ hangs in Server.wait_closed().
+                cwriter.close()
+                raise
+            await self._relay_handler(port, creader, cwriter)
+        finally:
+            self._relay_tasks.discard(task)
 
     async def _relay_handler(self, port: int, creader: asyncio.StreamReader, cwriter: asyncio.StreamWriter) -> None:
         try:
@@ -514,61 +596,6 @@ class UserspaceDialPlane:
             with suppress(Exception):
                 psock.close()
 
-    async def _ensure_relay(self, port: int) -> _RelayOpener:
-        if self._closing:
-            raise ConnectionError("userspace dial plane is closed")
-        key = (self._device_addr, port)
-        if key in self._relays:
-            return self._relays[key]
-
-        async def handle(creader: asyncio.StreamReader, cwriter: asyncio.StreamWriter) -> None:
-            if self._closing:
-                # Accepted just as teardown began (see __aexit__): close the transport so
-                # Server.wait_closed() can complete, and never touch the stack.
-                cwriter.close()
-                return
-            # Track the handler task so __aexit__ can cancel any relay still in flight
-            # (start_server's own task bookkeeping offers no cross-version cancel API).
-            task = asyncio.current_task()
-            assert task is not None
-            self._relay_tasks.add(task)
-            try:
-                await self._relay_handler(port, creader, cwriter)
-            finally:
-                self._relay_tasks.discard(task)
-
-        opener = await self._start_relay_server(port, handle)
-        self._relays[key] = opener
-        return opener
-
-    async def _start_relay_server(self, port: int, handle: _RelayHandler) -> _RelayOpener:
-        """Bind a relay listener and return the opener that connects to it.
-
-        A unix socket is preferred: it lives in a 0700 temp directory, so the filesystem —
-        not the network stack — decides who may connect, whereas a loopback TCP port is
-        connectable by any local process for the tunnel's whole lifetime. TCP remains the
-        fallback where AF_UNIX is unavailable (e.g. Windows), and can be forced anywhere via
-        :data:`TCP_RELAY_ENV_VAR` to debug that path."""
-        if get_os_utils().supports_unix_sockets and not os.getenv(TCP_RELAY_ENV_VAR):
-            if self._socket_dir is None:
-                self._socket_dir = tempfile.mkdtemp(prefix="pmd3-")
-            path = os.path.join(self._socket_dir, f"{port}.sock")
-            try:
-                self._servers.append(await asyncio.start_unix_server(handle, path))
-            except OSError as e:
-                # e.g. sun_path length exceeded by an unusually long TMPDIR. The fallback is a
-                # loopback TCP port any local process can connect to — losing the unix socket's
-                # filesystem access control — so say so visibly.
-                logger.warning("unix-socket relay bind failed (%s); falling back to loopback TCP", e)
-            else:
-                logger.debug("userspace relay %s:%s -> %s", self._device_addr, port, path)
-                return partial(asyncio.open_unix_connection, path)
-        srv = await asyncio.start_server(handle, "127.0.0.1", 0)
-        self._servers.append(srv)
-        lport = srv.sockets[0].getsockname()[1]
-        logger.debug("userspace relay %s:%s -> 127.0.0.1:%s", self._device_addr, port, lport)
-        return partial(asyncio.open_connection, "127.0.0.1", lport)
-
     async def dial(self, host: Optional[str] = None, port: Optional[int] = None, **kwargs: Any):
         """``asyncio.open_connection``-compatible dialer passed to the RSD via ``open_connection=``.
 
@@ -576,12 +603,23 @@ class UserspaceDialPlane:
         everything else falls through to the stdlib ``asyncio.open_connection`` unchanged."""
         if host is not None and str(host) == self._device_addr:
             assert port is not None
-            if self._closing:
-                # A dial racing (or following) teardown must not re-create relay state that
-                # nothing will ever clean up — and its stream would only yield silent EOF.
+            if self._closing or self._opener is None:
+                # Post-teardown the connect would fail anyway (the listener is gone) — fail
+                # with a clear error instead of a refused/missing-socket OSError.
                 raise ConnectionError("userspace dial plane is closed")
-            opener = await self._ensure_relay(port)
-            return await opener(**kwargs)
+            # Track in-flight connects: __aexit__ waits for them before closing the listener,
+            # because a connect completing against a just-closed Server makes asyncio's accept
+            # path abandon the accepted socket without closing it.
+            self._inflight_dials += 1
+            try:
+                reader, writer = await self._opener(**kwargs)
+            finally:
+                self._inflight_dials -= 1
+            if self._closing:
+                writer.close()
+                raise ConnectionError("userspace dial plane is closed")
+            writer.write(port.to_bytes(2, "big"))  # header for _handle; flushed with first payload
+            return reader, writer
         return await asyncio.open_connection(host, port, **kwargs)
 
 

--- a/tests/test_userspace_tunnel.py
+++ b/tests/test_userspace_tunnel.py
@@ -326,6 +326,48 @@ async def test_transport_watcher_tears_down_on_transport_death():
     assert tunnel._exit_stack is None  # aclose() ran
 
 
+async def test_stray_connection_without_header_is_shed(monkeypatch):
+    # Only dial() speaks the 2-byte port-header protocol; a stray local connection that
+    # sends nothing (trivial on the TCP fallback, where any local process can connect) must
+    # be shed by the header timeout instead of pinning a handler and its transport until
+    # tunnel close.
+    monkeypatch.setattr(userspace_tunnel, "RELAY_HEADER_TIMEOUT", 0.2)
+    tun = FakeTun()
+    async with UserspaceDialPlane(cast(UserspaceTun, tun), DEVICE_ADDR) as dial_plane:
+        assert dial_plane._opener is not None
+        reader, writer = await dial_plane._opener()  # no header
+        assert await asyncio.wait_for(reader.read(), timeout=5) == b""  # shed with EOF
+        assert not tun.socks  # never touched the stack
+        await _poll_until(lambda: not dial_plane._relay_tasks)
+        await close_stream_writer(writer)
+
+
+async def test_aclose_waits_for_watcher_teardown():
+    # An explicit aclose() while the transport watcher is mid-unwind (device just
+    # disconnected) must wait for that unwind, not return early — aclose() returning is the
+    # signal that the process-global pytcp stack is really stopped and a tunnel may be
+    # reopened.
+    released = []
+
+    async def slow_release() -> None:
+        await asyncio.sleep(0.1)
+        released.append(True)
+
+    tunnel = userspace_tunnel.UserspaceRsdTunnel()
+    tunnel._exit_stack = AsyncExitStack()
+    tunnel._exit_stack.push_async_callback(slow_release)
+
+    class FakeTunnelClient:
+        async def wait_closed(self) -> None:
+            return  # the transport read task has ended
+
+    watcher = asyncio.create_task(tunnel._watch_transport_closed(cast(Any, FakeTunnelClient())))
+    await asyncio.sleep(0.02)  # watcher is now inside slow_release
+    await asyncio.wait_for(tunnel.aclose(), timeout=5)
+    assert released  # aclose returned only after the watcher's unwind completed
+    await watcher
+
+
 async def test_tun_address_usable_when_up_returns():
     # The stack installs the interface address from its own tasks shortly AFTER stack.start()
     # returns, so up() must not return before the address is usable: a connect issued right

--- a/tests/test_userspace_tunnel.py
+++ b/tests/test_userspace_tunnel.py
@@ -266,7 +266,7 @@ async def test_dial_after_close_raises():
     with pytest.raises(ConnectionError):
         await dial_plane.dial(DEVICE_ADDR, 5555)
     assert dial_plane._socket_dir is None
-    assert not dial_plane._servers
+    assert dial_plane._server is None
 
 
 @pytest.mark.skipif(not get_os_utils().supports_unix_sockets, reason="platform has no AF_UNIX")


### PR DESCRIPTION
## What

The dial plane bound one relay listener **per device service port, lazily on the dial path** — which listener you connected to *was* the port routing. A post-release leak/race hunt (deterministic probes plus randomized dial/cancellation/teardown storms on both relay flavors, with ResourceWarning-as-error and fd/task accounting) kept finding leaks inherent to that shape:

- A dial parked in the listener bind while teardown swept `_servers` registered a live listener nothing would ever close. The window is wide on the TCP fallback (`start_server` resolves `127.0.0.1` through the getaddrinfo executor — a storm landed **8 leaked serving listeners in one round**), and on the unix path the raced bind hits ENOENT after the socket-dir removal and falls back to a **loopback TCP** listener.
- A cancellation landing on `create_server`'s final internal suspension — routine via `create_using_tcp`'s connect timeout — discards the `Server` while the loop's selector keeps its serving socket alive forever (stdlib behavior, reproduced deterministically).
- N concurrent first dials to one port each bound their own listener.

Each was fixable only by adding another guard. Instead, this changes the shape: `dial()` writes a **2-byte port header** after connecting and the handler reads it, so **one listener serves every port and is bound eagerly in `__aenter__`** — before any dial exists. Nothing binds on the dial path anymore, so no bind can race a timeout, a cancellation, or teardown: the per-port cache, the bind lock, and their guards are structurally unnecessary and deleted. The one remaining bind site keeps a cancellation shield (`_bind_listener`).

## Verification

- Probe battery (deterministic bind-window probe; 150-round dial/teardown storm; 200-round cancellation+traffic storm; same-port herd) clean on **both** relay flavors: zero leaked listeners/tasks/fds, socket dir always removed.
- Live device: RSD + lockdown + AFC at benchmark parity (push ~11.5, pull ~26 MiB/s, stat ~3.8 ms), `dvt ls`, `dvt oslog` streaming, and 1 s teardown on transport death.
- 14 unit tests, ruff + pyright clean.

## Second commit: teardown serialization + header-path hardening

Continuing the hunt on the redesigned plane surfaced two more (both fixed, regression-tested):
- an explicit `aclose()` during the transport watcher's unwind returned early while resources were still being released — disconnect-then-reopen could race the process-global stack's shutdown; both teardown paths now serialize on a lock, and `aclose()` returning means the unwind finished;
- a stray local connection that sends no port header (any local process can, on the TCP fallback) pinned a handler and its transport until tunnel close — shed after `RELAY_HEADER_TIMEOUT` (dial() writes the header before returning, so real connections are unaffected).

Final battery: all probes (bind-window, teardown storm, cancellation+traffic storm, herd, header attacks, aenter failure paths, aclose/watcher concurrency) clean on both flavors with zero fd/task deltas, plus five live device open/close cycles with zero growth.

## Third commit: serialize the singleton lifecycle

Concurrent `establish_userspace_rsd()`/`aopen()` calls both passed the singleton guard (checked at entry, published only after the whole establishment) and drove the process-global pytcp stack at once — measured live: every racer failed with `IncompleteReadError` and the stack was left half-started (`ARP Cache.start() called while a worker is still running`). All open/close transitions now serialize on one per-loop lifecycle lock (replacing the per-instance teardown lock, and additionally covering a new open racing a previous handle's unwind), and `establish_userspace_rsd()` shares the winner's tunnel when losing the race for the same device — three concurrent callers now all get the one RSD (verified live).

## Later commits

- **Close the CLI tunnel at exit instead of hard-exiting**: `force_exit`'s `os._exit` guarded costs that no longer exist (no threads since pure-asyncio, no pending-task GC noise since the CLI loop is abandoned rather than closed, and a clean `aclose()` measures ~3 ms live). The CLI now closes its tunnel at interpreter exit — the device gets clean FINs, exit codes and other atexit handlers work normally.
- **Let in-flight dials land before closing the relay listener**: a connect completing against a just-closed Server makes asyncio's accept path abandon the accepted socket unclosed; teardown now waits (bounded) for in-flight connects, and a dial landing after teardown began raises `ConnectionError` instead of returning a doomed stream. Probes now account for stderr separately (earlier runs filtered it), and report zero ResourceWarnings on both flavors.
- **Docs**: new "Understanding the network stacks" guide with mermaid diagrams for all four transport paths (usbmux, Wi-Fi lockdown, kernel tunnel, userspace tunnel incl. dial sequence and disconnect teardown); mermaid enabled via superfences; linked from the iOS 17+ tunnels guide. `mkdocs build --strict` passes.
