### PR TITLE
cli: restore lockdown on/off state as a positional argument

### DIFF
--- a/pymobiledevice3/cli/lockdown.py
+++ b/pymobiledevice3/cli/lockdown.py
@@ -181,7 +181,8 @@ async def lockdown_device_name(service_provider: ServiceProviderDep, new_name: O
 @cli.command("wifi-connections")
 @async_command
 async def lockdown_wifi_connections(
-    service_provider: ServiceProviderDep, state: Optional[Literal["on", "off"]] = None
+    service_provider: ServiceProviderDep,
+    state: Annotated[Optional[Literal["on", "off"]], typer.Argument()] = None,
 ) -> None:
     """get/set wifi connections state"""
     if not state:
@@ -270,7 +271,8 @@ async def cli_remotepairing(
 @cli.command("assistive-touch")
 @async_command
 async def lockdown_assistive_touch(
-    service_provider: ServiceProviderDep, state: Optional[Literal["on", "off"]] = None
+    service_provider: ServiceProviderDep,
+    state: Annotated[Optional[Literal["on", "off"]], typer.Argument()] = None,
 ) -> None:
     """get/set assistive touch icon state (visibility)"""
     if not state:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -346,3 +346,16 @@ def test_service_provider_dependency_records_resolved_udid(monkeypatch):
 
     assert provider is not None
     assert cli_common.resolved_udid() == "RESOLVED-UDID"
+
+
+@pytest.mark.parametrize("command", ["wifi-connections", "assistive-touch"])
+def test_lockdown_on_off_state_is_a_positional_argument(command):
+    """Regression: the Typer migration turned these `on`/`off` arguments into a `--state` option."""
+    runner = CliRunner()
+    result = runner.invoke(__main__.app, ["lockdown", command, "--help"])
+
+    assert result.exit_code == 0
+    # Rich interleaves ANSI codes inside option names and wraps text in panel borders
+    output = " ".join(ANSI_ESCAPE.sub("", result.output).replace("│", " ").split())
+    assert "Arguments" in output
+    assert "--state" not in output


### PR DESCRIPTION
`lockdown wifi-connections on` and `lockdown assistive-touch on` have been failing since the Typer migration:

```
$ pymobiledevice3 lockdown wifi-connections on
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ Got unexpected extra argument(s) (on)                                        │
╰──────────────────────────────────────────────────────────────────────────────╯
```

fac18022 translated `click.argument("state", type=click.Choice(["on", "off"]))` into a plain function parameter, and Typer exposes those as options — so the argument silently became `--state`. The documented syntax (`docs/guides/ios17-tunnels.md`, and every existing invocation in the wild) has been broken ever since.

Annotating both with `typer.Argument()` restores it:

```
Usage: pymobiledevice3 lockdown wifi-connections [OPTIONS] [state]:<on|off>
```

`--state` was never released as documented syntax, so nothing is being taken away here.

A parametrized test asserts each command's `--help` renders `state` in the Arguments panel and no `--state` option; it fails on both commands without the change.

Verified against a physical iPhone (iOS 27): `wifi-connections off` / `on` and `assistive-touch` all round-trip positionally.