### PR TITLE
remote: DeviceNotFoundError for the native tunnel, and a message on every raise site

### DIFF
--- a/docs/guides/environment-variables.md
+++ b/docs/guides/environment-variables.md
@@ -1,0 +1,55 @@
+---
+search:
+  boost: 2
+---
+
+# Environment variables
+
+Every `pymobiledevice3` environment variable, what it sets, and where it is explained in depth.
+Each one is a default: the matching command-line option always wins.
+
+## Device selection
+
+| Variable | Value | Effect |
+| --- | --- | --- |
+| `PYMOBILEDEVICE3_UDID` | device UDID | Default for `--udid` — the device every command targets. |
+| `PYMOBILEDEVICE3_USBMUX` | unix socket path or `HOST:PORT` | Default for `--usbmux` — where `usbmuxd` is listening. |
+| `USBMUXD_SOCKET_ADDRESS` | unix socket path or `HOST:PORT` | Same as above; honored for compatibility with `libimobiledevice`. |
+
+## Transport (iOS 17+ tunnels)
+
+| Variable | Value | Effect |
+| --- | --- | --- |
+| `PYMOBILEDEVICE3_DEFAULT_FALLBACK` | `native`, `userspace` or `tunneld` | Which transport the **automatic** selection prefers, both for commands that require an RSD and for the retry the CLI performs when a command turns out to need a tunnel. Built-in default: `native` on macOS, `userspace` elsewhere. An unrecognized value logs a warning and is ignored. |
+| `PYMOBILEDEVICE3_NATIVE` | `1` | Same as `--native`: piggyback Apple's `remoted` tunnel via `remotepairingd`. macOS only, no root. |
+| `PYMOBILEDEVICE3_USERSPACE` | `1` | Same as `--userspace`: force the in-process pure-Python userspace tunnel. |
+| `PYMOBILEDEVICE3_TUNNEL` | `UDID`, `UDID:PORT` or `UDID:UDS_PATH` | Same as `--tunnel`: take the tunnel from a running `tunneld`. An empty UDID picks the only tunnel, or prompts. |
+
+`--rsd`, `--tunnel`, `--userspace` and `--native` are mutually exclusive, so set at most one of
+their variables. See [iOS 17+ tunnels](ios17-tunnels.md) for when each transport applies, and
+[Understanding the network stacks](network-stacks.md) for how they differ.
+
+```shell
+# opt back out of the macOS native default for this shell
+export PYMOBILEDEVICE3_DEFAULT_FALLBACK=userspace
+```
+
+## Advanced
+
+| Variable | Value | Effect |
+| --- | --- | --- |
+| `PYMOBILEDEVICE3_NATIVE_TARGET_UID` | numeric uid | Which login user's `remotepairingd` the native tunnel talks to. `remotepairingd` is registered per-user, so a **root** process (CI runner, LaunchDaemon) needs this to reach the pairing owned by the logged-in user. Ignored (with a warning) when not running as root. |
+| `PYMOBILEDEVICE3_USERSPACE_TCP_RELAY` | any non-empty value | Debug: force the userspace tunnel's relays onto loopback TCP even where `AF_UNIX` exists, reproducing the Windows relay path on any platform. |
+
+## Set by your environment, not by you
+
+These are read from the environment your shell or OS already provides; they are listed so their
+effect is not a surprise.
+
+| Variable | Effect |
+| --- | --- |
+| `SUDO_USER` | Under `sudo`, pymobiledevice3 resolves `~` (and therefore `~/.pymobiledevice3`, where pair records live) to the **invoking** user's home, not root's. |
+| `SUDO_UID`, `SUDO_GID` | Files pymobiledevice3 creates under `sudo` are chowned back to the invoking user, so a later non-root run can still read them. |
+| `ALLUSERSPROFILE` | Windows only: where Apple's `Lockdown` pair records are looked up (`%ALLUSERSPROFILE%\Apple\Lockdown`). |
+| `TERM` | Passed through to the shell `developer debugserver` spawns; defaults to `xterm-256color`. |
+| `_PYMOBILEDEVICE3_COMPLETE` | Set by the shell-completion scripts (`--install-completion`). Its presence makes commands skip connecting to the device. |

