### PR TITLE
docs: explain why the RSD path suspends remoted

### DIFF
--- a/docs/guides/network-stacks.md
+++ b/docs/guides/network-stacks.md
@@ -62,6 +62,37 @@ flowchart LR
   out; service connections also run TCP keep-alive.
 - Highest host→device throughput; the only path external tools can use.
 
+### Why this path suspends `remoted` (and why that needs root)
+
+Root is needed here for **two** independent reasons. The obvious one is creating the `utun`.
+The second is `remoted` contention, and it is worth spelling out because it is easy to
+misdiagnose.
+
+Discovery on this path is bonjour **plus a direct RSD connection**: `get_rsds()` browses
+`_remoted._tcp` and then opens the device's RSD RemoteXPC endpoint (port `58783`) on the USB NCM
+link (`fe80::…%enX`). macOS `remoted` owns that link — it keeps its own RemoteXPC session to the
+device open at all times (`lsof` shows an ESTABLISHED `…->[fe80::…]:58783`). While `remoted` is
+running, the device **resets** a second, independent RSD root channel opened by pymobiledevice3 —
+seen as an HTTP/2 `RST_STREAM` with `error_code=5`, or a plain connection reset, during the
+check-in handshake. So discovery finds the device but yields no usable RSD.
+
+`stop_remoted()` SIGSTOPs `remoted` for the duration of the handshake and resumes it afterwards;
+suspending a root-owned daemon is what needs root. With `remoted` suspended the handshake succeeds
+reliably, and the device will even accept *several* concurrent RSD sessions — which shows the reset
+is caused by `remoted` owning the link, not by any device-side one-session cap.
+
+> **This is not a pairing problem.** A long-standing assumption held that the device *closes the
+> host's RSD fd during pairing*, forcing `remoted` to race us — hence `sudo`. That is not what
+> happens. The contention reproduces against an already-paired device with no pairing in flight,
+> and completing a pairing does **not** tear down existing RSD connections (the device simply adds
+> the new tunnel endpoint; `remotepairingdeviced` logs no control-channel teardown). The trigger is
+> only that `remoted` is an always-on RSD client for the NCM link. Verified empirically on
+> iPhone18,4 / iOS 26.6.1, and against the iOS 17.0, 26.6 and 27 device daemons.
+>
+> The no-root [userspace tunnel](#userspace-tunnel-the-no-root-default) sidesteps all of this: it
+> reaches RSD through the `CoreDeviceProxy` lockdown service over usbmux, never touching the NCM
+> link or `remoted`.
+
 ## Userspace tunnel (the no-root default)
 
 The default for RSD-required commands on iOS 17.4+ over USB. The kernel interface is

--- a/pymobiledevice3/remote/utils.py
+++ b/pymobiledevice3/remote/utils.py
@@ -92,6 +92,28 @@ def resume_remoted_if_required() -> None:
 
 @contextlib.contextmanager
 def stop_remoted() -> Generator[None, None, None]:
+    """SIGSTOP macOS ``remoted`` for the duration of an RSD discovery/handshake, then resume it.
+
+    The RSD-over-bonjour path (:func:`get_rsds`, used by ``remote start-tunnel`` and ``tunneld``)
+    connects *directly* to the device's RSD RemoteXPC endpoint (``RSD_PORT`` 58783) over the USB
+    NCM link. macOS ``remoted`` is the system-wide owner of that link and keeps its own RemoteXPC
+    session to the device open at all times. While ``remoted`` is running, the device resets a
+    second, independent RSD root channel opened from this process -- observed as an HTTP/2
+    ``RST_STREAM`` (``error_code=5``) or a plain connection reset during the check-in handshake --
+    so :func:`get_rsds` discovers the device over bonjour but cannot complete the handshake and
+    returns nothing usable.
+
+    Suspending ``remoted`` yields the link and the handshake then succeeds reliably (with
+    ``remoted`` suspended the device will even accept several concurrent RSD sessions, which shows
+    the reset comes from ``remoted`` owning the link, not from a device-side one-session cap).
+    Suspending a root-owned daemon needs root -- this is the *second* reason the RSD/kernel-tunnel
+    path requires ``sudo`` (the first being ``utun`` creation). ``remoted`` is resumed on exit.
+
+    This competition is unrelated to pairing: it reproduces against an already-paired device with no
+    pairing in flight, and completing a pairing does not tear down existing RSD connections. The
+    no-root userspace/``CoreDeviceProxy`` path avoids it entirely by reaching RSD over usbmux
+    instead of the NCM link, so it never touches ``remoted``.
+    """
     stop_remoted_if_required()
     try:
         yield


### PR DESCRIPTION
The reason `remote start-tunnel` / `tunneld` suspend macOS `remoted` was never documented, and was long attributed to the device *closing the host's RSD fd during pairing*. That attribution is wrong.

## Root cause (verified empirically on iPhone18,4 / iOS 26.6.1, USB)

Instrumenting `get_rsds()` per stage isolates the contention to a single boundary:

- **bonjour discovery always succeeds** — it finds the device every time.
- **the direct RSD connect is where it breaks** — pymobiledevice3 opens the device RSD RemoteXPC endpoint (`RSD_PORT` 58783) on the USB NCM link; while `remoted` is running the device resets that second root channel (`RST_STREAM error_code=5` / connection reset).

`lsof` confirms `remoted` holds an ESTABLISHED session to that exact endpoint. `stop_remoted()` (SIGSTOP, needs root) yields the link → handshake succeeds 5/5. With `remoted` suspended the device even accepts **two concurrent** RSD sessions, so it is `remoted` owning the link, not a device one-session cap.

**Not a pairing problem:** it reproduces against an already-paired device with nothing being paired, and completing a pairing does not tear down RSD connections (`remotepairingdeviced` just adds the tunnel endpoint). In iOS 17.0 the only tunnel path was RSD/RemotePairing (no `CoreDeviceProxy` service until 17.4), so the contention always coincided with pairing — the likely source of the misconception.

## Changes (docs only, no behavior change)

- `stop_remoted()` gains a docstring explaining the mechanism and the two root reasons (`utun` creation + suspending `remoted`).
- `docs/guides/network-stacks.md` gains a subsection under *Kernel tunnel* with the same explanation and a callout debunking the pairing theory, pointing at the userspace path that avoids it entirely.