### PR TITLE
remote: reach the per-user remotepairingd from a root process

### DIFF
--- a/docs/guides/network-stacks.md
+++ b/docs/guides/network-stacks.md
@@ -245,6 +245,18 @@ How it works (all via `ctypes` + libxpc, no pyobjc):
    kernel-routable — and run the standard RSD handshake.
 
 - **Root:** not required. **Xcode:** not required.
+- **Running as root anyway (CI runners, LaunchDaemons):** `remotepairingd` is an XPCService
+  declaring `ServiceType = User`, so launchd registers it **per-uid, in a logged-in user's domain
+  and never in the system/root domain**. A root process therefore gets `Connection invalid` from the
+  plain mach lookup — the service does not exist in its domain, which surfaces as
+  `remotepairingd reported no device`. Rather than relocating the process into the user's domain
+  (`launchctl asuser <uid>`), the connection is retargeted selectively with the libxpc SPI
+  `xpc_connection_set_target_uid`, so the process stays root and reaches only this one service.
+  This happens automatically when `geteuid() == 0`: the target uid is taken from
+  `PYMOBILEDEVICE3_NATIVE_TARGET_UID` when set, otherwise from the console user (the owner of
+  `/dev/console`). Set the variable explicitly on a host with no console user — a headless CI
+  runner — since there is no other way to guess which user holds the pairing. Note the SPI is
+  root-only: calling it as a normal user traps the process, so it is never used off the root path.
 - **Reachability:** the tunnel address is a real kernel route (Apple's tunnel), so unlike the
   userspace tunnel it *is* reachable by other tools; it lives only while the handle (its assertion)
   is held. `remote start-tunnel` publishes this address for other processes (no `sudo`; the native

--- a/pymobiledevice3/remote/native_tunnel.py
+++ b/pymobiledevice3/remote/native_tunnel.py
@@ -23,6 +23,8 @@ import asyncio
 import atexit
 import contextlib
 import ctypes
+import logging
+import os
 import platform
 import socket
 import struct
@@ -34,10 +36,20 @@ from typing import Any, Callable, Optional, cast
 from pymobiledevice3.exceptions import UserspaceTunnelUnavailableError
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService, parse_device_kvs_data
 
+logger = logging.getLogger(__name__)
+
 _IS_DARWIN = platform.system() == "Darwin"
 
 REMOTEPAIRING_MACH_SERVICE = "com.apple.CoreDevice.remotepairingd"
 REMOTED_PATH = "/usr/libexec/remoted"
+
+# ``remotepairingd`` is an XPCService declaring ``ServiceType = User``, so launchd registers it
+# per-uid in a logged-in user's domain and never in the system/root domain: a process running as
+# root (CI runner, LaunchDaemon, ``launchctl asuser 0``) gets "Connection invalid" from the plain
+# lookup, not an empty device list. ``xpc_connection_set_target_uid`` redirects the lookup into
+# another uid's domain, which lets such a process stay root and reach the login user's daemon
+# selectively. Set this to choose that uid explicitly -- required on a host with no console user.
+NATIVE_TARGET_UID_ENV_VAR = "PYMOBILEDEVICE3_NATIVE_TARGET_UID"
 
 # com.apple.dt.RemotePairingError code returned by InitiatePairingCommand when the host is already
 # paired -- a benign no-op, not a failure.
@@ -91,6 +103,11 @@ class _LibXpc:
         )
         self.connection_create_from_endpoint: Callable[..., int] = self._cfg(
             "xpc_connection_create_from_endpoint", vp, [vp]
+        )
+        # SPI, absent from every SDK header, and the surface drifts across releases (the sibling
+        # xpc_connection_set_target_gid is already gone), so bind it defensively.
+        self.connection_set_target_uid: Optional[Callable[..., None]] = self._cfg_optional(
+            "xpc_connection_set_target_uid", None, [vp, ctypes.c_uint32]
         )
         self.connection_set_event_handler: Callable[..., None] = self._cfg(
             "xpc_connection_set_event_handler", None, [vp, vp]
@@ -153,6 +170,13 @@ class _LibXpc:
         fn.restype = restype
         fn.argtypes = argtypes
         return fn
+
+    def _cfg_optional(self, name: str, restype: Any, argtypes: list[Any]) -> Optional[Any]:
+        """Bind a symbol that may not exist on every macOS release; ``None`` when it is absent."""
+        try:
+            return self._cfg(name, restype, argtypes)
+        except AttributeError:
+            return None
 
     def make_block(self, func: Callable[[int], None]) -> ctypes.c_void_p:
         """Wrap ``func(xpc_object_ptr)`` in an Objective-C global block for an xpc handler.
@@ -274,6 +298,59 @@ def xpc_to_python(xpc: _LibXpc, obj: int) -> Any:
     return f"<{type_name}>"
 
 
+def _console_user_uid() -> Optional[int]:
+    """uid of the console (window-server) user, or ``None`` when nobody is logged in.
+
+    ``/dev/console`` is chowned to the console user at login and back to root at logout, so its
+    owner is a dependency-free stand-in for ``SCDynamicStoreCopyConsoleUser``.
+    """
+    try:
+        uid = os.stat("/dev/console").st_uid
+    except OSError:
+        return None
+    return uid or None
+
+
+def native_target_uid() -> Optional[int]:
+    """uid whose launchd domain should be searched for ``remotepairingd``, or ``None`` for our own.
+
+    Only root can retarget, and only root needs to: an unprivileged process is already running in
+    the domain that holds the daemon. ``PYMOBILEDEVICE3_NATIVE_TARGET_UID`` wins when set, otherwise
+    the console user is assumed to be the one holding the pairing.
+    """
+    if os.geteuid() != 0:
+        # xpc_connection_set_target_uid traps (SIGTRAP) when a non-root caller invokes it.
+        return None
+    value = os.getenv(NATIVE_TARGET_UID_ENV_VAR)
+    if value:
+        try:
+            return int(value.strip())
+        except ValueError:
+            logger.warning("ignoring invalid %s=%r (expected a numeric uid)", NATIVE_TARGET_UID_ENV_VAR, value)
+    return _console_user_uid()
+
+
+def _create_remotepairing_connection(xpc: _LibXpc, queue: int) -> int:
+    """Create the ``remotepairingd`` mach-service connection, retargeted when we are running as root.
+
+    Returned inactive: the caller installs its event handler before activating.
+    """
+    conn = xpc.connection_create_mach_service(REMOTEPAIRING_MACH_SERVICE.encode(), queue, 0)
+    uid = native_target_uid()
+    if uid is None or uid == 0:
+        return conn
+    if xpc.connection_set_target_uid is None:
+        logger.warning(
+            "running as root, but xpc_connection_set_target_uid is unavailable on this macOS: "
+            "%s is registered per-user and will not be reachable from the root domain",
+            REMOTEPAIRING_MACH_SERVICE,
+        )
+        return conn
+    xpc.connection_set_target_uid(conn, uid)  # must precede xpc_connection_activate
+    logger.debug("searching uid %d's launchd domain for %s", uid, REMOTEPAIRING_MACH_SERVICE)
+    return conn
+
+
 def _send_browse_request(xpc: _LibXpc, conn: int, queue: int) -> None:
     """Send ``RemotePairing.BrowseRequest``; devices arrive via the connection's event handler.
 
@@ -364,7 +441,7 @@ class _RemotePairingSession:
                 endpoint_holder.append(endpoint)
                 found.set()
 
-        conn = xpc.connection_create_mach_service(REMOTEPAIRING_MACH_SERVICE.encode(), self._queue, 0)
+        conn = _create_remotepairing_connection(xpc, self._queue)
         self._browse_conn = conn
         xpc.connection_set_event_handler(conn, xpc.make_block(on_event))
         xpc.connection_activate(conn)
@@ -372,6 +449,12 @@ class _RemotePairingSession:
 
         if not found.wait(self._REPLY_TIMEOUT):
             hint = f" matching udid {serial}" if serial is not None else ""
+            if os.geteuid() == 0 and native_target_uid() is None:
+                hint += (
+                    f"; running as root with no console user -- {REMOTEPAIRING_MACH_SERVICE} is registered "
+                    f"per-user, so set {NATIVE_TARGET_UID_ENV_VAR} to the uid of the logged-in user "
+                    "that owns the pairing"
+                )
             raise _RemotePairingError(f"remotepairingd reported no device{hint}")
 
         device_conn = xpc.connection_create_from_endpoint(endpoint_holder[0])
@@ -473,7 +556,7 @@ def _browse_native_devices_sync(xpc: _LibXpc, timeout: float) -> list[dict[str, 
                 seen.add(key)
                 devices.append(info_dict)
 
-    conn = xpc.connection_create_mach_service(REMOTEPAIRING_MACH_SERVICE.encode(), queue, 0)
+    conn = _create_remotepairing_connection(xpc, queue)
     xpc.connection_set_event_handler(conn, xpc.make_block(on_event))
     xpc.connection_activate(conn)
     _send_browse_request(xpc, conn, queue)

--- a/tests/test_native_tunnel.py
+++ b/tests/test_native_tunnel.py
@@ -347,3 +347,80 @@ def test_default_transport_preference_env(monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.setenv("PYMOBILEDEVICE3_DEFAULT_FALLBACK", "bogus")  # invalid -> built-in default (Linux here)
     assert cli_common.default_transport_preference() == "userspace"
+
+
+class _FakeXpcForTargeting:
+    """Minimal ``_LibXpc`` stand-in recording the retargeting calls made before activation."""
+
+    def __init__(self, has_spi: bool = True) -> None:
+        self.calls: list[tuple[int, int]] = []
+        self.connection_set_target_uid: Optional[Any] = self._record if has_spi else None
+
+    def _record(self, conn: int, uid: int) -> None:
+        self.calls.append((conn, uid))
+
+    def connection_create_mach_service(self, name: bytes, queue: Optional[int], flags: int) -> int:
+        return 0xC0FFEE
+
+
+def test_native_target_uid_is_none_when_unprivileged(monkeypatch: pytest.MonkeyPatch) -> None:
+    # xpc_connection_set_target_uid traps for a non-root caller, so it must never be reached.
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 501)
+    monkeypatch.setenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, "501")
+    assert native_tunnel.native_target_uid() is None
+
+
+def test_native_target_uid_env_var_wins_over_console_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(native_tunnel, "_console_user_uid", lambda: 501)
+    monkeypatch.setenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, " 502 ")
+    assert native_tunnel.native_target_uid() == 502
+
+
+def test_native_target_uid_invalid_env_falls_back_to_console_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(native_tunnel, "_console_user_uid", lambda: 501)
+    monkeypatch.setenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, "not-a-uid")
+    assert native_tunnel.native_target_uid() == 501
+
+
+def test_native_target_uid_none_without_console_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0)
+    monkeypatch.delenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, raising=False)
+    monkeypatch.setattr(native_tunnel, "_console_user_uid", lambda: None)
+    assert native_tunnel.native_target_uid() is None
+
+
+def test_console_user_uid_reads_dev_console_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_stat = native_tunnel.os.stat
+
+    def fake_stat(path: Any, *args: Any, **kwargs: Any) -> Any:
+        if path == "/dev/console":
+            return real_stat("/dev/console" if platform.system() == "Darwin" else ".")
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(native_tunnel.os, "stat", fake_stat)
+    uid = native_tunnel._console_user_uid()
+    assert uid is None or uid > 0  # root-owned (logged out) reports None rather than uid 0
+
+
+def test_create_remotepairing_connection_retargets_when_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_tunnel, "native_target_uid", lambda: 501)
+    xpc = _FakeXpcForTargeting()
+    conn = native_tunnel._create_remotepairing_connection(cast(Any, xpc), 0)
+    assert conn == 0xC0FFEE
+    assert xpc.calls == [(0xC0FFEE, 501)]
+
+
+def test_create_remotepairing_connection_leaves_plain_lookup_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_tunnel, "native_target_uid", lambda: None)
+    xpc = _FakeXpcForTargeting()
+    native_tunnel._create_remotepairing_connection(cast(Any, xpc), 0)
+    assert xpc.calls == []
+
+
+def test_create_remotepairing_connection_survives_missing_spi(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A future macOS could drop the SPI the way xpc_connection_set_target_gid was dropped.
+    monkeypatch.setattr(native_tunnel, "native_target_uid", lambda: 501)
+    xpc = _FakeXpcForTargeting(has_spi=False)
+    assert native_tunnel._create_remotepairing_connection(cast(Any, xpc), 0) == 0xC0FFEE


### PR DESCRIPTION
`--native` is unusable from any process running as root — a GitLab runner, a LaunchDaemon, anything under `launchctl asuser 0` — which fails with:

```
ERROR remotepairingd reported no device
```

## Root cause

`remotepairingd` is an XPCService declaring `ServiceType = User`:

```
/Library/Apple/System/Library/PrivateFrameworks/RemotePairing.framework/Versions/A/XPCServices/remotepairingd.xpc
  CFBundleIdentifier => com.apple.CoreDevice.remotepairingd
  XPCService => { ServiceType => "User" }
```

launchd therefore registers it **per-uid, in a logged-in user's domain and never in the system/root domain**. The mach lookup from root does not return an empty device list — it returns `Connection invalid`, because the service does not exist in that domain at all. The browse then times out and reports "no device", which points in entirely the wrong direction.

## Fix

Retarget the connection with the libxpc SPI `xpc_connection_set_target_uid` rather than relocating the process into the user's domain with `launchctl asuser <uid>`. The process stays root and reaches into that domain for this one service only, which is far easier to reason about than a permanent relocation.

Applied automatically when `geteuid() == 0`; the uid comes from `PYMOBILEDEVICE3_NATIVE_TARGET_UID` when set, otherwise from the console user (owner of `/dev/console`). It is never used off the root path — the SPI traps (SIGTRAP) when a non-root caller invokes it. It is bound defensively via `_cfg_optional`, since it appears in no SDK header and the surface drifts across releases: its sibling `xpc_connection_set_target_gid` is already gone from current macOS.

The failure message now names the variable when running as root with no console user, where the uid cannot be guessed.

## Verification

On a physical iPhone 17-class device (iPhone17,3, iOS 26.1), macOS 26:

| run | euid | target uid | result |
|---|---|---|---|
| `remote browse --native` | 501 | — | 1 device (unchanged) |
| `launchctl asuser 0 … browse --native`, before | 0 | — | 0 devices, `Connection invalid` |
| `launchctl asuser 0 … browse --native`, after | 0 | console user | 1 device |
| `… env PYMOBILEDEVICE3_NATIVE_TARGET_UID=501` | 0 | 501 | 1 device |
| `… env PYMOBILEDEVICE3_NATIVE_TARGET_UID=502` | 0 | 502 | 0 devices (variable honored) |
| `… env PYMOBILEDEVICE3_NATIVE_TARGET_UID=bogus` | 0 | console user | warns, falls back |

End to end as root, which previously could not work at all:

```
$ sudo launchctl asuser 0 pymobiledevice3 remote start-tunnel
INFO native tunnel is up
Identifier: 0000FE01-EAAC65A26AF18CA4
RSD Address: fd9d:18ae:62ae::1
RSD Port: 61655
```

and `remote rsd-info` as root with no flags completes a full RSD handshake over the in-process native tunnel.

Also: 8 new unit tests, `462 passed, 8 skipped` on the non-device suite, repo-wide pyright 0 errors, ruff clean.
