### PR TITLE
remote: expose device auxiliary metadata (deviceKVSData) over RSD

### DIFF
--- a/docs/guides/network-stacks.md
+++ b/docs/guides/network-stacks.md
@@ -262,3 +262,37 @@ How it works (all via `ctypes` + libxpc, no pyobjc):
   is USB-bound and on par with the userspace tunnel (~36 MB/s both), while host->device is ~1.8x
   faster (~36 vs ~20 MB/s — the userspace stack keeps its send segments deliberately small) and
   per-request latency is ~1.6x lower (~8 vs ~13 ms). All with no root.
+
+## Device auxiliary metadata (`RemoteServiceDiscoveryService.auxiliary_metadata`)
+
+Alongside the tunnel, the pairing layer carries the device's **`deviceKVSData`** — a binary-plist
+key-value store keyed by preference domain (e.g. `com.apple.WebInspector`,
+`com.apple.mobile.wireless_lockdown`), plus a `NULL` bucket of loose device properties. It is
+**not** part of the RSD handshake (`peer_info`); it rides the RemotePairing handshake / the host
+`remotepairingd`. When the transport that built the RSD had it, it is decoded onto
+`RemoteServiceDiscoveryService.auxiliary_metadata` (`{domain: {key: value}}`), with
+`get_auxiliary_metadata(domain)` and a typed
+`is_remote_web_inspector_enabled()` (whether Safari/WebKit remote inspection is enabled — no
+service is opened) reading from it.
+
+Availability differs by transport, because only some perform a metadata-carrying pairing handshake:
+
+- **Native (macOS default):** the host `remotepairingd` exposes its *merged, persisted* KVS, which
+  reliably includes `com.apple.WebInspector`. `is_remote_web_inspector_enabled()` returns a real
+  `True`/`False` here.
+- **`tunneld` / RemotePairing-over-bonjour:** the RemotePairing handshake carries the device's
+  **base** KVS. A fresh handshake omits lazily-registered domains like `com.apple.WebInspector`, so
+  `is_remote_web_inspector_enabled()` is typically `None` (unknown).
+- **Userspace no-root default (CoreDeviceProxy, iOS 17.4+):** the tunnel is established without a
+  pair-verify handshake, so no `deviceKVSData` is exchanged — `auxiliary_metadata` is empty and the
+  helper returns `None`.
+
+`None` means *unknown on this transport*, not *disabled*. Use `--native` on macOS when you need a
+definitive Web Inspector answer.
+
+From the CLI, `pymobiledevice3 remote auxiliary-metadata` prints the whole decoded map as JSON (it
+uses the same transport selection as `rsd-info`, so it defaults to `--native` on macOS):
+
+```shell
+pymobiledevice3 remote auxiliary-metadata | jq '.["com.apple.WebInspector"].EnableRemoteInspection'
+```

--- a/pymobiledevice3/cli/remote.py
+++ b/pymobiledevice3/cli/remote.py
@@ -179,6 +179,16 @@ def rsd_info(service_provider: RSDServiceProviderDep) -> None:
     print_json(service_provider.peer_info)
 
 
+@cli.command("auxiliary-metadata")
+def auxiliary_metadata(service_provider: RSDServiceProviderDep) -> None:
+    """show device auxiliary metadata (decoded deviceKVSData), keyed by preference domain
+
+    e.g. ``com.apple.WebInspector.EnableRemoteInspection`` (Web Inspector on/off). Reliably populated
+    on the macOS ``--native`` transport; empty or partial on others (see the network-stacks guide).
+    """
+    print_json(service_provider.auxiliary_metadata)
+
+
 async def tunnel_task(
     service: Union[RemotePairingProtocol, CoreDeviceTunnelProxy],
     secrets: Optional[TextIO] = None,

--- a/pymobiledevice3/remote/native_tunnel.py
+++ b/pymobiledevice3/remote/native_tunnel.py
@@ -32,7 +32,7 @@ import uuid
 from typing import Any, Callable, Optional, cast
 
 from pymobiledevice3.exceptions import UserspaceTunnelUnavailableError
-from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService, parse_device_kvs_data
 
 _IS_DARWIN = platform.system() == "Darwin"
 
@@ -114,6 +114,9 @@ class _LibXpc:
         self.dictionary_get_value: Callable[..., int] = self._cfg("xpc_dictionary_get_value", vp, [vp, cp])
         self.dictionary_get_string: Callable[..., bytes] = self._cfg("xpc_dictionary_get_string", cp, [vp, cp])
         self.dictionary_get_int64: Callable[..., int] = self._cfg("xpc_dictionary_get_int64", ctypes.c_int64, [vp, cp])
+        self.dictionary_get_data: Callable[..., Optional[int]] = self._cfg(
+            "xpc_dictionary_get_data", vp, [vp, cp, ctypes.POINTER(ctypes.c_size_t)]
+        )
         self.retain: Callable[..., int] = self._cfg("xpc_retain", vp, [vp])
         self.release: Callable[..., None] = self._cfg("xpc_release", None, [vp])
         self.copy_description: Callable[..., bytes] = self._cfg("xpc_copy_description", cp, [vp])
@@ -194,6 +197,14 @@ class _LibXpc:
         )
         self._block_keepalive.extend([trampoline, descriptor, block])
         return ctypes.cast(ctypes.byref(block), ctypes.c_void_p)
