### PR TITLE
sysmon: Add --keep-monitoring to survive relaunches and transient misses

### DIFF
--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -272,6 +272,10 @@ pymobiledevice3 developer dvt sysmon process monitor process --filter pid=123 --
 # Stream one process with human-readable memory sizes
 pymobiledevice3 developer dvt sysmon process monitor process --filter name=SpringBoard --key name --key physFootprint --human
 
+# Keep streaming across relaunches: re-apply the filter on every snapshot instead of
+# stopping once the originally selected process is gone
+pymobiledevice3 developer dvt sysmon process monitor process --filter name=MyApp --choose last --keep-monitoring
+
 # Stream oslog
 pymobiledevice3 developer dvt oslog
 

--- a/pymobiledevice3/cli/developer/dvt/sysmon/process.py
+++ b/pymobiledevice3/cli/developer/dvt/sysmon/process.py
@@ -109,6 +109,18 @@ HumanReadableProcessValues = Annotated[
     ),
 ]
 
+KeepMonitoringProcess = Annotated[
+    bool,
+    typer.Option(
+        "--keep-monitoring",
+        help=(
+            "Re-apply the filters on every snapshot instead of locking onto the process selected from the first one. "
+            "Snapshots where nothing matches are skipped instead of ending the command, and a relaunched process is "
+            'picked up again automatically. Requires "--choose first" or "--choose last".'
+        ),
+    ),
+]
+
 ProcessResultsOutputPath = Annotated[
     Optional[Path],
     typer.Option(
@@ -326,20 +338,57 @@ def _matches_selected_process(process: dict[str, Any], selected_process_identifi
     return process.get(identifier_key) == identifier_value
 
 
+def _resolve_matching_process(
+    process_snapshot: list[dict[str, Any]],
+    parsed_filters: dict[str, list[str]],
+    selection_mode: ProcessSelectionMode,
+) -> Optional[dict[str, Any]]:
+    """Re-apply the filters against a single snapshot. Returns None when nothing currently matches."""
+    # All process entries in a sysmon sample share the same schema, so validating one entry is sufficient.
+    _validate_process_keys(process_snapshot[0], list(parsed_filters))
+
+    matching_processes = [process for process in process_snapshot if _matches_filters(process, parsed_filters)]
+    if len(matching_processes) == 0:
+        return None
+
+    return _select_process_from_candidates(matching_processes, selection_mode)
+
+
+def _resolve_tracked_process(
+    process_snapshot: list[dict[str, Any]],
+    tracked_process_identifier: tuple[str, object],
+    tracked_process_description: str,
+) -> Optional[dict[str, Any]]:
+    """Locate the process locked in at selection time. Returns None once it is absent from the snapshot."""
+    tracked_process_matches = [
+        process for process in process_snapshot if _matches_selected_process(process, tracked_process_identifier)
+    ]
+
+    if len(tracked_process_matches) == 0:
+        return None
+
+    if len(tracked_process_matches) > 1:
+        matching_processes_description = [_describe_process(process) for process in tracked_process_matches]
+        raise typer.BadParameter(
+            f"Selected process identity is ambiguous for {tracked_process_description!r}. "
+            f"Matching processes: {matching_processes_description}. Please refine the filters."
+        )
+
+    return tracked_process_matches[0]
+
+
 def _select_process_from_snapshot(
     process_snapshot: list[dict[str, Any]],
     parsed_filters: dict[str, list[str]],
     selection_mode: ProcessSelectionMode,
 ) -> dict[str, Any]:
-    if process_snapshot:
-        # All process entries in a sysmon sample share the same schema, so validating one entry is sufficient.
-        _validate_process_keys(process_snapshot[0], list(parsed_filters))
-
-    matching_processes = [process for process in process_snapshot if _matches_filters(process, parsed_filters)]
-    if len(matching_processes) == 0:
+    selected_process = (
+        _resolve_matching_process(process_snapshot, parsed_filters, selection_mode) if process_snapshot else None
+    )
+    if selected_process is None:
         raise typer.BadParameter("Failed to find a process matching the given filters in the current snapshot")
 
-    return _select_process_from_candidates(matching_processes, selection_mode)
+    return selected_process
 
 
 async def _select_process_from_sysmon(
@@ -445,6 +494,7 @@ async def sysmon_process_monitor_process(
             ),
         ),
     ] = ProcessSelectionMode.PROMPT,
+    keep_monitoring: KeepMonitoringProcess = False,
     interval: Annotated[
         int,
         typer.Option(
@@ -462,7 +512,7 @@ async def sysmon_process_monitor_process(
     with contextlib.ExitStack() as stack:
         out = stack.enter_context(open(output, "w")) if output else None
         await sysmon_process_monitor_process_task(
-            service_provider, filter_expressions, interval, duration, choose, keys, human, out
+            service_provider, filter_expressions, interval, duration, choose, keys, human, out, keep_monitoring
         )
 
 
@@ -510,17 +560,28 @@ async def sysmon_process_monitor_process_task(
     keys: Optional[list[str]] = None,
     human: bool = False,
     out: Optional[TextIO] = None,
+    keep_monitoring: bool = False,
 ) -> None:
     """Continuously monitor one process selected from the current snapshot by key=value filters."""
 
     parsed_filters = _parse_process_filters(filter_expressions)
 
-    async with DvtProvider(service_provider) as dvt:
-        selected_process = await _select_process_from_sysmon(dvt, parsed_filters, keys, choose)
-        selected_process_identifier = _get_process_identifier(selected_process)
-        selected_process_description = _describe_process(selected_process)
+    if keep_monitoring and choose == ProcessSelectionMode.PROMPT:
+        raise typer.BadParameter(
+            '"--keep-monitoring" re-selects the monitored process on every snapshot, so it cannot prompt for one. '
+            'Re-run with "--choose first" or "--choose last".'
+        )
 
-        _write_status(f"Monitoring {selected_process_description}")
+    async with DvtProvider(service_provider) as dvt:
+        selected_process_identifier: Optional[tuple[str, object]] = None
+        selected_process_description = ""
+
+        if not keep_monitoring:
+            selected_process = await _select_process_from_sysmon(dvt, parsed_filters, keys, choose)
+            selected_process_identifier = _get_process_identifier(selected_process)
+            selected_process_description = _describe_process(selected_process)
+
+            _write_status(f"Monitoring {selected_process_description}")
 
         monitoring_start_time = None
         async with await Sysmontap.create(dvt, interval=interval) as monitor_sysmon:
@@ -539,26 +600,26 @@ async def sysmon_process_monitor_process_task(
                 # All process entries in a sysmon sample share the same schema, so validating one entry is sufficient.
                 _validate_process_keys(process_snapshot[0], keys or [])
 
-                selected_process_matches = [
-                    process
-                    for process in process_snapshot
-                    if _matches_selected_process(process, selected_process_identifier)
-                ]
+                if keep_monitoring:
+                    monitored_process = _resolve_matching_process(process_snapshot, parsed_filters, choose)
+                    if monitored_process is None:
+                        # A snapshot may transiently omit the process, and a relaunched one reappears later on.
+                        continue
 
-                if len(selected_process_matches) == 0:
-                    _write_status(f"Selected process exited: {selected_process_description}")
-                    break
-
-                if len(selected_process_matches) > 1:
-                    matching_processes_description = [
-                        _describe_process(process) for process in selected_process_matches
-                    ]
-                    raise typer.BadParameter(
-                        f"Selected process identity is ambiguous for {selected_process_description!r}. "
-                        f"Matching processes: {matching_processes_description}. Please refine the filters."
+                    monitored_process_identifier = _get_process_identifier(monitored_process)
+                    if monitored_process_identifier != selected_process_identifier:
+                        selected_process_identifier = monitored_process_identifier
+                        _write_status(f"Monitoring {_describe_process(monitored_process)}")
+                else:
+                    assert selected_process_identifier is not None  # always resolved when not keep_monitoring
+                    monitored_process = _resolve_tracked_process(
+                        process_snapshot, selected_process_identifier, selected_process_description
                     )
+                    if monitored_process is None:
+                        _write_status(f"Selected process exited: {selected_process_description}")
+                        break
 
-                _write_process(out, _serialize_process(selected_process_matches[0], keys, human))
+                _write_process(out, _serialize_process(monitored_process, keys, human))
 
                 if _duration_elapsed(monitoring_start_time, duration):
                     # Avoid waiting for the next snapshot

--- a/tests/cli/developer/dvt/sysmon/test_process.py
+++ b/tests/cli/developer/dvt/sysmon/test_process.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 import json
 from io import StringIO
 from typing import Any
@@ -10,10 +12,15 @@ from pymobiledevice3.cli.developer.dvt.sysmon.process import (
     _process_sort_key,
     _select_process_from_snapshot,
     iter_processes,
+    sysmon_process_monitor_process_task,
     sysmon_process_monitor_threshold_task,
     sysmon_process_single_task,
 )
+from pymobiledevice3.services.dvt.instruments.process_control import ProcessControl
 from pymobiledevice3.services.dvt.instruments.sysmontap import Sysmontap
+
+RELAUNCHABLE_BUNDLE_ID = "com.apple.mobilesafari"
+RELAUNCHABLE_PROCESS_NAME = "MobileSafari"
 
 
 @pytest_asyncio.fixture
@@ -78,3 +85,77 @@ async def test_sysmon_process_monitor_threshold_task_writes_jsonl_to_buffer(serv
     assert len(lines) > 0
     first_record = json.loads(lines[0])
     assert first_record.get("pid")
+
+
+@pytest.mark.asyncio
+async def test_sysmon_process_monitor_process_task_keep_monitoring_streams_by_filter(service_provider) -> None:
+    out = StringIO()
+
+    await sysmon_process_monitor_process_task(
+        service_provider,
+        filter_expressions=["name=SpringBoard"],
+        duration=1500,
+        choose=ProcessSelectionMode.LAST,
+        keys=["pid", "name"],
+        out=out,
+        keep_monitoring=True,
+    )
+
+    records = [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+    assert len(records) > 0
+    assert {record["name"] for record in records} == {"SpringBoard"}
+
+
+async def _wait_for_monitored_pid(pid: int, out: StringIO, monitor_task: "asyncio.Task[None]") -> None:
+    """Wait for `pid` to show up in the monitor's JSONL output, failing if monitoring stops first."""
+
+    def emitted_pids() -> set[int]:
+        return {json.loads(line)["pid"] for line in out.getvalue().splitlines() if line.strip()}
+
+    deadline = asyncio.get_running_loop().time() + 30
+    while asyncio.get_running_loop().time() < deadline:
+        if pid in emitted_pids():
+            return
+        if monitor_task.done():
+            # Surfaces a monitoring exception, and otherwise reports the early exit this test guards against.
+            monitor_task.result()
+            pytest.fail(f"monitoring stopped before pid {pid} was observed. Emitted pids: {sorted(emitted_pids())}")
+        await asyncio.sleep(0.25)
+
+    pytest.fail(f"pid {pid} was not observed within the timeout. Emitted pids: {sorted(emitted_pids())}")
+
+
+@pytest.mark.asyncio
+async def test_sysmon_process_monitor_process_task_keep_monitoring_reacquires_relaunched_process(
+    dvt, service_provider
+) -> None:
+    out = StringIO()
+
+    async with ProcessControl(dvt) as process_control:
+        first_pid = await process_control.launch(RELAUNCHABLE_BUNDLE_ID)
+
+        monitor_task = asyncio.create_task(
+            sysmon_process_monitor_process_task(
+                service_provider,
+                filter_expressions=[f"name={RELAUNCHABLE_PROCESS_NAME}"],
+                # Upper bound only. The test cancels the task as soon as the relaunched process is observed.
+                duration=120000,
+                choose=ProcessSelectionMode.LAST,
+                keys=["pid", "name"],
+                out=out,
+                keep_monitoring=True,
+            )
+        )
+
+        try:
+            await _wait_for_monitored_pid(first_pid, out, monitor_task)
+
+            # launch() kills the running instance first, so the app comes back under a fresh identity.
+            second_pid = await process_control.launch(RELAUNCHABLE_BUNDLE_ID)
+            assert second_pid != first_pid
+
+            await _wait_for_monitored_pid(second_pid, out, monitor_task)
+        finally:
+            monitor_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await monitor_task

--- a/tests/cli/developer/dvt/sysmon/test_process_unit.py
+++ b/tests/cli/developer/dvt/sysmon/test_process_unit.py
@@ -20,6 +20,8 @@ from pymobiledevice3.cli.developer.dvt.sysmon.process import (
     _matches_selected_process,
     _parse_process_filters,
     _process_sort_key,
+    _resolve_matching_process,
+    _resolve_tracked_process,
     _select_process_from_candidates,
     _select_process_from_snapshot,
     _select_process_from_sysmon,
@@ -30,6 +32,7 @@ from pymobiledevice3.cli.developer.dvt.sysmon.process import (
     _write_json,
     _write_process,
     iter_processes,
+    sysmon_process_monitor_process_task,
     sysmon_process_monitor_threshold_task,
 )
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
@@ -481,3 +484,120 @@ async def test_select_process_from_sysmon_raises_when_no_usable_snapshot(monkeyp
 
     with pytest.raises(typer.BadParameter, match="Failed to collect a process snapshot"):
         await _select_process_from_sysmon(cast(DvtProvider, object()), {}, None, ProcessSelectionMode.FIRST)
+
+
+def test_resolve_matching_process_reapplies_filters():
+    process_snapshot = [
+        {"pid": 10, "ppid": 1, "name": "alpha"},
+        {"pid": 20, "ppid": 1, "name": "beta"},
+    ]
+
+    assert _resolve_matching_process(process_snapshot, {"name": ["beta"]}, ProcessSelectionMode.FIRST) == {
+        "pid": 20,
+        "ppid": 1,
+        "name": "beta",
+    }
+
+
+def test_resolve_matching_process_returns_none_when_nothing_matches():
+    assert (
+        _resolve_matching_process(
+            [{"pid": 10, "ppid": 1, "name": "alpha"}], {"name": ["beta"]}, ProcessSelectionMode.FIRST
+        )
+        is None
+    )
+
+
+def test_resolve_matching_process_rejects_unknown_filter_keys():
+    with pytest.raises(typer.BadParameter, match="does not have the following keys"):
+        _resolve_matching_process(
+            [{"pid": 10, "ppid": 1, "name": "alpha"}], {"missing": ["value"]}, ProcessSelectionMode.FIRST
+        )
+
+
+def test_resolve_tracked_process_returns_none_when_identity_is_absent():
+    assert _resolve_tracked_process([{"pid": 10, "uniqueID": 11}], ("uniqueID", 99), "pid=1, ppid=0, name=abc") is None
+
+
+def test_resolve_tracked_process_rejects_ambiguous_identity():
+    with pytest.raises(typer.BadParameter, match="Selected process identity is ambiguous"):
+        _resolve_tracked_process(
+            [{"pid": 10, "ppid": 1, "name": "a", "uniqueID": 11}, {"pid": 20, "ppid": 1, "name": "b", "uniqueID": 11}],
+            ("uniqueID", 11),
+            "pid=10, ppid=1, name=a",
+        )
+
+
+def _monitor_snapshots_patch(monkeypatch, snapshots):
+    async def fake_create(_dvt, interval=None):
+        return _FakeSysmontap(snapshots)
+
+    monkeypatch.setattr(process_module, "DvtProvider", _FakeDvtProvider)
+    monkeypatch.setattr(process_module.Sysmontap, "create", fake_create)
+
+
+async def _run_monitor_process_task(snapshots, monkeypatch, **kwargs):
+    _monitor_snapshots_patch(monkeypatch, snapshots)
+    out = StringIO()
+    await sysmon_process_monitor_process_task(
+        cast(LockdownServiceProvider, object()),
+        filter_expressions=["name=App"],
+        keys=["pid"],
+        out=out,
+        **kwargs,
+    )
+    return [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+
+
+@pytest.mark.asyncio
+async def test_sysmon_process_monitor_process_task_stops_when_selected_process_exits(monkeypatch, capsys):
+    snapshots = [
+        [{"pid": 10, "ppid": 1, "name": "App", "uniqueID": 11}],
+        [{"pid": 99, "ppid": 1, "name": "other", "uniqueID": 99}],
+        [{"pid": 20, "ppid": 1, "name": "App", "uniqueID": 22}],
+    ]
+
+    emitted = await _run_monitor_process_task(snapshots, monkeypatch, choose=ProcessSelectionMode.FIRST)
+
+    assert [record["pid"] for record in emitted] == [10]
+    assert "Selected process exited: pid=10, ppid=1, name=App" in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_sysmon_process_monitor_process_task_keep_monitoring_skips_unmatched_snapshots(monkeypatch):
+    snapshots = [
+        [{"pid": 10, "ppid": 1, "name": "App", "uniqueID": 11}],
+        [{"pid": 99, "ppid": 1, "name": "other", "uniqueID": 99}],
+        [{"pid": 10, "ppid": 1, "name": "App", "uniqueID": 11}],
+    ]
+
+    emitted = await _run_monitor_process_task(
+        snapshots, monkeypatch, choose=ProcessSelectionMode.FIRST, keep_monitoring=True
+    )
+
+    assert [record["pid"] for record in emitted] == [10, 10]
+
+
+@pytest.mark.asyncio
+async def test_sysmon_process_monitor_process_task_keep_monitoring_reacquires_relaunched_process(monkeypatch, capsys):
+    snapshots = [
+        [{"pid": 10, "ppid": 1, "name": "App", "uniqueID": 11}],
+        [{"pid": 99, "ppid": 1, "name": "other", "uniqueID": 99}],
+        [{"pid": 20, "ppid": 1, "name": "App", "uniqueID": 22}],
+    ]
+
+    emitted = await _run_monitor_process_task(
+        snapshots, monkeypatch, choose=ProcessSelectionMode.LAST, keep_monitoring=True
+    )
+
+    assert [record["pid"] for record in emitted] == [10, 20]
+    status_output = capsys.readouterr().out
+    assert "Monitoring pid=10, ppid=1, name=App" in status_output
+    assert "Monitoring pid=20, ppid=1, name=App" in status_output
+    assert "Selected process exited" not in status_output
+
+
+@pytest.mark.asyncio
+async def test_sysmon_process_monitor_process_task_keep_monitoring_rejects_prompt_selection(monkeypatch):
+    with pytest.raises(typer.BadParameter, match='Re-run with "--choose first" or "--choose last"'):
+        await _run_monitor_process_task([], monkeypatch, keep_monitoring=True)


### PR DESCRIPTION
Closes #1875

## Problem

`developer dvt sysmon process monitor process` resolves the monitored process
once, from the first snapshot, and locks onto its identity
(`uniqueID` → `startAbsTime` → `pid`). The first snapshot missing that identity
ends the command:

- an app relaunched mid-session comes back under a new identity, so monitoring
  stops instead of following it;
- a sampling hiccup where one snapshot transiently omits the process is treated
  as proof of death, silently truncating long collections.

## Change

`--keep-monitoring` skips identity resolution entirely. Every snapshot
re-applies the `--filter` expressions and resolves the match with `--choose`:

- no match in a snapshot → the tick is skipped, monitoring continues;
- a relaunched process matches the same filter on its next sample and is picked
  up automatically, emitting a fresh `Monitoring pid=..., ppid=..., name=...`
  status line whenever the resolved instance changes.

Without the flag, behavior is byte-for-byte what it was.

The flag requires `--choose first|last`, rejected up front with an actionable
message. Per-snapshot re-selection cannot block on an interactive prompt, and
erroring on a transient ambiguity — both the dying and the new instance visible
during a relaunch — would defeat the flag's purpose.

Internally the two per-snapshot resolutions are now `_resolve_matching_process()`
(filter-based, `None` when nothing matches) and `_resolve_tracked_process()`
(identity-based, `None` once gone). Initial selection reuses the former, so
one-shot and continuous selection share a code path.

```
pymobiledevice3 developer dvt sysmon process monitor process \
    --filter name=MyApp --choose last --keep-monitoring
```

## Verification

Real device (iPhone17,3 / iOS 26.1), the exact reported repro — launch Safari,
monitor it, kill and relaunch mid-run:

```
Monitoring pid=3935, ppid=1, name=MobileSafari
Monitoring pid=3964, ppid=1, name=MobileSafari
pid sequence: [3935, 3964] records: 79
```

No `Selected process exited`, monitoring ran the full duration across the gap.

That scenario is now a device test
(`..._keep_monitoring_reacquires_relaunched_process`): it launches the app,
relaunches it through `ProcessControl` while monitoring, and fails if monitoring
stops before the new pid is observed. Flipping the flag off in that test
reproduces the bug, confirming it guards the regression:

```
Monitoring pid=4588, ppid=1, name=MobileSafari
Selected process exited: pid=4588, ppid=1, name=MobileSafari
Failed: monitoring stopped before pid 4593 was observed. Emitted pids: [4588]
```

Plus unit coverage for skip-on-miss, re-acquisition, the `--choose prompt`
rejection and both new helpers.

- `pytest tests` → 717 passed
- `pytest tests/cli/developer/dvt/sysmon --rsd ...` → 75 passed (device tests included)
- ruff + pyright clean
