### PR TITLE
device-link: report the free space the device actually requires

### DIFF
--- a/pymobiledevice3/services/device_link.py
+++ b/pymobiledevice3/services/device_link.py
@@ -11,7 +11,7 @@ from io import BufferedWriter
 from pathlib import Path
 from typing import Any, Callable, Optional, cast
 
-from pymobiledevice3.exceptions import PyMobileDevice3Exception
+from pymobiledevice3.exceptions import NotEnoughDiskSpaceError, PyMobileDevice3Exception
 from pymobiledevice3.service_connection import ServiceConnection
 
 SIZE_FORMAT = ">I"
@@ -24,6 +24,12 @@ FILE_TRANSFER_TERMINATOR = b"\x00\x00\x00\x00"
 BULK_OPERATION_ERROR = -13
 PURGE_DISK_SPACE_ERROR = -1
 PURGE_DISK_SPACE_ERROR_STRING = "DLPurgeDiskSpace failed to purge"
+# `-[MBDriveBackupEngine _prepareFreeSpace]` pads every purge request by this much beyond the
+# space it actually needs, so `CACHE_DELETE_AMOUNT` overstates the requirement by a flat 2 GiB.
+# See `purge_disk_space()` for how this was measured.
+PURGE_REQUEST_OVERSHOOT = 0x80000000
+# MBErrorDomain/105, the device's own verdict once the host answers the purge request.
+MB_ERROR_INSUFFICIENT_DISK_SPACE = 105
 APPLE_EPOCH = 978307200
 ERRNO_TO_DEVICE_ERROR = {
     2: -6,
@@ -110,6 +116,10 @@ class DeviceLink:
         self.preserve_file = preserve_file
         self.post_file_receive = post_file_receive
         self._discarded_files: set[Path] = set()
+        # Last figure answered to `DLMessageGetFreeDiskSpace`, and the requirement derived from it
+        # when the device follows up with a purge request. See `purge_disk_space()`.
+        self._reported_free_space: Optional[int] = None
+        self._required_free_space: Optional[int] = None
         self._dl_handlers: dict[str, DLHandler] = {
             "DLMessageCreateDirectory": self.create_directory,
             "DLMessageUploadFiles": self.upload_files,
@@ -152,9 +162,28 @@ class DeviceLink:
             if command == "DLMessageProcessMessage":
                 if not message[1]["ErrorCode"]:
                     return message[1].get("Content")
+                elif message[1]["ErrorCode"] == MB_ERROR_INSUFFICIENT_DISK_SPACE:
+                    raise NotEnoughDiskSpaceError(self._insufficient_disk_space_error(message[1]))
                 else:
                     raise PyMobileDevice3Exception(f"Device link error: {message[1]}")
             await self._dl_handlers[command](message)
+
+    def _insufficient_disk_space_error(self, response: Mapping[str, Any]) -> str:
+        """Describe an ``MBErrorDomain/105`` refusal in terms of the bytes involved.
+
+        The device only reaches this after the host has answered its purge request, so
+        :meth:`purge_disk_space` has normally already recovered the threshold the device is
+        comparing against. Without it - an unrecognised amount, or a 105 that arrived with no
+        preceding purge - fall back to the device's own wording.
+        """
+        if self._required_free_space is None or self._reported_free_space is None:
+            return f"Device refused the backup: {response}"
+        return (
+            f"Device refused the backup: it needs more than {self._required_free_space} bytes free "
+            f"at {self.root_path}, host reported {self._reported_free_space} "
+            f"({self._required_free_space + 1 - self._reported_free_space} more needed) "
+            f"(MBErrorDomain/{MB_ERROR_INSUFFICIENT_DISK_SPACE})"
+        )
 
     async def version_exchange(self) -> None:
         dl_message_version_exchange = await self.receive_message()
@@ -297,6 +326,7 @@ class DeviceLink:
             if important is not None:
                 freespace = max(freespace, important)
         logger.debug("reporting %d bytes free at %s", freespace, self.root_path)
+        self._reported_free_space = freespace
         await self.status_response(0, status_dict=freespace)
 
     async def move_items(self, message: DLMessage) -> None:
@@ -345,16 +375,84 @@ class DeviceLink:
         (status -1, "DLPurgeDiskSpace failed to purge", zero bytes reclaimed) and let the device
         decide how to continue. Tearing the link down here instead hid the device's own diagnosis
         behind a guessed "not enough disk space" (issue #1879).
+
+        ``CACHE_DELETE_AMOUNT`` is *not* the amount of free space the backup requires - it
+        overstates it by a flat 2 GiB - so derive and log the real threshold. In
+        ``-[MBDriveBackupEngine _prepareFreeSpace]`` (``BackupAgent2``, ``MobileBackup-2969.120.2``,
+        iPhone17,3 iOS 26.5 23F77, ``0x10001e484``)::
+
+            v4  = [_operationJournal sizeForType:2];        // uploadSize
+            v12 = v4 + 0x8000000;                           // + 128 MiB of headroom
+            [_drive freeSpace:&reported error:&e];          // -> DLMessageGetFreeDiskSpace
+            if ((int64) (v12 - reported) < 0) goto ok;      // proceed iff reported > v12
+            [_drive purgeDiskSpace:&out
+                    amountRequested:(v12 - reported) + 0x80000000
+                       urgencyLevel:4 error:&e];            // -> DLMessagePurgeDiskSpace
+
+        So ``amount == (required - reported) + 0x80000000`` and therefore
+        ``required == amount + reported - 0x80000000``, where the backup proceeds only when free
+        space *exceeds* ``required``. Because the purge is requested only when
+        ``required - reported >= 0``, ``amount`` is always at least ``0x80000000``; an amount below
+        that means this model no longer holds, so fall back to reporting the raw request.
+
+        Measured against the above on an iPhone18,4 running iOS 26.6.1 (23G83), by answering
+        ``DLMessageGetFreeDiskSpace`` with controlled figures while reading the device's own log.
+        The last two rows answer the purge request with *success* instead, which makes the device
+        re-read free space, so the threshold recovered from the first exchange can be replayed
+        back to it exactly:
+
+        ==============  ==================  ============================================
+        reported        CACHE_DELETE_AMOUNT device log
+        ==============  ==================  ============================================
+        1,000,000       2,335,105,975       ``uploadSize:54404599`` / deficit ``187622327``
+        188,500,000     2,147,606,193       ``uploadSize:54404817`` / deficit ``122545``
+        188,622,945     -                   refused; ``54405217 + 134217728`` exactly
+        188,622,946     -                   accepted, backup ran
+        ==============  ==================  ============================================
+
+        The last two rows pin the comparison as strict: the device refuses at exactly
+        ``uploadSize + 128 MiB`` and accepts one byte above it. (Its own error string prints
+        ``(188622945 < 188622945)`` there, because the message says ``<`` while the code tests
+        ``required - reported >= 0``.)
+
+        Both constants were read on iOS 26.5 and confirmed on 26.6 (issue #1879) and 26.6.1. They
+        are unverified on earlier majors, hence the guard in :meth:`_derive_required_free_space`.
         """
         amount = message[1] if len(message) > 1 else None
         urgency = message[2] if len(message) > 2 else None
-        logger.warning(
-            "device asked the host to free %s bytes under %s at %s; no purge backend available",
-            amount,
-            urgency,
-            self.root_path,
-        )
+        self._required_free_space = self._derive_required_free_space(amount)
+        if self._required_free_space is None:
+            logger.warning(
+                "device asked the host to free %s bytes under %s at %s; no purge backend available",
+                amount,
+                urgency,
+                self.root_path,
+            )
+        else:
+            logger.warning(
+                "device needs more than %d bytes free at %s to back up; host reported %d "
+                "(%d more needed). No purge backend available, so the device decides how to proceed",
+                self._required_free_space,
+                self.root_path,
+                self._reported_free_space,
+                self._required_free_space + 1 - cast(int, self._reported_free_space),
+            )
+            logger.debug("DLMessagePurgeDiskSpace: amount=%s urgency=%s", amount, urgency)
         await self.status_response(PURGE_DISK_SPACE_ERROR, PURGE_DISK_SPACE_ERROR_STRING, status_dict=0)
+
+    def _derive_required_free_space(self, amount: Any) -> Optional[int]:
+        """Recover the free space the device demands from a ``CACHE_DELETE_AMOUNT``.
+
+        Returns ``None`` when the figures don't fit the model documented in
+        :meth:`purge_disk_space` - an unknown reported figure, a non-integer amount, or an amount
+        below the 2 GiB overshoot that the device always adds. Callers then report the raw request
+        rather than a derived number that may be wrong on an untested iOS version.
+        """
+        if self._reported_free_space is None or not isinstance(amount, int) or isinstance(amount, bool):
+            return None
+        if amount < PURGE_REQUEST_OVERSHOOT:
+            return None
+        return amount + self._reported_free_space - PURGE_REQUEST_OVERSHOOT
 
     async def remove_items(self, message: DLMessage) -> None:
         for path in cast(Iterable[str], message[1]):

--- a/pymobiledevice3/services/device_link.py
+++ b/pymobiledevice3/services/device_link.py
@@ -175,14 +175,41 @@ class DeviceLink:
         :meth:`purge_disk_space` has normally already recovered the threshold the device is
         comparing against. Without it - an unrecognised amount, or a 105 that arrived with no
         preceding purge - fall back to the device's own wording.
+
+        The requirement can dwarf the device's used space, which reads as a bug until you see how
+        it is accumulated. ``-[MBDriveBackupEngine _addFileToUploadAndMove:flags:]`` tags each
+        upload operation with a two-bit flag - bit 0 when the file hardlinks an inode already seen
+        in this backup, bit 1 when it clones an already-seen ``cloneID``::
+
+            v9 = 0;
+            if ([file isHardLink])
+                if ([_inodeCache containsObject:file.inodeNumber])  v9 = 1;
+                else [_inodeCache addObject:file.inodeNumber];
+            if ([file isFullClone])
+                if ([_cloneIDCache containsObject:file.cloneID])    v9 |= 2;
+                else [_cloneIDCache addObject:file.cloneID];
+            op = [MBBackupOperation backupOperationWithType:2 ... size:file.size flags:v9];
+
+        ``-[MBBackupOperationJournal addOperation:]`` then adds ``op.size`` to ``_sizeByType``
+        unconditionally, and to ``_sizeExcludingHardlinksAndClonesForType`` only when both bits are
+        clear. ``_prepareFreeSpace`` gates on the former, so every repeat reference counts at full
+        size. That is not an over-estimate: :meth:`upload_files` writes each file to its own path
+        under the backup root, so a device-side clone family really does land as N full copies.
+
+        The device logs both totals as ``uploadSize:<inclusive>(<excluding>)`` before the
+        free-space check, which is the cheapest way to see how far the two diverge.
         """
+        detail = (
+            " The device counts every hardlink and clone at full size, because each is stored as a "
+            "separate file in the backup, so this can far exceed the data stored on the device."
+        )
         if self._required_free_space is None or self._reported_free_space is None:
-            return f"Device refused the backup: {response}"
+            return f"Device refused the backup: {response}.{detail}"
         return (
             f"Device refused the backup: it needs more than {self._required_free_space} bytes free "
             f"at {self.root_path}, host reported {self._reported_free_space} "
             f"({self._required_free_space + 1 - self._reported_free_space} more needed) "
-            f"(MBErrorDomain/{MB_ERROR_INSUFFICIENT_DISK_SPACE})"
+            f"(MBErrorDomain/{MB_ERROR_INSUFFICIENT_DISK_SPACE}).{detail}"
         )
 
     async def version_exchange(self) -> None:

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -14,11 +14,13 @@ from pymobiledevice3.exceptions import (
     BackupFilterPasswordRequiredError,
     ConnectionFailedError,
     ConnectionTerminatedError,
+    NotEnoughDiskSpaceError,
 )
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.services.device_link import (
     PURGE_DISK_SPACE_ERROR,
     PURGE_DISK_SPACE_ERROR_STRING,
+    PURGE_REQUEST_OVERSHOOT,
     DeviceLink,
 )
 from pymobiledevice3.services.mobilebackup2 import (
@@ -352,6 +354,87 @@ async def test_device_link_dl_loop_survives_purge_disk_space(tmp_path: Path) -> 
     device_link = DeviceLink(service, tmp_path)
 
     assert await device_link.dl_loop() == "done"
+
+
+@pytest.mark.asyncio
+async def test_device_link_purge_disk_space_derives_requirement(tmp_path: Path) -> None:
+    """CACHE_DELETE_AMOUNT is turned back into the free space the device actually demands.
+
+    Real figures from an iPhone18,4 on iOS 26.6.1: reporting 1,000,000 bytes drew a request for
+    2,335,105,975, and the device's own log put the threshold at 54,404,599 + 128 MiB.
+    """
+    service = AsyncMock()
+    device_link = DeviceLink(service, tmp_path)
+    device_link._reported_free_space = 1_000_000
+
+    await device_link.purge_disk_space(["DLMessagePurgeDiskSpace", 2_335_105_975, 4])
+
+    assert device_link._required_free_space == 54_404_599 + 0x8000000
+
+
+@pytest.mark.asyncio
+async def test_device_link_purge_disk_space_ignores_implausible_amount(tmp_path: Path) -> None:
+    """An amount below the 2 GiB overshoot means the model no longer holds, so derive nothing."""
+    service = AsyncMock()
+    device_link = DeviceLink(service, tmp_path)
+    device_link._reported_free_space = 1_000_000
+
+    await device_link.purge_disk_space(["DLMessagePurgeDiskSpace", PURGE_REQUEST_OVERSHOOT - 1, 4])
+
+    assert device_link._required_free_space is None
+
+
+@pytest.mark.asyncio
+async def test_device_link_purge_disk_space_without_preceding_free_space_query(tmp_path: Path) -> None:
+    """Nothing to derive from until the host has answered DLMessageGetFreeDiskSpace."""
+    service = AsyncMock()
+    device_link = DeviceLink(service, tmp_path)
+
+    await device_link.purge_disk_space(["DLMessagePurgeDiskSpace", 2_335_105_975, 4])
+
+    assert device_link._required_free_space is None
+
+
+@pytest.mark.asyncio
+async def test_device_link_dl_loop_reports_insufficient_disk_space(tmp_path: Path) -> None:
+    """MBErrorDomain/105 names the byte figures instead of dumping the raw response."""
+    service = AsyncMock()
+    service.recv_plist = AsyncMock(
+        side_effect=[
+            ["DLMessagePurgeDiskSpace", 2_335_105_975, 4],
+            [
+                "DLMessageProcessMessage",
+                {
+                    "ErrorCode": 105,
+                    "ErrorDescription": "Insufficient free disk space on drive to back up (MBErrorDomain/105)",
+                },
+            ],
+        ]
+    )
+    device_link = DeviceLink(service, tmp_path)
+    device_link._reported_free_space = 1_000_000
+
+    with pytest.raises(NotEnoughDiskSpaceError) as excinfo:
+        await device_link.dl_loop()
+
+    required = 54_404_599 + 0x8000000
+    assert f"needs more than {required} bytes free" in str(excinfo.value)
+    assert f"host reported {1_000_000}" in str(excinfo.value)
+    assert f"({required + 1 - 1_000_000} more needed)" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_device_link_dl_loop_insufficient_disk_space_without_derivation(tmp_path: Path) -> None:
+    """A 105 with nothing to derive from still raises, using the device's own wording."""
+    service = AsyncMock()
+    response = {"ErrorCode": 105, "ErrorDescription": "Insufficient free disk space on drive to back up"}
+    service.recv_plist = AsyncMock(side_effect=[["DLMessageProcessMessage", response]])
+    device_link = DeviceLink(service, tmp_path)
+
+    with pytest.raises(NotEnoughDiskSpaceError) as excinfo:
+        await device_link.dl_loop()
+
+    assert str(response) in str(excinfo.value)
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_backup2.py
+++ b/tests/services/test_backup2.py
@@ -421,6 +421,7 @@ async def test_device_link_dl_loop_reports_insufficient_disk_space(tmp_path: Pat
     assert f"needs more than {required} bytes free" in str(excinfo.value)
     assert f"host reported {1_000_000}" in str(excinfo.value)
     assert f"({required + 1 - 1_000_000} more needed)" in str(excinfo.value)
+    assert "counts every hardlink and clone at full size" in str(excinfo.value)
 
 
 @pytest.mark.asyncio
@@ -435,6 +436,7 @@ async def test_device_link_dl_loop_insufficient_disk_space_without_derivation(tm
         await device_link.dl_loop()
 
     assert str(response) in str(excinfo.value)
+    assert "counts every hardlink and clone at full size" in str(excinfo.value)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #1884, which stopped `DLMessagePurgeDiskSpace` from aborting the backup. That surfaced the device's own verdict, but the numbers around it are still misleading.

## Problem

`CACHE_DELETE_AMOUNT` is not the backup's space requirement — it overstates it by a flat 2 GiB. We log it raw:

```
WARNING device asked the host to free 667490157139 bytes under 4 at /backups
```

In #1879 two people independently reverse-engineered a "per-device constant" out of that line across multiple runs, because it never states the one actionable number: how much free space the backup needs. The refusal that follows is also raised as a raw dict repr:

```
PyMobileDevice3Exception: Device link error: {'ErrorCode': 105, 'ErrorDescription':
'Insufficient free disk space on drive to back up (MBErrorDomain/105)', 'MessageName': 'Response'}
```

## What the device does

`-[MBDriveBackupEngine _prepareFreeSpace]` (`BackupAgent2`, `MobileBackup-2969.120.2`, `0x10001e484`):

```objc
v4  = [_operationJournal sizeForType:2];        // uploadSize
v12 = v4 + 0x8000000;                           // + 128 MiB headroom
[_drive freeSpace:&reported error:&e];          // -> DLMessageGetFreeDiskSpace
if ((int64)(v12 - reported) < 0) goto ok;       // proceed iff reported > v12
[_drive purgeDiskSpace:&out
        amountRequested:(v12 - reported) + 0x80000000
           urgencyLevel:4 error:&e];            // -> DLMessagePurgeDiskSpace
```

So `required == amount + reported - 2 GiB`, and the backup proceeds only when free space *exceeds* it. There is no per-device constant — the sum users were computing is just `uploadSize + 2,281,701,376`.

## Change

```
WARNING device needs more than 188622945 bytes free at /backups to back up; host reported
        1000000 (187622946 more needed). No purge backend available, so the device decides
        how to proceed
DEBUG   DLMessagePurgeDiskSpace: amount=2335106593 urgency=4
```

```
NotEnoughDiskSpaceError: Device refused the backup: it needs more than 188622945 bytes free
at /backups, host reported 1000000 (187622946 more needed) (MBErrorDomain/105). The device
counts every hardlink and clone at full size, because each is stored as a separate file in
the backup, so this can far exceed the data stored on the device.
```

## Why the requirement can exceed the device's used space

A 256 GB iPhone demanding ~967 GB reads as a bug until you see how the figure is accumulated. `-[MBDriveBackupEngine _addFileToUploadAndMove:flags:]`:

```objc
v9 = 0;
if ([file isHardLink])
    if ([_inodeCache containsObject:file.inodeNumber])  v9 = 1;    // bit 0
    else [_inodeCache addObject:file.inodeNumber];
if ([file isFullClone])
    if ([_cloneIDCache containsObject:file.cloneID])    v9 |= 2;   // bit 1
    else [_cloneIDCache addObject:file.cloneID];
op = [MBBackupOperation backupOperationWithType:2 ... size:file.size flags:v9];
```

`-[MBBackupOperationJournal addOperation:]` adds `op.size` to `_sizeByType` unconditionally, and to `_sizeExcludingHardlinksAndClonesForType` only when both bits are clear. `_prepareFreeSpace` gates on the former, so every repeat reference counts at full size.

This is **not** an over-estimate on the device's part: `upload_files` writes each file to its own path under the backup root, so a device-side clone family really does land as N full copies. The error says so rather than leaving users to conclude the device is lying.

The device also logs both totals as `uploadSize:<inclusive>(<excluding>)` before the free-space check — the cheapest way to see how far the two diverge on a given device.

`NotEnoughDiskSpaceError` was orphaned by #1884, which removed the unconditional raise from `purge_disk_space()` while leaving the class exported. It subclasses `PyMobileDevice3Exception`, so existing handlers are unaffected.

## Guard

The purge is only requested when `required - reported >= 0`, so `amount` is always at least `0x80000000`. If it comes in below that, the model no longer holds and both messages fall back to today's exact wording rather than printing a derived number that may be wrong on an untested iOS version.

## Verification

Constants read on iOS 26.5, confirmed on 26.6 (the reporter's figures in #1879 fit exactly) and measured on an iPhone18,4 running 26.6.1 by answering `DLMessageGetFreeDiskSpace` with controlled values while reading the device's log:

| reported | `CACHE_DELETE_AMOUNT` | device log | outcome |
|---|---|---|---|
| 1,000,000 | 2,335,105,975 | `uploadSize:54404599(54404599)`, deficit `187622327` | refused |
| 188,500,000 | 2,147,606,193 | `uploadSize:54404817(…)`, deficit `122545` | refused |
| 188,622,945 | — | `Insufficient … (188622945 < 54405217 + 134217728)` | refused |
| 188,622,946 | — | — | **accepted, backup ran** |

The last two rows answer the purge with *success*, which makes the device re-read free space, so the threshold recovered from the first exchange can be replayed back exactly. They pin the comparison as strict — and show Apple's own error string printing `188622945 < 188622945`, because the message says `<` while the code tests `required - reported >= 0`.

Finally, running this branch against the device with only the raw free-space source faked: the warning named `188622945`, and reporting `188622946` completed the backup with no purge request at all.

Five tests cover the derivation, both fallback paths, and the 105 mapping.