+
+    def get_data_bytes(self, dictionary: int, key: bytes) -> Optional[bytes]:
+        """Copy the raw bytes of an xpc ``data`` value, or ``None`` if the key is absent/empty."""
+        length = ctypes.c_size_t(0)
+        ptr = self.dictionary_get_data(dictionary, key, ctypes.byref(length))
+        if not ptr or length.value == 0:
+            return None
+        return ctypes.string_at(ptr, length.value)
 
 
 _libxpc_singleton: Optional[_LibXpc] = None
@@ -297,6 +308,9 @@ class _RemotePairingSession:
         self._device_conn: Optional[int] = None
         self._assertion_id: Optional[int] = None  # retained xpc uuid object
         self.tunnel_ip: Optional[str] = None
+        # Device auxiliary metadata (decoded ``deviceKVSData``) captured from the browse ``deviceInfo``.
+        # remotepairingd's merged KVS reliably carries domains like ``com.apple.WebInspector`` here.
+        self.auxiliary_metadata: dict[str, dict[str, Any]] = {}
 
     def _request(self, conn: int, mangled_type_name: bytes, body_setup: Callable[[int], None]) -> int:
         """Send ``{mangledTypeName, value}`` and block for the reply. Returns the (retained) reply."""
@@ -345,6 +359,7 @@ class _RemotePairingSession:
                 return
             endpoint = xpc.dictionary_get_value(info, b"endpoint")
             if endpoint and not found.is_set():
+                self.auxiliary_metadata = parse_device_kvs_data(xpc.get_data_bytes(info, b"deviceKVSData"))
                 xpc.retain(endpoint)
                 endpoint_holder.append(endpoint)
                 found.set()
@@ -588,7 +603,7 @@ class NativeRemotedTunnel:
         session = _RemotePairingSession(xpc)
         try:
             tunnel_ip = await asyncio.to_thread(self._establish, session)
-            rsd = await self._connect_rsd(xpc, tunnel_ip)
+            rsd = await self._connect_rsd(xpc, tunnel_ip, session.auxiliary_metadata)
         except BaseException:
             await asyncio.to_thread(session.close)
             raise
@@ -600,7 +615,9 @@ class NativeRemotedTunnel:
         session.browse(self.serial)
         return session.open_tunnel()
 
-    async def _connect_rsd(self, xpc: _LibXpc, tunnel_ip: str) -> RemoteServiceDiscoveryService:
+    async def _connect_rsd(
+        self, xpc: _LibXpc, tunnel_ip: str, auxiliary_metadata: Optional[dict[str, dict[str, Any]]] = None
+    ) -> RemoteServiceDiscoveryService:
         # Right after the tunnel comes up the device may reset the just-established RSD connection
         # ("Device must renegotiate TLS" in remoted's log) and remoted transparently redials -- onto
         # a NEW device port. Apple's own client treats that reset as routine, so retry here too, and
@@ -611,7 +628,7 @@ class NativeRemotedTunnel:
             if attempt:
                 await asyncio.sleep(_RSD_CONNECT_RETRY_DELAY)
             for port in await asyncio.to_thread(find_rsd_port, xpc, tunnel_ip):
