### PR TITLE
remote: add --native to start-tunnel/browse and default to it on macOS

### DIFF
--- a/.codex/skills/pymobiledevice3-device-operator/references/task-map.md
+++ b/.codex/skills/pymobiledevice3-device-operator/references/task-map.md
@@ -14,7 +14,7 @@ Read this file when the user asks to do something on-device and you need to map 
 
 Start here when the task is blocked on "find the device", "connect to the device", "`--rsd` details", or "start a tunnel".
 
-Explicit tunnel setup is rarely needed: on iOS 17.4+, commands that require an RSD tunnel establish a no-root in-process userspace tunnel automatically — just run the command. Reach for `tunneld` or `start-tunnel` (see `references/transport-and-safety.md`) only for iOS 17.0-17.3 devices or when the userspace path is not viable.
+Explicit tunnel setup is rarely needed: on iOS 17.4+, commands that require an RSD tunnel establish a no-root tunnel automatically — the native `remoted` tunnel on macOS, the in-process userspace tunnel elsewhere — so just run the command. Reach for `tunneld` or `start-tunnel` (see `references/transport-and-safety.md`) only for iOS 17.0-17.3 devices or when the no-root path is not viable.
 
 ## Files, Containers, And App Data
 

--- a/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -53,6 +53,11 @@ the mounted image before assuming the code is broken.
   latency) and needs no root. Fall back to a privileged `tunneld` only when no no-root path is
   viable: non-macOS iOS 17.0-17.3, `debugserver start-server` without `--local-port`, or a tunnel
   that must be shared across processes.
+- On macOS, `remote start-tunnel` publishes Apple's own kernel-routable tunnel with no sudo (the
+  native path is the macOS default) — prefer it over the privileged options below when another
+  process just needs an `--rsd HOST PORT` address. `remote browse` likewise lists the devices
+  `remotepairingd` sees with no root on macOS. `--no-native` (or any classic-tunnel option, e.g.
+  `-t wifi`) routes `start-tunnel` to the classic root tunnel.
 - Privileged options: an already-running `tunneld`, or a one-off
   `lockdown start-tunnel` (iOS 17.4+) / `remote start-tunnel` (iOS 17.0-17.3.1).
 - Privileged tunnel creation can require `sudo` because it creates a TUN/TAP interface.

--- a/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -36,11 +36,12 @@ Many `developer dvt` and related developer commands need all of the following:
    On iOS 17+ the same image can instead be installed as a cryptex, bypassing the image
    mounter: `uvx --from . pymobiledevice3 cryptex auto-install` (needs RSD; both cache the
    download under `~/.pymobiledevice3` and end up mounted at `/System/Developer`).
-3. A CoreDevice transport path. On iOS 17.4+ this needs **no setup**: the no-root
-   userspace tunnel is established automatically when the command runs. iOS 17.0-17.3
-   devices (which predate CoreDeviceProxy) route automatically to the no-root `--native`
-   tunnel on macOS; on other hosts they route to `tunneld`, which needs a privileged
-   daemon: `sudo uvx --from . pymobiledevice3 remote tunneld` in the background, then pass
+3. A CoreDevice transport path. On iOS 17.4+ this needs **no setup**: a no-root tunnel is
+   established automatically when the command runs — the native `remoted` tunnel on macOS,
+   the in-process userspace tunnel elsewhere. iOS 17.0-17.3 devices (which predate
+   CoreDeviceProxy) route automatically to the no-root `--native` tunnel on macOS; on other
+   hosts they route to `tunneld`, which needs a privileged daemon:
+   `sudo uvx --from . pymobiledevice3 remote tunneld` in the background, then pass
    `--tunnel ''` or `--tunnel <UDID>`.
 
 If a developer command fails with service-availability errors, verify Developer Mode and

--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -110,6 +110,11 @@ python3 -m pymobiledevice3 developer dvt ls /
 ## Starting a tunnel manually
 
 ```shell
+# macOS (the default there): no sudo — publishes Apple's own remoted tunnel
+# (kernel-routable, so other tools can use the printed --rsd too). See "Native
+# remoted tunnel" in the network stacks guide.
+python3 -m pymobiledevice3 remote start-tunnel
+
 # Optional for remote-pairing devices.
 python3 -m pymobiledevice3 remote pair
 
@@ -119,8 +124,9 @@ sudo python3 -m pymobiledevice3 lockdown start-tunnel
 # Optional: allow Wi-Fi connections over lockdown
 python3 -m pymobiledevice3 lockdown wifi-connections on
 
-# iOS 17.0-17.3.1 fallback
-# Add `-t wifi` to force Wi-Fi transport.
+# iOS 17.0-17.3.1 fallback, and the default off macOS.
+# Add `-t wifi` to force Wi-Fi transport (on macOS this routes to this classic
+# tunnel automatically, as does --no-native or any other classic-tunnel option).
 sudo python3 -m pymobiledevice3 remote start-tunnel
 ```
 
