### PR TITLE
remote: add macOS --native tunnel that piggybacks remoted (no root, no Xcode)

### DIFF
--- a/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -7,12 +7,16 @@ Read this file when the request touches transport selection, iOS 17+ developer s
 ## Transport Selection
 
 - USB lockdown is the default path for most commands.
-- `ServiceProviderDep` already resolves USB, `--rsd`, `--tunnel`, and `--userspace` flows for repo-native CLI commands.
-- When a command requires an RSD tunnel and no transport flag is given, a **no-root
-  in-process userspace tunnel** is established automatically on iOS 17.4+ — no `sudo`,
+- `ServiceProviderDep` already resolves USB, `--rsd`, `--tunnel`, `--userspace`, and `--native` flows for repo-native CLI commands.
+- When a command requires an RSD tunnel and no transport flag is given, a **no-root tunnel** is
+  established automatically — the native tunnel on macOS, the in-process userspace tunnel elsewhere — no `sudo`,
   no `start-tunnel`, no `tunneld`. This is the preferred path for agents.
 - `--userspace` forces the userspace tunnel explicitly (`PYMOBILEDEVICE3_USERSPACE=1` is
-  equivalent); it is mutually exclusive with `--rsd`/`--tunnel`.
+  equivalent).
+- `--native` (**macOS only, the macOS default**) forces the no-root native tunnel that piggybacks
+  Apple's `remoted` (`PYMOBILEDEVICE3_NATIVE=1` is equivalent): no `sudo`, no entitlement, no Xcode,
+  `remoted` left running, faster host->device and lower latency than the userspace stack.
+- `--rsd`, `--tunnel`, `--userspace`, and `--native` are mutually exclusive.
 - `--rsd HOST PORT` is for a specific RemoteServiceDiscovery endpoint.
 - `--tunnel ''` or `--tunnel <UDID>` targets a device already exposed by `tunneld`.
 - With multiple devices attached, always pass `--udid <UDID>` (or set
@@ -33,26 +37,31 @@ Many `developer dvt` and related developer commands need all of the following:
    mounter: `uvx --from . pymobiledevice3 cryptex auto-install` (needs RSD; both cache the
    download under `~/.pymobiledevice3` and end up mounted at `/System/Developer`).
 3. A CoreDevice transport path. On iOS 17.4+ this needs **no setup**: the no-root
-   userspace tunnel is established automatically when the command runs. Only iOS
-   17.0-17.3 devices (which predate CoreDeviceProxy) route to `tunneld` and need a
-   privileged daemon: `sudo uvx --from . pymobiledevice3 remote tunneld` in the
-   background, then pass `--tunnel ''` or `--tunnel <UDID>`.
+   userspace tunnel is established automatically when the command runs. iOS 17.0-17.3
+   devices (which predate CoreDeviceProxy) route automatically to the no-root `--native`
+   tunnel on macOS; on other hosts they route to `tunneld`, which needs a privileged
+   daemon: `sudo uvx --from . pymobiledevice3 remote tunneld` in the background, then pass
+   `--tunnel ''` or `--tunnel <UDID>`.
 
 If a developer command fails with service-availability errors, verify Developer Mode and
 the mounted image before assuming the code is broken.
 
 ## Tunnel Notes
 
-- The userspace tunnel is the default; prefer it. Fall back to a privileged tunnel only
-  when userspace is not viable: sustained host->device throughput (DDI mounts and large
-  file pushes are deliberately slower over userspace), `debugserver start-server`
-  without `--local-port`, or iOS 17.0-17.3.
+- The default no-root tunnel is native on macOS and userspace elsewhere; prefer the default. The
+  native tunnel rides Apple's `remoted` at kernel-tunnel throughput (faster host->device, lower
+  latency) and needs no root. Fall back to a privileged `tunneld` only when no no-root path is
+  viable: non-macOS iOS 17.0-17.3, `debugserver start-server` without `--local-port`, or a tunnel
+  that must be shared across processes.
 - Privileged options: an already-running `tunneld`, or a one-off
   `lockdown start-tunnel` (iOS 17.4+) / `remote start-tunnel` (iOS 17.0-17.3.1).
 - Privileged tunnel creation can require `sudo` because it creates a TUN/TAP interface.
 - For agent-driven `start-tunnel`, use `--script-mode`, read the RSD host and port from
   stdout, and reuse those exact values in later commands via `--rsd HOST PORT`.
-- `PYMOBILEDEVICE3_PREFER_TUNNELD=1` opts out of the userspace default entirely.
+- `PYMOBILEDEVICE3_DEFAULT_FALLBACK=native|userspace|tunneld` overrides which transport the automatic
+  selection prefers (the required-RSD default and the CLI retry). Built-in default: `native` on
+  macOS, `userspace` elsewhere. Set `userspace` to opt back out of the macOS native default, or
+  `tunneld` to opt out of the no-root default entirely.
 
 See `docs/guides/ios17-tunnels.md` for the repo’s detailed guidance.
 
@@ -79,7 +88,7 @@ When a command fails, check in this order:
 
 1. Device presence and pairing: `usbmux list`, `lockdown info`
 2. Correct transport: USB vs `--rsd` vs `--tunnel`
-3. Developer prerequisites: Developer Mode, mounted image, and — only on iOS 17.0-17.3 or when a privileged tunnel is explicitly used — a running `tunneld` / sufficient privileges for `start-tunnel` such as `sudo`
+3. Developer prerequisites: Developer Mode, mounted image, and — only on non-macOS iOS 17.0-17.3 or when a privileged tunnel is explicitly used — a running `tunneld` / sufficient privileges for `start-tunnel` such as `sudo`
 4. Capability location: existing CLI command vs service method vs unsupported feature
 
 Only after those checks should you consider implementing new code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,20 +58,28 @@ Guidance for AI coding agents and automation contributors working in this reposi
 ## Running Developer Commands Against Devices
 
 - Developer/DVT commands on iOS 17+ devices require an RSD tunnel, and every
-  command that requires one **already establishes it in-process by default**,
-  with a pure-Python userspace network stack and **no `sudo`/root**. Just run
-  the command — do not reach for a flag.
+  command that requires one **already establishes it in-process by default**, with
+  **no `sudo`/root**. Just run the command — do not reach for a flag. The default
+  transport is the **native** tunnel on macOS and the **userspace** tunnel
+  elsewhere (see below).
   - Example: `pymobiledevice3 developer dvt oslog`, `pymobiledevice3 cryptex list`.
-- `--userspace` only *forces* that path; it is redundant on a required-RSD
-  command. It matters on iOS 17.0-17.3, which the default deliberately routes to
-  `tunneld` instead (those versions predate CoreDeviceProxy, so the no-root path
-  is the fragile Wi-Fi-only RemotePairing one). `PYMOBILEDEVICE3_USERSPACE=1` is
-  the env-var equivalent.
-- Use a privileged `tunneld` (needs root) only when the userspace tunnel is not
-  viable — e.g. when you need higher host->device throughput, since userspace
-  host->device transfers (DDI mounts, file pushes) are deliberately slower.
-  `PYMOBILEDEVICE3_PREFER_TUNNELD=1` opts out of the userspace default entirely.
-- `--userspace` is mutually exclusive with `--rsd`/`--tunnel`.
+- `--native` (**macOS only**, the macOS default) reaches the tunnel by
+  piggybacking Apple's own `remoted` tunnel via the `remotepairingd` service —
+  **no `sudo`/root, no entitlement, no Xcode** — and leaves `remoted` running (so
+  it coexists with Xcode/`devicectl`). It rides the kernel-routable tunnel:
+  faster host->device and lower latency than the userspace stack.
+  `PYMOBILEDEVICE3_NATIVE=1` forces it explicitly.
+- `--userspace` forces the pure-Python in-process userspace tunnel (the default
+  off macOS). `PYMOBILEDEVICE3_USERSPACE=1` is the env-var equivalent.
+- Use a privileged `tunneld` (needs root) only when the no-root paths are not
+  viable — e.g. non-macOS iOS 17.0-17.3, or when you need a tunnel shared across
+  processes / reachable by external tools where `--native` is unavailable.
+- `PYMOBILEDEVICE3_DEFAULT_FALLBACK=native|userspace|tunneld` overrides which
+  transport the automatic selection prefers (both the required-RSD default and
+  the retry the CLI performs when a command turns out to need a tunnel). Built-in
+  default: `native` on macOS, `userspace` elsewhere. `=tunneld` opts out of the
+  no-root default entirely.
+- `--rsd`, `--tunnel`, `--userspace` and `--native` are mutually exclusive.
 
 ## Testing Expectations
 

--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -98,12 +98,12 @@ sudo python3 -m pymobiledevice3 remote tunneld --uds /var/run/tunneld.sock
 python3 -m pymobiledevice3 developer dvt ls / --tunnel ':/var/run/tunneld.sock'
 ```
 
-To make `tunneld` the **default** fallback again — so commands route to it automatically without
-passing `--tunnel`, restoring the pre-userspace-default behavior — set the
-`PYMOBILEDEVICE3_PREFER_TUNNELD` environment variable (any non-empty value):
+To make `tunneld` the **default** fallback — so commands route to it automatically without passing
+`--tunnel`, restoring the pre-userspace-default behavior — set
+`PYMOBILEDEVICE3_DEFAULT_FALLBACK=tunneld`:
 
 ```shell
