### PR TITLE
remote: never leave remoted suspended if tunnel establishment fails

### DIFF
--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -1430,18 +1430,26 @@ async def start_tunnel_over_core_device(
     max_idle_timeout: float = RemotePairingQuicTunnel.MAX_IDLE_TIMEOUT,
     protocol: TunnelProtocol = TunnelProtocol.QUIC,
 ) -> AsyncGenerator[TunnelResult, None]:
+    # ``remoted`` is suspended only for the establishment window and resumed as soon as the tunnel
+    # is up. The ``finally`` guarantees it is never left suspended if establishment raises: a
+    # SIGSTOP'd ``remoted`` persists past process exit and would break Xcode/devicectl until it is
+    # manually resumed. ``resume_remoted_if_required`` is idempotent, so the early resume on the
+    # success path and the ``finally`` safety net do not conflict.
     stop_remoted_if_required()
-    async with service_provider:
-        if protocol == TunnelProtocol.QUIC:
-            async with service_provider.start_quic_tunnel(
-                secrets_log_file=secrets, max_idle_timeout=max_idle_timeout
-            ) as tunnel_result:
-                resume_remoted_if_required()
-                yield tunnel_result
-        elif protocol == TunnelProtocol.TCP:
-            async with service_provider.start_tcp_tunnel() as tunnel_result:
-                resume_remoted_if_required()
-                yield tunnel_result
+    try:
+        async with service_provider:
+            if protocol == TunnelProtocol.QUIC:
+                async with service_provider.start_quic_tunnel(
+                    secrets_log_file=secrets, max_idle_timeout=max_idle_timeout
+                ) as tunnel_result:
+                    resume_remoted_if_required()
+                    yield tunnel_result
+            elif protocol == TunnelProtocol.TCP:
+                async with service_provider.start_tcp_tunnel() as tunnel_result:
+                    resume_remoted_if_required()
+                    yield tunnel_result
+    finally:
+        resume_remoted_if_required()
 
 
 @asynccontextmanager


### PR DESCRIPTION
On macOS, `start-tunnel`/`tunneld` suspend `remoted` (SIGSTOP) during RSD tunnel establishment to avoid it racing us for the RSD RemoteXPC endpoint, and resume it once the tunnel is up.

`start_tunnel_over_core_device()` did this with a **bare** `stop_remoted_if_required()` and only called `resume_remoted_if_required()` *after* the tunnel came up (inside the inner `async with`). If entering the service-provider context or starting the QUIC/TCP tunnel raised before that point, resume was skipped — and a SIGSTOP'd `remoted` **persists past process exit**, leaving the user's Xcode/`devicectl`/Finder device access broken until `remoted` is manually resumed or the machine reboots.

Guard the establishment window with `try/finally`. `resume_remoted_if_required()` is idempotent (it no-ops when `remoted` is already running), so the early success-path resume still frees `remoted` for the tunnel's lifetime, and the `finally` is a pure safety net for the error path.

No behavior change on the happy path or on non-Darwin (where `remoted` does not exist). `get_rsds()` and the `tunneld` NCM handler already use the `with stop_remoted()` context manager and were unaffected.