@@ -134,7 +140,14 @@ Use the following connection option:
 --rsd fd7b:e5b:6f53::1 64337
 ```
 
-The tunnel creation command must run with elevated privileges because it creates a TUN/TAP interface.
+The classic tunnel creation command must run with elevated privileges because it creates a TUN/TAP
+interface. The native path (`--native`, the macOS default) is the exception: it rides Apple's
+already-existing tunnel instead of creating one, so it needs no privileges. Device selection there
+is by `--udid`; the classic-tunnel-shaping options (`--protocol`/`--secrets`/`--max-idle-timeout`/
+`-t`) don't apply to it, and passing one routes the command to the classic tunnel (as does
+`--no-native`, or `PYMOBILEDEVICE3_DEFAULT_FALLBACK` set to anything but `native`). The same
+default applies to `remote browse`: on macOS it lists devices via `remotepairingd` with no root
+(`--no-native` forces the bonjour browse, which needs root to suspend `remoted`).
 
 !!! tip "Bootstrap the RemotePairing record over USB (no Trust dialog)"
 

--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -28,13 +28,23 @@ Reference protocol details:
 
 ## The default: a no-root tunnel, automatically
 
-When a developer command needs an RSD tunnel and you passed none of `--rsd` / `--tunnel` /
-`--userspace`, pymobiledevice3 brings up an **in-process userspace tunnel** using a pure-Python
-network stack (PyTCP) — no kernel interface, so **no root/admin**. The tunnel is built when the
-command starts and torn down when it exits.
+When a developer command needs an RSD tunnel and you passed no transport flag (`--rsd` /
+`--tunnel` / `--userspace` / `--native`), pymobiledevice3 brings up a **no-root tunnel** for you,
+built when the command starts and torn down when it exits. The kind depends on the host:
 
-This covers iOS 17.4+ over USB on macOS, Linux and Windows with no privileges (it uses the
-CoreDeviceProxy lockdown service). iOS 17.0-17.3.1 is handled differently — see the note below.
+- **macOS** rides Apple's own `remoted` tunnel (the **native** path) by piggybacking
+  `remotepairingd` — no root, no Xcode, and `remoted` is left running so it coexists with
+  Xcode/`devicectl`. Its address is kernel-routable, so it is faster host->device and lower
+  latency than the userspace stack. See
+  [Native remoted tunnel](network-stacks.md#native-remoted-tunnel-macos-only).
+- **Linux/Windows** bring up an **in-process userspace tunnel** using a pure-Python network stack
+  (PyTCP) — no kernel interface, so no root/admin either.
+
+If the native path is unavailable on macOS it falls back automatically (userspace, then `tunneld`).
+Either way you just run the command. This covers iOS 17.4+ over USB with no privileges (it uses the
+CoreDeviceProxy lockdown service); iOS 17.0-17.3.1 is handled differently — see the note below.
+Set `PYMOBILEDEVICE3_DEFAULT_FALLBACK=native|userspace|tunneld` to change which transport the
+automatic selection prefers.
 
 !!! warning "iOS 17.0-17.3.1 uses `tunneld` by default"
     These versions predate the CoreDeviceProxy service, so the userspace tunnel can only reach them

--- a/docs/guides/network-stacks.md
+++ b/docs/guides/network-stacks.md
@@ -247,7 +247,9 @@ How it works (all via `ctypes` + libxpc, no pyobjc):
 - **Root:** not required. **Xcode:** not required.
 - **Reachability:** the tunnel address is a real kernel route (Apple's tunnel), so unlike the
   userspace tunnel it *is* reachable by other tools; it lives only while the handle (its assertion)
-  is held.
+  is held. `remote start-tunnel` publishes this address for other processes (no `sudo`; the native
+  path is its macOS default) and `remote browse` lists the devices `remotepairingd` reports (also
+  the macOS default; `--no-native` forces the classic tunnel / bonjour browse).
 - **Default on macOS:** this is the built-in default transport for RSD-required commands (and the
   CLI's automatic retry) on macOS — chosen ahead of the userspace tunnel, with userspace and then
   `tunneld` as fallbacks. On other platforms the userspace tunnel remains the default (`remoted` does

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/task-map.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/task-map.md
@@ -14,7 +14,7 @@ Read this file when the user asks to do something on-device and you need to map 
 
 Start here when the task is blocked on "find the device", "connect to the device", "`--rsd` details", or "start a tunnel".
 
-Explicit tunnel setup is rarely needed: on iOS 17.4+, commands that require an RSD tunnel establish a no-root in-process userspace tunnel automatically — just run the command. Reach for `tunneld` or `start-tunnel` (see `references/transport-and-safety.md`) only for iOS 17.0-17.3 devices or when the userspace path is not viable.
+Explicit tunnel setup is rarely needed: on iOS 17.4+, commands that require an RSD tunnel establish a no-root tunnel automatically — the native `remoted` tunnel on macOS, the in-process userspace tunnel elsewhere — so just run the command. Reach for `tunneld` or `start-tunnel` (see `references/transport-and-safety.md`) only for iOS 17.0-17.3 devices or when the no-root path is not viable.
 
 ## Files, Containers, And App Data
 

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -53,6 +53,11 @@ the mounted image before assuming the code is broken.
   latency) and needs no root. Fall back to a privileged `tunneld` only when no no-root path is
   viable: non-macOS iOS 17.0-17.3, `debugserver start-server` without `--local-port`, or a tunnel
   that must be shared across processes.
+- On macOS, `remote start-tunnel` publishes Apple's own kernel-routable tunnel with no sudo (the
+  native path is the macOS default) — prefer it over the privileged options below when another
+  process just needs an `--rsd HOST PORT` address. `remote browse` likewise lists the devices
+  `remotepairingd` sees with no root on macOS. `--no-native` (or any classic-tunnel option, e.g.
+  `-t wifi`) routes `start-tunnel` to the classic root tunnel.
 - Privileged options: an already-running `tunneld`, or a one-off
   `lockdown start-tunnel` (iOS 17.4+) / `remote start-tunnel` (iOS 17.0-17.3.1).
 - Privileged tunnel creation can require `sudo` because it creates a TUN/TAP interface.

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -36,11 +36,12 @@ Many `developer dvt` and related developer commands need all of the following:
    On iOS 17+ the same image can instead be installed as a cryptex, bypassing the image
    mounter: `uvx --from . pymobiledevice3 cryptex auto-install` (needs RSD; both cache the
    download under `~/.pymobiledevice3` and end up mounted at `/System/Developer`).
-3. A CoreDevice transport path. On iOS 17.4+ this needs **no setup**: the no-root
-   userspace tunnel is established automatically when the command runs. iOS 17.0-17.3
-   devices (which predate CoreDeviceProxy) route automatically to the no-root `--native`
-   tunnel on macOS; on other hosts they route to `tunneld`, which needs a privileged
-   daemon: `sudo uvx --from . pymobiledevice3 remote tunneld` in the background, then pass
+3. A CoreDevice transport path. On iOS 17.4+ this needs **no setup**: a no-root tunnel is
+   established automatically when the command runs — the native `remoted` tunnel on macOS,
+   the in-process userspace tunnel elsewhere. iOS 17.0-17.3 devices (which predate
+   CoreDeviceProxy) route automatically to the no-root `--native` tunnel on macOS; on other
+   hosts they route to `tunneld`, which needs a privileged daemon:
+   `sudo uvx --from . pymobiledevice3 remote tunneld` in the background, then pass
    `--tunnel ''` or `--tunnel <UDID>`.
 
 If a developer command fails with service-availability errors, verify Developer Mode and

--- a/pymobiledevice3/cli/remote.py
+++ b/pymobiledevice3/cli/remote.py
@@ -327,18 +327,22 @@ async def cli_start_tunnel(
         typer.Option(help="Print only HOST and port for scripts instead of formatted output."),
     ] = False,
     max_idle_timeout: Annotated[
-        float,
-        typer.Option(help="Maximum idle time before QUIC keepalive pings are sent."),
-    ] = MAX_IDLE_TIMEOUT,
+        Optional[float],
+        typer.Option(
+            show_default=str(MAX_IDLE_TIMEOUT),
+            help="Maximum idle time before QUIC keepalive pings are sent.",
+        ),
+    ] = None,
     protocol: Annotated[
-        TunnelProtocol,
+        Optional[TunnelProtocol],
         typer.Option(
             "--protocol",
             "-p",
             case_sensitive=False,
-            help="Transport protocol for the tunnel (default: TCP on Python >=3.13, otherwise QUIC).",
+            show_default="TCP on Python >=3.13, otherwise QUIC",
+            help="Transport protocol for the tunnel.",
         ),
-    ] = TunnelProtocol.DEFAULT,
+    ] = None,
     native: Annotated[
         Optional[bool],
         typer.Option(
@@ -350,13 +354,16 @@ async def cli_start_tunnel(
     ] = None,
 ) -> None:
     """start tunnel (Apple's native tunnel on macOS by default — no root; classic tunnel elsewhere)"""
+    # Detect explicitly-passed classic-tunnel options via sentinel Nones rather than value-vs-default
+    # (TunnelProtocol.DEFAULT is version-dependent -- QUIC on Python <3.13, TCP otherwise -- so a
+    # value comparison cannot tell an explicit `--protocol quic` on 3.12 from the default).
     classic_options = [
         name
         for name, is_set in (
             ("--connection-type", connection_type is not ConnectionType.USB),
             ("--secrets", secrets is not None),
-            ("--protocol", protocol is not TunnelProtocol.DEFAULT),
-            ("--max-idle-timeout", max_idle_timeout != MAX_IDLE_TIMEOUT),
+            ("--protocol", protocol is not None),
+            ("--max-idle-timeout", max_idle_timeout is not None),
         )
         if is_set
     ]
@@ -380,7 +387,7 @@ async def cli_start_tunnel(
                 raise typer.BadParameter("--connection-type cannot be combined with --native (select with --udid)")
             if secrets is not None:
                 raise typer.BadParameter("--secrets cannot be combined with --native")
-            if protocol is not TunnelProtocol.DEFAULT:
+            if protocol is not None:
                 raise typer.BadParameter("--protocol cannot be combined with --native")
             raise typer.BadParameter("--max-idle-timeout cannot be combined with --native")
         await native_tunnel_task(udid, script_mode=script_mode)
@@ -395,8 +402,8 @@ async def cli_start_tunnel(
             secrets_file,
             udid,
             script_mode,
-            max_idle_timeout=max_idle_timeout,
-            protocol=protocol,
+            max_idle_timeout=MAX_IDLE_TIMEOUT if max_idle_timeout is None else max_idle_timeout,
+            protocol=protocol if protocol is not None else TunnelProtocol.DEFAULT,
         )
 
 

--- a/pymobiledevice3/cli/remote.py
+++ b/pymobiledevice3/cli/remote.py
@@ -15,17 +15,19 @@ from typer_injector import InjectingTyper
 
 from pymobiledevice3.bonjour import DEFAULT_BONJOUR_TIMEOUT, browse_remotepairing_manual_pairing
 from pymobiledevice3.cli.cli_common import (
+    OSUTILS,
     USBMUX_ENV_VARS,
     USBMUX_OPTION_HELP,
     RSDServiceProviderDep,
     async_command,
+    default_transport_preference,
     print_json,
     prompt_device_list,
     sudo_required,
     user_requested_colored_output,
 )
 from pymobiledevice3.common import get_home_folder
-from pymobiledevice3.exceptions import NoDeviceConnectedError
+from pymobiledevice3.exceptions import AccessDeniedError, NoDeviceConnectedError
 from pymobiledevice3.pair_records import PAIRING_RECORD_EXT, get_remote_pairing_record_filename
 from pymobiledevice3.remote.common import ConnectionType, TunnelProtocol
 from pymobiledevice3.remote.module_imports import MAX_IDLE_TIMEOUT, start_tunnel, verify_tunnel_imports
@@ -150,9 +152,24 @@ def cli_tunneld(
 @cli.command("browse")
 @async_command
 async def browse(
-    timeout: Annotated[float, typer.Option(help="Bonjour timeout (in seconds)")] = DEFAULT_BONJOUR_TIMEOUT,
+    timeout: Annotated[float, typer.Option(help="Browse timeout (in seconds)")] = DEFAULT_BONJOUR_TIMEOUT,
+    native: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--native/--no-native",
+            help="Browse via Apple's remotepairingd (the remoted tunnel daemon) instead of bonjour; no root, "
+            "macOS only, and the default there. --no-native forces the bonjour browse.",
+        ),
+    ] = None,
 ) -> None:
-    """browse RemoteXPC devices using bonjour"""
+    """browse RemoteXPC devices (remotepairingd on macOS by default, bonjour elsewhere)"""
+    if native is None:
+        native = default_transport_preference() == "native"
+    if native:
+        from pymobiledevice3.remote.native_tunnel import browse_native_devices
+
+        print_json(await browse_native_devices(timeout=timeout))
+        return
     await cli_browse(timeout)
 
 
@@ -256,8 +273,36 @@ async def start_tunnel_task(
     )
 
 
+async def native_tunnel_task(udid: Optional[str] = None, script_mode: bool = False) -> None:
+    # establish_native_rsd holds the tunnel assertion for the process lifetime and releases it at
+    # interpreter exit; the RSD address is kernel-routable (Apple's tunnel), so other processes can
+    # use the printed --rsd directly.
+    from pymobiledevice3.remote.native_tunnel import establish_native_rsd
+
+    rsd = await establish_native_rsd(serial=udid)
+    address, port = rsd.service.address
+    logger.info("native tunnel is up")
+    if script_mode:
+        print(f"{address} {port}", flush=True)
+    else:
+        if user_requested_colored_output():
+            print(typer.style("Identifier: ", bold=True, fg="yellow") + typer.style(rsd.udid, bold=True, fg="white"))
+            print(typer.style("RSD Address: ", bold=True, fg="yellow") + typer.style(address, bold=True, fg="white"))
+            print(typer.style("RSD Port: ", bold=True, fg="yellow") + typer.style(str(port), bold=True, fg="white"))
+            print(
+                typer.style("Use the follow connection option:\n", bold=True, fg="yellow")
+                + typer.style(f"--rsd {address} {port}", bold=True, fg="cyan")
+            )
+        else:
+            print(f"Identifier: {rsd.udid}")
+            print(f"RSD Address: {address}")
+            print(f"RSD Port: {port}")
+            print(f"Use the follow connection option:\n--rsd {address} {port}")
+    sys.stdout.flush()
+    await asyncio.Event().wait()  # hold the assertion until Ctrl-C
+
+
 @cli.command("start-tunnel")
-@sudo_required
 @async_command
 async def cli_start_tunnel(
     connection_type: Annotated[
@@ -294,8 +339,42 @@ async def cli_start_tunnel(
             help="Transport protocol for the tunnel (default: TCP on Python >=3.13, otherwise QUIC).",
         ),
     ] = TunnelProtocol.DEFAULT,
+    native: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--native/--no-native",
+            help="Piggyback Apple's remoted tunnel via remotepairingd and publish its RSD address instead of "
+            "creating a new tunnel; no root, macOS only, and the default there. --no-native forces the "
+            "classic (root) tunnel, as does passing any of the classic-tunnel options.",
+        ),
+    ] = None,
 ) -> None:
-    """start tunnel"""
+    """start tunnel (Apple's native tunnel on macOS by default — no root; classic tunnel elsewhere)"""
+    classic_options = (
+        connection_type is not ConnectionType.USB
+        or secrets is not None
+        or protocol is not TunnelProtocol.DEFAULT
+        or max_idle_timeout != MAX_IDLE_TIMEOUT
+    )
+    if native is None:
+        # Auto: native on macOS (unless PYMOBILEDEVICE3_DEFAULT_FALLBACK opts out of it); an option
+        # that shapes a new tunnel implies the classic path -- those options don't apply to Apple's
+        # already-existing tunnel.
+        native = default_transport_preference() == "native" and not classic_options
+    if native:
+        if classic_options:
+            # Explicit --native: fail loud rather than silently ignore an inapplicable option.
+            if connection_type is not ConnectionType.USB:
+                raise typer.BadParameter("--connection-type cannot be combined with --native (select with --udid)")
+            if secrets is not None:
+                raise typer.BadParameter("--secrets cannot be combined with --native")
+            if protocol is not TunnelProtocol.DEFAULT:
+                raise typer.BadParameter("--protocol cannot be combined with --native")
+            raise typer.BadParameter("--max-idle-timeout cannot be combined with --native")
+        await native_tunnel_task(udid, script_mode=script_mode)
+        return
+    if not OSUTILS.is_admin:
+        raise AccessDeniedError()
     if not verify_tunnel_imports():
         return
     with secrets.open("wt") if secrets is not None else nullcontext() as secrets_file:

--- a/pymobiledevice3/cli/remote.py
+++ b/pymobiledevice3/cli/remote.py
@@ -350,17 +350,29 @@ async def cli_start_tunnel(
     ] = None,
 ) -> None:
     """start tunnel (Apple's native tunnel on macOS by default — no root; classic tunnel elsewhere)"""
-    classic_options = (
-        connection_type is not ConnectionType.USB
-        or secrets is not None
-        or protocol is not TunnelProtocol.DEFAULT
-        or max_idle_timeout != MAX_IDLE_TIMEOUT
-    )
+    classic_options = [
+        name
+        for name, is_set in (
+            ("--connection-type", connection_type is not ConnectionType.USB),
+            ("--secrets", secrets is not None),
+            ("--protocol", protocol is not TunnelProtocol.DEFAULT),
+            ("--max-idle-timeout", max_idle_timeout != MAX_IDLE_TIMEOUT),
+        )
+        if is_set
+    ]
     if native is None:
         # Auto: native on macOS (unless PYMOBILEDEVICE3_DEFAULT_FALLBACK opts out of it); an option
         # that shapes a new tunnel implies the classic path -- those options don't apply to Apple's
         # already-existing tunnel.
-        native = default_transport_preference() == "native" and not classic_options
+        prefers_native = default_transport_preference() == "native"
+        native = prefers_native and not classic_options
+        if prefers_native and classic_options:
+            # Make the divert visible: the classic path needs root, and the user did not ask for it.
+            logger.info(
+                "%s only applies to the classic tunnel, so using it instead of the no-root native "
+                "default (this requires root; drop the option, or pass --native, for the no-root tunnel).",
+                ", ".join(classic_options),
+            )
     if native:
         if classic_options:
             # Explicit --native: fail loud rather than silently ignore an inapplicable option.

--- a/pymobiledevice3/remote/native_tunnel.py
+++ b/pymobiledevice3/remote/native_tunnel.py
@@ -27,7 +27,9 @@ import platform
 import socket
 import struct
 import threading
-from typing import Any, Callable, Optional
+import time
+import uuid
+from typing import Any, Callable, Optional, cast
 
 from pymobiledevice3.exceptions import UserspaceTunnelUnavailableError
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
@@ -48,6 +50,11 @@ _INP_IPV6 = 0x02
 
 # Objective-C block flags.
 _BLOCK_IS_GLOBAL = 1 << 28
+
+# RSD handshake retry budget (see NativeRemotedTunnel._connect_rsd): covers the device resetting
+# the initial post-tunnel RSD connection while remoted redials onto a new port.
+_RSD_CONNECT_ATTEMPTS = 5
+_RSD_CONNECT_RETRY_DELAY = 0.5
 
 
 class _BlockDescriptor(ctypes.Structure):
@@ -111,6 +118,22 @@ class _LibXpc:
         self.release: Callable[..., None] = self._cfg("xpc_release", None, [vp])
         self.copy_description: Callable[..., bytes] = self._cfg("xpc_copy_description", cp, [vp])
 
+        self.get_type: Callable[..., int] = self._cfg("xpc_get_type", vp, [vp])
+        self.type_get_name: Callable[..., bytes] = self._cfg("xpc_type_get_name", cp, [vp])
+        self.dictionary_apply: Callable[..., bool] = self._cfg("xpc_dictionary_apply", ctypes.c_bool, [vp, vp])
+        self.array_apply: Callable[..., bool] = self._cfg("xpc_array_apply", ctypes.c_bool, [vp, vp])
+        self.string_get_string_ptr: Callable[..., bytes] = self._cfg("xpc_string_get_string_ptr", cp, [vp])
+        self.int64_get_value: Callable[..., int] = self._cfg("xpc_int64_get_value", ctypes.c_int64, [vp])
+        self.uint64_get_value: Callable[..., int] = self._cfg("xpc_uint64_get_value", ctypes.c_uint64, [vp])
+        self.double_get_value: Callable[..., float] = self._cfg("xpc_double_get_value", ctypes.c_double, [vp])
+        self.bool_get_value: Callable[..., bool] = self._cfg("xpc_bool_get_value", ctypes.c_bool, [vp])
+        self.date_get_value: Callable[..., int] = self._cfg("xpc_date_get_value", ctypes.c_int64, [vp])
+        self.data_get_length: Callable[..., int] = self._cfg("xpc_data_get_length", ctypes.c_size_t, [vp])
+        self.data_get_bytes: Callable[..., int] = self._cfg(
+            "xpc_data_get_bytes", ctypes.c_size_t, [vp, vp, ctypes.c_size_t, ctypes.c_size_t]
+        )
+        self.uuid_get_bytes: Callable[..., int] = self._cfg("xpc_uuid_get_bytes", vp, [vp])
+
         self.proc_pidpath: Callable[..., int] = self._cfg(
             "proc_pidpath", ctypes.c_int, [ctypes.c_int, cp, ctypes.c_uint32]
         )
@@ -140,8 +163,27 @@ class _LibXpc:
         def _invoke(_block: Optional[int], obj: Optional[int]) -> None:
             func(int(obj or 0))
 
-        trampoline = invoke_t(_invoke)
+        return self._wrap_block(invoke_t(_invoke))
 
+    def make_dictionary_apply_block(self, func: Callable[[bytes, int], bool]) -> ctypes.c_void_p:
+        """Applier block for ``xpc_dictionary_apply``: ``func(key, xpc_object_ptr) -> keep_going``."""
+        invoke_t = ctypes.CFUNCTYPE(ctypes.c_bool, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p)
+
+        def _invoke(_block: Optional[int], key: Optional[bytes], obj: Optional[int]) -> bool:
+            return func(key or b"", int(obj or 0))
+
+        return self._wrap_block(invoke_t(_invoke))
+
+    def make_array_apply_block(self, func: Callable[[int, int], bool]) -> ctypes.c_void_p:
+        """Applier block for ``xpc_array_apply``: ``func(index, xpc_object_ptr) -> keep_going``."""
+        invoke_t = ctypes.CFUNCTYPE(ctypes.c_bool, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p)
+
+        def _invoke(_block: Optional[int], index: int, obj: Optional[int]) -> bool:
+            return func(index, int(obj or 0))
+
+        return self._wrap_block(invoke_t(_invoke))
+
+    def _wrap_block(self, trampoline: Any) -> ctypes.c_void_p:
         descriptor = _BlockDescriptor(0, ctypes.sizeof(_ObjcBlock))
         block = _ObjcBlock(
             ctypes.c_void_p(self._global_block_isa),
@@ -164,6 +206,74 @@ def _libxpc() -> _LibXpc:
     if _libxpc_singleton is None:
         _libxpc_singleton = _LibXpc()
     return _libxpc_singleton
+
+
+def xpc_to_python(xpc: _LibXpc, obj: int) -> Any:
+    """Best-effort conversion of a libxpc object into plain Python data.
+
+    Types with no data representation (endpoints, connections, ...) become a ``"<type-name>"``
+    placeholder so callers still see the key exists.
+    """
+    if not obj:
+        return None
+    type_name = (xpc.type_get_name(xpc.get_type(obj)) or b"?").decode(errors="replace")
+    if type_name == "dictionary":
+        result: dict[str, Any] = {}
+
+        def on_entry(key: bytes, value: int) -> bool:
+            result[key.decode(errors="replace")] = xpc_to_python(xpc, value)
+            return True
+
+        xpc.dictionary_apply(obj, xpc.make_dictionary_apply_block(on_entry))
+        return result
+    if type_name == "array":
+        items: list[Any] = []
+
+        def on_item(_index: int, value: int) -> bool:
+            items.append(xpc_to_python(xpc, value))
+            return True
+
+        xpc.array_apply(obj, xpc.make_array_apply_block(on_item))
+        return items
+    if type_name == "string":
+        raw = xpc.string_get_string_ptr(obj)
+        return raw.decode(errors="replace") if raw else ""
+    if type_name == "int64":
+        return int(xpc.int64_get_value(obj))
+    if type_name == "uint64":
+        return int(xpc.uint64_get_value(obj))
+    if type_name == "double":
+        return float(xpc.double_get_value(obj))
+    if type_name == "bool":
+        return bool(xpc.bool_get_value(obj))
+    if type_name == "date":
+        return int(xpc.date_get_value(obj))  # nanoseconds since the epoch
+    if type_name == "data":
+        length = int(xpc.data_get_length(obj))
+        if length == 0:
+            return b""
+        buf = (ctypes.c_uint8 * length)()
+        got = int(xpc.data_get_bytes(obj, buf, 0, length))
+        return bytes(buf[:got])
+    if type_name == "uuid":
+        ptr = xpc.uuid_get_bytes(obj)
+        return str(uuid.UUID(bytes=ctypes.string_at(ptr, 16))) if ptr else None
+    if type_name == "null":
+        return None
+    return f"<{type_name}>"
+
+
+def _send_browse_request(xpc: _LibXpc, conn: int, queue: int) -> None:
+    """Send ``RemotePairing.BrowseRequest``; devices arrive via the connection's event handler.
+
+    Mercury needs a reply channel or it silently drops the request; the reply itself is ignored.
+    """
+    message = xpc.dictionary_create(None, None, 0)
+    body = xpc.dictionary_create(None, None, 0)
+    xpc.dictionary_set_bool(body, b"currentDevicesOnly", False)
+    xpc.dictionary_set_string(message, b"mangledTypeName", b"RemotePairing.BrowseRequest")
+    xpc.dictionary_set_value(message, b"value", body)
+    xpc.connection_send_message_with_reply(conn, message, queue, xpc.make_block(lambda _obj: None))
 
 
 class _RemotePairingError(UserspaceTunnelUnavailableError):
@@ -243,18 +353,7 @@ class _RemotePairingSession:
         self._browse_conn = conn
         xpc.connection_set_event_handler(conn, xpc.make_block(on_event))
         xpc.connection_activate(conn)
-
-        def browse_body(body: int) -> None:
-            xpc.dictionary_set_bool(body, b"currentDevicesOnly", False)
-
-        # Mercury needs a reply channel or it silently drops the request; the device list itself
-        # arrives asynchronously via on_event, so the reply is ignored.
-        message = xpc.dictionary_create(None, None, 0)
-        body = xpc.dictionary_create(None, None, 0)
-        browse_body(body)
-        xpc.dictionary_set_string(message, b"mangledTypeName", b"RemotePairing.BrowseRequest")
-        xpc.dictionary_set_value(message, b"value", body)
-        xpc.connection_send_message_with_reply(conn, message, self._queue, xpc.make_block(lambda _obj: None))
+        _send_browse_request(xpc, conn, self._queue)
 
         if not found.wait(self._REPLY_TIMEOUT):
             hint = f" matching udid {serial}" if serial is not None else ""
@@ -331,6 +430,53 @@ class _RemotePairingSession:
                     xpc.connection_cancel(conn)
         self._device_conn = None
         self._browse_conn = None
+
+
+def _browse_native_devices_sync(xpc: _LibXpc, timeout: float) -> list[dict[str, Any]]:
+    """Collect the ``deviceInfo`` of every device ``remotepairingd`` reports within ``timeout`` seconds."""
+    queue = xpc.dispatch_queue_create(b"pymobiledevice3.native-browse", None)
+    lock = threading.Lock()
+    devices: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def on_event(obj: int) -> None:
+        if not obj:
+            return
+        value = xpc.dictionary_get_value(obj, b"value")
+        device_found = xpc.dictionary_get_value(value, b"deviceFound") if value else 0
+        zero = xpc.dictionary_get_value(device_found, b"_0") if device_found else 0
+        info = xpc.dictionary_get_value(zero, b"deviceInfo") if zero else 0
+        if not info:
+            return
+        converted = xpc_to_python(xpc, info)
+        if not isinstance(converted, dict):
+            return
+        info_dict = cast(dict[str, Any], converted)
+        key = str(info_dict.get("udid", info_dict))
+        with lock:
+            if key not in seen:
+                seen.add(key)
+                devices.append(info_dict)
+
+    conn = xpc.connection_create_mach_service(REMOTEPAIRING_MACH_SERVICE.encode(), queue, 0)
+    xpc.connection_set_event_handler(conn, xpc.make_block(on_event))
+    xpc.connection_activate(conn)
+    _send_browse_request(xpc, conn, queue)
+    time.sleep(timeout)  # deviceFound events stream in asynchronously; collect for the whole window
+    xpc.connection_cancel(conn)
+    with lock:
+        return list(devices)
+
+
+async def browse_native_devices(timeout: float = 3.0) -> list[dict[str, Any]]:
+    """List the devices Apple's ``remotepairingd`` reports (macOS only, no root).
+
+    Each entry is the daemon's ``deviceInfo`` dictionary converted to plain Python data via
+    :func:`xpc_to_python` (XPC endpoints render as ``"<endpoint>"`` placeholders).
+
+    Raises :class:`~pymobiledevice3.exceptions.UserspaceTunnelUnavailableError` off macOS.
+    """
+    return await asyncio.to_thread(_browse_native_devices_sync, _libxpc(), timeout)
 
 
 def parse_tcp_pcbs(data: bytes) -> list[tuple[int, int, bytes, int]]:
@@ -441,10 +587,8 @@ class NativeRemotedTunnel:
         xpc = _libxpc()
         session = _RemotePairingSession(xpc)
         try:
-            tunnel_ip, ports = await asyncio.to_thread(self._establish, xpc, session)
-            if not ports:
-                raise _RemotePairingError(f"could not find remoted's RSD connection to the tunnel address {tunnel_ip}")
-            rsd = await self._connect_rsd(tunnel_ip, ports)
+            tunnel_ip = await asyncio.to_thread(self._establish, session)
+            rsd = await self._connect_rsd(xpc, tunnel_ip)
         except BaseException:
             await asyncio.to_thread(session.close)
             raise
@@ -452,22 +596,31 @@ class NativeRemotedTunnel:
         self.rsd = rsd
         return rsd
 
-    def _establish(self, xpc: _LibXpc, session: _RemotePairingSession) -> tuple[str, list[int]]:
+    def _establish(self, session: _RemotePairingSession) -> str:
         session.browse(self.serial)
-        tunnel_ip = session.open_tunnel()
-        return tunnel_ip, find_rsd_port(xpc, tunnel_ip)
+        return session.open_tunnel()
 
-    async def _connect_rsd(self, tunnel_ip: str, ports: list[int]) -> RemoteServiceDiscoveryService:
+    async def _connect_rsd(self, xpc: _LibXpc, tunnel_ip: str) -> RemoteServiceDiscoveryService:
+        # Right after the tunnel comes up the device may reset the just-established RSD connection
+        # ("Device must renegotiate TLS" in remoted's log) and remoted transparently redials -- onto
+        # a NEW device port. Apple's own client treats that reset as routine, so retry here too, and
+        # re-scan the pcblist on every attempt: a cached candidate list goes stale the moment
+        # remoted redials (the scan may also simply run before remoted has connected at all).
         last_error: Optional[Exception] = None
-        for port in ports:
-            rsd = RemoteServiceDiscoveryService((tunnel_ip, port))
-            try:
-                await rsd.connect()
-            except Exception as e:  # try the next candidate port
-                last_error = e
-                await rsd.close()
-            else:
-                return rsd
+        for attempt in range(_RSD_CONNECT_ATTEMPTS):
+            if attempt:
+                await asyncio.sleep(_RSD_CONNECT_RETRY_DELAY)
+            for port in await asyncio.to_thread(find_rsd_port, xpc, tunnel_ip):
+                rsd = RemoteServiceDiscoveryService((tunnel_ip, port))
+                try:
+                    await rsd.connect()
+                except Exception as e:  # try the next candidate port
+                    last_error = e
+                    await rsd.close()
+                else:
+                    return rsd
+        if last_error is None:
+            raise _RemotePairingError(f"could not find remoted's RSD connection to the tunnel address {tunnel_ip}")
         raise _RemotePairingError(
             f"failed to complete RSD handshake over the native tunnel [{tunnel_ip}]: {last_error!r}"
         )

--- a/tests/cli/test_remote.py
+++ b/tests/cli/test_remote.py
@@ -133,6 +133,34 @@ def test_cli_start_tunnel_non_native_preference_uses_classic_path(monkeypatch):
         remote.cli_start_tunnel()
 
 
+def test_cli_start_tunnel_auto_reroute_to_classic_is_logged(monkeypatch, caplog):
+    # When a classic-tunnel option diverts the macOS native default to the root path, say so (and
+    # name the option) instead of dying with a bare "requires root" error.
+    monkeypatch.setattr(remote, "default_transport_preference", lambda: "native")
+    monkeypatch.setattr(type(remote.OSUTILS), "is_admin", property(lambda self: False))
+
+    from pymobiledevice3.exceptions import AccessDeniedError
+
+    with caplog.at_level("INFO", logger=remote.logger.name), pytest.raises(AccessDeniedError):
+        remote.cli_start_tunnel(secrets=Path("secrets.txt"))
+
+    assert any("--secrets" in r.message and "classic tunnel" in r.message for r in caplog.records)
+
+
+def test_cli_start_tunnel_native_default_does_not_log_reroute(monkeypatch, caplog):
+    # No classic option: the native default is taken silently, with no spurious reroute notice.
+    async def fake_native_tunnel_task(udid=None, script_mode=False):
+        pass
+
+    monkeypatch.setattr(remote, "native_tunnel_task", fake_native_tunnel_task)
+    monkeypatch.setattr(remote, "default_transport_preference", lambda: "native")
+
+    with caplog.at_level("INFO", logger=remote.logger.name):
+        remote.cli_start_tunnel()
+
+    assert not any("classic tunnel" in r.message for r in caplog.records)
+
+
 @pytest.mark.asyncio
 async def test_native_tunnel_task_prints_rsd_and_holds(monkeypatch, capsys):
     class FakeService:

--- a/tests/cli/test_remote.py
+++ b/tests/cli/test_remote.py
@@ -1,8 +1,13 @@
+import asyncio
+from pathlib import Path
+
 import pytest
+import typer
 
 from pymobiledevice3.cli import remote
 from pymobiledevice3.exceptions import NoDeviceConnectedError
-from pymobiledevice3.remote.common import ConnectionType
+from pymobiledevice3.remote import native_tunnel
+from pymobiledevice3.remote.common import ConnectionType, TunnelProtocol
 
 
 @pytest.mark.asyncio
@@ -45,3 +50,156 @@ async def test_start_tunnel_task_raises_after_discovery_retries(monkeypatch):
         await remote.start_tunnel_task(ConnectionType.USB, secrets=None)
 
     assert tunnel_services_calls == remote.TUNNEL_SERVICE_DISCOVERY_ATTEMPTS
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"connection_type": ConnectionType.WIFI},
+        {"secrets": Path("secrets.txt")},
+        {"protocol": TunnelProtocol.QUIC},
+        {"max_idle_timeout": 99.0},
+    ],
+)
+def test_cli_start_tunnel_native_rejects_incompatible_options(kwargs):
+    with pytest.raises(typer.BadParameter):
+        remote.cli_start_tunnel(native=True, **kwargs)
+
+
+def test_cli_start_tunnel_native_skips_sudo_check(monkeypatch):
+    # --native must not require root: the native task is reached without the admin gate.
+    called_with = None
+
+    async def fake_native_tunnel_task(udid=None, script_mode=False):
+        nonlocal called_with
+        called_with = (udid, script_mode)
+
+    monkeypatch.setattr(remote, "native_tunnel_task", fake_native_tunnel_task)
+    monkeypatch.setattr(type(remote.OSUTILS), "is_admin", property(lambda self: False))
+
+    remote.cli_start_tunnel(native=True, udid="UDID", script_mode=True)
+
+    assert called_with == ("UDID", True)
+
+
+def test_cli_start_tunnel_defaults_to_native_on_macos(monkeypatch):
+    # No --native/--no-native given: the macOS transport preference routes to the native task,
+    # with no root required.
+    called = False
+
+    async def fake_native_tunnel_task(udid=None, script_mode=False):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(remote, "native_tunnel_task", fake_native_tunnel_task)
+    monkeypatch.setattr(remote, "default_transport_preference", lambda: "native")
+    monkeypatch.setattr(type(remote.OSUTILS), "is_admin", property(lambda self: False))
+
+    remote.cli_start_tunnel()
+
+    assert called
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"native": False},  # explicit opt-out
+        {"connection_type": ConnectionType.WIFI},  # classic-tunnel option implies the classic path
+        {"secrets": Path("secrets.txt")},
+        {"protocol": TunnelProtocol.QUIC},
+        {"max_idle_timeout": 99.0},
+    ],
+)
+def test_cli_start_tunnel_auto_native_yields_to_classic_path(monkeypatch, kwargs):
+    # Under the auto default, --no-native or any classic-tunnel option must route to the classic
+    # (root) tunnel instead of erroring: hitting the sudo gate proves the classic path was taken.
+    monkeypatch.setattr(remote, "default_transport_preference", lambda: "native")
+    monkeypatch.setattr(type(remote.OSUTILS), "is_admin", property(lambda self: False))
+
+    from pymobiledevice3.exceptions import AccessDeniedError
+
+    with pytest.raises(AccessDeniedError):
+        remote.cli_start_tunnel(**kwargs)
+
+
+def test_cli_start_tunnel_non_native_preference_uses_classic_path(monkeypatch):
+    # Off macOS (or with PYMOBILEDEVICE3_DEFAULT_FALLBACK opting out) the default stays classic.
+    monkeypatch.setattr(remote, "default_transport_preference", lambda: "userspace")
+    monkeypatch.setattr(type(remote.OSUTILS), "is_admin", property(lambda self: False))
+
+    from pymobiledevice3.exceptions import AccessDeniedError
+
+    with pytest.raises(AccessDeniedError):
+        remote.cli_start_tunnel()
+
+
+@pytest.mark.asyncio
+async def test_native_tunnel_task_prints_rsd_and_holds(monkeypatch, capsys):
+    class FakeService:
+        address = ("fdf4:cb47:dd51::1", 61234)
+
+    class FakeRsd:
+        udid = "UDID"
+        service = FakeService()
+
+    async def fake_establish_native_rsd(serial=None):
+        return FakeRsd()
+
+    monkeypatch.setattr(native_tunnel, "establish_native_rsd", fake_establish_native_rsd)
+    monkeypatch.setattr(remote, "user_requested_colored_output", lambda: False)
+
+    # The task prints the RSD endpoint and then holds the assertion forever (until Ctrl-C).
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(remote.native_tunnel_task("UDID", script_mode=True), timeout=0.1)
+    assert capsys.readouterr().out == "fdf4:cb47:dd51::1 61234\n"
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(remote.native_tunnel_task("UDID"), timeout=0.1)
+    out = capsys.readouterr().out
+    assert "RSD Address: fdf4:cb47:dd51::1" in out
+    assert "RSD Port: 61234" in out
+    assert "--rsd fdf4:cb47:dd51::1 61234" in out
+
+
+def test_cli_browse_native_uses_remotepairingd(monkeypatch):
+    browsed_timeout = None
+
+    async def fake_browse_native_devices(timeout):
+        nonlocal browsed_timeout
+        browsed_timeout = timeout
+        return [{"udid": "UDID"}]
+
+    printed = []
+    monkeypatch.setattr(native_tunnel, "browse_native_devices", fake_browse_native_devices)
+    monkeypatch.setattr(remote, "print_json", printed.append)
+
+    remote.browse(timeout=1.5, native=True)
+
+    assert browsed_timeout == 1.5
+    assert printed == [[{"udid": "UDID"}]]
+
+
+def test_cli_browse_defaults_by_transport_preference(monkeypatch):
+    # No --native/--no-native: the transport preference decides (native on macOS, bonjour elsewhere);
+    # --no-native forces bonjour even when the preference is native.
+    calls = []
+
+    async def fake_browse_native_devices(timeout):
+        calls.append("native")
+        return []
+
+    async def fake_cli_browse(timeout):
+        calls.append("bonjour")
+
+    monkeypatch.setattr(native_tunnel, "browse_native_devices", fake_browse_native_devices)
+    monkeypatch.setattr(remote, "cli_browse", fake_cli_browse)
+    monkeypatch.setattr(remote, "print_json", lambda obj: None)
+
+    monkeypatch.setattr(remote, "default_transport_preference", lambda: "native")
+    remote.browse()
+    monkeypatch.setattr(remote, "default_transport_preference", lambda: "userspace")
+    remote.browse()
+    monkeypatch.setattr(remote, "default_transport_preference", lambda: "native")
+    remote.browse(native=False)
+
+    assert calls == ["native", "bonjour", "bonjour"]

--- a/tests/test_native_tunnel.py
+++ b/tests/test_native_tunnel.py
@@ -1,6 +1,8 @@
+import ctypes
+import platform
 import socket
 import struct
-from typing import Optional
+from typing import Any, Optional, cast
 
 import pytest
 
@@ -48,6 +50,116 @@ def test_parse_tcp_pcbs_stops_on_truncated_record() -> None:
     # keep the already-parsed connection and stop rather than read out of bounds.
     truncated = full[:-8] + struct.pack("<II", 4096, native_tunnel._XSO_INPCB)
     assert native_tunnel.parse_tcp_pcbs(truncated) == [(4321, native_tunnel._INP_IPV6, addr, 50881)]
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="libxpc is macOS-only")
+def test_xpc_to_python_converts_nested_objects() -> None:
+    xpc = native_tunnel._libxpc()
+    lib = xpc._lib
+    vp = ctypes.c_void_p
+
+    def bind(name: str, argtypes: list[Any]) -> Any:
+        fn = getattr(lib, name)
+        fn.restype = vp
+        fn.argtypes = argtypes
+        return fn
+
+    string_create = bind("xpc_string_create", [ctypes.c_char_p])
+    data_create = bind("xpc_data_create", [ctypes.c_char_p, ctypes.c_size_t])
+    uuid_create = bind("xpc_uuid_create", [ctypes.c_char_p])
+    fd_create = bind("xpc_fd_create", [ctypes.c_int])
+    array_create = bind("xpc_array_create", [vp, ctypes.c_size_t])
+    array_append = lib.xpc_array_append_value
+    array_append.restype = None
+    array_append.argtypes = [vp, vp]
+
+    root = xpc.dictionary_create(None, None, 0)
+    xpc.dictionary_set_string(root, b"udid", b"00008120-000000000000001E")
+    xpc.dictionary_set_int64(root, b"answer", -42)
+    xpc.dictionary_set_bool(root, b"paired", True)
+    xpc.dictionary_set_value(root, b"blob", data_create(b"\x00\x01\x02", 3))
+    xpc.dictionary_set_value(root, b"identifier", uuid_create(b"\x01" * 16))
+    xpc.dictionary_set_value(root, b"endpoint", fd_create(0))  # no data representation -> placeholder
+
+    array = array_create(None, 0)
+    array_append(array, string_create(b"first"))
+    array_append(array, string_create(b"second"))
+    xpc.dictionary_set_value(root, b"names", array)
+
+    nested = xpc.dictionary_create(None, None, 0)
+    xpc.dictionary_set_string(nested, b"inner", b"value")
+    xpc.dictionary_set_value(root, b"info", nested)
+
+    assert native_tunnel.xpc_to_python(xpc, root) == {
+        "udid": "00008120-000000000000001E",
+        "answer": -42,
+        "paired": True,
+        "blob": b"\x00\x01\x02",
+        "identifier": "01010101-0101-0101-0101-010101010101",
+        "endpoint": "<fd>",
+        "names": ["first", "second"],
+        "info": {"inner": "value"},
+    }
+
+
+def test_xpc_to_python_null_pointer_is_none() -> None:
+    if platform.system() != "Darwin":
+        pytest.skip("libxpc is macOS-only")
+    assert native_tunnel.xpc_to_python(native_tunnel._libxpc(), 0) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scans", [[[51011], [51013]], [[], [51013]]])
+async def test_aopen_retries_handshake_with_fresh_port_scan(
+    monkeypatch: pytest.MonkeyPatch, scans: list[list[int]]
+) -> None:
+    """Right after tunnel establishment the device may reset the initial RSD connection ("Device
+    must renegotiate TLS") and remoted transparently redials — onto a NEW device port. aopen must
+    re-scan and retry instead of failing on the first RST (or on a scan that ran before remoted
+    connected at all)."""
+    scan_iter = iter(scans)
+    scan_count = 0
+
+    class FakeSession:
+        def __init__(self, xpc: object) -> None:
+            pass
+
+        def browse(self, serial: Optional[str]) -> None:
+            pass
+
+        def open_tunnel(self) -> str:
+            return "fdcd:5fb2:b94b::1"
+
+        def close(self) -> None:
+            pass
+
+    class FakeRsd:
+        def __init__(self, address: tuple[str, int]) -> None:
+            self.address = address
+
+        async def connect(self) -> None:
+            if self.address[1] == 51011:
+                raise ConnectionError("RST_STREAM error_code=5")
+
+        async def close(self) -> None:
+            pass
+
+    def fake_find_rsd_port(xpc: object, tunnel_ip: str) -> list[int]:
+        nonlocal scan_count
+        scan_count += 1
+        return next(scan_iter)
+
+    monkeypatch.setattr(native_tunnel, "_libxpc", lambda: object())
+    monkeypatch.setattr(native_tunnel, "_RemotePairingSession", FakeSession)
+    monkeypatch.setattr(native_tunnel, "find_rsd_port", fake_find_rsd_port)
+    monkeypatch.setattr(native_tunnel, "RemoteServiceDiscoveryService", FakeRsd)
+    monkeypatch.setattr(native_tunnel, "_RSD_CONNECT_RETRY_DELAY", 0, raising=False)
+
+    tunnel = native_tunnel.NativeRemotedTunnel()
+    rsd = cast(Any, await tunnel.aopen())
+    assert rsd.address == ("fdcd:5fb2:b94b::1", 51013)
+    assert scan_count == 2
+    await tunnel.aclose()
 
 
 def test_libxpc_requires_darwin(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What

Extends the native remoted tunnel (piggybacking Apple's `remotepairingd` — no root, no Xcode) to the two `remote` commands that previously had **no no-root option on macOS**, and makes native the macOS default for both.

### `remote start-tunnel`
- New `--native/--no-native`, **defaulting to native on macOS** (honoring `PYMOBILEDEVICE3_DEFAULT_FALLBACK`).
- Publishes Apple's already-existing, kernel-routable tunnel with **no `sudo`**, so other processes can use the printed `--rsd HOST PORT`.
- Passing a classic-tunnel option (`-t wifi`, `--secrets`, `--protocol`, `--max-idle-timeout`) or `--no-native` routes to the classic root tunnel, preserving existing workflows. Explicit `--native` still rejects those options.

### `remote browse`
- New `--native/--no-native`, **defaulting to native on macOS**.
- Lists the devices `remotepairingd` reports (rootless) instead of the bonjour browse, which needs root to suspend `remoted`. On master `browse` always required root; this makes it rootless on macOS for the first time.
- Adds a generic libxpc→Python converter and `browse_native_devices()` to render each `deviceInfo` dict.

### Hardening
Right after the tunnel comes up the device may reset the initial RSD connection ("Device must renegotiate TLS" in `remoted`'s log) while `remoted` transparently redials onto a **new** port. `_connect_rsd` now retries and re-scans `net.inet.tcp.pcblist_n` on each attempt instead of failing on the first `RstStreamFrame(error_code=5)` (this also covers a scan that runs before `remoted` has connected). Root-caused from the unified log at the exact failure timestamp.

## Testing
- New unit tests: the libxpc→Python converter (real-libxpc round-trip, macOS-only), the reset-then-new-port retry, the macOS-default routing for both commands, and the auto-default yielding to the classic path.
- Full targeted suite passes (40 tests); pyright clean; pre-commit hooks green.
- Verified live against a physical device: both commands run rootless; the printed `--rsd` completes a full handshake from a separate process; 15/15 back-to-back tunnel open/close cycles succeed.

## Docs
Updated `docs/guides/ios17-tunnels.md`, `docs/guides/network-stacks.md`, and the device-operator skill (vendored plugin copy synced).

## Note
On macOS the native path selects the device by `--udid`; it does not yet honor `-t usb|wifi` (remotepairingd chooses the interface). `remoted` *does* model transport internally (`_desiredTransportType`/`_tunnelType`), so steering it may be feasible — pending a device reachable over both USB and Wi-Fi to verify. Passing `-t` currently routes to the classic path, which genuinely selects the transport.