-export PYMOBILEDEVICE3_PREFER_TUNNELD=1
+export PYMOBILEDEVICE3_DEFAULT_FALLBACK=tunneld
 python3 -m pymobiledevice3 developer dvt ls /
 ```
 

--- a/docs/guides/network-stacks.md
+++ b/docs/guides/network-stacks.md
@@ -1,6 +1,6 @@
 # Understanding the network stacks
 
-Every pymobiledevice3 command reaches the device through one of four transport paths. This
+Every pymobiledevice3 command reaches the device through one of five transport paths. This
 guide shows what each path actually looks like — which sockets exist, what needs root, and
 how a device disconnect is detected. For choosing between them day-to-day, see
 [iOS 17+ tunnels](ios17-tunnels.md).
@@ -208,3 +208,55 @@ Teardown details worth knowing when reading the code:
   forever.
 - The CLI keeps its tunnel for the process lifetime and closes it at interpreter exit
   (~3 ms), so the device always sees clean FINs.
+
+## Native remoted tunnel (macOS only)
+
+`--native` (or `PYMOBILEDEVICE3_NATIVE=1`) reaches the RSD by **piggybacking Apple's own
+`remoted` tunnel** instead of building one. It needs no root, no entitlement and no Xcode, and
+leaves `remoted` running — so it coexists with Xcode/`devicectl` (contrast the kernel/bonjour path,
+which must suspend `remoted`; see the callout above).
+
+```mermaid
+flowchart LR
+    subgraph host["host (no root)"]
+        cli["pymobiledevice3"]
+        rp["remotepairingd<br/>(RemotePairing.framework)"]
+        rd["remoted"]
+    end
+    dev["iOS device<br/>RSD + services at fdxx::1"]
+
+    cli -->|"XPC: browse / CreateAssertion"| rp
+    cli -->|"read net.inet.tcp.pcblist_n<br/>(find remoted's RSD port)"| rd
+    rp -.->|"keeps the tunnel alive"| rd
+    rd -->|"encrypted CoreDevice tunnel"| dev
+    cli -->|"TCP6 to [fdxx::1]:rsd_port<br/>(kernel-routable)"| dev
+```
+
+How it works (all via `ctypes` + libxpc, no pyobjc):
+
+1. Ask `com.apple.CoreDevice.remotepairingd` (provided by the base-OS `RemotePairing.framework`,
+   present on stock macOS — it backs iPhone Mirroring — **not** the Xcode-only `CoreDevice.framework`)
+   to browse for the device and open its per-device XPC endpoint.
+2. `RemotePairing.CreateAssertionCommand` returns the device's in-tunnel `tunnelIPAddress` and an
+   assertion identifier that keeps Apple's tunnel up for as long as the handle is held.
+3. Find the in-tunnel RSD port by reading the `net.inet.tcp.pcblist_n` sysctl (no root) and matching
+   `remoted`'s own connection to that tunnel address.
+4. Connect a normal TCP socket to `[tunnelIPAddress]:rsd_port` — the tunnel address is
+   kernel-routable — and run the standard RSD handshake.
+
+- **Root:** not required. **Xcode:** not required.
+- **Reachability:** the tunnel address is a real kernel route (Apple's tunnel), so unlike the
+  userspace tunnel it *is* reachable by other tools; it lives only while the handle (its assertion)
+  is held.
+- **Default on macOS:** this is the built-in default transport for RSD-required commands (and the
+  CLI's automatic retry) on macOS — chosen ahead of the userspace tunnel, with userspace and then
+  `tunneld` as fallbacks. On other platforms the userspace tunnel remains the default (`remoted` does
+  not exist there).
+- **Overriding the default:** `PYMOBILEDEVICE3_DEFAULT_FALLBACK=native|userspace|tunneld` sets which
+  transport the automatic selection prefers. Set it to `userspace` to opt back out of the macOS
+  native default, or `tunneld` to route to the privileged daemon.
+- **Throughput:** rides the kernel-routable tunnel, so it avoids the userspace stack's per-packet
+  Python overhead. Fair same-device AFC comparison on a physical iPhone 17-class device: device->host
+  is USB-bound and on par with the userspace tunnel (~36 MB/s both), while host->device is ~1.8x
+  faster (~36 vs ~20 MB/s — the userspace stack keeps its send segments deliberately small) and
+  per-request latency is ~1.6x lower (~8 vs ~13 ms). All with no root.

--- a/docs/guides/python-api.md
+++ b/docs/guides/python-api.md
@@ -20,11 +20,13 @@ based on the iOS version and the service you need:
 | Connection | Python entry point | iOS | Root? | Use when |
 | --- | --- | --- | --- | --- |
 | Lockdown (USB / Wi-Fi) | `create_using_usbmux` | all | no | Classic services: AFC, app install, syslog, diagnostics, backup, profiles |
-| RSD — userspace tunnel | `UserspaceRsdTunnel` | 17+ | no | **Default** for developer/DVT from your own code or CI; the tunnel is in-process only |
+| RSD — best no-root tunnel | `PreferredRsdTunnel` | 17+ | no | **Default** for developer/DVT: auto-picks the native tunnel on macOS, the userspace tunnel elsewhere |
+| RSD — native (macOS) | `NativeRemotedTunnel` | 17+ | no | macOS only: piggybacks Apple's `remoted`; faster host->device, coexists with Xcode |
+| RSD — userspace | `UserspaceRsdTunnel` | 17+ | no | Cross-platform in-process tunnel; the tunnel address is reachable only from this process |
 | RSD — `tunneld` | `get_tunneld_devices` | 17+ | yes (daemon) | You need a shared/persistent tunnel, or an external tool (e.g. `lldb`) must reach the device |
 
-Rule of thumb: **need a developer/DVT service on iOS 17+? use a tunnel (userspace by default);
-everything else goes over lockdown.** Classic lockdown services work over USB on every iOS version
+Rule of thumb: **need a developer/DVT service on iOS 17+? use `PreferredRsdTunnel` (it picks the best
+no-root transport for the host); everything else goes over lockdown.** Classic lockdown services work over USB on every iOS version
 (and developer services did too, before Apple's iOS 17 refactor moved them behind RSD). A lockdown
 connection is a `LockdownClient`; a tunnel connection is a `RemoteServiceDiscoveryService`. The
 sections below show each path.
@@ -50,24 +52,30 @@ asyncio.run(main())
 
 Developer/DVT services on iOS 17+ require an RSD tunnel.
 
-**Preferred: a no-root, in-process tunnel.** `UserspaceRsdTunnel` brings the tunnel up inside your
-own process over a pure-Python network stack — **no `sudo` and no separate `tunneld` daemon**. It is
-a closeable async context manager that yields a connected `RemoteServiceDiscoveryService`:
+**Preferred: `PreferredRsdTunnel`.** It picks the best no-root transport for the host — the native
+tunnel on macOS (piggybacks Apple's `remoted`: faster host->device, lower latency, and it coexists
+with Xcode), the in-process userspace tunnel elsewhere — and falls back automatically if the first
+choice is unavailable. **No `sudo` and no separate `tunneld` daemon.** It is a closeable async
+context manager that yields a connected `RemoteServiceDiscoveryService`:
 
 ```python
-from pymobiledevice3.remote.userspace_tunnel import UserspaceRsdTunnel
+from pymobiledevice3.remote.rsd_tunnel import PreferredRsdTunnel
 
 
 async def main():