--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -44,7 +44,8 @@ If the native path is unavailable on macOS it falls back automatically (userspac
 Either way you just run the command. This covers iOS 17.4+ over USB with no privileges (it uses the
 CoreDeviceProxy lockdown service); iOS 17.0-17.3.1 is handled differently — see the note below.
 Set `PYMOBILEDEVICE3_DEFAULT_FALLBACK=native|userspace|tunneld` to change which transport the
-automatic selection prefers.
+automatic selection prefers (see [Environment variables](environment-variables.md) for every
+variable the CLI honors).
 
 !!! warning "iOS 17.0-17.3.1 uses `tunneld` by default"
     These versions predate the CoreDeviceProxy service, so the userspace tunnel can only reach them

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -41,8 +41,9 @@ The usbmuxd daemon itself is not reachable.
 
 ### "Device not found: ..." (`DeviceNotFoundError`)
 
-The UDID you passed (via `--udid` or `PYMOBILEDEVICE3_UDID`) doesn't match any connected
-device. List what's actually connected:
+The UDID you passed (via `--udid` or `PYMOBILEDEVICE3_UDID`) doesn't match any device known to
+the transport that was asked for it — the message names that transport (`usbmux`, `tunneld`,
+`remotepairingd` for the native tunnel). List what's actually connected:
 
 ```shell
 pymobiledevice3 usbmux list

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ plugins:
         Guides:
           - guides/cli-recipes.md
           - guides/ios17-tunnels.md
+          - guides/environment-variables.md
           - guides/webview-debugging.md
           - guides/machine-readable-output.md
           - guides/python-api.md
@@ -123,6 +124,7 @@ nav:
       - Mounting AFC in Finder (WebDAV): guides/webdav-mounting.md
       - iOS 17+ tunnels: guides/ios17-tunnels.md
       - Understanding the network stacks: guides/network-stacks.md
+      - Environment variables: guides/environment-variables.md
       - WebView debugging: guides/webview-debugging.md
       - Machine-readable output: guides/machine-readable-output.md
       - Python API: guides/python-api.md

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -366,6 +366,13 @@ def invoke_cli_with_error_handling() -> bool:
         )
     except RoutableTunnelRequiredError as e:
         logger.error(str(e))
+    except DeviceNotFoundError as e:
+        # A transport that explains why (e.g. the native tunnel) carries its own message; the
+        # usbmux/tunneld paths carry only the udid.
+        logger.error(str(e) if e.args else f"Device not found: {e.udid}")
+        # Reconnectable: after a disconnect the target device may still be re-enumerating
+        # while other devices are attached, making re-invocation fail with this error.
+        return True
     except UserspaceTunnelUnavailableError as e:
         logger.error(str(e))
     except DeviceFeatureNotSupportedError as e:
@@ -423,11 +430,6 @@ def invoke_cli_with_error_handling() -> bool:
         logger.error(
             "Unable to connect to Tunneld. You can start one using:\nsudo python3 -m pymobiledevice3 remote tunneld"
         )
-    except DeviceNotFoundError as e:
-        logger.error(f"Device not found: {e.udid}")
-        # Reconnectable: after a disconnect the target device may still be re-enumerating
-        # while other devices are attached, making re-invocation fail with this error.
-        return True
     except NotEnoughDiskSpaceError:
         logger.error("Not enough disk space")
     except DeprecationError:

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -367,9 +367,8 @@ def invoke_cli_with_error_handling() -> bool:
     except RoutableTunnelRequiredError as e:
         logger.error(str(e))
     except DeviceNotFoundError as e:
-        # A transport that explains why (e.g. the native tunnel) carries its own message; the
-        # usbmux/tunneld paths carry only the udid.
-        logger.error(str(e) if e.args else f"Device not found: {e.udid}")
+        # The message names the lookup that failed (usbmux/tunneld/remotepairingd/...).
+        logger.error(str(e))
         # Reconnectable: after a disconnect the target device may still be re-enumerating
         # while other devices are attached, making re-invocation fail with this error.
         return True

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -307,7 +307,12 @@ async def _tunneld(udid: Optional[str] = None) -> Optional[RemoteServiceDiscover
     if udid != "":
         service_provider = next((rsd for rsd in rsds if rsd.udid == udid), None)
         if service_provider is None:
-            raise DeviceNotFoundError(udid) from None
+            where = (
+                tunneld_address if isinstance(tunneld_address, str) else f"{tunneld_address[0]}:{tunneld_address[1]}"
+            )
+            raise DeviceNotFoundError(
+                udid, f"Device not found: tunneld ({where}) serves no tunnel for udid {udid}"
+            ) from None
     else:
         service_provider = rsds[0] if len(rsds) == 1 else prompt_device_list(rsds)
 

--- a/pymobiledevice3/cli/developer/wda.py
+++ b/pymobiledevice3/cli/developer/wda.py
@@ -64,7 +64,10 @@ async def wait_for_xctest_app(service_provider: LockdownServiceProvider, xctrunn
 
             device = await usbmux.select_device(service_provider.udid)
             if device is None:
-                raise DeviceNotFoundError(service_provider.udid)
+                raise DeviceNotFoundError(
+                    service_provider.udid,
+                    f"Device not found: {service_provider.udid} left usbmux while waiting for WDA to become reachable",
+                )
             try:
                 probe_sock = await device.connect(DEFAULT_WDA_PORT)
             except ConnectionFailedError:

--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -144,8 +144,15 @@ class InterfaceIndexNotFoundError(PyMobileDevice3Exception):
 
 
 class DeviceNotFoundError(PyMobileDevice3Exception):
-    def __init__(self, udid: Optional[str]):
-        super().__init__()
+    """A device with the requested UDID was not found by the transport that was asked for it.
+
+    Every raise site passes a message naming the lookup that failed (usbmux, tunneld,
+    remotepairingd, ...) — ``str(exc)`` is therefore self-explanatory — while ``udid`` remains a
+    dedicated member so callers can act on the target itself.
+    """
+
+    def __init__(self, udid: Optional[str], message: Optional[str] = None) -> None:
+        super().__init__(message or f"Device not found: {udid}")
         self.udid = udid
 
 

--- a/pymobiledevice3/remote/native_tunnel.py
+++ b/pymobiledevice3/remote/native_tunnel.py
@@ -473,11 +473,8 @@ class _RemotePairingDeviceNotFoundError(_RemotePairingError, DeviceNotFoundError
     so the CLI's native -> userspace/tunneld routing keeps treating it as a native-path failure.
     """
 
-    def __init__(self, message: str, udid: Optional[str] = None) -> None:
-        # Explicit, since DeviceNotFoundError.__init__ takes the udid as its only argument and
-        # would swallow the message.
-        Exception.__init__(self, message)
-        self.udid = udid
+    def __init__(self, udid: Optional[str], message: Optional[str] = None) -> None:
+        DeviceNotFoundError.__init__(self, udid, message)
 
 
 class _RemotePairingSession:
@@ -584,7 +581,9 @@ class _RemotePairingSession:
                     f"per-user, so set {NATIVE_TARGET_UID_ENV_VAR} to the uid of the logged-in user "
                     "that owns the pairing"
                 )
-            raise _RemotePairingDeviceNotFoundError(f"remotepairingd reported no device{hint}", serial)
+            raise _RemotePairingDeviceNotFoundError(
+                serial, f"Device not found: remotepairingd reported no device{hint}"
+            )
 
         device_conn = xpc.connection_create_from_endpoint(endpoint_holder[0])
         self._device_conn = device_conn

--- a/pymobiledevice3/remote/native_tunnel.py
+++ b/pymobiledevice3/remote/native_tunnel.py
@@ -32,7 +32,7 @@ import threading
 import uuid
 from typing import Any, Callable, Optional, cast
 
-from pymobiledevice3.exceptions import UserspaceTunnelUnavailableError
+from pymobiledevice3.exceptions import DeviceNotFoundError, UserspaceTunnelUnavailableError
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService, parse_device_kvs_data
 
 logger = logging.getLogger(__name__)
@@ -465,6 +465,21 @@ class _RemotePairingError(UserspaceTunnelUnavailableError):
     pass
 
 
+class _RemotePairingDeviceNotFoundError(_RemotePairingError, DeviceNotFoundError):
+    """``remotepairingd`` reported no matching device.
+
+    Inherits :class:`~pymobiledevice3.exceptions.DeviceNotFoundError` so callers get the same
+    exception type the usbmux/tunneld paths raise for a missing device, and ``_RemotePairingError``
+    so the CLI's native -> userspace/tunneld routing keeps treating it as a native-path failure.
+    """
+
+    def __init__(self, message: str, udid: Optional[str] = None) -> None:
+        # Explicit, since DeviceNotFoundError.__init__ takes the udid as its only argument and
+        # would swallow the message.
+        Exception.__init__(self, message)
+        self.udid = udid
+
+
 class _RemotePairingSession:
     """Synchronous libxpc conversation with ``remotepairingd`` that owns the tunnel assertion.
 
@@ -569,7 +584,7 @@ class _RemotePairingSession:
                     f"per-user, so set {NATIVE_TARGET_UID_ENV_VAR} to the uid of the logged-in user "
                     "that owns the pairing"
                 )
-            raise _RemotePairingError(f"remotepairingd reported no device{hint}")
+            raise _RemotePairingDeviceNotFoundError(f"remotepairingd reported no device{hint}", serial)
 
         device_conn = xpc.connection_create_from_endpoint(endpoint_holder[0])
         self._device_conn = device_conn

--- a/pymobiledevice3/service_connection.py
+++ b/pymobiledevice3/service_connection.py
@@ -189,7 +189,8 @@ class ServiceConnection:
         target_device = await select_device(udid, connection_type=connection_type, usbmux_address=usbmux_address)
         if target_device is None:
             if udid:
-                raise DeviceNotFoundError(udid)
+                over = f" over {connection_type}" if connection_type else ""
+                raise DeviceNotFoundError(udid, f"Device not found: usbmux has no device matching udid {udid}{over}")
             raise NoDeviceConnectedError()
         sock = await target_device.connect(port, usbmux_address=usbmux_address)
         return ServiceConnection(sock, mux_device=target_device)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -246,6 +246,18 @@ def test_device_not_found_is_a_reconnectable_failure(monkeypatch):
     assert __main__.invoke_cli_with_error_handling() is True
 
 
+def test_native_tunnel_device_not_found_is_reconnectable(monkeypatch):
+    """The native tunnel's "no such device" error is both a DeviceNotFoundError and a native-path
+    failure; it must be handled as the former (reconnectable, keeps its explanatory message)."""
+    from pymobiledevice3.remote.native_tunnel import _RemotePairingDeviceNotFoundError
+
+    def raise_not_found(*args, **kwargs):
+        raise _RemotePairingDeviceNotFoundError("remotepairingd reported no device matching udid X", "X")
+
+    monkeypatch.setattr(__main__, "app", raise_not_found)
+    assert __main__.invoke_cli_with_error_handling() is True
+
+
 def test_reconnect_reuses_interactively_selected_device(monkeypatch):
     """When the device was chosen at the interactive prompt (no --udid on argv/env), `--reconnect`
     must wait for and re-target that same device, not whichever device appears first."""

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -246,13 +246,46 @@ def test_device_not_found_is_a_reconnectable_failure(monkeypatch):
     assert __main__.invoke_cli_with_error_handling() is True
 
 
+def test_tunneld_device_not_found_names_the_tunneld_instance(monkeypatch):
+    """The tunneld lookup must say which tunneld was queried, on top of the `udid` member."""
+    import asyncio
+
+    from pymobiledevice3.cli import cli_common
+    from pymobiledevice3.exceptions import DeviceNotFoundError
+
+    class _FakeRsd:
+        udid = "OTHER-UDID"
+
+        async def close(self):
+            pass
+
+    async def fake_get_tunneld_devices(address):
+        return [_FakeRsd()]
+
+    monkeypatch.setattr(cli_common, "get_tunneld_devices", fake_get_tunneld_devices)
+
+    # A private loop, not asyncio.run: its cleanup unsets the main-thread event loop and breaks
+    # later sync tests on Python 3.9 (see _patch_isolated_asyncio_run above).
+    loop = asyncio.new_event_loop()
+    try:
+        with pytest.raises(DeviceNotFoundError) as exc_info:
+            loop.run_until_complete(cli_common._tunneld("TARGET-UDID:1234"))
+    finally:
+        loop.close()
+
+    assert exc_info.value.udid == "TARGET-UDID"
+    assert str(exc_info.value) == ("Device not found: tunneld (127.0.0.1:1234) serves no tunnel for udid TARGET-UDID")
+
+
 def test_native_tunnel_device_not_found_is_reconnectable(monkeypatch):
     """The native tunnel's "no such device" error is both a DeviceNotFoundError and a native-path
     failure; it must be handled as the former (reconnectable, keeps its explanatory message)."""
     from pymobiledevice3.remote.native_tunnel import _RemotePairingDeviceNotFoundError
 
     def raise_not_found(*args, **kwargs):
-        raise _RemotePairingDeviceNotFoundError("remotepairingd reported no device matching udid X", "X")
+        raise _RemotePairingDeviceNotFoundError(
+            "X", "Device not found: remotepairingd reported no device matching udid X"
+        )
 
     monkeypatch.setattr(__main__, "app", raise_not_found)
     assert __main__.invoke_cli_with_error_handling() is True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,11 +132,13 @@ async def service_provider(
                 try:
                     selected_rsd = rsds[0]
                 except IndexError as e:
-                    raise DeviceNotFoundError(tunnel_option) from e
+                    raise DeviceNotFoundError(tunnel_option, "Device not found: tunneld serves no tunnel") from e
             else:
                 selected_rsd = next((rsd for rsd in rsds if rsd.udid == tunnel_option), None)
                 if selected_rsd is None:
-                    raise DeviceNotFoundError(tunnel_option)
+                    raise DeviceNotFoundError(
+                        tunnel_option, f"Device not found: tunneld serves no tunnel for udid {tunnel_option}"
+                    )
 
             yield selected_rsd
         finally:

--- a/tests/test_native_tunnel.py
+++ b/tests/test_native_tunnel.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, cast
 
 import pytest
 
-from pymobiledevice3.exceptions import UserspaceTunnelUnavailableError
+from pymobiledevice3.exceptions import DeviceNotFoundError, UserspaceTunnelUnavailableError
 from pymobiledevice3.remote import native_tunnel
 
 
@@ -161,6 +161,36 @@ async def test_aopen_retries_handshake_with_fresh_port_scan(
     assert rsd.address == ("fdcd:5fb2:b94b::1", 51013)
     assert scan_count == 2
     await tunnel.aclose()
+
+
+def test_browse_missing_device_raises_device_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A device remotepairingd does not report must surface as DeviceNotFoundError -- the same type
+    the usbmux/tunneld paths raise -- while staying a native-path (UserspaceTunnelUnavailable)
+    failure so the CLI's transport routing keeps falling back."""
+    import threading
+
+    class FakeAttempt:
+        def __init__(self, xpc: object, queue: object, on_device: object, target_uid: object, settled: Any) -> None:
+            self.conn = 0
+            self.invalid = threading.Event()
+            settled.set()  # nothing matched; settle instead of blocking on the reply timeout
+
+        def cancel(self) -> None:
+            pass
+
+    monkeypatch.setattr(native_tunnel, "_BrowseAttempt", FakeAttempt)
+    monkeypatch.setattr(native_tunnel, "_seeded_target_uid", lambda: None)
+    monkeypatch.setattr(native_tunnel, "_is_root", lambda: False)
+
+    session = cast(Any, native_tunnel._RemotePairingSession.__new__(native_tunnel._RemotePairingSession))
+    session._xpc = object()
+    session._queue = 0
+
+    with pytest.raises(DeviceNotFoundError) as exc_info:
+        session.browse("BOGUS-UDID")
+    assert exc_info.value.udid == "BOGUS-UDID"
+    assert isinstance(exc_info.value, UserspaceTunnelUnavailableError)
+    assert "BOGUS-UDID" in str(exc_info.value)
 
 
 def test_libxpc_requires_darwin(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_native_tunnel.py
+++ b/tests/test_native_tunnel.py
@@ -190,7 +190,7 @@ def test_browse_missing_device_raises_device_not_found(monkeypatch: pytest.Monke
         session.browse("BOGUS-UDID")
     assert exc_info.value.udid == "BOGUS-UDID"
     assert isinstance(exc_info.value, UserspaceTunnelUnavailableError)
-    assert "BOGUS-UDID" in str(exc_info.value)
+    assert "BOGUS-UDID" in str(exc_info.value) and "remotepairingd" in str(exc_info.value)
 
 
 def test_libxpc_requires_darwin(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_service_connection.py
+++ b/tests/test_service_connection.py
@@ -5,7 +5,7 @@ from typing import cast
 
 import pytest
 
-from pymobiledevice3.exceptions import ConnectionTerminatedError
+from pymobiledevice3.exceptions import ConnectionTerminatedError, DeviceNotFoundError
 from pymobiledevice3.service_connection import ServiceConnection
 
 
@@ -27,6 +27,30 @@ class _FakeWriter:
 
     async def wait_closed(self) -> None:
         await asyncio.Future()
+
+
+@pytest.mark.asyncio
+async def test_create_using_usbmux_missing_device_explains_the_failed_lookup(monkeypatch):
+    """DeviceNotFoundError must carry a message naming the lookup that failed, on top of the
+    machine-readable `udid` member."""
+
+    async def no_device(udid, connection_type=None, usbmux_address=None):
+        return None
+
+    monkeypatch.setattr("pymobiledevice3.service_connection.select_device", no_device)
+
+    with pytest.raises(DeviceNotFoundError) as exc_info:
+        await ServiceConnection.create_using_usbmux("TARGET-UDID", 62078, connection_type="USB")
+
+    assert exc_info.value.udid == "TARGET-UDID"
+    assert str(exc_info.value) == "Device not found: usbmux has no device matching udid TARGET-UDID over USB"
+
+
+def test_device_not_found_error_defaults_to_a_message() -> None:
+    """A raise site that passes only the udid still yields a self-explanatory `str(exc)`."""
+    error = DeviceNotFoundError("TARGET-UDID")
+    assert str(error) == "Device not found: TARGET-UDID"
+    assert error.udid == "TARGET-UDID"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

With the native tunnel, a device that `remotepairingd` does not report failed with a bare `_RemotePairingError` (a `UserspaceTunnelUnavailableError`) — a different exception type than the usbmux/tunneld paths, which raise `DeviceNotFoundError`. Callers catching `DeviceNotFoundError` missed the native case entirely.

`DeviceNotFoundError` itself also carried only the UDID (`super().__init__()` with no args), so `str(exc)` was empty and every consumer had to re-render the message.

## Changes

**1. The native tunnel raises `DeviceNotFoundError`**

`_RemotePairingDeviceNotFoundError(_RemotePairingError, DeviceNotFoundError)` is raised at the browse "no device" site with `.udid` set to the requested serial. It keeps the `_RemotePairingError` base so the CLI's native -> userspace -> tunneld routing still treats it as a native-path failure.

In `__main__`, the `DeviceNotFoundError` handler moves ahead of the `UserspaceTunnelUnavailableError` one (the hybrid would otherwise be caught by the latter). As a result this failure is now reconnectable under `--reconnect`, as it already was on the other transports.

**2. Every `DeviceNotFoundError` carries a full message, `udid` stays its own member**

`__init__(udid, message=None)` defaults to `Device not found: <udid>`, and each raise site names the lookup that failed:

| transport | message |
|---|---|
| usbmux | `Device not found: usbmux has no device matching udid X[ over USB]` |
| tunneld | `Device not found: tunneld (127.0.0.1:49151) serves no tunnel for udid X` |
| native | `Device not found: remotepairingd reported no device matching udid X` |
| WDA probe | `Device not found: X left usbmux while waiting for WDA to become reachable` |

The CLI handler is now just `logger.error(str(e))`.

```
$ pymobiledevice3 remote start-tunnel --native --udid BOGUSUDID
ERROR Device not found: remotepairingd reported no device matching udid BOGUSUDID

$ pymobiledevice3 lockdown info --udid BOGUSUDID
ERROR Device not found: usbmux has no device matching udid BOGUSUDID
```

## Tests

- `test_browse_missing_device_raises_device_not_found` — drives the real `browse()` raise site with `_BrowseAttempt` stubbed; asserts both exception types, `.udid` and the message.
- `test_native_tunnel_device_not_found_is_reconnectable`, `test_tunneld_device_not_found_names_the_tunneld_instance`.
- `test_create_using_usbmux_missing_device_explains_the_failed_lookup`, `test_device_not_found_error_defaults_to_a_message`.
- Full `pytest`: 736 passed, 44 skipped, 10 xfailed. pre-commit (ruff + pyright) clean.

## Docs (separate commit)

`PYMOBILEDEVICE3_DEFAULT_FALLBACK` and its siblings were only mentioned in passing inside the tunnel guides, with no place to look up what the CLI honors. Added `docs/guides/environment-variables.md` — one table per group (device selection, transport, advanced/debug) — wired into the nav and `llms.txt` sections, and linked from the tunnels guide. `mkdocs build --strict` passes.
