### PR TITLE
remote: fix native target-uid tests on Windows

### DIFF
--- a/pymobiledevice3/remote/native_tunnel.py
+++ b/pymobiledevice3/remote/native_tunnel.py
@@ -311,6 +311,16 @@ def _console_user_uid() -> Optional[int]:
     return uid or None
 
 
+def _is_root() -> bool:
+    """Whether we are running with effective uid 0.
+
+    ``os.geteuid`` is POSIX-only and absent on Windows, where importing this module is still legal
+    even though its tunnel is macOS-only -- so probe for it rather than calling it blind.
+    """
+    geteuid = getattr(os, "geteuid", None)
+    return geteuid is not None and geteuid() == 0
+
+
 def native_target_uid() -> Optional[int]:
     """uid whose launchd domain should be searched for ``remotepairingd``, or ``None`` for our own.
 
@@ -318,7 +328,7 @@ def native_target_uid() -> Optional[int]:
     the domain that holds the daemon. ``PYMOBILEDEVICE3_NATIVE_TARGET_UID`` wins when set, otherwise
     the console user is assumed to be the one holding the pairing.
     """
-    if os.geteuid() != 0:
+    if not _is_root():
         # xpc_connection_set_target_uid traps (SIGTRAP) when a non-root caller invokes it.
         return None
     value = os.getenv(NATIVE_TARGET_UID_ENV_VAR)
@@ -449,7 +459,7 @@ class _RemotePairingSession:
 
         if not found.wait(self._REPLY_TIMEOUT):
             hint = f" matching udid {serial}" if serial is not None else ""
-            if os.geteuid() == 0 and native_target_uid() is None:
+            if _is_root() and native_target_uid() is None:
                 hint += (
                     f"; running as root with no console user -- {REMOTEPAIRING_MACH_SERVICE} is registered "
                     f"per-user, so set {NATIVE_TARGET_UID_ENV_VAR} to the uid of the logged-in user "

--- a/tests/test_native_tunnel.py
+++ b/tests/test_native_tunnel.py
@@ -365,27 +365,27 @@ class _FakeXpcForTargeting:
 
 def test_native_target_uid_is_none_when_unprivileged(monkeypatch: pytest.MonkeyPatch) -> None:
     # xpc_connection_set_target_uid traps for a non-root caller, so it must never be reached.
-    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 501)
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 501, raising=False)
     monkeypatch.setenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, "501")
     assert native_tunnel.native_target_uid() is None
 
 
 def test_native_target_uid_env_var_wins_over_console_user(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0, raising=False)
     monkeypatch.setattr(native_tunnel, "_console_user_uid", lambda: 501)
     monkeypatch.setenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, " 502 ")
     assert native_tunnel.native_target_uid() == 502
 
 
 def test_native_target_uid_invalid_env_falls_back_to_console_user(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0, raising=False)
     monkeypatch.setattr(native_tunnel, "_console_user_uid", lambda: 501)
     monkeypatch.setenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, "not-a-uid")
     assert native_tunnel.native_target_uid() == 501
 
 
 def test_native_target_uid_none_without_console_user(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0, raising=False)
     monkeypatch.delenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, raising=False)
     monkeypatch.setattr(native_tunnel, "_console_user_uid", lambda: None)
     assert native_tunnel.native_target_uid() is None


### PR DESCRIPTION
Follow-up to #1880, which went in during the GitHub Actions outage and so merged without CI. The Windows job caught what local macOS runs could not.

## The failure

`test (3.11, windows-latest)`:

```
E  AttributeError: <module 'os' (frozen)> has no attribute 'geteuid'
   tests\test_native_tunnel.py:368
FAILED test_native_target_uid_is_none_when_unprivileged
FAILED test_native_target_uid_env_var_wins_over_console_user
FAILED test_native_target_uid_invalid_env_falls_back_to_console_user
FAILED test_native_target_uid_none_without_console_user
```

`os.geteuid` is POSIX-only. Importing `native_tunnel` on Windows is legal — the module is only *useful* on macOS, but nothing stops it being imported — and the four new tests monkeypatched `os.geteuid` without `raising=False`, so `setattr` refused to create the missing attribute.

## The fix

Probe for the attribute in a `_is_root()` helper instead of calling it blind, and let the tests create it:

```python
def _is_root() -> bool:
    geteuid = getattr(os, "geteuid", None)
    return geteuid is not None and geteuid() == 0
```

**Shipped behaviour is unaffected.** `native_target_uid()` is reachable only from `_create_remotepairing_connection` and the browse failure hint, both behind `_libxpc()`, which raises `UserspaceTunnelUnavailableError` off Darwin. The v11.1.1 wheel is not broken on Windows — this was a test-only failure.

## Verification

Reproduced locally by running the suite with `os.geteuid` deleted, which is what the Windows runner looks like:

| | before | after |
|---|---|---|
| macOS, unmodified | 29 passed | 29 passed |
| `os.geteuid` deleted | **4 failed**, 25 passed | 29 passed |

Production path with no `os.geteuid`: `_is_root() -> False`, `native_target_uid() -> None`.

Plus `462 passed, 8 skipped` on the non-device suite, repo-wide pyright 0 errors, ruff clean.