-    # serial=None -> first USB device; autopair pairs on the fly if needed
-    async with UserspaceRsdTunnel(serial=None, autopair=True) as rsd:
+    # serial=None -> first device; prefer_native=False forces the userspace tunnel even on macOS
+    async with PreferredRsdTunnel(serial=None) as rsd:
         print(rsd.product_version)
         # `rsd` now drives any developer service / DvtProvider
 ```
 
-It also exposes an explicit `aopen()` / `aclose()` handle if you can't use a context manager.
-Caveats: one tunnel per process, and the device address is reachable only from this process — don't
-hand it to external tools such as `lldb`.
+macOS embedders who want to be explicit can use `NativeRemotedTunnel` (from
+`pymobiledevice3.remote.native_tunnel`) directly; `UserspaceRsdTunnel` (from
+`pymobiledevice3.remote.userspace_tunnel`) is the cross-platform in-process tunnel. All three expose
+the same async-context-manager / `aopen()` + `aclose()` shape. Caveats: one userspace tunnel per
+process, and the userspace tunnel's device address is reachable only from this process (don't hand it
+to external tools such as `lldb`) — the native tunnel's address is kernel-routable, so it does not
+have that limitation.
 
 The CLI's `--userspace` flag uses the same machinery through the convenience wrapper
 `establish_userspace_rsd()`, which opens the tunnel and keeps it alive for the process lifetime

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -7,12 +7,16 @@ Read this file when the request touches transport selection, iOS 17+ developer s
 ## Transport Selection
 
 - USB lockdown is the default path for most commands.
-- `ServiceProviderDep` already resolves USB, `--rsd`, `--tunnel`, and `--userspace` flows for repo-native CLI commands.
-- When a command requires an RSD tunnel and no transport flag is given, a **no-root
-  in-process userspace tunnel** is established automatically on iOS 17.4+ — no `sudo`,
+- `ServiceProviderDep` already resolves USB, `--rsd`, `--tunnel`, `--userspace`, and `--native` flows for repo-native CLI commands.
+- When a command requires an RSD tunnel and no transport flag is given, a **no-root tunnel** is
+  established automatically — the native tunnel on macOS, the in-process userspace tunnel elsewhere — no `sudo`,
   no `start-tunnel`, no `tunneld`. This is the preferred path for agents.
 - `--userspace` forces the userspace tunnel explicitly (`PYMOBILEDEVICE3_USERSPACE=1` is
-  equivalent); it is mutually exclusive with `--rsd`/`--tunnel`.
+  equivalent).
+- `--native` (**macOS only, the macOS default**) forces the no-root native tunnel that piggybacks
+  Apple's `remoted` (`PYMOBILEDEVICE3_NATIVE=1` is equivalent): no `sudo`, no entitlement, no Xcode,
+  `remoted` left running, faster host->device and lower latency than the userspace stack.
+- `--rsd`, `--tunnel`, `--userspace`, and `--native` are mutually exclusive.
 - `--rsd HOST PORT` is for a specific RemoteServiceDiscovery endpoint.
 - `--tunnel ''` or `--tunnel <UDID>` targets a device already exposed by `tunneld`.
 - With multiple devices attached, always pass `--udid <UDID>` (or set
@@ -33,26 +37,31 @@ Many `developer dvt` and related developer commands need all of the following:
    mounter: `uvx --from . pymobiledevice3 cryptex auto-install` (needs RSD; both cache the
    download under `~/.pymobiledevice3` and end up mounted at `/System/Developer`).
 3. A CoreDevice transport path. On iOS 17.4+ this needs **no setup**: the no-root
-   userspace tunnel is established automatically when the command runs. Only iOS
-   17.0-17.3 devices (which predate CoreDeviceProxy) route to `tunneld` and need a
-   privileged daemon: `sudo uvx --from . pymobiledevice3 remote tunneld` in the
-   background, then pass `--tunnel ''` or `--tunnel <UDID>`.
+   userspace tunnel is established automatically when the command runs. iOS 17.0-17.3
+   devices (which predate CoreDeviceProxy) route automatically to the no-root `--native`
+   tunnel on macOS; on other hosts they route to `tunneld`, which needs a privileged
+   daemon: `sudo uvx --from . pymobiledevice3 remote tunneld` in the background, then pass
+   `--tunnel ''` or `--tunnel <UDID>`.
 
 If a developer command fails with service-availability errors, verify Developer Mode and
 the mounted image before assuming the code is broken.
 
 ## Tunnel Notes
 
-- The userspace tunnel is the default; prefer it. Fall back to a privileged tunnel only
-  when userspace is not viable: sustained host->device throughput (DDI mounts and large
-  file pushes are deliberately slower over userspace), `debugserver start-server`
-  without `--local-port`, or iOS 17.0-17.3.
+- The default no-root tunnel is native on macOS and userspace elsewhere; prefer the default. The
+  native tunnel rides Apple's `remoted` at kernel-tunnel throughput (faster host->device, lower
+  latency) and needs no root. Fall back to a privileged `tunneld` only when no no-root path is
+  viable: non-macOS iOS 17.0-17.3, `debugserver start-server` without `--local-port`, or a tunnel
+  that must be shared across processes.
 - Privileged options: an already-running `tunneld`, or a one-off
   `lockdown start-tunnel` (iOS 17.4+) / `remote start-tunnel` (iOS 17.0-17.3.1).
 - Privileged tunnel creation can require `sudo` because it creates a TUN/TAP interface.
 - For agent-driven `start-tunnel`, use `--script-mode`, read the RSD host and port from
   stdout, and reuse those exact values in later commands via `--rsd HOST PORT`.
-- `PYMOBILEDEVICE3_PREFER_TUNNELD=1` opts out of the userspace default entirely.
+- `PYMOBILEDEVICE3_DEFAULT_FALLBACK=native|userspace|tunneld` overrides which transport the automatic
+  selection prefers (the required-RSD default and the CLI retry). Built-in default: `native` on
+  macOS, `userspace` elsewhere. Set `userspace` to opt back out of the macOS native default, or
+  `tunneld` to opt out of the no-root default entirely.
 
 See `docs/guides/ios17-tunnels.md` for the repo’s detailed guidance.
 
@@ -79,7 +88,7 @@ When a command fails, check in this order:
 
 1. Device presence and pairing: `usbmux list`, `lockdown info`
 2. Correct transport: USB vs `--rsd` vs `--tunnel`
-3. Developer prerequisites: Developer Mode, mounted image, and — only on iOS 17.0-17.3 or when a privileged tunnel is explicitly used — a running `tunneld` / sufficient privileges for `start-tunnel` such as `sudo`
+3. Developer prerequisites: Developer Mode, mounted image, and — only on non-macOS iOS 17.0-17.3 or when a privileged tunnel is explicitly used — a running `tunneld` / sufficient privileges for `start-tunnel` such as `sudo`
 4. Capability location: existing CLI command vs service method vs unsupported feature
 
 Only after those checks should you consider implementing new code.

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -26,13 +26,14 @@ except ImportError:  # pragma: no cover
 # chains are lazy on Python 3.15+; see the module docstring.
 import pymobiledevice3._lazy_imports  # noqa: F401
 from pymobiledevice3.cli.cli_common import (
-    PREFER_TUNNELD_ENV_VAR,
+    FORCE_TUNNEL_ENV_VAR,
+    NATIVE_ENV_VAR,
     TUNNEL_ENV_VAR,
     UDID_ENV_VAR,
     USERSPACE_ENV_VAR,
     _cli_udid,
+    default_transport_preference,
     isatty,
-    requires_kernel_tunnel,
     resolved_udid,
     set_color_flag,
     set_verbosity,
@@ -380,34 +381,35 @@ def invoke_cli_with_error_handling() -> bool:
             and ("developer" in sys.argv)
             and ("--tunnel" not in sys.argv)
             and ("--userspace" not in sys.argv)
+            and ("--native" not in sys.argv)
             and product_version_needs_tunnel(product_version)
         ):
             reason = "it is a developer command on an iOS 17+ device"
-        # Retry once. Default to the no-root in-process userspace tunnel; iOS 17.0-17.3 falls back
-        # to tunneld — the userspace tunnel can only reach those over the fragile RemotePairing path
-        # (see requires_kernel_tunnel) — as does PYMOBILEDEVICE3_PREFER_TUNNELD (explicit opt-out of
-        # the userspace default). Either env var doubles as the one-shot guard: already set means we
-        # are the retry failing again — don't loop.
-        if reason and not os.getenv(USERSPACE_ENV_VAR) and not os.getenv(TUNNEL_ENV_VAR):
-            if requires_kernel_tunnel(product_version):
-                logger.warning(
-                    f"Trying again over tunneld since {reason} "
-                    "(iOS 17.0-17.3 has no reliable no-root tunnel; needs a privileged `remote tunneld`)"
-                )
-                # use a single space because Typer/Click will ignore envvars of empty strings
-                os.environ[TUNNEL_ENV_VAR] = e.identifier or " "
-            elif os.getenv(PREFER_TUNNELD_ENV_VAR):
-                logger.warning(f"Trying again over tunneld since {reason} ({PREFER_TUNNELD_ENV_VAR} is set)")
-                # use a single space because Typer/Click will ignore envvars of empty strings
-                os.environ[TUNNEL_ENV_VAR] = e.identifier or " "
-            else:
-                logger.warning(
-                    f"Trying again over a no-root userspace tunnel since {reason} (pass --tunnel to use tunneld)"
-                )
-                os.environ[USERSPACE_ENV_VAR] = "1"
-                # Target the same device the userspace tunnel would otherwise resolve by default.
-                if e.identifier and not os.getenv(UDID_ENV_VAR):
-                    os.environ[UDID_ENV_VAR] = e.identifier
+        # Retry once, establishing the default RSD chain in-process (see make_rsd_dependency): the
+        # preferred transport is chosen by default_transport_preference() (native on macOS, else
+        # userspace; PYMOBILEDEVICE3_DEFAULT_FALLBACK overrides) and falls back through the other
+        # no-root path and tunneld as needed. FORCE_TUNNEL_ENV_VAR both requests this and guards
+        # against looping; an explicit transport env means the user already chose one, so don't retry.
+        if (
+            reason
+            and not os.getenv(USERSPACE_ENV_VAR)
+            and not os.getenv(TUNNEL_ENV_VAR)
+            and not os.getenv(NATIVE_ENV_VAR)
+            and not os.getenv(FORCE_TUNNEL_ENV_VAR)
+        ):
+            preferred = {
+                "native": "the native tunnel",
+                "userspace": "a no-root userspace tunnel",
+                "tunneld": "tunneld",
+            }[default_transport_preference()]
+            logger.warning(
+                f"Trying again over {preferred} since {reason} "
+                "(override with PYMOBILEDEVICE3_DEFAULT_FALLBACK, or --tunnel/--userspace/--native)"
+            )
+            os.environ[FORCE_TUNNEL_ENV_VAR] = "1"
+            # Target the same device the tunnel would otherwise resolve by default.
+            if e.identifier and not os.getenv(UDID_ENV_VAR):
+                os.environ[UDID_ENV_VAR] = e.identifier
             main()
             return False
         logger.error(INVALID_SERVICE_MESSAGE)

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import logging
 import os
+import platform
 import sys
 import uuid
 from collections.abc import Coroutine
@@ -16,7 +17,6 @@ import coloredlogs
 import hexdump
 import questionary
 import typer
-from packaging.version import Version
 from pygments import formatters, highlight, lexers
 from typer_injector import Depends
 from typing_extensions import ParamSpec
@@ -38,9 +38,16 @@ from pymobiledevice3.utils import ask_prompt, get_asyncio_loop
 UDID_ENV_VAR = "PYMOBILEDEVICE3_UDID"
 TUNNEL_ENV_VAR = "PYMOBILEDEVICE3_TUNNEL"
 USERSPACE_ENV_VAR = "PYMOBILEDEVICE3_USERSPACE"
-# When set (non-empty), the automatic tunnel fallback uses tunneld instead of the
-# no-root userspace tunnel — restoring the pre-userspace-default behavior.
-PREFER_TUNNELD_ENV_VAR = "PYMOBILEDEVICE3_PREFER_TUNNELD"
+# macOS only: piggyback Apple's remoted tunnel via remotepairingd (no root, no Xcode).
+NATIVE_ENV_VAR = "PYMOBILEDEVICE3_NATIVE"
+# Overrides which transport the automatic fallback prefers — both the required-RSD default and the
+# `__main__` retry. One of "native" (built-in default on macOS), "userspace" (built-in default
+# elsewhere), or "tunneld".
+DEFAULT_FALLBACK_ENV_VAR = "PYMOBILEDEVICE3_DEFAULT_FALLBACK"
+_VALID_DEFAULT_FALLBACKS = ("native", "userspace", "tunneld")
+# Internal one-shot marker set by the `__main__` retry: make a lockdown-or-RSD command establish the
+# default RSD chain (like a required-RSD command) instead of returning None. Not user-facing.
+FORCE_TUNNEL_ENV_VAR = "PYMOBILEDEVICE3_FORCE_TUNNEL"
 USBMUX_ENV_VAR = "PYMOBILEDEVICE3_USBMUX"
 USBMUXD_SOCKET_ADDRESS_ENV_VAR = "USBMUXD_SOCKET_ADDRESS"
 USBMUX_ENV_VARS = [USBMUX_ENV_VAR, USBMUXD_SOCKET_ADDRESS_ENV_VAR]
@@ -357,24 +364,26 @@ def _resolve_target_serial(serial: Optional[str]) -> Optional[str]:
             cli_loop.run_until_complete(lockdown.close())
 
 
-def requires_kernel_tunnel(product_version: str) -> bool:
-    """True when a device needs the privileged kernel tunnel (``tunneld``) rather than the
-    no-root in-process userspace tunnel.
+def default_transport_preference() -> str:
+    """Preferred transport for the automatic fallback (required-RSD default and the ``__main__`` retry).
 
-    iOS 17.0-17.3 always qualifies: those versions predate the CoreDeviceProxy lockdown service
-    (17.4+), so the userspace tunnel can only reach them over the RemotePairing/bonjour path — which
-    is Wi-Fi-only and, on macOS, races ``remoted`` (the no-root path cannot ``stop_remoted()``
-    without root). Rather than make the default depend on that fragile path, 17.0-17.3 routes to
-    ``tunneld`` on every platform. iOS 17.4+ uses CoreDeviceProxy over USB and works root-free, so
-    it stays on the userspace default. (``--userspace`` can still force the RemotePairing path on
-    17.0-17.3 where it applies.)
-
-    Used by the ``__main__`` exception-retry path, which already carries the product version from the
-    raised exception. The required-RSD default path (:func:`make_rsd_dependency`) instead reuses the
-    tunnel's own lockdown connection and routes via ``UserspaceTunnelUnavailableError``, so it needs
-    no separate version query.
+    Returns one of ``"native"``, ``"userspace"`` or ``"tunneld"``. The built-in default is
+    ``"native"`` on macOS (faster, no root, coexists with Xcode) and ``"userspace"`` elsewhere
+    (``remoted`` only exists on macOS). Set via ``PYMOBILEDEVICE3_DEFAULT_FALLBACK`` to override; an
+    unrecognized value is ignored (falls back to the built-in default).
     """
-    return Version("17.0") <= Version(product_version) < Version("17.4")
+    value = os.getenv(DEFAULT_FALLBACK_ENV_VAR)
+    if value:
+        normalized = value.strip().lower()
+        if normalized in _VALID_DEFAULT_FALLBACKS:
+            return normalized
+        logging.getLogger(__name__).warning(
+            "ignoring invalid %s=%r (expected one of: %s)",
+            DEFAULT_FALLBACK_ENV_VAR,
+            value,
+            ", ".join(_VALID_DEFAULT_FALLBACKS),
+        )
+    return "native" if platform.system() == "Darwin" else "userspace"
 
 
 def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteServiceDiscoveryService]]:
@@ -391,9 +400,9 @@ def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteSer
       ``core-device`` / ``remote rsd-info``), so a default tunnel is established here rather than
       returning ``None``: the no-root userspace tunnel by default; a pre-17.4 device (iOS 17.0-17.3)
       raises :class:`~pymobiledevice3.exceptions.UserspaceTunnelUnavailableError` during
-      establishment (RemotePairing fallback disabled), which is caught here and routed to tunneld
-      (with the resolved UDID). Setting ``PYMOBILEDEVICE3_PREFER_TUNNELD`` skips the userspace
-      attempt and goes straight to tunneld.
+      establishment (RemotePairing fallback disabled), which is caught here and routed to the native
+      tunnel (macOS) or tunneld (with the resolved UDID). ``PYMOBILEDEVICE3_DEFAULT_FALLBACK``
+      selects the preferred transport (see :func:`default_transport_preference`).
     """
 
     def rsd_dependency(
@@ -436,6 +445,20 @@ def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteSer
                 rich_help_panel=DEVICE_OPTIONS_PANEL_TITLE,
             ),
         ] = False,
+        native: Annotated[
+            bool,
+            typer.Option(
+                "--native",
+                envvar=NATIVE_ENV_VAR,
+                help=dedent("""\
+                    macOS only: reach the iOS 17+ tunnel by piggybacking Apple's own `remoted` tunnel via the
+                    `remotepairingd` service. NO root, no entitlement, no Xcode, and `remoted` is left running (so
+                    it coexists with Xcode/devicectl). Rides Apple's kernel-routable tunnel, so throughput matches
+                    the kernel tunnel. Mutually exclusive with --rsd/--tunnel/--userspace.
+                """),
+                rich_help_panel=DEVICE_OPTIONS_PANEL_TITLE,
+            ),
+        ] = False,
     ) -> Optional[RemoteServiceDiscoveryService]:
         if is_invoked_for_completion():
             # prevent lockdown connection establishment when in autocomplete mode
@@ -443,8 +466,15 @@ def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteSer
 
         if rsd is not None and tunnel is not None:
             ctx.fail("Illegal usage: --rsd is mutually exclusive with --tunnel.")
-        if userspace and (rsd is not None or tunnel is not None):
-            ctx.fail("Illegal usage: --userspace is mutually exclusive with --rsd/--tunnel.")
+        explicit_tunnel_sources = sum([rsd is not None, tunnel is not None, userspace, native])
+        if explicit_tunnel_sources > 1:
+            ctx.fail("Illegal usage: --rsd, --tunnel, --userspace and --native are mutually exclusive.")
+
+        if native:
+            serial = _resolve_target_serial(_cli_udid())
+            from pymobiledevice3.remote import native_tunnel
+
+            return cli_loop.run_until_complete(native_tunnel.establish_native_rsd(serial=serial))
 
         # Explicit tunnel sources take precedence.
         if rsd is not None:
@@ -470,22 +500,36 @@ def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteSer
 
             return cli_loop.run_until_complete(userspace_tunnel.establish_userspace_rsd(serial=serial))
 
-        # Default for a required RSD: prefer the no-root in-process userspace tunnel. A pre-17.4
-        # device (no CoreDeviceProxy — i.e. iOS 17.0-17.3, reachable no-root only over the fragile
-        # RemotePairing path) is served by tunneld instead: establishment is asked NOT to attempt
-        # RemotePairing (remotepairing_fallback=False), so it raises UserspaceTunnelUnavailableError,
-        # which we catch and route to tunneld. This reuses the single lockdown connection
-        # establishment already opens — no separate version probe.
-        if not allow_none:
-            # Resolve (and, with multiple devices, prompt for) the target so both the userspace
-            # attempt and the tunneld fallback act on the same user-chosen device.
+        # Default for a required RSD. The preferred transport is configurable via
+        # PYMOBILEDEVICE3_DEFAULT_FALLBACK (default: the no-root in-process userspace tunnel). A
+        # pre-17.4 device (no CoreDeviceProxy — iOS 17.0-17.3) can't use the userspace path; on macOS
+        # it is served no-root by the native tunnel (piggybacking remoted), elsewhere by tunneld.
+        # Establish the default RSD chain when the command requires an RSD (allow_none=False) or the
+        # `__main__` retry marked this run to force one (FORCE_TUNNEL_ENV_VAR) after a lockdown-only
+        # attempt hit InvalidServiceError/RSDRequiredError.
+        if not allow_none or os.getenv(FORCE_TUNNEL_ENV_VAR):
+            # Resolve (and, with multiple devices, prompt for) the target so every attempt acts on
+            # the same user-chosen device.
             serial = _resolve_target_serial(_cli_udid())
-            # PYMOBILEDEVICE3_PREFER_TUNNELD opts out of the userspace default entirely,
-            # restoring the pre-userspace-default behavior (straight to tunneld).
-            if os.getenv(PREFER_TUNNELD_ENV_VAR):
+            preference = default_transport_preference()
+
+            if preference == "tunneld":
                 return cli_loop.run_until_complete(_tunneld(serial or ""))
-            # Imported lazily: see the --userspace branch above — the PyTCP stack import is
-            # expensive and must stay off the hot path of commands that never need it.
+
+            tried_native = False
+            if preference == "native" and platform.system() == "Darwin":
+                from pymobiledevice3.remote import native_tunnel
+
+                tried_native = True
+                try:
+                    return cli_loop.run_until_complete(native_tunnel.establish_native_rsd(serial=serial))
+                except Exception as e:
+                    # Any native-path failure (unavailable, or an unexpected ctypes/libxpc error)
+                    # degrades to the userspace path rather than aborting the command.
+                    logging.getLogger(__name__).debug("native tunnel unavailable, falling back: %r", e)
+
+            # Imported lazily: the PyTCP stack import is expensive and must stay off the hot path of
+            # commands that never establish a userspace tunnel.
             from pymobiledevice3.remote import userspace_tunnel
 
             try:
@@ -493,6 +537,17 @@ def make_rsd_dependency(*, allow_none: bool) -> Callable[..., Optional[RemoteSer
                     userspace_tunnel.establish_userspace_rsd(serial=serial, remotepairing_fallback=False)
                 )
             except UserspaceTunnelUnavailableError:
+                # The userspace path can't serve this device (iOS 17.0-17.3 has no CoreDeviceProxy).
+                # On macOS, piggyback remoted's own tunnel (no root) unless we already tried it above;
+                # elsewhere remoted does not exist, so go straight to the privileged tunneld.
+                if platform.system() == "Darwin" and not tried_native:
+                    from pymobiledevice3.remote import native_tunnel
+
+                    try:
+                        return cli_loop.run_until_complete(native_tunnel.establish_native_rsd(serial=serial))
+                    except Exception as e:
+                        # Native path not viable either (or an unexpected error); fall through to tunneld.
+                        logging.getLogger(__name__).debug("native tunnel unavailable, falling back: %r", e)
                 # Propagate the resolved UDID so tunneld targets the same device (empty => auto/prompt).
                 return cli_loop.run_until_complete(_tunneld(serial or ""))
 

--- a/pymobiledevice3/remote/native_tunnel.py
+++ b/pymobiledevice3/remote/native_tunnel.py
@@ -1,0 +1,532 @@
+"""macOS-only: reach an iOS 17+ device's RSD by piggybacking Apple's own ``remoted`` tunnel.
+
+Instead of building our own tunnel (kernel ``utun`` -> root, or the in-process userspace stack) or
+suspending ``remoted`` for the bonjour/RSD path, this asks the base-OS pairing daemon
+``com.apple.CoreDevice.remotepairingd`` (provided by ``RemotePairing.framework`` -- present on stock
+macOS, no Xcode) to hand us the device's existing tunnel, then rides it:
+
+1. Browse ``remotepairingd`` for the device and open its per-device XPC endpoint.
+2. ``RemotePairing.CreateAssertionCommand`` -> the device's in-tunnel ``tunnelIPAddress`` plus an
+   assertion identifier that keeps Apple's tunnel alive for as long as we hold it.
+3. Discover the in-tunnel RSD port by reading ``net.inet.tcp.pcblist_n`` (no root) and finding
+   ``remoted``'s own connection to that tunnel address.
+4. Connect a normal TCP socket to ``[tunnelIPAddress]:rsd_port`` (the tunnel address is
+   kernel-routable, so no root) and run the standard RSD handshake via
+   :class:`~pymobiledevice3.remote.remote_service_discovery.RemoteServiceDiscoveryService`.
+
+No root, no entitlement, no Xcode, and ``remoted`` is left running -- so unlike the kernel/bonjour
+path this coexists with Xcode/``devicectl``. The whole XPC conversation goes through ``ctypes`` +
+libxpc (no pyobjc). See ``docs/guides/network-stacks.md``.
+"""
+
+import asyncio
+import atexit
+import contextlib
+import ctypes
+import platform
+import socket
+import struct
+import threading
+from typing import Any, Callable, Optional
+
+from pymobiledevice3.exceptions import UserspaceTunnelUnavailableError
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+
+_IS_DARWIN = platform.system() == "Darwin"
+
+REMOTEPAIRING_MACH_SERVICE = "com.apple.CoreDevice.remotepairingd"
+REMOTED_PATH = "/usr/libexec/remoted"
+
+# com.apple.dt.RemotePairingError code returned by InitiatePairingCommand when the host is already
+# paired -- a benign no-op, not a failure.
+_REMOTEPAIRING_ALREADY_PAIRED = 1002
+
+# net.inet.tcp.pcblist_n item kinds (xgen_n.xgn_kind) and inp_vflag bit.
+_XSO_SOCKET = 0x001
+_XSO_INPCB = 0x010
+_INP_IPV6 = 0x02
+
+# Objective-C block flags.
+_BLOCK_IS_GLOBAL = 1 << 28
+
+
+class _BlockDescriptor(ctypes.Structure):
+    _fields_ = [("reserved", ctypes.c_ulong), ("size", ctypes.c_ulong)]
+
+
+class _ObjcBlock(ctypes.Structure):
+    _fields_ = [
+        ("isa", ctypes.c_void_p),
+        ("flags", ctypes.c_int),
+        ("reserved", ctypes.c_int),
+        ("invoke", ctypes.c_void_p),
+        ("descriptor", ctypes.c_void_p),
+    ]
+
+
+class _LibXpc:
+    """Lazily-bound libxpc / libdispatch / libproc surface, plus an Objective-C global-block factory.
+
+    Instantiated only on macOS (see :func:`_libxpc`). Every bound function is annotated with a
+    concrete return type so call sites stay pyright-clean despite ctypes being dynamic.
+    """
+
+    def __init__(self) -> None:
+        lib = ctypes.CDLL("/usr/lib/libSystem.B.dylib", use_errno=True)
+        self._lib = lib
+        vp = ctypes.c_void_p
+        cp = ctypes.c_char_p
+
+        self.dispatch_queue_create: Callable[..., int] = self._cfg("dispatch_queue_create", vp, [cp, vp])
+
+        self.connection_create_mach_service: Callable[..., int] = self._cfg(
+            "xpc_connection_create_mach_service", vp, [cp, vp, ctypes.c_uint64]
+        )
+        self.connection_create_from_endpoint: Callable[..., int] = self._cfg(
+            "xpc_connection_create_from_endpoint", vp, [vp]
+        )
+        self.connection_set_event_handler: Callable[..., None] = self._cfg(
+            "xpc_connection_set_event_handler", None, [vp, vp]
+        )
+        self.connection_activate: Callable[..., None] = self._cfg("xpc_connection_activate", None, [vp])
+        self.connection_cancel: Callable[..., None] = self._cfg("xpc_connection_cancel", None, [vp])
+        self.connection_send_message: Callable[..., None] = self._cfg("xpc_connection_send_message", None, [vp, vp])
+        self.connection_send_message_with_reply: Callable[..., None] = self._cfg(
+            "xpc_connection_send_message_with_reply", None, [vp, vp, vp, vp]
+        )
+
+        self.dictionary_create: Callable[..., int] = self._cfg("xpc_dictionary_create", vp, [vp, vp, ctypes.c_size_t])
+        self.dictionary_set_string: Callable[..., None] = self._cfg("xpc_dictionary_set_string", None, [vp, cp, cp])
+        self.dictionary_set_bool: Callable[..., None] = self._cfg(
+            "xpc_dictionary_set_bool", None, [vp, cp, ctypes.c_bool]
+        )
+        self.dictionary_set_int64: Callable[..., None] = self._cfg(
+            "xpc_dictionary_set_int64", None, [vp, cp, ctypes.c_int64]
+        )
+        self.dictionary_set_value: Callable[..., None] = self._cfg("xpc_dictionary_set_value", None, [vp, cp, vp])
+        self.dictionary_get_value: Callable[..., int] = self._cfg("xpc_dictionary_get_value", vp, [vp, cp])
+        self.dictionary_get_string: Callable[..., bytes] = self._cfg("xpc_dictionary_get_string", cp, [vp, cp])
+        self.dictionary_get_int64: Callable[..., int] = self._cfg("xpc_dictionary_get_int64", ctypes.c_int64, [vp, cp])
+        self.retain: Callable[..., int] = self._cfg("xpc_retain", vp, [vp])
+        self.release: Callable[..., None] = self._cfg("xpc_release", None, [vp])
+        self.copy_description: Callable[..., bytes] = self._cfg("xpc_copy_description", cp, [vp])
+
+        self.proc_pidpath: Callable[..., int] = self._cfg(
+            "proc_pidpath", ctypes.c_int, [ctypes.c_int, cp, ctypes.c_uint32]
+        )
+        self.sysctlbyname: Callable[..., int] = self._cfg(
+            "sysctlbyname", ctypes.c_int, [cp, vp, ctypes.POINTER(ctypes.c_size_t), vp, ctypes.c_size_t]
+        )
+
+        # Address of the _NSConcreteGlobalBlock class object -> the block's isa pointer.
+        self._global_block_isa = ctypes.addressof(ctypes.c_void_p.in_dll(lib, "_NSConcreteGlobalBlock"))
+        self._block_keepalive: list[Any] = []
+
+    def _cfg(self, name: str, restype: Any, argtypes: list[Any]) -> Any:
+        fn = getattr(self._lib, name)
+        fn.restype = restype
+        fn.argtypes = argtypes
+        return fn
+
+    def make_block(self, func: Callable[[int], None]) -> ctypes.c_void_p:
+        """Wrap ``func(xpc_object_ptr)`` in an Objective-C global block for an xpc handler.
+
+        The block, its descriptor and the trampoline are retained for the process lifetime -- an
+        xpc handler may fire on a libdispatch thread long after this returns, so they must never be
+        collected.
+        """
+        invoke_t = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p)
+
+        def _invoke(_block: Optional[int], obj: Optional[int]) -> None:
+            func(int(obj or 0))
+
+        trampoline = invoke_t(_invoke)
+
+        descriptor = _BlockDescriptor(0, ctypes.sizeof(_ObjcBlock))
+        block = _ObjcBlock(
+            ctypes.c_void_p(self._global_block_isa),
+            _BLOCK_IS_GLOBAL,
+            0,
+            ctypes.cast(trampoline, ctypes.c_void_p),
+            ctypes.cast(ctypes.byref(descriptor), ctypes.c_void_p),
+        )
+        self._block_keepalive.extend([trampoline, descriptor, block])
+        return ctypes.cast(ctypes.byref(block), ctypes.c_void_p)
+
+
+_libxpc_singleton: Optional[_LibXpc] = None
+
+
+def _libxpc() -> _LibXpc:
+    global _libxpc_singleton
+    if not _IS_DARWIN:
+        raise UserspaceTunnelUnavailableError("the native remoted tunnel is only available on macOS")
+    if _libxpc_singleton is None:
+        _libxpc_singleton = _LibXpc()
+    return _libxpc_singleton
+
+
+class _RemotePairingError(UserspaceTunnelUnavailableError):
+    pass
+
+
+class _RemotePairingSession:
+    """Synchronous libxpc conversation with ``remotepairingd`` that owns the tunnel assertion.
+
+    Blocking by design (waits on reply events); the async wrapper runs it in a worker thread. The
+    browse/per-device XPC connections and the assertion must stay alive for the tunnel's lifetime,
+    so this object is held open until :meth:`close`.
+    """
+
+    _REPLY_TIMEOUT = 10.0
+
+    def __init__(self, xpc: _LibXpc) -> None:
+        self._xpc = xpc
+        self._queue = xpc.dispatch_queue_create(b"pymobiledevice3.native-remotepairing", None)
+        self._browse_conn: Optional[int] = None
+        self._device_conn: Optional[int] = None
+        self._assertion_id: Optional[int] = None  # retained xpc uuid object
+        self.tunnel_ip: Optional[str] = None
+
+    def _request(self, conn: int, mangled_type_name: bytes, body_setup: Callable[[int], None]) -> int:
+        """Send ``{mangledTypeName, value}`` and block for the reply. Returns the (retained) reply."""
+        xpc = self._xpc
+        body = xpc.dictionary_create(None, None, 0)
+        body_setup(body)
+        message = xpc.dictionary_create(None, None, 0)
+        xpc.dictionary_set_string(message, b"mangledTypeName", mangled_type_name)
+        xpc.dictionary_set_value(message, b"value", body)
+
+        holder: list[int] = []
+        done = threading.Event()
+
+        def on_reply(reply: int) -> None:
+            xpc.retain(reply)
+            holder.append(reply)
+            done.set()
+
+        xpc.connection_send_message_with_reply(conn, message, self._queue, xpc.make_block(on_reply))
+        if not done.wait(self._REPLY_TIMEOUT):
+            raise _RemotePairingError(f"timed out waiting for reply to {mangled_type_name.decode()}")
+        return holder[0]
+
+    def browse(self, serial: Optional[str]) -> None:
+        """Browse for ``serial`` (or the first device) and open its per-device XPC endpoint."""
+        xpc = self._xpc
+        want = serial.encode() if serial is not None else None
+        endpoint_holder: list[int] = []
+        found = threading.Event()
+
+        def on_event(obj: int) -> None:
+            if not obj:
+                return
+            value = xpc.dictionary_get_value(obj, b"value")
+            if not value:
+                return
+            device_found = xpc.dictionary_get_value(value, b"deviceFound")
+            if not device_found:
+                return
+            zero = xpc.dictionary_get_value(device_found, b"_0")
+            info = xpc.dictionary_get_value(zero, b"deviceInfo") if zero else 0
+            if not info:
+                return
+            udid = xpc.dictionary_get_string(info, b"udid")
+            if want is not None and udid != want:
+                return
+            endpoint = xpc.dictionary_get_value(info, b"endpoint")
+            if endpoint and not found.is_set():
+                xpc.retain(endpoint)
+                endpoint_holder.append(endpoint)
+                found.set()
+
+        conn = xpc.connection_create_mach_service(REMOTEPAIRING_MACH_SERVICE.encode(), self._queue, 0)
+        self._browse_conn = conn
+        xpc.connection_set_event_handler(conn, xpc.make_block(on_event))
+        xpc.connection_activate(conn)
+
+        def browse_body(body: int) -> None:
+            xpc.dictionary_set_bool(body, b"currentDevicesOnly", False)
+
+        # Mercury needs a reply channel or it silently drops the request; the device list itself
+        # arrives asynchronously via on_event, so the reply is ignored.
+        message = xpc.dictionary_create(None, None, 0)
+        body = xpc.dictionary_create(None, None, 0)
+        browse_body(body)
+        xpc.dictionary_set_string(message, b"mangledTypeName", b"RemotePairing.BrowseRequest")
+        xpc.dictionary_set_value(message, b"value", body)
+        xpc.connection_send_message_with_reply(conn, message, self._queue, xpc.make_block(lambda _obj: None))
+
+        if not found.wait(self._REPLY_TIMEOUT):
+            hint = f" matching udid {serial}" if serial is not None else ""
+            raise _RemotePairingError(f"remotepairingd reported no device{hint}")
+
+        device_conn = xpc.connection_create_from_endpoint(endpoint_holder[0])
+        self._device_conn = device_conn
+        xpc.connection_set_event_handler(device_conn, xpc.make_block(lambda _obj: None))
+        xpc.connection_activate(device_conn)
+
+    def open_tunnel(self) -> str:
+        """Ensure paired, create the tunnel assertion, and return the device tunnel IP address."""
+        xpc = self._xpc
+        assert self._device_conn is not None
+
+        # Ensure paired. Already-paired comes back as a RemotePairingError (code 1002) -- benign.
+        initiate = self._request(
+            self._device_conn,
+            b"RemotePairing.InitiatePairingCommand",
+            lambda body: xpc.dictionary_set_bool(body, b"requireNonInteractive", False),
+        )
+        error = xpc.dictionary_get_value(initiate, b"error")
+        if error:
+            # Compare the numeric code, not the localized message: RemotePairingError code 1002 is
+            # the benign "device is already paired" case, and NSLocalizedDescription is localized
+            # (matching the English string would misfire on non-English macOS).
+            code = xpc.dictionary_get_int64(error, b"code")
+            if code != _REMOTEPAIRING_ALREADY_PAIRED:
+                description = xpc.dictionary_get_value(error, b"userInfo")
+                message = xpc.dictionary_get_string(description, b"NSLocalizedDescription") if description else b""
+                raise _RemotePairingError(
+                    f"pairing failed (code {code}): {(message or b'unknown error').decode(errors='replace')}"
+                )
+        xpc.release(initiate)
+
+        assertion = self._request(
+            self._device_conn,
+            b"RemotePairing.CreateAssertionCommand",
+            lambda body: xpc.dictionary_set_int64(body, b"flags", 0),
+        )
+        response = xpc.dictionary_get_value(assertion, b"response")
+        if not response:
+            raise _RemotePairingError(f"CreateAssertion had no response: {self._describe(assertion)}")
+        assertion_id = xpc.dictionary_get_value(response, b"assertionIdentifier")
+        if assertion_id:
+            self._assertion_id = xpc.retain(assertion_id)
+        info = xpc.dictionary_get_value(response, b"info")
+        tunnel_ip = xpc.dictionary_get_string(info, b"tunnelIPAddress") if info else None
+        xpc.release(assertion)
+        if not tunnel_ip:
+            raise _RemotePairingError("CreateAssertion returned no tunnelIPAddress")
+        self.tunnel_ip = tunnel_ip.decode()
+        return self.tunnel_ip
+
+    def _describe(self, obj: int) -> str:
+        raw = self._xpc.copy_description(obj)
+        return raw.decode(errors="replace") if raw else "<no description>"
+
+    def close(self) -> None:
+        xpc = self._xpc
+        if self._assertion_id is not None and self._device_conn is not None:
+            with contextlib.suppress(Exception):
+                release = self._request(
+                    self._device_conn,
+                    b"RemotePairing.ReleaseAssertionRequest",
+                    lambda body, aid=self._assertion_id: xpc.dictionary_set_value(body, b"assertionIdentifier", aid),
+                )
+                xpc.release(release)
+            xpc.release(self._assertion_id)
+            self._assertion_id = None
+        for conn in (self._device_conn, self._browse_conn):
+            if conn is not None:
+                with contextlib.suppress(Exception):
+                    xpc.connection_cancel(conn)
+        self._device_conn = None
+        self._browse_conn = None
+
+
+def parse_tcp_pcbs(data: bytes) -> list[tuple[int, int, bytes, int]]:
+    """Parse ``net.inet.tcp.pcblist_n`` bytes into ``(effective_pid, version_flag, foreign_addr, foreign_port)``.
+
+    The buffer is a sequence of ``{uint32 length; uint32 kind}`` records after a leading ``xinpgen``
+    header (whose first uint32 is its own length); each connection contributes an ``XSO_SOCKET``
+    record (carrying the owning pid) and an ``XSO_INPCB`` record (carrying the addresses/ports),
+    terminated by a trailing ``xinpgen`` (length 24). Records are paired per connection regardless of
+    their order within the block.
+    """
+    connections: list[tuple[int, int, bytes, int]] = []
+    if len(data) < 4:
+        return connections
+    # Skip the leading xinpgen header (its first uint32 is xig_len).
+    offset = int(struct.unpack_from("<I", data, 0)[0])
+    pending_pid: Optional[int] = None
+    pending: Optional[tuple[int, bytes, int]] = None  # (version_flag, foreign_addr, foreign_port)
+    while offset + 8 <= len(data):
+        header = struct.unpack_from("<II", data, offset)
+        length, kind = int(header[0]), int(header[1])
+        if length == 24:  # trailing xinpgen end marker (sizeof(struct xinpgen))
+            break
+        if length < 8 or offset + length > len(data):  # malformed/truncated: avoid a bad or endless walk
+            break
+        if kind == _XSO_SOCKET and offset + 72 <= len(data):
+            pending_pid = int(struct.unpack_from("<i", data, offset + 68)[0])
+        elif kind == _XSO_INPCB and offset + 64 <= len(data):
+            foreign_port = int(struct.unpack_from(">H", data, offset + 16)[0])
+            version_flag = data[offset + 44]
+            foreign_addr = data[offset + 48 : offset + 48 + 16]
+            pending = (version_flag, foreign_addr, foreign_port)
+        if pending_pid is not None and pending is not None:
+            version_flag, foreign_addr, foreign_port = pending
+            connections.append((pending_pid, version_flag, foreign_addr, foreign_port))
+            pending_pid = None
+            pending = None
+        step = length if length % 8 == 0 else length + (8 - length % 8)
+        offset += step
+    return connections
+
+
+def _read_tcp_pcblist(xpc: _LibXpc) -> Optional[bytes]:
+    """Read the ``net.inet.tcp.pcblist_n`` sysctl, tolerating growth between the sizing and data calls.
+
+    The socket table can grow on a busy host in the window between the size query and the fetch, which
+    makes the fetch fail with ENOMEM; over-allocate and retry a few times instead of giving up.
+    """
+    name = b"net.inet.tcp.pcblist_n"
+    for _ in range(5):
+        size = ctypes.c_size_t(0)
+        if xpc.sysctlbyname(name, None, ctypes.byref(size), None, 0) != 0 or size.value == 0:
+            return None
+        capacity = size.value + 16384  # slack for connections opened since the sizing call
+        buf = (ctypes.c_uint8 * capacity)()
+        got = ctypes.c_size_t(capacity)
+        if xpc.sysctlbyname(name, buf, ctypes.byref(got), None, 0) == 0:
+            return bytes(buf[: got.value])
+    return None
+
+
+def find_rsd_port(xpc: _LibXpc, tunnel_ip: str) -> list[int]:
+    """Return candidate in-tunnel RSD ports: ``remoted``'s TCP connections to ``tunnel_ip``.
+
+    Reads ``net.inet.tcp.pcblist_n`` (available without root) rather than shelling out to netstat.
+    """
+    target = socket.inet_pton(socket.AF_INET6, tunnel_ip)
+    data = _read_tcp_pcblist(xpc)
+    if data is None:
+        return []
+
+    ports: list[int] = []
+    for pid, version_flag, foreign_addr, foreign_port in parse_tcp_pcbs(data):
+        if (version_flag & _INP_IPV6) and foreign_addr == target and _proc_path(xpc, pid) == REMOTED_PATH:
+            ports.append(foreign_port)
+    return ports
+
+
+def _proc_path(xpc: _LibXpc, pid: int) -> str:
+    buf = ctypes.create_string_buffer(4096)
+    if xpc.proc_pidpath(pid, buf, 4096) <= 0:
+        return ""
+    return buf.value.decode(errors="replace")
+
+
+class NativeRemotedTunnel:
+    """A no-root macOS RSD obtained by piggybacking ``remoted``'s tunnel via ``remotepairingd``.
+
+    Async context manager (closes automatically)::
+
+        async with NativeRemotedTunnel(serial=udid) as rsd:
+            ...  # rsd is a connected RemoteServiceDiscoveryService
+
+    Or open/close explicitly with :meth:`aopen` / :meth:`aclose`. ``serial`` selects the device by
+    UDID (``None`` -> the single device ``remotepairingd`` reports). The RSD address is
+    kernel-routable (Apple's tunnel), so unlike the userspace tunnel it is reachable by other tools;
+    the tunnel lives only while this handle (its assertion) is held open.
+    """
+
+    def __init__(self, serial: Optional[str] = None) -> None:
+        self.serial = serial
+        self.rsd: Optional[RemoteServiceDiscoveryService] = None
+        self._session: Optional[_RemotePairingSession] = None
+
+    async def aopen(self) -> RemoteServiceDiscoveryService:
+        if self.rsd is not None:
+            return self.rsd
+        xpc = _libxpc()
+        session = _RemotePairingSession(xpc)
+        try:
+            tunnel_ip, ports = await asyncio.to_thread(self._establish, xpc, session)
+            if not ports:
+                raise _RemotePairingError(f"could not find remoted's RSD connection to the tunnel address {tunnel_ip}")
+            rsd = await self._connect_rsd(tunnel_ip, ports)
+        except BaseException:
+            await asyncio.to_thread(session.close)
+            raise
+        self._session = session
+        self.rsd = rsd
+        return rsd
+
+    def _establish(self, xpc: _LibXpc, session: _RemotePairingSession) -> tuple[str, list[int]]:
+        session.browse(self.serial)
+        tunnel_ip = session.open_tunnel()
+        return tunnel_ip, find_rsd_port(xpc, tunnel_ip)
+
+    async def _connect_rsd(self, tunnel_ip: str, ports: list[int]) -> RemoteServiceDiscoveryService:
+        last_error: Optional[Exception] = None
+        for port in ports:
+            rsd = RemoteServiceDiscoveryService((tunnel_ip, port))
+            try:
+                await rsd.connect()
+            except Exception as e:  # try the next candidate port
+                last_error = e
+                await rsd.close()
+            else:
+                return rsd
+        raise _RemotePairingError(
+            f"failed to complete RSD handshake over the native tunnel [{tunnel_ip}]: {last_error!r}"
+        )
+
+    async def aclose(self) -> None:
+        if self.rsd is not None:
+            await self.rsd.close()
+            self.rsd = None
+        if self._session is not None:
+            await asyncio.to_thread(self._session.close)
+            self._session = None
+
+    async def __aenter__(self) -> RemoteServiceDiscoveryService:
+        return await self.aopen()
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        await self.aclose()
+
+
+_cli_native_tunnel: Optional[NativeRemotedTunnel] = None
+_cli_native_atexit_registered = False
+
+
+async def establish_native_rsd(serial: Optional[str] = None) -> RemoteServiceDiscoveryService:
+    """CLI convenience: open a native tunnel, keep it alive for the process, and return its RSD.
+
+    Embedders should use :class:`NativeRemotedTunnel` directly — it is a closeable handle / async
+    context manager. This wrapper exists for the CLI, which has no teardown hook: it stashes the
+    tunnel for the process lifetime and releases the assertion at interpreter exit.
+
+    Raises :class:`~pymobiledevice3.exceptions.UserspaceTunnelUnavailableError` when the native path
+    is not usable (non-macOS, ``remotepairingd`` unavailable, or the device cannot be reached).
+    """
+    global _cli_native_tunnel, _cli_native_atexit_registered
+    if (
+        _cli_native_tunnel is not None
+        and _cli_native_tunnel.rsd is not None
+        and (serial is None or serial in (_cli_native_tunnel.serial, _cli_native_tunnel.rsd.udid))
+    ):
+        return _cli_native_tunnel.rsd
+    # A stored tunnel for a different device: release its on-device assertion before replacing it.
+    if _cli_native_tunnel is not None:
+        stale, _cli_native_tunnel = _cli_native_tunnel, None
+        await stale.aclose()
+    tunnel = NativeRemotedTunnel(serial=serial)
+    rsd = await tunnel.aopen()
+    _cli_native_tunnel = tunnel
+    if not _cli_native_atexit_registered:
+        atexit.register(_close_cli_native_tunnel_at_exit)
+        _cli_native_atexit_registered = True
+    return rsd
+
+
+def _close_cli_native_tunnel_at_exit() -> None:
+    """Release the CLI's process-lifetime native tunnel (and its assertion) at interpreter exit."""
+    global _cli_native_tunnel
+    tunnel = _cli_native_tunnel
+    if tunnel is None:
+        return
+    _cli_native_tunnel = None
+    with contextlib.suppress(Exception):
+        asyncio.run(tunnel.aclose())

--- a/pymobiledevice3/remote/rsd_tunnel.py
+++ b/pymobiledevice3/remote/rsd_tunnel.py
@@ -1,0 +1,85 @@
+"""A no-root iOS 17+ RSD tunnel that automatically picks the best transport for the host.
+
+On macOS this prefers the :class:`~pymobiledevice3.remote.native_tunnel.NativeRemotedTunnel`
+(piggybacks Apple's own ``remoted`` — faster host->device and lower latency, and it coexists with
+Xcode), falling back to the in-process
+:class:`~pymobiledevice3.remote.userspace_tunnel.UserspaceRsdTunnel` when the native path is not
+available. On every other platform (where ``remoted`` does not exist) it uses the userspace tunnel.
+Both are no-root.
+
+Prefer this over picking a concrete tunnel class when you just want "a working no-root RSD on iOS
+17+" and don't care which mechanism provides it.
+"""
+
+import platform
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+
+if TYPE_CHECKING:
+    from pymobiledevice3.remote.native_tunnel import NativeRemotedTunnel
+    from pymobiledevice3.remote.userspace_tunnel import UserspaceRsdTunnel
+
+_IS_DARWIN = platform.system() == "Darwin"
+
+
+class PreferredRsdTunnel:
+    """A no-root iOS 17+ RSD tunnel that selects the best available transport for the host.
+
+    Async context manager (closes automatically)::
+
+        async with PreferredRsdTunnel(serial=udid) as rsd:
+            ...  # rsd is a connected RemoteServiceDiscoveryService
+
+    Or open/close explicitly with :meth:`aopen` / :meth:`aclose`. ``serial`` selects the device
+    (``None`` => first/only device). ``prefer_native=False`` forces the userspace tunnel even on
+    macOS. On macOS the native tunnel is tried first and, if it is unavailable, the userspace tunnel
+    is used instead; elsewhere the userspace tunnel is used directly.
+    """
+
+    def __init__(self, serial: Optional[str] = None, autopair: bool = True, prefer_native: bool = True) -> None:
+        self.serial = serial
+        self.autopair = autopair
+        self.prefer_native = prefer_native
+        self.rsd: Optional[RemoteServiceDiscoveryService] = None
+        self._handle: Optional[Union[NativeRemotedTunnel, UserspaceRsdTunnel]] = None
+
+    async def aopen(self) -> RemoteServiceDiscoveryService:
+        if self.rsd is not None:
+            return self.rsd
+        if _IS_DARWIN and self.prefer_native:
+            # Imported here so non-macOS callers never touch the ctypes/libxpc layer.
+            from pymobiledevice3.remote.native_tunnel import NativeRemotedTunnel
+
+            native = NativeRemotedTunnel(serial=self.serial)
+            try:
+                rsd = await native.aopen()
+            except Exception:
+                # Any native-path failure (unavailable, or an unexpected ctypes/libxpc error) falls
+                # back to the userspace tunnel rather than propagating.
+                await native.aclose()  # release anything half-acquired before falling back
+            else:
+                self.rsd = rsd
+                self._handle = native
+                return rsd
+
+        # Imported lazily: the userspace stack (pmd-pytcp) import is expensive.
+        from pymobiledevice3.remote.userspace_tunnel import UserspaceRsdTunnel
+
+        userspace = UserspaceRsdTunnel(serial=self.serial, autopair=self.autopair)
+        rsd = await userspace.aopen()
+        self.rsd = rsd
+        self._handle = userspace
+        return rsd
+
+    async def aclose(self) -> None:
+        if self._handle is not None:
+            await self._handle.aclose()
+            self._handle = None
+            self.rsd = None
+
+    async def __aenter__(self) -> RemoteServiceDiscoveryService:
+        return await self.aopen()
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        await self.aclose()

--- a/tests/test_native_tunnel.py
+++ b/tests/test_native_tunnel.py
@@ -1,0 +1,236 @@
+import socket
+import struct
+from typing import Optional
+
+import pytest
+
+from pymobiledevice3.exceptions import UserspaceTunnelUnavailableError
+from pymobiledevice3.remote import native_tunnel
+
+
+def _pcblist_with_one_connection(pid: int, addr: bytes, port: int) -> bytes:
+    """Build a synthetic ``net.inet.tcp.pcblist_n`` buffer with a single IPv6 TCP connection."""
+    buf = bytearray()
+    buf += struct.pack("<I", 24) + b"\x00" * 20  # leading xinpgen: first uint32 is its own length
+
+    sock = bytearray(72)  # XSO_SOCKET record; effective_pid is an int32 at offset 68
+    struct.pack_into("<II", sock, 0, 72, native_tunnel._XSO_SOCKET)
+    struct.pack_into("<i", sock, 68, pid)
+    buf += sock
+
+    inpcb = bytearray(88)  # XSO_INPCB record: foreign_port@16 (BE), inp_vflag@44, foreign_addr@48
+    struct.pack_into("<II", inpcb, 0, 88, native_tunnel._XSO_INPCB)
+    struct.pack_into(">H", inpcb, 16, port)
+    inpcb[44] = native_tunnel._INP_IPV6
+    inpcb[48:64] = addr
+    buf += inpcb
+
+    buf += struct.pack("<II", 24, 0)  # trailing xinpgen (length 24) ends the walk
+    return bytes(buf)
+
+
+def test_parse_tcp_pcbs_pairs_socket_and_inpcb() -> None:
+    addr = socket.inet_pton(socket.AF_INET6, "fd7b:7934:1752::1")
+    connections = native_tunnel.parse_tcp_pcbs(_pcblist_with_one_connection(4321, addr, 50881))
+    assert connections == [(4321, native_tunnel._INP_IPV6, addr, 50881)]
+
+
+def test_parse_tcp_pcbs_ignores_malformed_or_empty() -> None:
+    assert native_tunnel.parse_tcp_pcbs(b"") == []
+    assert native_tunnel.parse_tcp_pcbs(struct.pack("<I", 9999)) == []  # header points past the end
+    assert native_tunnel.parse_tcp_pcbs(struct.pack("<III", 8, 0, 0)) == []  # header==8, then length 0 -> stop
+
+
+def test_parse_tcp_pcbs_stops_on_truncated_record() -> None:
+    addr = socket.inet_pton(socket.AF_INET6, "fd7b:7934:1752::1")
+    full = _pcblist_with_one_connection(4321, addr, 50881)
+    # Replace the trailing xinpgen with a record claiming a huge length but no body: the parser must
+    # keep the already-parsed connection and stop rather than read out of bounds.
+    truncated = full[:-8] + struct.pack("<II", 4096, native_tunnel._XSO_INPCB)
+    assert native_tunnel.parse_tcp_pcbs(truncated) == [(4321, native_tunnel._INP_IPV6, addr, 50881)]
+
+
+def test_libxpc_requires_darwin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_tunnel, "_IS_DARWIN", False)
+    monkeypatch.setattr(native_tunnel, "_libxpc_singleton", None)
+    with pytest.raises(UserspaceTunnelUnavailableError):
+        native_tunnel._libxpc()
+
+
+# --- required-RSD transport selection / fallback routing (pymobiledevice3.cli.cli_common) ---
+
+
+class _Ctx:
+    def fail(self, message: str) -> None:
+        raise _CtxFail(message)
+
+
+class _CtxFail(Exception):
+    pass
+
+
+def _route(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    system: str,
+    default_fallback: Optional[str] = None,
+    userspace_exc: Optional[BaseException] = None,
+    native_exc: Optional[BaseException] = None,
+    native_flag: bool = False,
+    allow_none: bool = False,
+    force_tunnel: bool = False,
+) -> tuple[object, list[str]]:
+    """Drive the RSD dependency with the three establishers stubbed; return (result, calls)."""
+    from pymobiledevice3.cli import cli_common
+    from pymobiledevice3.remote import native_tunnel as nt
+    from pymobiledevice3.remote import userspace_tunnel as ut
+
+    calls: list[str] = []
+    monkeypatch.setattr(cli_common.platform, "system", lambda: system)
+    monkeypatch.setattr(cli_common, "is_invoked_for_completion", lambda: False)
+    monkeypatch.setattr(cli_common, "_cli_udid", lambda: None)
+    monkeypatch.setattr(cli_common, "_resolve_target_serial", lambda serial: "UDID")
+    if default_fallback is not None:
+        monkeypatch.setenv("PYMOBILEDEVICE3_DEFAULT_FALLBACK", default_fallback)
+    else:
+        monkeypatch.delenv("PYMOBILEDEVICE3_DEFAULT_FALLBACK", raising=False)
+    if force_tunnel:
+        monkeypatch.setenv("PYMOBILEDEVICE3_FORCE_TUNNEL", "1")
+    else:
+        monkeypatch.delenv("PYMOBILEDEVICE3_FORCE_TUNNEL", raising=False)
+
+    async def fake_tunneld(udid: object = None) -> str:
+        calls.append("tunneld")
+        return "TUNNELD"
+
+    async def fake_userspace(*args: object, **kwargs: object) -> str:
+        calls.append("userspace")
+        if userspace_exc is not None:
+            raise userspace_exc
+        return "USERSPACE"
+
+    async def fake_native(*args: object, **kwargs: object) -> str:
+        calls.append("native")
+        if native_exc is not None:
+            raise native_exc
+        return "NATIVE"
+
+    monkeypatch.setattr(cli_common, "_tunneld", fake_tunneld)
+    monkeypatch.setattr(ut, "establish_userspace_rsd", fake_userspace)
+    monkeypatch.setattr(nt, "establish_native_rsd", fake_native)
+
+    dependency = cli_common.make_rsd_dependency(allow_none=allow_none)
+    result = dependency(_Ctx(), rsd=None, tunnel=None, userspace=False, native=native_flag)
+    return result, calls
+
+
+def test_macos_default_uses_native_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    # On macOS the built-in default prefers the native tunnel (no DEFAULT_FALLBACK set).
+    result, calls = _route(monkeypatch, system="Darwin")
+    assert result == "NATIVE"
+    assert calls == ["native"]  # userspace/tunneld never attempted
+
+
+def test_macos_default_falls_through_native_userspace_tunneld(monkeypatch: pytest.MonkeyPatch) -> None:
+    result, calls = _route(
+        monkeypatch,
+        system="Darwin",
+        native_exc=UserspaceTunnelUnavailableError("no remotepairingd"),
+        userspace_exc=UserspaceTunnelUnavailableError("no 17.4"),
+    )
+    assert result == "TUNNELD"
+    assert calls == ["native", "userspace", "tunneld"]
+
+
+def test_non_macos_default_uses_userspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    result, calls = _route(monkeypatch, system="Linux")
+    assert result == "USERSPACE"
+    assert calls == ["userspace"]  # native only exists on macOS
+
+
+def test_non_macos_falls_back_to_tunneld(monkeypatch: pytest.MonkeyPatch) -> None:
+    result, calls = _route(monkeypatch, system="Linux", userspace_exc=UserspaceTunnelUnavailableError("no 17.4"))
+    assert result == "TUNNELD"
+    assert "native" not in calls  # remoted only exists on macOS
+
+
+def test_explicit_native_flag_forces_native(monkeypatch: pytest.MonkeyPatch) -> None:
+    result, calls = _route(monkeypatch, system="Linux", native_flag=True)
+    assert result == "NATIVE"
+    assert calls == ["native"]  # explicit --native bypasses userspace/tunneld selection
+
+
+def test_transport_flags_are_mutually_exclusive() -> None:
+    from pymobiledevice3.cli import cli_common
+
+    dependency = cli_common.make_rsd_dependency(allow_none=False)
+    with pytest.raises(_CtxFail):
+        dependency(_Ctx(), rsd=None, tunnel=None, userspace=True, native=True)
+
+
+def test_default_fallback_native_is_tried_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    # PYMOBILEDEVICE3_DEFAULT_FALLBACK=native: native is preferred over userspace on macOS.
+    result, calls = _route(monkeypatch, system="Darwin", default_fallback="native")
+    assert result == "NATIVE"
+    assert calls == ["native"]  # userspace never attempted
+
+
+def test_default_fallback_native_falls_through_when_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    result, calls = _route(
+        monkeypatch,
+        system="Darwin",
+        default_fallback="native",
+        native_exc=UserspaceTunnelUnavailableError("no remotepairingd"),
+    )
+    assert result == "USERSPACE"
+    assert calls == ["native", "userspace"]  # native tried first, then userspace; native not retried
+
+
+def test_default_fallback_native_on_non_macos_uses_userspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    result, calls = _route(monkeypatch, system="Linux", default_fallback="native")
+    assert result == "USERSPACE"
+    assert "native" not in calls  # native preference is a no-op off macOS
+
+
+def test_default_fallback_tunneld_skips_no_root_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    result, calls = _route(monkeypatch, system="Darwin", default_fallback="tunneld")
+    assert result == "TUNNELD"
+    assert calls == ["tunneld"]
+
+
+def test_default_fallback_userspace_forces_userspace_on_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Opt back out of the macOS native default without going all the way to tunneld.
+    result, calls = _route(monkeypatch, system="Darwin", default_fallback="userspace")
+    assert result == "USERSPACE"
+    assert calls == ["userspace"]
+
+
+def test_force_tunnel_marker_establishes_chain_for_lockdown_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    # allow_none=True commands normally return None (use lockdown); the __main__ retry sets
+    # FORCE_TUNNEL to make them establish the default chain instead.
+    none_result, none_calls = _route(monkeypatch, system="Darwin", allow_none=True)
+    assert none_result is None
+    assert none_calls == []  # no tunnel attempted without the marker
+
+    result, calls = _route(monkeypatch, system="Darwin", allow_none=True, force_tunnel=True)
+    assert result == "NATIVE"
+    assert calls == ["native"]  # marker -> full chain, macOS default is native
+
+
+def test_default_transport_preference_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from pymobiledevice3.cli import cli_common
+
+    monkeypatch.delenv("PYMOBILEDEVICE3_DEFAULT_FALLBACK", raising=False)
+    monkeypatch.setattr(cli_common.platform, "system", lambda: "Darwin")
+    assert cli_common.default_transport_preference() == "native"  # built-in default on macOS
+    monkeypatch.setattr(cli_common.platform, "system", lambda: "Linux")
+    assert cli_common.default_transport_preference() == "userspace"  # built-in default elsewhere
+
+    monkeypatch.setenv("PYMOBILEDEVICE3_DEFAULT_FALLBACK", "NATIVE")  # case-insensitive
+    assert cli_common.default_transport_preference() == "native"
+
+    monkeypatch.setenv("PYMOBILEDEVICE3_DEFAULT_FALLBACK", "tunneld")
+    assert cli_common.default_transport_preference() == "tunneld"
+
+    monkeypatch.setenv("PYMOBILEDEVICE3_DEFAULT_FALLBACK", "bogus")  # invalid -> built-in default (Linux here)
+    assert cli_common.default_transport_preference() == "userspace"


### PR DESCRIPTION
## Summary

Adds a macOS-only `--native` tunnel that reaches an iOS 17+ device's RSD by **piggybacking Apple's own `remoted` tunnel** — no root, no entitlement, no Xcode, and without suspending `remoted` (so it coexists with Xcode/`devicectl`). This is the approach frida uses; the mechanism was reverse-engineered from frida-core and validated end-to-end on a physical device (iPhone18,4, iOS 26.6.1).

## How it works

All via `ctypes` + libxpc (no pyobjc):

1. Ask `com.apple.CoreDevice.remotepairingd` — provided by the base-OS `RemotePairing.framework` (present on stock macOS; it backs iPhone Mirroring), **not** the Xcode-only `CoreDevice.framework` — to browse for the device and open its per-device XPC endpoint.
2. `RemotePairing.CreateAssertionCommand` returns the device's in-tunnel `tunnelIPAddress` and an assertion identifier that keeps Apple's tunnel alive while the handle is held.
3. Discover the in-tunnel RSD port by reading `net.inet.tcp.pcblist_n` (readable without root) and matching `remoted`'s own connection to that tunnel address.
4. Connect a normal TCP socket to `[tunnelIPAddress]:rsd_port` (kernel-routable) and run the standard RSD handshake via the existing `RemoteServiceDiscoveryService`.

## Performance

The kernel-routable tunnel avoids the userspace stack's per-packet Python overhead. On a **real** iPhone 17-class device throughput is USB-bound (~35-40 MB/s over AFC, matching `fetch-symbols`); the practical win over the userspace tunnel is on host->device transfers, whose send segments the userspace stack keeps deliberately small. (An earlier draft cited ~9x/2x/4x figures — those were a measurement artifact of benchmarking native against an attached vphone; corrected.)

## Exposure

- `--native` / `PYMOBILEDEVICE3_NATIVE` (mutually exclusive with `--rsd`/`--tunnel`/`--userspace`).
- Wired as the **macOS default fallback**: an iOS 17.0-17.3 device (no CoreDeviceProxy, unreachable by the userspace tunnel) is routed here instead of the privileged `tunneld`.
- `PYMOBILEDEVICE3_DEFAULT_FALLBACK=native|userspace|tunneld` overrides which transport the automatic fallback prefers. **BREAKING:** `PYMOBILEDEVICE3_PREFER_TUNNELD` is removed (use `=tunneld`); this PR targets a major version.
- `tunneld` is untouched and remains the explicit fallback.

## Tests / docs

- `tests/test_native_tunnel.py` — CI-safe unit tests for the `pcblist_n` parser, the non-macOS guard, and the transport selection/fallback routing incl. the env-var overrides.
- `docs/guides/network-stacks.md`, `AGENTS.md`, and the device-operator skill reference document `--native` and `PYMOBILEDEVICE3_DEFAULT_FALLBACK`.

## Notes / limitations

- macOS-only; depends on the private `RemotePairing.framework` XPC surface, so ABI could shift between releases (guarded by fallback to the existing paths).
- The iOS 17.0-17.3 default-fallback routing is implemented but validated on 17.4+ only (no 17.0-17.3 device on hand); the mechanism is version-independent.