-                rsd = RemoteServiceDiscoveryService((tunnel_ip, port))
+                rsd = RemoteServiceDiscoveryService((tunnel_ip, port), auxiliary_metadata=auxiliary_metadata)
                 try:
                     await rsd.connect()
                 except Exception as e:  # try the next candidate port

--- a/pymobiledevice3/remote/remote_service_discovery.py
+++ b/pymobiledevice3/remote/remote_service_discovery.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import plistlib
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime
@@ -34,6 +35,46 @@ class RSDDevice:
 # from remoted ([RSDRemoteNCMDeviceDevice createPortListener])
 RSD_PORT = 58783
 
+logger = logging.getLogger(__name__)
+
+# Auxiliary metadata domain/key that `webinspectord` registers with the pairing daemon to advertise
+# whether Safari/WebKit remote inspection ("Web Inspector") is enabled (see
+# `-[RWIWebinspectordRelayDelegateIOS relay:remoteInspectionEnablementDidChange:]`).
+WEBINSPECTOR_METADATA_DOMAIN = "com.apple.WebInspector"
+WEBINSPECTOR_ENABLE_REMOTE_INSPECTION_KEY = "EnableRemoteInspection"
+
+
+def parse_device_kvs_data(raw: Optional[Union[bytes, str]]) -> dict[str, dict[str, Any]]:
+    """Decode a device's ``deviceKVSData`` blob into a ``{domain: {key: value}}`` mapping.
+
+    ``deviceKVSData`` is the binary-plist key-value store the device advertises to a paired host: a
+    dictionary keyed by preference domain (e.g. ``com.apple.WebInspector``), plus a ``NULL`` bucket
+    holding loose device properties. It reaches us either as raw bytes (the native ``remotepairingd``
+    XPC ``deviceInfo``) or as a base64 string (the userspace/tunneld RemotePairing handshake
+    ``peerDeviceInfo``); both are accepted.
+
+    Returns an empty mapping for missing/undecodable input rather than raising, since the metadata is
+    advisory and absence is a valid state (a fresh device handshake only reports the domains that
+    have registered so far).
+    """
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        try:
+            raw = base64.b64decode(raw)
+        except (ValueError, TypeError):
+            logger.debug("deviceKVSData is not valid base64; ignoring")
+            return {}
+    try:
+        decoded = plistlib.loads(raw)
+    except Exception:
+        logger.debug("deviceKVSData is not a valid plist; ignoring")
+        return {}
+    if not isinstance(decoded, dict):
+        logger.debug("deviceKVSData decoded to %s, expected dict; ignoring", type(decoded).__name__)
+        return {}
+    return cast(dict[str, dict[str, Any]], decoded)
+
 
 class RemoteServiceDiscoveryService(LockdownServiceProvider):
     """
@@ -58,7 +99,11 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
     """
 
     def __init__(
-        self, address: tuple[str, int], name: Optional[str] = None, open_connection: Optional[Callable[..., Any]] = None
+        self,
+        address: tuple[str, int],
+        name: Optional[str] = None,
+        open_connection: Optional[Callable[..., Any]] = None,
+        auxiliary_metadata: Optional[dict[str, dict[str, Any]]] = None,
     ) -> None:
         """
         :param address: ``(host, port)`` of the RSD endpoint to connect to.
@@ -67,9 +112,20 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
             RemoteXPC handshake and every service connection opened through this RSD. ``None`` uses
             the stdlib dialer; the userspace tunnel injects a relay dialer so device-bound
             connections route through its in-process stack.
+        :param auxiliary_metadata: decoded device ``deviceKVSData`` (``{domain: {key: value}}``), when
+            the transport that built this RSD had it. The pairing handshake carries it, but the RSD
+            handshake does not, so paths without a pairing handshake leave it empty. See
+            `parse_device_kvs_data` and `auxiliary_metadata`.
         """
         super().__init__()
         self.name = name
