### PR TITLE
remote: retarget remotepairingd only after the lookup actually fails

### DIFF
--- a/docs/guides/network-stacks.md
+++ b/docs/guides/network-stacks.md
@@ -247,16 +247,25 @@ How it works (all via `ctypes` + libxpc, no pyobjc):
 - **Root:** not required. **Xcode:** not required.
 - **Running as root anyway (CI runners, LaunchDaemons):** `remotepairingd` is an XPCService
   declaring `ServiceType = User`, so launchd registers it **per-uid, in a logged-in user's domain
-  and never in the system/root domain**. A root process therefore gets `Connection invalid` from the
-  plain mach lookup — the service does not exist in its domain, which surfaces as
-  `remotepairingd reported no device`. Rather than relocating the process into the user's domain
-  (`launchctl asuser <uid>`), the connection is retargeted selectively with the libxpc SPI
-  `xpc_connection_set_target_uid`, so the process stays root and reaches only this one service.
-  This happens automatically when `geteuid() == 0`: the target uid is taken from
-  `PYMOBILEDEVICE3_NATIVE_TARGET_UID` when set, otherwise from the console user (the owner of
-  `/dev/console`). Set the variable explicitly on a host with no console user — a headless CI
-  runner — since there is no other way to guess which user holds the pairing. Note the SPI is
-  root-only: calling it as a normal user traps the process, so it is never used off the root path.
+  and never in the system/root domain**. Whether a root process can reach it depends entirely on
+  which bootstrap namespace it inherited, not on its uid: plain `sudo` from a logged-in user's
+  terminal inherits that user's namespace and works unchanged, while a LaunchDaemon or anything
+  under `launchctl asuser 0` lands in a domain where the service is simply not registered and gets
+  `XPC_ERROR_CONNECTION_INVALID` back.
+
+  So the ordinary lookup is always tried first, and only if the daemon reports the service missing
+  is another uid's domain searched, via the libxpc SPI `xpc_connection_set_target_uid`. That keeps
+  the process root — it reaches selectively into one domain rather than relocating itself — and it
+  reacts to what actually happened instead of guessing from the uid. The probe is free: the error
+  arrives about 0.2 ms after `xpc_connection_activate`, not at a timeout. The outcome is memoized
+  per process, so later browses go straight to the domain that answered.
+
+  The retry resolves the uid from the console user (owner of `/dev/console`). On a host with no
+  console user — a headless CI runner — set `PYMOBILEDEVICE3_NATIVE_TARGET_UID` to the uid that
+  holds the pairing; that also seeds the memo, skipping the first attempt entirely. Setting it to
+  `0` pins the ordinary lookup and disables retargeting. The SPI is root-only and **traps the
+  process** when a non-root caller invokes it, so a seeded uid is refused with a warning unless the
+  effective uid is 0.
 - **Reachability:** the tunnel address is a real kernel route (Apple's tunnel), so unlike the
   userspace tunnel it *is* reachable by other tools; it lives only while the handle (its assertion)
   is held. `remote start-tunnel` publishes this address for other processes (no `sudo`; the native

--- a/pymobiledevice3/remote/native_tunnel.py
+++ b/pymobiledevice3/remote/native_tunnel.py
@@ -29,7 +29,6 @@ import platform
 import socket
 import struct
 import threading
-import time
 import uuid
 from typing import Any, Callable, Optional, cast
 
@@ -50,6 +49,11 @@ REMOTED_PATH = "/usr/libexec/remoted"
 # another uid's domain, which lets such a process stay root and reach the login user's daemon
 # selectively. Set this to choose that uid explicitly -- required on a host with no console user.
 NATIVE_TARGET_UID_ENV_VAR = "PYMOBILEDEVICE3_NATIVE_TARGET_UID"
+
+# Per-process memo of how to reach remotepairingd, resolved from what the daemon actually does
+# rather than guessed from our own uid: ``None`` = not established yet, ``0`` = the ordinary lookup
+# works (never retarget), a positive uid = search that uid's launchd domain.
+_remotepairing_target_uid: Optional[int] = None
 
 # com.apple.dt.RemotePairingError code returned by InitiatePairingCommand when the host is already
 # paired -- a benign no-op, not a failure.
@@ -160,6 +164,15 @@ class _LibXpc:
         self.sysctlbyname: Callable[..., int] = self._cfg(
             "sysctlbyname", ctypes.c_int, [cp, vp, ctypes.POINTER(ctypes.c_size_t), vp, ctypes.c_size_t]
         )
+
+        # XPC_ERROR_CONNECTION_INVALID is `&_xpc_error_connection_invalid`: the symbol *is* the
+        # error object, so the sentinel to compare against is its address, not its value.
+        try:
+            self.error_connection_invalid: int = ctypes.addressof(
+                ctypes.c_void_p.in_dll(lib, "_xpc_error_connection_invalid")
+            )
+        except ValueError:
+            self.error_connection_invalid = 0
 
         # Address of the _NSConcreteGlobalBlock class object -> the block's isa pointer.
         self._global_block_isa = ctypes.addressof(ctypes.c_void_p.in_dll(lib, "_NSConcreteGlobalBlock"))
@@ -321,44 +334,118 @@ def _is_root() -> bool:
     return geteuid is not None and geteuid() == 0
 
 
-def native_target_uid() -> Optional[int]:
-    """uid whose launchd domain should be searched for ``remotepairingd``, or ``None`` for our own.
+def _seeded_target_uid() -> Optional[int]:
+    """Memoized target uid for this process, or ``None`` to use the ordinary lookup.
 
-    Only root can retarget, and only root needs to: an unprivileged process is already running in
-    the domain that holds the daemon. ``PYMOBILEDEVICE3_NATIVE_TARGET_UID`` wins when set, otherwise
-    the console user is assumed to be the one holding the pairing.
+    Seeded once from ``PYMOBILEDEVICE3_NATIVE_TARGET_UID`` when set, which skips the ordinary
+    attempt entirely -- what a daemon on a host with no console user wants, since it already knows
+    which uid holds the pairing. ``=0`` pins the ordinary lookup and disables retargeting.
     """
-    if not _is_root():
-        # xpc_connection_set_target_uid traps (SIGTRAP) when a non-root caller invokes it.
-        return None
+    global _remotepairing_target_uid
+    if _remotepairing_target_uid is not None:
+        return _remotepairing_target_uid or None
     value = os.getenv(NATIVE_TARGET_UID_ENV_VAR)
-    if value:
-        try:
-            return int(value.strip())
-        except ValueError:
-            logger.warning("ignoring invalid %s=%r (expected a numeric uid)", NATIVE_TARGET_UID_ENV_VAR, value)
-    return _console_user_uid()
+    if not value:
+        return None
+    try:
+        _remotepairing_target_uid = int(value.strip())
+    except ValueError:
+        logger.warning("ignoring invalid %s=%r (expected a numeric uid)", NATIVE_TARGET_UID_ENV_VAR, value)
+        return None
+    return _remotepairing_target_uid or None
 
 
-def _create_remotepairing_connection(xpc: _LibXpc, queue: int) -> int:
-    """Create the ``remotepairingd`` mach-service connection, retargeted when we are running as root.
+def _remember_plain_lookup_works() -> None:
+    """Memoize that the ordinary lookup reached the daemon, so later browses skip the retry dance."""
+    global _remotepairing_target_uid
+    if _remotepairing_target_uid is None:
+        _remotepairing_target_uid = 0
+
+
+def _resolve_target_uid_after_invalid(xpc: _LibXpc) -> Optional[int]:
+    """uid to retry in after the ordinary lookup reported the service missing, or ``None``.
+
+    Reached only once ``remotepairingd`` has actually told us it is not registered in our domain, so
+    nothing here is guessed from our own uid. ``None`` means there is no second thing to try -- most
+    importantly when we are not root, where the retarget SPI is both useless and fatal.
+    """
+    global _remotepairing_target_uid
+    if not _is_root():
+        return None
+    if xpc.connection_set_target_uid is None:
+        logger.warning(
+            "%s is not registered in this domain and xpc_connection_set_target_uid is unavailable "
+            "on this macOS, so another user's domain cannot be searched",
+            REMOTEPAIRING_MACH_SERVICE,
+        )
+        return None
+    uid = _console_user_uid()
+    if uid is None:
+        return None
+    _remotepairing_target_uid = uid
+    return uid
+
+
+def _create_remotepairing_connection(xpc: _LibXpc, queue: int, target_uid: Optional[int]) -> int:
+    """Create the ``remotepairingd`` mach-service connection, optionally aimed at another uid's domain.
 
     Returned inactive: the caller installs its event handler before activating.
     """
     conn = xpc.connection_create_mach_service(REMOTEPAIRING_MACH_SERVICE.encode(), queue, 0)
-    uid = native_target_uid()
-    if uid is None or uid == 0:
+    if not target_uid:
+        return conn
+    if not _is_root():
+        # xpc_connection_set_target_uid traps (SIGTRAP) when a non-root caller invokes it, so a
+        # seeded uid must never be honoured unprivileged.
+        logger.warning("ignoring %s: retargeting another uid's domain requires root", NATIVE_TARGET_UID_ENV_VAR)
         return conn
     if xpc.connection_set_target_uid is None:
         logger.warning(
-            "running as root, but xpc_connection_set_target_uid is unavailable on this macOS: "
-            "%s is registered per-user and will not be reachable from the root domain",
-            REMOTEPAIRING_MACH_SERVICE,
+            "ignoring %s: xpc_connection_set_target_uid is unavailable on this macOS", NATIVE_TARGET_UID_ENV_VAR
         )
         return conn
-    xpc.connection_set_target_uid(conn, uid)  # must precede xpc_connection_activate
-    logger.debug("searching uid %d's launchd domain for %s", uid, REMOTEPAIRING_MACH_SERVICE)
+    xpc.connection_set_target_uid(conn, target_uid)  # must precede xpc_connection_activate
+    logger.debug("searching uid %d's launchd domain for %s", target_uid, REMOTEPAIRING_MACH_SERVICE)
     return conn
+
+
+class _BrowseAttempt:
+    """One activated browse connection, tracking whether libxpc reported the service missing.
+
+    ``XPC_ERROR_CONNECTION_INVALID`` on a freshly activated connection means the mach service is not
+    registered in the domain we searched. Since ``remotepairingd`` is per-user, that is the signal
+    -- observed, not guessed -- that we are looking in the wrong domain. It arrives essentially
+    immediately (~0.2 ms), which is what makes trying the ordinary lookup first free. libxpc also
+    delivers the same error after our own ``cancel``, so ``invalid`` is only meaningful before that.
+    """
+
+    def __init__(
+        self,
+        xpc: _LibXpc,
+        queue: int,
+        on_device: Callable[[int], None],
+        target_uid: Optional[int],
+        settled: Optional[threading.Event] = None,
+    ) -> None:
+        self._xpc = xpc
+        self.invalid = threading.Event()
+        self.conn = _create_remotepairing_connection(xpc, queue, target_uid)
+
+        def handler(obj: int) -> None:
+            if obj and obj == xpc.error_connection_invalid:
+                self.invalid.set()
+                if settled is not None:
+                    settled.set()
+                return
+            on_device(obj)
+
+        xpc.connection_set_event_handler(self.conn, xpc.make_block(handler))
+        xpc.connection_activate(self.conn)
+        _send_browse_request(xpc, self.conn, queue)
+
+    def cancel(self) -> None:
+        with contextlib.suppress(Exception):
+            self._xpc.connection_cancel(self.conn)
 
 
 def _send_browse_request(xpc: _LibXpc, conn: int, queue: int) -> None:
@@ -422,44 +509,61 @@ class _RemotePairingSession:
         return holder[0]
 
     def browse(self, serial: Optional[str]) -> None:
-        """Browse for ``serial`` (or the first device) and open its per-device XPC endpoint."""
+        """Browse for ``serial`` (or the first device) and open its per-device XPC endpoint.
+
+        Tries the ordinary lookup first and only retargets another uid's domain if the daemon
+        reports it is not registered here -- see :class:`_BrowseAttempt`.
+        """
         xpc = self._xpc
         want = serial.encode() if serial is not None else None
         endpoint_holder: list[int] = []
-        found = threading.Event()
 
-        def on_event(obj: int) -> None:
-            if not obj:
-                return
-            value = xpc.dictionary_get_value(obj, b"value")
-            if not value:
-                return
-            device_found = xpc.dictionary_get_value(value, b"deviceFound")
-            if not device_found:
-                return
-            zero = xpc.dictionary_get_value(device_found, b"_0")
-            info = xpc.dictionary_get_value(zero, b"deviceInfo") if zero else 0
-            if not info:
-                return
-            udid = xpc.dictionary_get_string(info, b"udid")
-            if want is not None and udid != want:
-                return
-            endpoint = xpc.dictionary_get_value(info, b"endpoint")
-            if endpoint and not found.is_set():
-                self.auxiliary_metadata = parse_device_kvs_data(xpc.get_data_bytes(info, b"deviceKVSData"))
-                xpc.retain(endpoint)
-                endpoint_holder.append(endpoint)
-                found.set()
+        def make_on_device(settled: threading.Event) -> Callable[[int], None]:
+            def on_device(obj: int) -> None:
+                if not obj:
+                    return
+                value = xpc.dictionary_get_value(obj, b"value")
+                if not value:
+                    return
+                device_found = xpc.dictionary_get_value(value, b"deviceFound")
+                if not device_found:
+                    return
+                zero = xpc.dictionary_get_value(device_found, b"_0")
+                info = xpc.dictionary_get_value(zero, b"deviceInfo") if zero else 0
+                if not info:
+                    return
+                udid = xpc.dictionary_get_string(info, b"udid")
+                if want is not None and udid != want:
+                    return
+                endpoint = xpc.dictionary_get_value(info, b"endpoint")
+                if endpoint and not settled.is_set():
+                    self.auxiliary_metadata = parse_device_kvs_data(xpc.get_data_bytes(info, b"deviceKVSData"))
+                    xpc.retain(endpoint)
+                    endpoint_holder.append(endpoint)
+                    settled.set()
 
-        conn = _create_remotepairing_connection(xpc, self._queue)
-        self._browse_conn = conn
-        xpc.connection_set_event_handler(conn, xpc.make_block(on_event))
-        xpc.connection_activate(conn)
-        _send_browse_request(xpc, conn, self._queue)
+            return on_device
 
-        if not found.wait(self._REPLY_TIMEOUT):
+        def attempt(target_uid: Optional[int]) -> _BrowseAttempt:
+            settled = threading.Event()
+            att = _BrowseAttempt(xpc, self._queue, make_on_device(settled), target_uid, settled)
+            self._browse_conn = att.conn
+            settled.wait(self._REPLY_TIMEOUT)
+            return att
+
+        seeded = _seeded_target_uid()
+        att = attempt(seeded)
+        if not endpoint_holder and att.invalid.is_set():
+            retry_uid = _resolve_target_uid_after_invalid(xpc)
+            if retry_uid is not None:
+                att.cancel()
+                attempt(retry_uid)
+        elif endpoint_holder and not seeded:
+            _remember_plain_lookup_works()
+
+        if not endpoint_holder:
             hint = f" matching udid {serial}" if serial is not None else ""
-            if _is_root() and native_target_uid() is None:
+            if _is_root() and _console_user_uid() is None and _seeded_target_uid() is None:
                 hint += (
                     f"; running as root with no console user -- {REMOTEPAIRING_MACH_SERVICE} is registered "
                     f"per-user, so set {NATIVE_TARGET_UID_ENV_VAR} to the uid of the logged-in user "
@@ -566,12 +670,23 @@ def _browse_native_devices_sync(xpc: _LibXpc, timeout: float) -> list[dict[str, 
                 seen.add(key)
                 devices.append(info_dict)
 
-    conn = _create_remotepairing_connection(xpc, queue)
-    xpc.connection_set_event_handler(conn, xpc.make_block(on_event))
-    xpc.connection_activate(conn)
-    _send_browse_request(xpc, conn, queue)
-    time.sleep(timeout)  # deviceFound events stream in asynchronously; collect for the whole window
-    xpc.connection_cancel(conn)
+    def attempt(target_uid: Optional[int]) -> _BrowseAttempt:
+        att = _BrowseAttempt(xpc, queue, on_event, target_uid)
+        # deviceFound events stream in asynchronously, so collect for the whole window -- unless the
+        # domain turns out to be wrong, which libxpc reports at once and ends the wait early.
+        att.invalid.wait(timeout)
+        return att
+
+    seeded = _seeded_target_uid()
+    att = attempt(seeded)
+    if att.invalid.is_set():
+        retry_uid = _resolve_target_uid_after_invalid(xpc)
+        if retry_uid is not None:
+            att.cancel()
+            att = attempt(retry_uid)
+    elif not seeded:
+        _remember_plain_lookup_works()
+    att.cancel()
     with lock:
         return list(devices)
 

--- a/tests/test_native_tunnel.py
+++ b/tests/test_native_tunnel.py
@@ -363,32 +363,67 @@ class _FakeXpcForTargeting:
         return 0xC0FFEE
 
 
-def test_native_target_uid_is_none_when_unprivileged(monkeypatch: pytest.MonkeyPatch) -> None:
-    # xpc_connection_set_target_uid traps for a non-root caller, so it must never be reached.
-    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 501, raising=False)
-    monkeypatch.setenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, "501")
-    assert native_tunnel.native_target_uid() is None
-
-
-def test_native_target_uid_env_var_wins_over_console_user(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0, raising=False)
-    monkeypatch.setattr(native_tunnel, "_console_user_uid", lambda: 501)
-    monkeypatch.setenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, " 502 ")
-    assert native_tunnel.native_target_uid() == 502
-
-
-def test_native_target_uid_invalid_env_falls_back_to_console_user(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0, raising=False)
-    monkeypatch.setattr(native_tunnel, "_console_user_uid", lambda: 501)
-    monkeypatch.setenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, "not-a-uid")
-    assert native_tunnel.native_target_uid() == 501
-
-
-def test_native_target_uid_none_without_console_user(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0, raising=False)
+@pytest.fixture(autouse=True)
+def _reset_target_uid_memo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The resolved domain is memoized per process; keep it from leaking between tests."""
+    monkeypatch.setattr(native_tunnel, "_remotepairing_target_uid", None, raising=False)
     monkeypatch.delenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, raising=False)
+
+
+def test_seeded_target_uid_is_none_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No env and nothing established yet: the ordinary lookup is tried first, unaimed.
+    assert native_tunnel._seeded_target_uid() is None
+
+
+def test_seeded_target_uid_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, " 502 ")
+    assert native_tunnel._seeded_target_uid() == 502
+
+
+def test_seeded_target_uid_zero_pins_the_ordinary_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, "0")
+    assert native_tunnel._seeded_target_uid() is None
+    assert native_tunnel._remotepairing_target_uid == 0  # memoized, so retargeting stays disabled
+
+
+def test_seeded_target_uid_ignores_invalid_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(native_tunnel.NATIVE_TARGET_UID_ENV_VAR, "not-a-uid")
+    assert native_tunnel._seeded_target_uid() is None
+
+
+def test_remember_plain_lookup_works_memoizes(monkeypatch: pytest.MonkeyPatch) -> None:
+    native_tunnel._remember_plain_lookup_works()
+    assert native_tunnel._remotepairing_target_uid == 0
+    assert native_tunnel._seeded_target_uid() is None
+
+
+def test_resolve_after_invalid_is_none_when_unprivileged(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Not root: there is no second thing to try, and the SPI would trap.
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 501, raising=False)
+    monkeypatch.setattr(native_tunnel, "_console_user_uid", lambda: 501)
+    assert native_tunnel._resolve_target_uid_after_invalid(cast(Any, _FakeXpcForTargeting())) is None
+
+
+def test_resolve_after_invalid_returns_console_user_and_memoizes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0, raising=False)
+    monkeypatch.setattr(native_tunnel, "_console_user_uid", lambda: 501)
+    assert native_tunnel._resolve_target_uid_after_invalid(cast(Any, _FakeXpcForTargeting())) == 501
+    assert native_tunnel._remotepairing_target_uid == 501
+    assert native_tunnel._seeded_target_uid() == 501  # later browses go straight to that domain
+
+
+def test_resolve_after_invalid_none_without_console_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0, raising=False)
     monkeypatch.setattr(native_tunnel, "_console_user_uid", lambda: None)
-    assert native_tunnel.native_target_uid() is None
+    assert native_tunnel._resolve_target_uid_after_invalid(cast(Any, _FakeXpcForTargeting())) is None
+
+
+def test_resolve_after_invalid_none_when_spi_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A future macOS could drop the SPI the way xpc_connection_set_target_gid was dropped.
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0, raising=False)
+    monkeypatch.setattr(native_tunnel, "_console_user_uid", lambda: 501)
+    xpc = _FakeXpcForTargeting(has_spi=False)
+    assert native_tunnel._resolve_target_uid_after_invalid(cast(Any, xpc)) is None
 
 
 def test_console_user_uid_reads_dev_console_owner(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -404,23 +439,29 @@ def test_console_user_uid_reads_dev_console_owner(monkeypatch: pytest.MonkeyPatc
     assert uid is None or uid > 0  # root-owned (logged out) reports None rather than uid 0
 
 
-def test_create_remotepairing_connection_retargets_when_root(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(native_tunnel, "native_target_uid", lambda: 501)
+def test_create_connection_retargets_when_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0, raising=False)
     xpc = _FakeXpcForTargeting()
-    conn = native_tunnel._create_remotepairing_connection(cast(Any, xpc), 0)
-    assert conn == 0xC0FFEE
+    assert native_tunnel._create_remotepairing_connection(cast(Any, xpc), 0, 501) == 0xC0FFEE
     assert xpc.calls == [(0xC0FFEE, 501)]
 
 
-def test_create_remotepairing_connection_leaves_plain_lookup_alone(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(native_tunnel, "native_target_uid", lambda: None)
+def test_create_connection_without_target_is_a_plain_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0, raising=False)
     xpc = _FakeXpcForTargeting()
-    native_tunnel._create_remotepairing_connection(cast(Any, xpc), 0)
+    native_tunnel._create_remotepairing_connection(cast(Any, xpc), 0, None)
     assert xpc.calls == []
 
 
-def test_create_remotepairing_connection_survives_missing_spi(monkeypatch: pytest.MonkeyPatch) -> None:
-    # A future macOS could drop the SPI the way xpc_connection_set_target_gid was dropped.
-    monkeypatch.setattr(native_tunnel, "native_target_uid", lambda: 501)
+def test_create_connection_never_retargets_unprivileged(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Honouring a seeded uid without root would trap the process (SIGTRAP), so it must be refused.
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 501, raising=False)
+    xpc = _FakeXpcForTargeting()
+    native_tunnel._create_remotepairing_connection(cast(Any, xpc), 0, 501)
+    assert xpc.calls == []
+
+
+def test_create_connection_survives_missing_spi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_tunnel.os, "geteuid", lambda: 0, raising=False)
     xpc = _FakeXpcForTargeting(has_spi=False)
-    assert native_tunnel._create_remotepairing_connection(cast(Any, xpc), 0) == 0xC0FFEE
+    assert native_tunnel._create_remotepairing_connection(cast(Any, xpc), 0, 501) == 0xC0FFEE


### PR DESCRIPTION
Follow-up to #1880 / #1881. Reaching the per-user `remotepairingd` from root is not really a uid question, and keying off `euid == 0` was the wrong signal.

## What was wrong

What decides reachability is which **bootstrap namespace** the process inherited, not its uid:

| how root was reached | ordinary lookup | v11.1.2 behaviour |
|---|---|---|
| plain `sudo` from a logged-in terminal | **works** (inherits the user's namespace) | retargets anyway, on a guess |
| `launchctl asuser 0` / LaunchDaemon | `XPC_ERROR_CONNECTION_INVALID` | retargets — correct |

In the first row the retarget is unnecessary, and it aims at the console user, which on a multi-user machine need not be the uid whose namespace was actually inherited.

## What it does now

Try the ordinary lookup first; reach into another uid's domain only once the daemon has actually reported the service missing. The probe is free — measured **~0.2 ms** from `xpc_connection_activate` to the error, not a timeout:

| measurement | result |
|---|---|
| `Connection invalid`, root domain | 0.20 ms |
| `deviceFound`, working domain | 0.42 ms |

The outcome is memoized per process, so later browses go straight to whatever answered. `PYMOBILEDEVICE3_NATIVE_TARGET_UID` seeds that memo and skips the first attempt for a host that already knows which uid holds the pairing; `=0` pins the ordinary lookup and disables retargeting.

Two details worth flagging:

- The sentinel is compared **by pointer against `&_xpc_error_connection_invalid`** — the symbol *is* the error object, so the address is the sentinel, not its value. Comparing `.value` silently never matches.
- libxpc delivers the same error after our own `cancel`, so `invalid` is only consulted before cancelling.
- A seeded uid is refused unless `euid == 0`: the SPI **traps the process** (SIGTRAP) for a non-root caller.

## Verification

Live, against a physical iPhone17,3 / iOS 26.1 on macOS 26. `retargeted` is read from the debug log:

| case | euid | env | devices | retargeted | memo |
|---|---|---|---|---|---|
| 1. normal user | 501 | — | 1 | **False** | 0 |
| 2. `launchctl asuser 0` | 0 | — | 1 | **True** | 501 |
| 3. plain `sudo` (inherits user ns) | 0 | — | 1 | **False** | 0 |
| 4. `sudo` + seed, where plain would work | 0 | 501 | 1 | **True** | 501 |
| 5. non-root + seed | 501 | 501 | 1 | False, warns | — |

**Correction to an earlier draft of this description:** case 3 is *not* a bug fixed. Measured on master, v11.1.2 under plain `sudo` retargets to uid 501 and still finds the device — the retarget is unnecessary, not wrong, because the console user happens to be the same user whose namespace was inherited. The behaviours diverge only when those two differ (sudo from user A's SSH session while user B is at the console, or fast user switching), which I have **not** reproduced — it needs a second account. So on today's tested configurations this PR is behaviour-neutral; the gain is robustness, not a fix.

Case 4 proves the seed genuinely skips the probe — it retargets in a domain where the ordinary lookup would have succeeded. Case 5 exits 0, not 133, so the SIGTRAP guard holds.

`remote start-tunnel` under `launchctl asuser 0` still comes up end to end (`RSD Address: fd9d:18ae:62ae::1`, `RSD Port: 61655`).

`468 passed, 8 skipped` non-device, plus the suite re-run with `os.geteuid` deleted to cover the Windows runner. Repo-wide pyright 0 errors, ruff clean.

