### PR TITLE
device-link: answer DLMessagePurgeDiskSpace instead of aborting the backup

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -161,11 +161,20 @@ password: pass `--password` to `backup2` subcommands. A
 `--patch-manifest` on an encrypted backup — that also requires `--password`, so the manifest
 can be decrypted and re-encrypted.
 
-### "Not enough disk space" (`NotEnoughDiskSpaceError`)
+### "device asked the host to free N bytes"
 
-The host doesn't have room for the backup. Note that the first filtered backup still transfers
-*all* backup bytes from the device (filtering saves disk, not transfer) — budget space
-accordingly or free some up.
+The device decided the backup destination is too small and asked the host to make room
+(`DLMessagePurgeDiskSpace`). pymobiledevice3 has no way to reclaim space on your behalf, so it
+answers "failed to purge" — exactly like Apple's own host does when its purge fails — and lets
+the device report what it wants to do next.
+
+Free up at least the requested number of bytes and retry. Note that the first filtered backup
+still transfers *all* backup bytes from the device (filtering saves disk, not transfer) — budget
+space accordingly.
+
+Run with `-vv` to also see the figure the host reported for `DLMessageGetFreeDiskSpace`; that is
+the number the device compared against, and it comes from `statvfs` on the backup directory (on
+macOS, raised to the purgeable-aware capacity Finder uses).
 
 ## Still stuck?
 

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -60,7 +60,6 @@ from pymobiledevice3.exceptions import (
     MessageNotSupportedError,
     MissingValueError,
     NoDeviceConnectedError,
-    NotEnoughDiskSpaceError,
     NotPairedError,
     OSNotSupportedError,
     PairingDialogResponsePendingError,
@@ -429,8 +428,6 @@ def invoke_cli_with_error_handling() -> bool:
         logger.error(
             "Unable to connect to Tunneld. You can start one using:\nsudo python3 -m pymobiledevice3 remote tunneld"
         )
-    except NotEnoughDiskSpaceError:
-        logger.error("Not enough disk space")
     except DeprecationError:
         logger.error("failed to query MobileGestalt, MobileGestalt deprecated (iOS >= 17.4).")
     except CryptexdError as e:

--- a/pymobiledevice3/services/device_link.py
+++ b/pymobiledevice3/services/device_link.py
@@ -1,6 +1,7 @@
 import ctypes
 import ctypes.util
 import datetime
+import logging
 import shutil
 import struct
 import sys
@@ -10,7 +11,7 @@ from io import BufferedWriter
 from pathlib import Path
 from typing import Any, Callable, Optional, cast
 
-from pymobiledevice3.exceptions import NotEnoughDiskSpaceError, PyMobileDevice3Exception
+from pymobiledevice3.exceptions import PyMobileDevice3Exception
 from pymobiledevice3.service_connection import ServiceConnection
 
 SIZE_FORMAT = ">I"
@@ -21,6 +22,8 @@ CODE_ERROR_LOCAL = 0x6
 CODE_SUCCESS = 0
 FILE_TRANSFER_TERMINATOR = b"\x00\x00\x00\x00"
 BULK_OPERATION_ERROR = -13
+PURGE_DISK_SPACE_ERROR = -1
+PURGE_DISK_SPACE_ERROR_STRING = "DLPurgeDiskSpace failed to purge"
 APPLE_EPOCH = 978307200
 ERRNO_TO_DEVICE_ERROR = {
     2: -6,
@@ -35,6 +38,8 @@ ERRNO_TO_DEVICE_ERROR = {
 DLMessage = Sequence[Any]
 ProgressCallback = Callable[[Any], None]
 DLHandler = Callable[[DLMessage], Awaitable[None]]
+
+logger = logging.getLogger(__name__)
 
 
 def _darwin_important_available_capacity(path: Path) -> Optional[int]:
@@ -291,6 +296,7 @@ class DeviceLink:
             important = _darwin_important_available_capacity(self.root_path)
             if important is not None:
                 freespace = max(freespace, important)
+        logger.debug("reporting %d bytes free at %s", freespace, self.root_path)
         await self.status_response(0, status_dict=freespace)
 
     async def move_items(self, message: DLMessage) -> None:
@@ -325,8 +331,30 @@ class DeviceLink:
             self.post_file_receive(cast(str, message[2]), cast(str, message[1]))
         await self.status_response(0)
 
-    async def purge_disk_space(self, _message: DLMessage) -> None:
-        raise NotEnoughDiskSpaceError()
+    async def purge_disk_space(self, message: DLMessage) -> None:
+        """Answer the device's request that the host free up disk space.
+
+        ``DLMessagePurgeDiskSpace`` is a request, not a fatal error. Apple's own host
+        (``_DLPurgeDiskSpaceOnComputer`` in ``DeviceLink.framework``) builds a dictionary of
+        ``CACHE_DELETE_VOLUME`` (the backup root), ``CACHE_DELETE_AMOUNT`` (``message[1]``, the
+        bytes the device wants freed) and ``CACHE_DELETE_URGENCY_LIMIT`` (``message[2]``), hands
+        it to ``CacheDeletePurgeSpaceWithInfo()``, then replies with a ``DLMessageStatusResponse``
+        and keeps serving the connection either way.
+
+        There is no portable CacheDelete equivalent, so mirror Apple's purge-failed path
+        (status -1, "DLPurgeDiskSpace failed to purge", zero bytes reclaimed) and let the device
+        decide how to continue. Tearing the link down here instead hid the device's own diagnosis
+        behind a guessed "not enough disk space" (issue #1879).
+        """
+        amount = message[1] if len(message) > 1 else None
+        urgency = message[2] if len(message) > 2 else None
+        logger.warning(
+            "device asked the host to free %s bytes under %s at %s; no purge backend available",
+            amount,
+            urgency,
+            self.root_path,
+        )
+        await self.status_response(PURGE_DISK_SPACE_ERROR, PURGE_DISK_SPACE_ERROR_STRING, status_dict=0)
 
     async def remove_items(self, message: DLMessage) -> None:
         for path in cast(Iterable[str], message[1]):

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -1,3 +1,4 @@
+import ctypes
 import sqlite3
 import struct
 import time
@@ -15,7 +16,11 @@ from pymobiledevice3.exceptions import (
     ConnectionTerminatedError,
 )
 from pymobiledevice3.lockdown import LockdownClient
-from pymobiledevice3.services.device_link import DeviceLink
+from pymobiledevice3.services.device_link import (
+    PURGE_DISK_SPACE_ERROR,
+    PURGE_DISK_SPACE_ERROR_STRING,
+    DeviceLink,
+)
 from pymobiledevice3.services.mobilebackup2 import (
     BACKUP_OBSERVED_NOTIFICATIONS,
     BACKUP_SELECTIONS,
@@ -316,6 +321,37 @@ def test_prune_backup_directory_keeps_hashed_backup_file_layout(tmp_path: Path) 
 
     assert keep_path.exists()
     assert not drop_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_device_link_purge_disk_space_answers_instead_of_aborting(tmp_path: Path) -> None:
+    """A purge request is answered like Apple's host does, not turned into a fatal error."""
+    service = AsyncMock()
+    device_link = DeviceLink(service, tmp_path)
+
+    await device_link.purge_disk_space(["DLMessagePurgeDiskSpace", 42 * 1024, 1])
+
+    service.send_plist.assert_awaited_once_with([
+        "DLMessageStatusResponse",
+        ctypes.c_uint64(PURGE_DISK_SPACE_ERROR).value,
+        PURGE_DISK_SPACE_ERROR_STRING,
+        0,
+    ])
+
+
+@pytest.mark.asyncio
+async def test_device_link_dl_loop_survives_purge_disk_space(tmp_path: Path) -> None:
+    """The device gets to report its own outcome after a purge request."""
+    service = AsyncMock()
+    service.recv_plist = AsyncMock(
+        side_effect=[
+            ["DLMessagePurgeDiskSpace", 42 * 1024, 1],
+            ["DLMessageProcessMessage", {"ErrorCode": 0, "Content": "done"}],
+        ]
+    )
+    device_link = DeviceLink(service, tmp_path)
+
+    assert await device_link.dl_loop() == "done"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1879.

## Problem

`DLMessagePurgeDiskSpace` is a request, not a fatal error, but `purge_disk_space()` raised
`NotEnoughDiskSpaceError` without answering the device at all. That killed the link and replaced
the device's own diagnosis with a guess ("Not enough disk space"), while discarding the one useful
piece of information in the message: how many bytes the device wants freed.

## What Apple's host does

`_DLPurgeDiskSpaceOnComputer` in `/System/Library/PrivateFrameworks/DeviceLink.framework` builds a
dictionary of `CACHE_DELETE_VOLUME` (the backup root), `CACHE_DELETE_AMOUNT` (`message[1]`) and
`CACHE_DELETE_URGENCY_LIMIT` (`message[2]`), hands it to `CacheDeletePurgeSpaceWithInfo()`, then
sends a `DLMessageStatusResponse` and keeps serving the connection — success or failure. It never
tears the link down.

## Fix

There is no portable CacheDelete equivalent, so mirror Apple's purge-failed path (status `-1`,
`"DLPurgeDiskSpace failed to purge"`, zero bytes reclaimed), log the requested amount and urgency,
and let the device decide how to continue.

Also log the figure reported for `DLMessageGetFreeDiskSpace` at debug level. That is the number the
device compares against, and it was missing from every bug report on this so far.

## Measurements

On an iPhone18,4 running iOS 26.6.1 (backup ≈ 63 MB), reporting a controlled figure for
`DLMessageGetFreeDiskSpace`:

| reported | asked for | sum |
|---|---|---|
| 1,048,576 | 2,334,848,147 | 2,335,896,723 |
| 67,108,864 | 2,268,787,859 | 2,335,896,723 |
| 134,217,728 | 2,201,678,995 | 2,335,896,723 |

So `CACHE_DELETE_AMOUNT` is `required - reported` against a per-device constant. Urgency was `4`
in every run.

With this change the device gets to say what is actually wrong:

```
['DLMessageProcessMessage', {'ErrorCode': 105,
  'ErrorDescription': 'Insufficient free disk space on drive to back up (MBErrorDomain/105)'}]
```

Separately worth recording: the refusal threshold is far below that constant. 134,217,728 was
refused, 201,326,592 completed the backup — so the device asks to be topped up to ~2.34 GB but only
fails below roughly 128–192 MB. I did not pin the exact boundary down.

## Scope

This does not make a refused backup succeed — when the device wants more room than the destination
has, that is the device's call. It stops pymobiledevice3 from hiding the reason and prints the exact
byte figure being demanded.

## Testing

- `pytest tests/services/test_backup2.py` — 38 passed against a connected iPhone18,4 / iOS 26.6.1.
- Plain `pymobiledevice3 backup2 backup --full` completes normally (67 MB, exit 0).
- `pyright --venvpath .` — 0 errors. ruff check/format clean.
- Two new unit tests: the handler answers instead of raising, and `dl_loop` survives a purge request.