+        # Device-advertised auxiliary metadata keyed by preference domain, e.g.
+        # ``{"com.apple.WebInspector": {"EnableRemoteInspection": False}}``. Only the pairing
+        # handshake (native ``remotepairingd`` / userspace / tunneld) supplies this; the plain RSD
+        # handshake does not, so it is ``{}`` on those paths. See `is_remote_web_inspector_enabled`.
+        self.auxiliary_metadata: dict[str, dict[str, Any]] = (
+            auxiliary_metadata if auxiliary_metadata is not None else {}
+        )
         # ``asyncio.open_connection``-compatible dialer used for the RemoteXPC handshake and every
         # service connection opened through this RSD (read by callers such as FileServiceService).
         # ``None`` => stdlib ``asyncio.open_connection``; the userspace tunnel injects a relay dialer
@@ -87,6 +143,24 @@ class RemoteServiceDiscoveryService(LockdownServiceProvider):
         is then only reachable from THIS process, so it must not be handed to external tools such as
         lldb as a connect endpoint."""
         return self.open_connection is not None
+
+    def get_auxiliary_metadata(self, domain: str) -> dict[str, Any]:
+        """Return the device-advertised auxiliary metadata for ``domain`` (empty dict if absent).
+
+        See `auxiliary_metadata` for how this is populated and why it may be empty.
+        """
+        return self.auxiliary_metadata.get(domain, {})
+
+    def is_remote_web_inspector_enabled(self) -> Optional[bool]:
+        """Whether Safari/WebKit remote inspection ("Web Inspector") is enabled on the device.
+
+        Read from the device-advertised auxiliary metadata (no service is opened). Returns ``None``
+        when the device did not advertise the ``com.apple.WebInspector`` domain: reliably present on
+        the native (macOS ``remotepairingd``) path, but a fresh userspace/tunneld handshake omits it,
+        in which case the state is unknown here.
+        """
+        value = self.get_auxiliary_metadata(WEBINSPECTOR_METADATA_DOMAIN).get(WEBINSPECTOR_ENABLE_REMOTE_INSPECTION_KEY)
+        return None if value is None else bool(value)
 
     def _require_peer_info(self) -> dict[str, Any]:
         """Return the handshake ``peer_info``, raising if the RSD has not been connected yet."""

--- a/pymobiledevice3/remote/tunnel_service.py
+++ b/pymobiledevice3/remote/tunnel_service.py
@@ -87,7 +87,7 @@ from pymobiledevice3.pair_records import (
 )
 from pymobiledevice3.remote.common import TunnelProtocol
 from pymobiledevice3.remote.remote_service import RemoteService
-from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService, parse_device_kvs_data
 from pymobiledevice3.remote.siphash import compute_auth_tag
 from pymobiledevice3.remote.utils import get_rsds, resume_remoted_if_required, stop_remoted_if_required
 from pymobiledevice3.remote.xpc_message import XpcInt64Type, XpcUInt64Type
@@ -533,6 +533,10 @@ class RemotePairingTcpTunnel(RemotePairingTunnel):
                 await self._writer.wait_closed()
 
 
+def _empty_auxiliary_metadata() -> dict[str, dict[str, Any]]:
+    return {}
+
+
 @dataclasses.dataclass
 class TunnelResult:
     interface: str
@@ -540,6 +544,9 @@ class TunnelResult:
     port: int
     protocol: TunnelProtocol
     client: RemotePairingTunnel
+    # Device auxiliary metadata (decoded ``deviceKVSData``) from the pairing handshake, when the
+    # establishing service performed one (empty for the CoreDeviceProxy path, which does not).
+    auxiliary_metadata: dict[str, dict[str, Any]] = dataclasses.field(default_factory=_empty_auxiliary_metadata)
 
 
 class StartTcpTunnel(ABC):
@@ -690,6 +697,7 @@ class RemotePairingProtocol(StartTcpTunnel):
                         handshake_response["serverRSDPort"],
                         TunnelProtocol.QUIC,
                         client,
+                        self.auxiliary_metadata,
                     )
                 finally:
                     await client.stop_tunnel()
@@ -758,6 +766,7 @@ class RemotePairingProtocol(StartTcpTunnel):
                 handshake_response["serverRSDPort"],
                 TunnelProtocol.TCP,
                 tunnel,
+                self.auxiliary_metadata,
             )
         finally:
             await tunnel.stop_tunnel()
@@ -787,6 +796,13 @@ class RemotePairingProtocol(StartTcpTunnel):
     def remote_device_model(self) -> str:
         assert self.handshake_info is not None
         return self.handshake_info["peerDeviceInfo"]["model"]
+
+    @property
+    def auxiliary_metadata(self) -> dict[str, dict[str, Any]]:
+        """Decoded ``deviceKVSData`` from the handshake, or ``{}`` before the handshake completed."""
+        if self.handshake_info is None:
+            return {}
+        return parse_device_kvs_data(self.handshake_info.get("peerDeviceInfo", {}).get("deviceKVSData"))
 
     @property
     def pair_record_path(self) -> Path:

--- a/pymobiledevice3/remote/userspace_tunnel.py
+++ b/pymobiledevice3/remote/userspace_tunnel.py
@@ -843,7 +843,9 @@ class UserspaceRsdTunnel:
             # Inject the relay dialer into THIS rsd only (no global asyncio.open_connection patch),
             # so a library consumer's other connections in the same process stay on the stdlib default.
             rsd = RemoteServiceDiscoveryService(
-                (tunnel_result.address, tunnel_result.port), open_connection=dial_plane.dial
+                (tunnel_result.address, tunnel_result.port),
+                open_connection=dial_plane.dial,
+                auxiliary_metadata=tunnel_result.auxiliary_metadata,
             )
             stack.push_async_callback(rsd.close)
             await rsd.connect()

--- a/pymobiledevice3/tunneld/api.py
+++ b/pymobiledevice3/tunneld/api.py
@@ -91,7 +91,9 @@ async def _create_rsds_from_tunnels(tunnels: dict[str, list[dict[str, Any]]]) ->
     for _udid, details in tunnels.items():
         for tunnel_details in details:
             rsd = RemoteServiceDiscoveryService(
-                (tunnel_details["tunnel-address"], tunnel_details["tunnel-port"]), name=tunnel_details["interface"]
+                (tunnel_details["tunnel-address"], tunnel_details["tunnel-port"]),
+                name=tunnel_details["interface"],
+                auxiliary_metadata=tunnel_details.get("auxiliary-metadata"),
             )
             try:
                 await rsd.connect()

--- a/pymobiledevice3/tunneld/server.py
+++ b/pymobiledevice3/tunneld/server.py
@@ -572,6 +572,7 @@ class TunneldRunner:
                     "tunnel-address": active_tunnel.tunnel.address,
                     "tunnel-port": active_tunnel.tunnel.port,
                     "interface": ip,
+                    "auxiliary-metadata": active_tunnel.tunnel.auxiliary_metadata,
                 })
 
             upstream_urls = list(self._tunneld_core.upstream_urls)
@@ -663,6 +664,7 @@ class TunneldRunner:
                     "interface": udid_tunnels[0].interface,
                     "port": udid_tunnels[0].port,
                     "address": udid_tunnels[0].address,
+                    "auxiliary-metadata": udid_tunnels[0].auxiliary_metadata,
                 }
                 return generate_http_response(data)
 
@@ -733,7 +735,12 @@ class TunneldRunner:
 
             tunnel: Optional[TunnelResult] = await queue.get()
             if tunnel is not None:
-                data: dict[str, Any] = {"interface": tunnel.interface, "port": tunnel.port, "address": tunnel.address}
+                data: dict[str, Any] = {
+                    "interface": tunnel.interface,
+                    "port": tunnel.port,
+                    "address": tunnel.address,
+                    "auxiliary-metadata": tunnel.auxiliary_metadata,
+                }
                 return generate_http_response(data)
             else:
                 return fastapi.Response(

--- a/tests/remote/test_auxiliary_metadata.py
+++ b/tests/remote/test_auxiliary_metadata.py
@@ -1,0 +1,110 @@
+import base64
+import plistlib
+from typing import Any, cast
+
+from pymobiledevice3.remote.remote_service_discovery import (
+    WEBINSPECTOR_ENABLE_REMOTE_INSPECTION_KEY,
+    WEBINSPECTOR_METADATA_DOMAIN,
+    RemoteServiceDiscoveryService,
+    parse_device_kvs_data,
+)
+from pymobiledevice3.remote.tunnel_service import (
+    RemotePairingProtocol,
+    RemotePairingTunnel,
+    TunnelProtocol,
+    TunnelResult,
+)
+
+
+def _kvs(payload: dict[str, Any]) -> bytes:
+    return plistlib.dumps(payload, fmt=plistlib.FMT_BINARY)
+
+
+SAMPLE = {
+    "com.apple.WebInspector": {"EnableRemoteInspection": False},
+    "com.apple.mobile.wireless_lockdown": {"EnableWifiDebugging": True},
+    "NULL": {"ProductVersion": "26.6.1"},
+}
+
+
+def test_parse_device_kvs_data_from_bytes() -> None:
+    parsed = parse_device_kvs_data(_kvs(SAMPLE))
+    assert parsed[WEBINSPECTOR_METADATA_DOMAIN][WEBINSPECTOR_ENABLE_REMOTE_INSPECTION_KEY] is False
+    assert parsed["NULL"]["ProductVersion"] == "26.6.1"
+
+
+def test_parse_device_kvs_data_from_base64_str() -> None:
+    # The userspace/tunneld handshake carries deviceKVSData as a base64 string.
+    parsed = parse_device_kvs_data(base64.b64encode(_kvs(SAMPLE)).decode())
+    assert parsed[WEBINSPECTOR_METADATA_DOMAIN][WEBINSPECTOR_ENABLE_REMOTE_INSPECTION_KEY] is False
+
+
+def test_parse_device_kvs_data_none_and_garbage_return_empty() -> None:
+    assert parse_device_kvs_data(None) == {}
+    assert parse_device_kvs_data(b"not a plist") == {}
+    assert parse_device_kvs_data("!!!not base64 or plist!!!") == {}
+    # A plist that isn't a top-level dict is rejected.
+    assert parse_device_kvs_data(plistlib.dumps([1, 2, 3], fmt=plistlib.FMT_BINARY)) == {}
+
+
+def _rsd(auxiliary_metadata: dict[str, Any]) -> RemoteServiceDiscoveryService:
+    return RemoteServiceDiscoveryService(("127.0.0.1", 0), auxiliary_metadata=auxiliary_metadata)
+
+
+def test_auxiliary_metadata_defaults_empty() -> None:
+    rsd = RemoteServiceDiscoveryService(("127.0.0.1", 0))
+    assert rsd.auxiliary_metadata == {}
+    assert rsd.get_auxiliary_metadata("com.apple.WebInspector") == {}
+
+
+def test_get_auxiliary_metadata_returns_domain_dict() -> None:
+    rsd = _rsd({"com.apple.WebInspector": {"EnableRemoteInspection": True}})
+    assert rsd.get_auxiliary_metadata("com.apple.WebInspector") == {"EnableRemoteInspection": True}
+    assert rsd.get_auxiliary_metadata("com.apple.absent") == {}
+
+
+def test_is_remote_web_inspector_enabled_true() -> None:
+    rsd = _rsd({"com.apple.WebInspector": {"EnableRemoteInspection": True}})
+    assert rsd.is_remote_web_inspector_enabled() is True
+
+
+def test_is_remote_web_inspector_enabled_false() -> None:
+    rsd = _rsd({"com.apple.WebInspector": {"EnableRemoteInspection": False}})
+    assert rsd.is_remote_web_inspector_enabled() is False
+
+
+def test_is_remote_web_inspector_enabled_none_when_domain_absent() -> None:
+    # Off-native the device omits the WebInspector domain from the handshake KVS -> unknown.
+    rsd = _rsd({"NULL": {"ProductVersion": "26.6.1"}})
+    assert rsd.is_remote_web_inspector_enabled() is None
+
+
+class _FakeProtocol(RemotePairingProtocol):
+    async def close(self) -> None: ...
+
+    async def receive_response(self) -> dict[str, Any]:
+        return {}
+
+    async def send_request(self, data: dict[str, Any]) -> None: ...
+
+
+def test_remote_pairing_protocol_auxiliary_metadata_decodes_handshake() -> None:
+    proto = _FakeProtocol()
+    # The handshake carries deviceKVSData as a base64 string inside peerDeviceInfo.
+    proto.handshake_info = {"peerDeviceInfo": {"deviceKVSData": base64.b64encode(_kvs(SAMPLE)).decode()}}
+    assert proto.auxiliary_metadata["com.apple.WebInspector"]["EnableRemoteInspection"] is False
+
+
+def test_remote_pairing_protocol_auxiliary_metadata_empty_before_handshake() -> None:
+    assert _FakeProtocol().auxiliary_metadata == {}
+
+
+def test_tunnel_result_auxiliary_metadata_default_and_populated() -> None:
+    client = cast(RemotePairingTunnel, None)
+    default = TunnelResult("utun0", "fd::1", 1, TunnelProtocol.TCP, client)
+    assert default.auxiliary_metadata == {}
+
+    populated = TunnelResult(
+        "utun0", "fd::1", 1, TunnelProtocol.TCP, client, {"com.apple.WebInspector": {"EnableRemoteInspection": True}}
+    )
+    assert populated.auxiliary_metadata["com.apple.WebInspector"]["EnableRemoteInspection"] is True

--- a/tests/test_native_tunnel.py
+++ b/tests/test_native_tunnel.py
@@ -122,7 +122,7 @@ async def test_aopen_retries_handshake_with_fresh_port_scan(
 
     class FakeSession:
         def __init__(self, xpc: object) -> None:
-            pass
+            self.auxiliary_metadata: dict[str, dict[str, object]] = {}
 
         def browse(self, serial: Optional[str]) -> None:
             pass
@@ -134,8 +134,9 @@ async def test_aopen_retries_handshake_with_fresh_port_scan(
             pass
 
     class FakeRsd:
-        def __init__(self, address: tuple[str, int]) -> None:
+        def __init__(self, address: tuple[str, int], auxiliary_metadata: object = None) -> None:
             self.address = address
+            self.auxiliary_metadata = auxiliary_metadata
 
         async def connect(self) -> None:
             if self.address[1] == 51011:


### PR DESCRIPTION
## What

Surface the device's `deviceKVSData` — the binary-plist key-value store the pairing layer advertises, keyed by preference domain — on `RemoteServiceDiscoveryService.auxiliary_metadata`, with `get_auxiliary_metadata(domain)` and a typed `is_remote_web_inspector_enabled()`. Callers can now query, **without opening any service**, whether Safari/WebKit remote inspection is enabled (`com.apple.WebInspector.EnableRemoteInspection`) — plus other domains (`amfi` DeveloperModeStatus, `wireless_lockdown`, device props, …).

Adds a `remote auxiliary-metadata` CLI command:

```console
$ pymobiledevice3 remote auxiliary-metadata
{
    "com.apple.WebInspector": { "EnableRemoteInspection": false },
    "com.apple.security.mac.amfi": { "DeveloperModeStatus": 1 },
    ...
}
```

## Why it's transport-dependent

The metadata is **not** in the RSD `peer_info` — it rides the RemotePairing handshake / host `remotepairingd`. So availability depends on how the tunnel was built:

| Transport | WebInspector answer |
|---|---|
| `--native` (macOS default) | **real `True`/`False`** — `remotepairingd`'s merged, persisted KVS reliably carries it |
| `tunneld` / RemotePairing-over-bonjour | base KVS only; WebInspector usually absent → `None` |
| userspace no-root default (CoreDeviceProxy) | tunnel does no pair-verify handshake → `{}` |

`is_remote_web_inspector_enabled()` returns `None` when the domain wasn't advertised — *unknown on this transport*, not *disabled*. Use `--native` on macOS for a definitive answer.

## How

- New `parse_device_kvs_data()` decodes the bytes/base64 bplist into `{domain: {key: value}}`.
- **native**: decoded from the browse `deviceInfo.deviceKVSData` (adds an `xpc_dictionary_get_data` libxpc binding).
- **tunnel paths**: threaded through `TunnelResult.auxiliary_metadata` (from the handshake `peerDeviceInfo`) and round-tripped in the tunneld HTTP JSON.
- Docs: per-transport behavior added to `docs/guides/network-stacks.md`.

## Testing

- New `tests/remote/test_auxiliary_metadata.py` (decoder + RSD getters + `TunnelResult` + `RemotePairingProtocol.auxiliary_metadata`).
- Verified live on iPhone18,4 (iOS 26.6.1): `--native` returns the real value; `--userspace` returns `{}`.
- pyright 1.1.411 clean, ruff clean, full suite green.