### PR TITLE
build: exclude chardet 7.6.0 on Python 3.15; smoke-test the CLI in CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -53,6 +53,12 @@ jobs:
         run: uvx pre-commit run --all-files
       - name: Run device-free tests
         run: uv run --extra test pytest -m "not device"
+      - name: CLI smoke
+        # The test suite never imports every runtime dependency (e.g. chardet via ASGIWebDAV),
+        # so a dependency whose wheel crashes on import can pass CI while breaking the CLI —
+        # exactly what chardet 7.6.0's cp315 wheel did. One bare invocation catches that class.
+        # No output redirect: pwsh on the Windows runners has no /dev/null.
+        run: uv run pymobiledevice3 -h
 
   pyright:
     if: '! github.event.pull_request.draft'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,11 @@ dependencies = [
     # module ASGIWebDAV imports on 3.10-3.13 (stdlib on 3.14+); uvicorn is already a dependency above.
     "asgiwebdav>=2.0.1; python_version >= '3.10'",
     "backports.zstd; python_version >= '3.10' and python_version < '3.14'",
+    # chardet is pulled in by ASGIWebDAV. Its 7.6.0 cp315 wheel segfaults on import (Cython
+    # module init dies in __Pyx__ExceptionSave against the current 3.15 ABI), which crashed
+    # the CLI on Python 3.15 the moment anything touched the webdav import chain. Earlier
+    # and later releases are fine, so exclude exactly that build on 3.15.
+    "chardet!=7.6.0; python_version >= '3.15'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What

Fresh installs on Python 3.15 segfault after printing help: `chardet` 7.6.0's cp315 wheel crashes on import (Cython module init dies in `__Pyx__ExceptionSave` against the current 3.15 ABI). chardet arrives via ASGIWebDAV, so the CLI dies the moment the webdav import chain is touched. Verified by bisection: 7.5.1, 7.4.3 and 6.0.0 all import cleanly on 3.15, and 7.6.0 is fine on <= 3.14 — so the exclusion is scoped to exactly that release on 3.15 (`chardet!=7.6.0; python_version >= '3.15'`). A future 7.6.1 resolves automatically.

Also adds a bare-CLI smoke step to the CI matrix: the test suite never imports every runtime dependency, which is how this shipped green — `pymobiledevice3 -h` exits 139 on the broken combination and would have failed the 3.15 jobs.

## Verification

- `uvx --python 3.15 pymobiledevice3` (10.11.2 and 10.11.3): exit 139; with this tree: exit 0, resolver picks chardet 7.5.1.
- `import chardet` alone reproduces the segfault (crash report: `chardet/_kernel.cpython-315-darwin.so`, `__Pyx__ExceptionSave`, reached through the mypyc-compiled `chardet.pipeline` chain).
- Python 3.14 unaffected throughout.