### PR TITLE
webinspector: let the CDP bridge drive JSContext debuggables

### DIFF
--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -33,6 +33,10 @@ the duration of the debugging session.
 Open <http://127.0.0.1:9222/> in Google Chrome and pick a page. Prefer this landing
 page over `chrome://inspect` — see the command's `--help` for why.
 
+The listing keeps itself current: a tab opened, closed or navigated on the device
+appears there within a couple of seconds, with no reload. Leave it open in a
+background tab and it stops polling until you come back to it.
+
 ## JavaScript contexts
 
 A process that made a bare `JSContext` inspectable is listed alongside the web pages,

--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -16,6 +16,8 @@ JavaScript debugger.
   iOS >= 16.4 the app must set `webView.isInspectable = true`, or be a
   development/debug-signed build. Production apps that don't opt in cannot be
   inspected.
+- Bare `JSContext`s opt in the same way (`jsContext.isInspectable = true`); see
+  [JavaScript contexts](#javascript-contexts).
 
 ## Start the bridge
 
@@ -30,6 +32,22 @@ the duration of the debugging session.
 
 Open <http://127.0.0.1:9222/> in Google Chrome and pick a page. Prefer this landing
 page over `chrome://inspect` — see the command's `--help` for why.
+
+## JavaScript contexts
+
+A process that made a bare `JSContext` inspectable is listed alongside the web pages,
+named after the process hosting it (`myapp (1234): JSContext`). Such a debuggable is
+JavaScriptCore's own inspector: it implements the JavaScript half of the protocol -
+`Runtime`, `Debugger`, `Console`, `Heap` - and nothing else. There is no document behind
+it, so it has no URL and no DOM, page, or network domains.
+
+The landing page therefore opens them with Chrome's JavaScript-only DevTools frontend -
+the one Chrome uses for Node.js - which offers Console, Sources, and Memory. They are
+advertised as `"type": "node"` in `/json`.
+
+A `JSContext` only answers the inspector while the thread hosting it services its run
+loop. One whose host is blocked elsewhere is still listed (its process registered it) but
+never replies; the bridge gives up on it after a while rather than hanging.
 
 ## VS Code
 

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -398,7 +398,7 @@ async def cdp(
     chrome: Optional[str] = None,
 ) -> None:
     """
-    Start a CDP server for debugging WebViews.
+    Start a CDP server for debugging WebViews and inspectable JSContexts.
 
     \b
     Open the following URL in Google Chrome and pick a page to inspect:

--- a/pymobiledevice3/services/web_protocol/cdp_browser.py
+++ b/pymobiledevice3/services/web_protocol/cdp_browser.py
@@ -1,15 +1,27 @@
 import asyncio
 import logging
 import uuid
+from collections.abc import Iterator
 from typing import Any, Optional
 
 from fastapi import WebSocket
 
 from pymobiledevice3.services.web_protocol.cdp_target import CdpTarget
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
-from pymobiledevice3.services.webinspector import WebinspectorService, WirTypes
+from pymobiledevice3.services.webinspector import Application, Page, WebinspectorService, WirTypes, make_target_id
 
 logger = logging.getLogger(__name__)
+
+# Debuggable types the bridge can drive: WebKit's web pages, and JavaScriptCore's JSContexts
+# (an app or daemon that called -[JSContext setInspectable:YES], and every WKWebView's own
+# JSContext). The latter implement only the JS-side domains, so they are advertised to the
+# frontend as Chrome does for a bare V8 target - see JS_TARGET_TYPE.
+INSPECTABLE_TYPES = (WirTypes.WEB, WirTypes.WEB_PAGE, WirTypes.JAVASCRIPT)
+
+# Chrome's target type for a JavaScript-only debuggable (its Node.js targets). It is what makes
+# the frontend leave out the Elements/Network/Application panels and the Page/DOM/CSS domains a
+# JSContext does not implement.
+JS_TARGET_TYPE = "node"
 
 # Seconds to let webinspectord reply with the updated page listings before answering /json
 PAGE_LISTING_FLUSH = 0.5
@@ -25,6 +37,34 @@ PAGE_LOCK_TIMEOUT = 5
 # (otherwise its socket setup races the teardown and webinspectord ignores it). Shared between
 # the page endpoint and browser-endpoint attachments.
 PAGE_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+def iter_inspectable(inspector: WebinspectorService) -> "Iterator[tuple[str, Application, Page]]":
+    """Walk every debuggable the bridge can attach to, as (target id, application, page).
+
+    The target id qualifies the page with its application (see `make_target_id`); the bare page
+    identifier would collide, most visibly across JSContexts.
+    """
+    for app_id, pages in inspector.application_pages.items():
+        application = inspector.connected_application.get(app_id)
+        if application is None:
+            continue
+        for page_id, page in pages.items():
+            if page.type_ in INSPECTABLE_TYPES:
+                yield make_target_id(app_id, page_id), application, page
+
+
+def target_type(page: Page) -> str:
+    """Chrome target type to advertise a debuggable as."""
+    return JS_TARGET_TYPE if page.type_ == WirTypes.JAVASCRIPT else "page"
+
+
+def target_title(application: Application, page: Page) -> str:
+    """Title to advertise a debuggable under. JSContexts are all named "JSContext" and have no URL
+    to tell them apart, so name their process instead."""
+    if page.type_ == WirTypes.JAVASCRIPT:
+        return f"{application.name} ({application.pid}): {page.web_title or 'JSContext'}"
+    return page.web_title or ""
 
 
 class _PageSession:
@@ -221,13 +261,8 @@ class CdpBrowser:
             except Exception:
                 logger.exception("target refresh failed")
 
-    def _list_pages(self) -> dict[str, Any]:
-        pages: dict[str, Any] = {}
-        for app_id in self.inspector.application_pages:
-            for page_id, page in self.inspector.application_pages[app_id].items():
-                if page.type_ in (WirTypes.WEB, WirTypes.WEB_PAGE):
-                    pages[page_id] = page
-        return pages
+    def _list_pages(self) -> dict[str, tuple[Application, Page]]:
+        return {target_id: (application, page) for target_id, application, page in iter_inspectable(self.inspector)}
 
     async def _refresh_targets(self) -> None:
         async with self._refresh_lock:
@@ -236,12 +271,12 @@ class CdpBrowser:
             pages = self._list_pages()
             for page_id in [known for known in self._known_targets if known not in pages]:
                 await self._destroy_target(page_id)
-            for page_id, page in pages.items():
+            for page_id, (application, page) in pages.items():
                 is_new = page_id not in self._known_targets
                 self._known_targets[page_id] = {
                     "targetId": page_id,
-                    "type": "page",
-                    "title": page.web_title or "",
+                    "type": target_type(page),
+                    "title": target_title(application, page),
                     "url": page.web_url or "",
                     "attached": page_id in self._attached_pages,
                     "canAccessOpener": False,

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -18,10 +18,13 @@ from pymobiledevice3.services.web_protocol.cdp_browser import (
     PAGE_LOCKS,
     TARGET_CREATION_TIMEOUT,
     CdpBrowser,
+    iter_inspectable,
+    target_title,
+    target_type,
 )
 from pymobiledevice3.services.web_protocol.cdp_target import CdpTarget
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
-from pymobiledevice3.services.webinspector import WirTypes
+from pymobiledevice3.services.webinspector import Page, WirTypes
 
 # chrome://inspect routes a network target's DevTools through Chrome's browser-process relay,
 # which deadlocks after sustained console traffic (the console/screen freeze). Serving the DevTools
@@ -183,20 +186,24 @@ async def available_targets(request: Request, _: str):
     await app.state.inspector.flush_input(PAGE_LISTING_FLUSH)
     host = request.headers.get("host", "localhost:9222")
     targets: list[dict[str, Any]] = []
-    for app_id in app.state.inspector.application_pages:
-        for page_id, page in app.state.inspector.application_pages[app_id].items():
-            if page.type_ not in (WirTypes.WEB, WirTypes.WEB_PAGE):
-                continue
-            targets.append({
-                "description": "",
-                "id": page_id,
-                "title": page.web_title,
-                "type": "page",
-                "url": page.web_url,
-                "webSocketDebuggerUrl": f"ws://{host}/devtools/page/{page_id}",
-                "devtoolsFrontendUrl": f"/devtools/inspector.html?ws={host}/devtools/page/{page_id}",
-            })
+    for target_id, application, page in iter_inspectable(app.state.inspector):
+        targets.append({
+            "description": "",
+            "id": target_id,
+            "title": target_title(application, page),
+            "type": target_type(page),
+            "url": page.web_url,
+            "webSocketDebuggerUrl": f"ws://{host}/devtools/page/{target_id}",
+            "devtoolsFrontendUrl": f"{_frontend_url(page)}?ws={host}/devtools/page/{target_id}",
+        })
     return targets
+
+
+def _frontend_url(page: Page) -> str:
+    """DevTools frontend entry point for a debuggable. A JSContext gets Chrome's JavaScript-only
+    entry point (the one it uses for Node.js); inspector.html would come up expecting the Page/DOM
+    domains that JavaScriptCore's inspector does not implement."""
+    return "/devtools/js_app.html" if page.type_ == WirTypes.JAVASCRIPT else "/devtools/inspector.html"
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -208,13 +215,10 @@ async def index(request: Request) -> HTMLResponse:
     await app.state.inspector.flush_input(PAGE_LISTING_FLUSH)
     host = request.headers.get("host", "127.0.0.1:9222")
     items: list[str] = []
-    for app_id in app.state.inspector.application_pages:
-        for page_id, page in app.state.inspector.application_pages[app_id].items():
-            if page.type_ not in (WirTypes.WEB, WirTypes.WEB_PAGE):
-                continue
-            frontend = f"/devtools/inspector.html?ws={host}/devtools/page/{page_id}"
-            title = page.web_title or page.web_url or f"page {page_id}"
-            items.append(f'<li><a href="{frontend}">{title}</a><br><small>{page.web_url}</small></li>')
+    for target_id, application, page in iter_inspectable(app.state.inspector):
+        frontend = f"{_frontend_url(page)}?ws={host}/devtools/page/{target_id}"
+        title = target_title(application, page) or page.web_url or f"page {target_id}"
+        items.append(f'<li><a href="{frontend}">{title}</a><br><small>{page.web_url}</small></li>')
     body = "<ul>" + "".join(items) + "</ul>" if items else "<p>No inspectable pages. Open a page in Safari.</p>"
     return HTMLResponse(
         f"<!doctype html><meta charset=utf-8><title>pymobiledevice3 Web Inspector</title>"

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -343,7 +343,14 @@ async def browser_debugger(websocket: WebSocket, connection_id: str):
 
 @app.websocket("/devtools/page/{page_id}")
 async def page_debugger(websocket: WebSocket, page_id: str):
-    application, page = app.state.inspector.find_page_id(page_id)
+    try:
+        application, page = app.state.inspector.find_page_id(page_id)
+    except KeyError:
+        # The page closed on the device between being listed and being opened here - a link the
+        # user had on screen a moment too long. Refuse the connection instead of erroring out.
+        logger.warning(f"page {page_id} is no longer inspectable")
+        await websocket.close()
+        return
     session_id = str(uuid.uuid4()).upper()
     protocol = SessionProtocol(app.state.inspector, session_id, application, page, method_prefix="")
     # Accept before the device-side target setup: DevTools drops the connection if the

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -1,11 +1,14 @@
 import asyncio
+import json
 import shutil
 import subprocess
 import sys
 import tempfile
 import uuid
 from contextlib import asynccontextmanager
+from html import escape
 from pathlib import Path
+from string import Template
 from typing import Any, Optional
 from urllib.request import urlopen
 
@@ -17,6 +20,7 @@ from pymobiledevice3.services.web_protocol.cdp_browser import (
     PAGE_LISTING_FLUSH,
     PAGE_LOCKS,
     TARGET_CREATION_TIMEOUT,
+    TARGET_POLL_INTERVAL,
     CdpBrowser,
     iter_inspectable,
     target_title,
@@ -24,7 +28,7 @@ from pymobiledevice3.services.web_protocol.cdp_browser import (
 )
 from pymobiledevice3.services.web_protocol.cdp_target import CdpTarget
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
-from pymobiledevice3.services.webinspector import Page, WirTypes
+from pymobiledevice3.services.webinspector import Page, WebinspectorService, WirTypes
 
 # chrome://inspect routes a network target's DevTools through Chrome's browser-process relay,
 # which deadlocks after sustained console traffic (the console/screen freeze). Serving the DevTools
@@ -62,6 +66,60 @@ _CHROME_DEFAULT_PATHS: dict[str, tuple[str, ...]] = {
         "/snap/bin/chromium",
     ),
 }
+
+
+NO_TARGETS_MESSAGE = "No inspectable pages. Open a page in Safari."
+NO_TARGETS_MESSAGE_HTML = f"<p>{NO_TARGETS_MESSAGE}</p>"
+
+# How often the landing page re-reads the target list. Matches the browser endpoint's discovery
+# poll, so a tab opened - or a JSContext made inspectable - on the device shows up within a couple
+# of seconds either way. Each poll costs one listing round-trip to the device, so the page stops
+# polling while it is not the visible tab.
+INDEX_POLL_INTERVAL_MS = int(TARGET_POLL_INTERVAL * 1000)
+
+INDEX_SCRIPT = Template("""
+(function () {
+  const container = document.getElementById('targets');
+  let rendered = null;
+  function render(targets) {
+    container.textContent = '';
+    if (!targets.length) {
+      const empty = document.createElement('p');
+      empty.textContent = $empty;
+      container.appendChild(empty);
+      return;
+    }
+    const list = document.createElement('ul');
+    for (const target of targets) {
+      const link = document.createElement('a');
+      link.href = target.devtoolsFrontendUrl;
+      link.textContent = target.title || target.url || ('page ' + target.id);
+      const url = document.createElement('small');
+      url.textContent = target.url;
+      const item = document.createElement('li');
+      item.append(link, document.createElement('br'), url);
+      list.appendChild(item);
+    }
+    container.appendChild(list);
+  }
+  async function poll() {
+    if (!document.hidden) {
+      try {
+        const targets = await (await fetch('/json/list', {cache: 'no-store'})).json();
+        const serialized = JSON.stringify(targets);
+        if (serialized !== rendered) {
+          rendered = serialized;
+          render(targets);
+        }
+      } catch (error) {
+        // The bridge is momentarily busy or gone; leave the list as it is and try again.
+      }
+    }
+    setTimeout(poll, $interval);
+  }
+  setTimeout(poll, $interval);
+})();
+""").substitute(empty=json.dumps(NO_TARGETS_MESSAGE), interval=INDEX_POLL_INTERVAL_MS)
 
 
 def find_chrome(explicit: Optional[str] = None) -> Optional[str]:
@@ -210,20 +268,35 @@ def _frontend_url(page: Page) -> str:
 async def index(request: Request) -> HTMLResponse:
     """Landing page: link each inspectable page to the locally-served DevTools frontend, which
     connects directly to the bridge (bypassing chrome://inspect's relay). Use this instead of
-    chrome://inspect to avoid the console/screen freeze."""
+    chrome://inspect to avoid the console/screen freeze.
+
+    The listing keeps itself current, so a tab opened - or a JSContext made inspectable - after
+    the page was loaded appears without reloading it by hand."""
     await app.state.inspector.get_open_pages()
     await app.state.inspector.flush_input(PAGE_LISTING_FLUSH)
     host = request.headers.get("host", "127.0.0.1:9222")
-    items: list[str] = []
-    for target_id, application, page in iter_inspectable(app.state.inspector):
-        frontend = f"{_frontend_url(page)}?ws={host}/devtools/page/{target_id}"
-        title = target_title(application, page) or page.web_url or f"page {target_id}"
-        items.append(f'<li><a href="{frontend}">{title}</a><br><small>{page.web_url}</small></li>')
-    body = "<ul>" + "".join(items) + "</ul>" if items else "<p>No inspectable pages. Open a page in Safari.</p>"
     return HTMLResponse(
         f"<!doctype html><meta charset=utf-8><title>pymobiledevice3 Web Inspector</title>"
-        f"<h2>pymobiledevice3 Web Inspector</h2>{body}"
+        f"<h2>pymobiledevice3 Web Inspector</h2>"
+        # Rendered server-side once so the list is there before any script runs, then kept up to
+        # date in place by INDEX_SCRIPT.
+        f'<div id="targets">{targets_html(app.state.inspector, host)}</div>'
+        f"<script>{INDEX_SCRIPT}</script>"
     )
+
+
+def targets_html(inspector: WebinspectorService, host: str) -> str:
+    """The landing page's target list. Titles and URLs come from the device, so they are escaped."""
+    items: list[str] = []
+    for target_id, application, page in iter_inspectable(inspector):
+        frontend = f"{_frontend_url(page)}?ws={host}/devtools/page/{target_id}"
+        title = target_title(application, page) or page.web_url or f"page {target_id}"
+        items.append(
+            f'<li><a href="{escape(frontend)}">{escape(title)}</a><br><small>{escape(page.web_url)}</small></li>'
+        )
+    if not items:
+        return NO_TARGETS_MESSAGE_HTML
+    return "<ul>" + "".join(items) + "</ul>"
 
 
 @app.get("/devtools/{path:path}")

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -17,10 +17,8 @@ from fastapi.logger import logger
 from fastapi.responses import HTMLResponse, Response
 
 from pymobiledevice3.services.web_protocol.cdp_browser import (
-    PAGE_LISTING_FLUSH,
     PAGE_LOCKS,
     TARGET_CREATION_TIMEOUT,
-    TARGET_POLL_INTERVAL,
     CdpBrowser,
     iter_inspectable,
     target_title,
@@ -71,11 +69,11 @@ _CHROME_DEFAULT_PATHS: dict[str, tuple[str, ...]] = {
 NO_TARGETS_MESSAGE = "No inspectable pages. Open a page in Safari."
 NO_TARGETS_MESSAGE_HTML = f"<p>{NO_TARGETS_MESSAGE}</p>"
 
-# How often the landing page re-reads the target list. Matches the browser endpoint's discovery
-# poll, so a tab opened - or a JSContext made inspectable - on the device shows up within a couple
-# of seconds either way. Each poll costs one listing round-trip to the device, so the page stops
+# How often the landing page re-reads the target list. Serving one is a read of already-pushed
+# state (see refresh_listings), so this can be short enough that a tab opened or closed on the
+# device shows up about as fast as it does in Safari's own Develop menu. The page still stops
 # polling while it is not the visible tab.
-INDEX_POLL_INTERVAL_MS = int(TARGET_POLL_INTERVAL * 1000)
+INDEX_POLL_INTERVAL_MS = 750
 
 INDEX_SCRIPT = Template("""
 (function () {
@@ -238,10 +236,20 @@ def version(request: Request):
     }
 
 
+async def refresh_listings() -> None:
+    """Ask every connected application to re-report its pages, without waiting for the replies.
+
+    `webinspectord` pushes a fresh listing on its own whenever a page opens, closes or navigates,
+    so the cached state is already live and the answer can be built from it straight away; the
+    request is only a nudge for anything that does not announce itself. Blocking on the replies
+    instead put a fixed half-second on every listing request - the whole cost of serving one.
+    """
+    await app.state.inspector.get_open_pages()
+
+
 @app.get("/json{_:path}")
 async def available_targets(request: Request, _: str):
-    await app.state.inspector.get_open_pages()
-    await app.state.inspector.flush_input(PAGE_LISTING_FLUSH)
+    await refresh_listings()
     host = request.headers.get("host", "localhost:9222")
     targets: list[dict[str, Any]] = []
     for target_id, application, page in iter_inspectable(app.state.inspector):
@@ -272,8 +280,7 @@ async def index(request: Request) -> HTMLResponse:
 
     The listing keeps itself current, so a tab opened - or a JSContext made inspectable - after
     the page was loaded appears without reloading it by hand."""
-    await app.state.inspector.get_open_pages()
-    await app.state.inspector.flush_input(PAGE_LISTING_FLUSH)
+    await refresh_listings()
     host = request.headers.get("host", "127.0.0.1:9222")
     return HTMLResponse(
         f"<!doctype html><meta charset=utf-8><title>pymobiledevice3 Web Inspector</title>"

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import itertools
 import json
 import logging
 from collections.abc import Awaitable
@@ -9,6 +10,7 @@ from typing import Any, Callable, Optional, cast
 
 from pymobiledevice3.services.web_protocol.cdp_screencast import ScreenCast
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
+from pymobiledevice3.services.webinspector import WirTypes
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +51,16 @@ WEBKIT_ONLY_EVENTS = frozenset({
     "DOM.willDestroyDOMNode",
     "Page.defaultUserPreferencesDidChange",
 })
+
+# Message ids for the un-multiplexed (JSContext) path. Those replies come back on the inspector's
+# shared, id-keyed wir_message_results, where the frontend's own ids - small integers, restarting
+# at 1 in every session - would consume each other's responses and SessionProtocol's. Allocating
+# from a process-wide counter in a range neither of them reaches keeps them apart.
+_FLAT_WIRE_IDS = itertools.count(0x40000000)
+
+# The single execution context synthesized for a JSContext debuggable (see _runtime_enable).
+JS_CONTEXT_EXECUTION_ID = 1
+JS_CONTEXT_UNIQUE_ID = "jscontext.1"
 
 # Error synthesized for requests routed to a target that got destroyed before answering
 # (WebKit never answers those). Matches Chrome's own message for the same situation.
@@ -217,6 +229,7 @@ class CdpTarget:
             # acknowledged by the NOOP_ABSENT_DOMAINS fallback in _input_loop.
             "Overlay.highlightNode": self._overlay_highlight_node,
             "Runtime.runIfWaitingForDebugger": partial(self._simple_response, value=None),
+            "Runtime.enable": self._runtime_enable,
             "Runtime.evaluate": self._runtime_evaluate,
             "Runtime.compileScript": self._runtime_compile_script,
             "Runtime.runScript": self._runtime_run_script,
@@ -282,6 +295,14 @@ class CdpTarget:
             "Network.responseReceived": self._network_response_received,
             "Network.loadingFinished": self._network_loading_finished,
         }
+        # JavaScriptCore's JSContext inspector implements no Target domain at all: nothing is
+        # announced on attach, messages are exchanged as-is instead of through
+        # Target.sendMessageToTarget/Target.dispatchMessageFromTarget, and its replies - carrying a
+        # top-level id - are filed by the inspector into wir_message_results rather than
+        # wir_events. Talk to it directly and translate everything else the same way.
+        self._flat = protocol.page.type_ == WirTypes.JAVASCRIPT
+        # wire id -> the id the message was sent with, for the un-multiplexed path
+        self._flat_pending: dict[int, int] = {}
         self._waiting_for_id = 0
         self._input_task = asyncio.create_task(self._input_loop())
         self._receiving_task = asyncio.create_task(self._receive_loop())
@@ -336,6 +357,10 @@ class CdpTarget:
         :param pymobiledevice3.services.web_protocol.session_protocol.SessionProtocol protocol: Session protocol.
         """
         await protocol.inspector.setup_inspector_socket(protocol.id_, protocol.app.id_, protocol.page.id_)
+        if protocol.page.type_ == WirTypes.JAVASCRIPT:
+            # A JSContext debuggable has no Target domain, so it announces nothing on attach and
+            # there is only ever the one target - synthesize its id instead of waiting forever.
+            return cls(protocol, f"jscontext:{protocol.app.id_}:{protocol.page.id_}")
         while True:
             # wir_events is shared; another session's create may pop concurrently, so re-check
             # emptiness on every iteration instead of assuming a successful pop.
@@ -390,6 +415,8 @@ class CdpTarget:
             believed unresponsive, so a still-dead one barely re-pauses the receive loop).
         :returns: The matching target message, or None if it does not arrive within the timeout.
         """
+        if self._flat:
+            return await self._wait_for_flat_result(id_, timeout)
         deadline = asyncio.get_event_loop().time() + timeout
         while asyncio.get_event_loop().time() < deadline:
             if target_id is not None and target_id in self._destroyed_targets:
@@ -515,18 +542,36 @@ class CdpTarget:
 
     async def _receive_loop(self):
         while True:
-            if self._waiting_for_id or not self.protocol.inspector.wir_events:
+            if self._waiting_for_id:
                 await asyncio.sleep(0)
                 continue
-            message = self.protocol.inspector.wir_events.pop(0)
+            message = self._next_message()
+            if message is None:
+                await asyncio.sleep(0)
+                continue
             try:
-                await self._to_output_queue(message)
+                if self._flat:
+                    # No Target wrapper to unwrap: these already are the debuggable's own
+                    # protocol messages.
+                    await self._dispatch_target_message(message)
+                else:
+                    await self._to_output_queue(message)
             except asyncio.CancelledError:
                 raise
             except Exception:
                 # One failing event translation must not kill the whole receive loop - that
                 # silently starves every later response and the session appears dead.
                 logger.exception(f"Failed handling target event: {message.get('method')}")
+
+    def _next_message(self) -> Optional[dict[str, Any]]:
+        """Next message to translate, or None while there is nothing pending."""
+        if self._flat:
+            result = self._next_flat_result()
+            if result is not None:
+                return result
+        if not self.protocol.inspector.wir_events:
+            return None
+        return cast(dict[str, Any], self.protocol.inspector.wir_events.pop(0))
 
     async def _to_output_queue(self, message: dict[str, Any]):
         if message["method"] != "Target.dispatchMessageFromTarget":
@@ -544,9 +589,51 @@ class CdpTarget:
             self._pending_requests[message["id"]] = resolved_target_id
         if record:
             self._record_setup_message(message)
+        if self._flat:
+            await self._send_message_flat(message)
+            return
         await self.protocol.send_command(
             "Target.sendMessageToTarget", targetId=resolved_target_id, message=json.dumps(message)
         )
+
+    async def _send_message_flat(self, message: dict[str, Any]) -> None:
+        """Send straight to an un-multiplexed debuggable, under a wire id of our own (see
+        _FLAT_WIRE_IDS) that the reply is mapped back from."""
+        wire = dict(message)
+        if "id" in message:
+            wire_id = next(_FLAT_WIRE_IDS)
+            self._flat_pending[wire_id] = message["id"]
+            wire["id"] = wire_id
+        await self.protocol.inspector.send_socket_data(self.session_id, self.app_id, self.page_id, wire)
+
+    def _next_flat_result(self, id_: Optional[int] = None) -> Optional[dict[str, Any]]:
+        """Take one reply this target is still waiting for off the inspector's result table, with
+        its wire id mapped back to the id it was sent with. `id_` restricts the search to the reply
+        of that request; without it, the first available one is taken.
+
+        :returns: The reply, or None if none of the awaited ones arrived yet.
+        """
+        results = self.protocol.inspector.wir_message_results
+        for wire_id, original_id in list(self._flat_pending.items()):
+            if (id_ is not None and original_id != id_) or wire_id not in results:
+                continue
+            del self._flat_pending[wire_id]
+            message = cast(dict[str, Any], results.pop(wire_id))
+            message["id"] = original_id
+            return message
+        return None
+
+    async def _wait_for_flat_result(self, id_: int, timeout: float) -> Optional[dict[str, Any]]:
+        """wait_for_event_id for the un-multiplexed path: replies arrive on the inspector's result
+        table rather than as Target.dispatchMessageFromTarget events."""
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            message = self._next_flat_result(id_)
+            if message is not None:
+                self._pending_requests.pop(id_, None)
+                return message
+            await asyncio.sleep(0)
+        return None
 
     def _record_setup_message(self, message: dict[str, Any]):
         """
@@ -856,6 +943,42 @@ class CdpTarget:
         message["method"] = "DOM.highlightNode"
         await self._send_message_to_target(message)
 
+    async def _runtime_enable(self, message: dict[str, Any]):
+        await self._send_message_to_target(message)
+        if not self._flat:
+            return
+        # Chrome's frontend expects console output to follow from Runtime.enable alone (V8 emits
+        # Runtime.consoleAPICalled once the Runtime domain is on) and never enables a console
+        # domain on a JavaScript-only target - it sends Log.enable only for frame targets. WebKit
+        # gates Console.messageAdded behind Console.enable, so without this every console.log on
+        # the debuggable is silently dropped.
+        await self._send_message_to_target({
+            "id": self.next_internal_id(),
+            "method": "Console.enable",
+            "params": {},
+        })
+        if JS_CONTEXT_UNIQUE_ID in self._emitted_context_unique_ids:
+            return
+        # A JSContext debuggable announces no execution context - JavaScriptCore's inspector has no
+        # Page/frame model to hang one on - and Chrome's frontend will not evaluate anything before
+        # it knows one: the console prompt silently swallows every line while its context picker
+        # reads "Not selected". Announce the single context such a debuggable has, the way V8 does
+        # for a Node.js target.
+        self._emitted_context_unique_ids.add(JS_CONTEXT_UNIQUE_ID)
+        self._default_execution_id = JS_CONTEXT_EXECUTION_ID
+        await self.output_queue.put({
+            "method": "Runtime.executionContextCreated",
+            "params": {
+                "context": {
+                    "id": JS_CONTEXT_EXECUTION_ID,
+                    "origin": "",
+                    "name": "",
+                    "uniqueId": JS_CONTEXT_UNIQUE_ID,
+                    "auxData": {"isDefault": True},
+                }
+            },
+        })
+
     async def _runtime_evaluate(self, message: dict[str, Any]):
         # Chrome's console "eager evaluation" previews the current line as you type by evaluating it
         # with throwOnSideEffect=true, relying on V8 to ABORT the moment the expression would cause a
@@ -871,6 +994,12 @@ class CdpTarget:
         # through - refusing them would kill autocomplete. Only the eager preview (no completion
         # objectGroup) is refused.
         params = message["params"]
+        if self._flat:
+            # The context the frontend targets is the one synthesized in _runtime_enable, which the
+            # debuggable knows nothing about; addressing it explicitly would fail the lookup. It has
+            # exactly one context anyway - let it use its default.
+            params.pop("contextId", None)
+            params.pop("uniqueContextId", None)
         if params.get("throwOnSideEffect") and params.get("objectGroup") not in _COMPLETION_OBJECT_GROUPS:
             self._eval_side_effect_id += 1
             error_object = {
@@ -1210,10 +1339,13 @@ class CdpTarget:
                 CdpTarget._normalize_native_functions(value)
 
     async def _target_dispatch_message_from_target(self, message: dict[str, Any]):
+        await self._dispatch_target_message(json.loads(message["params"]["message"]))
+
+    async def _dispatch_target_message(self, message: dict[str, Any]):
+        """Translate one protocol message coming from the target and hand it to the frontend."""
         # Any message from the current target proves it is alive again (a wedged page that finally
         # navigated, a slow response that eventually arrived); resume sending it internal requests.
         self._mark_target_responsive(self.target_id)
-        message = json.loads(message["params"]["message"])
         if "result" in message:
             # Function objects in evaluate/callFunctionOn results carry native descriptions the
             # console autocomplete inspects; normalize them (see _normalize_native_functions).

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -361,13 +361,12 @@ class CdpTarget:
             # A JSContext debuggable has no Target domain, so it announces nothing on attach and
             # there is only ever the one target - synthesize its id instead of waiting forever.
             return cls(protocol, f"jscontext:{protocol.app.id_}:{protocol.page.id_}")
+        events = protocol.inspector.session_events(protocol.id_)
         while True:
-            # wir_events is shared; another session's create may pop concurrently, so re-check
-            # emptiness on every iteration instead of assuming a successful pop.
-            if not protocol.inspector.wir_events:
+            if not events:
                 await asyncio.sleep(0)
                 continue
-            created = protocol.inspector.wir_events.pop(0)
+            created = events.pop(0)
             if "targetInfo" in created.get("params", {}):
                 break
         target_id = created["params"]["targetInfo"]["targetId"]
@@ -421,8 +420,9 @@ class CdpTarget:
         while asyncio.get_event_loop().time() < deadline:
             if target_id is not None and target_id in self._destroyed_targets:
                 return None
-            for i in range(len(self.protocol.inspector.wir_events)):
-                message = self.protocol.inspector.wir_events[i]
+            events = self.protocol.inspector.session_events(self.session_id)
+            for i in range(len(events)):
+                message = events[i]
                 if message["method"] == "Target.targetDestroyed":
                     # Only give up the wait; the event stays queued for the receive loop.
                     if message["params"]["targetId"] == target_id:
@@ -433,7 +433,7 @@ class CdpTarget:
                 message = json.loads(message["params"]["message"])
                 if message.get("id", "") != id_:
                     continue
-                del self.protocol.inspector.wir_events[i]
+                del events[i]
                 self._pending_requests.pop(id_, None)
                 return message
             await asyncio.sleep(0)
@@ -569,9 +569,10 @@ class CdpTarget:
             result = self._next_flat_result()
             if result is not None:
                 return result
-        if not self.protocol.inspector.wir_events:
+        events = self.protocol.inspector.session_events(self.session_id)
+        if not events:
             return None
-        return cast(dict[str, Any], self.protocol.inspector.wir_events.pop(0))
+        return cast(dict[str, Any], events.pop(0))
 
     async def _to_output_queue(self, message: dict[str, Any]):
         if message["method"] != "Target.dispatchMessageFromTarget":

--- a/pymobiledevice3/services/web_protocol/inspector_session.py
+++ b/pymobiledevice3/services/web_protocol/inspector_session.py
@@ -125,11 +125,12 @@ class InspectorSession:
         await protocol.inspector.setup_inspector_socket(protocol.id_, protocol.app.id_, protocol.page.id_)
         target_id = None
         if wait_target:
-            while not protocol.inspector.wir_events:
+            events = protocol.inspector.session_events(protocol.id_)
+            while not events:
                 await asyncio.sleep(0)
-            created = protocol.inspector.wir_events.pop(0)
+            created = events.pop(0)
             while "targetInfo" not in created["params"]:
-                created = protocol.inspector.wir_events.pop(0)
+                created = events.pop(0)
             target_id = created["params"]["targetInfo"]["targetId"]
             logger.info(f"Created: {target_id}")
         target = cls(protocol, target_id)
@@ -214,10 +215,11 @@ class InspectorSession:
 
     async def _receive_loop(self):
         while True:
-            while not self.protocol.inspector.wir_events:
+            events = self.protocol.inspector.session_events(self.protocol.id_)
+            while not events:
                 await asyncio.sleep(0)
 
-            response = self.protocol.inspector.wir_events.pop(0)
+            response = events.pop(0)
             response_method = response["method"]
             if response_method in self.response_methods:
                 self.response_methods[response_method](response)

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -424,19 +424,20 @@ class WebinspectorService(LockdownService):
         pass
 
     async def _handle_application_sent_listing(self, arg: dict[str, Any]):
-        if arg["WIRApplicationIdentifierKey"] in self.application_pages:
-            # Update existing application pages
-            for id_, page in arg["WIRListingKey"].items():
-                if id_ in self.application_pages[arg["WIRApplicationIdentifierKey"]]:
-                    self.application_pages[arg["WIRApplicationIdentifierKey"]][id_].update(page)
-                else:
-                    self.application_pages[arg["WIRApplicationIdentifierKey"]][id_] = Page.from_page_dictionary(page)
-        else:
-            # Add new application pages
-            pages = {}
-            for id_, page in arg["WIRListingKey"].items():
+        app_id = arg["WIRApplicationIdentifierKey"]
+        known: dict[str, Page] = self.application_pages.get(app_id, {})
+        # A listing is the application's complete set of pages, not a delta: a page missing from it
+        # has been closed. Merging one in without dropping those kept every tab ever opened in the
+        # listing for the rest of the session. Pages that survive are updated in place - sessions
+        # hold references to them.
+        pages: dict[str, Page] = {}
+        for id_, page in arg["WIRListingKey"].items():
+            if id_ in known:
+                known[id_].update(page)
+                pages[id_] = known[id_]
+            else:
                 pages[id_] = Page.from_page_dictionary(page)
-            self.application_pages[arg["WIRApplicationIdentifierKey"]] = pages
+        self.application_pages[app_id] = pages
 
     async def _handle_application_updated(self, arg: dict[str, Any]):
         app = Application.from_application_dictionary(arg)

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -29,6 +29,21 @@ def key_to_pid(key: str) -> int:
     return int(key.split(":")[1])
 
 
+def make_target_id(app_id: str, page_id: str) -> str:
+    """Build an identifier addressing one page of one application.
+
+    `webinspectord` numbers pages per application, so a page identifier alone is ambiguous as soon
+    as more than one application is inspectable - and it always is with JSContext debuggables,
+    which are page 1 of every process hosting one. Qualifying it with the application identifier
+    keeps the identifiers the CDP bridge hands out unique. Resolve one with
+    `WebinspectorService.find_page_id`.
+
+    :param app_id: The owning application's identifier (`WIRApplicationIdentifierKey`).
+    :param page_id: The page's identifier within that application.
+    """
+    return f"{app_id}:{page_id}"
+
+
 class WirTypes(Enum):
     AUTOMATION = "WIRTypeAutomation"
     ITML = "WIRTypeITML"
@@ -66,6 +81,10 @@ class Page:
         if p.type_ in (WirTypes.WEB, WirTypes.WEB_PAGE):
             p.web_title = page_dict["WIRTitleKey"]
             p.web_url = page_dict["WIRURLKey"]
+        if p.type_ == WirTypes.JAVASCRIPT:
+            # A JSContext debuggable is listed with a title (its name, "JSContext" by default) but
+            # no URL - there is no document behind it.
+            p.web_title = page_dict.get("WIRTitleKey", "")
         if p.type_ == WirTypes.AUTOMATION:
             p.automation_is_paired_key = page_dict["WIRAutomationTargetIsPairedKey"]
             p.automation_name = page_dict["WIRAutomationTargetNameKey"]
@@ -349,10 +368,16 @@ class WebinspectorService(LockdownService):
     def find_page_id(self, page_id: str) -> tuple[Application, Page]:
         """Look up the application and page for a known page identifier.
 
-        :param page_id: The page identifier to search for.
+        :param page_id: An identifier as built by `make_target_id`. A bare page identifier is also
+            accepted, resolving to the first application reporting it - note that page identifiers
+            are only unique per application (every JSContext debuggable is page 1 of its own
+            process), so it cannot address them all.
         :returns: A tuple of the owning application and the matching page.
         :raises KeyError: No page with the given identifier is currently known.
         """
+        app_id, _, page_key = page_id.rpartition(":")
+        if page_key in self.application_pages.get(app_id, {}):
+            return self.connected_application[app_id], self.application_pages[app_id][page_key]
         for app_id in self.application_pages:
             for page in self.application_pages[app_id]:
                 if page == page_id:

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -163,7 +163,7 @@ class WebinspectorService(LockdownService):
         self.connected_application: dict[str, Application] = {}
         self.application_pages: dict[str, Any] = {}
         self.wir_message_results: dict[str, Any] = {}
-        self.wir_events: list[Any] = []
+        self.wir_events: dict[str, list[Any]] = {}
         self.receive_handlers = {
             "_rpc_reportCurrentState:": self._handle_report_current_state,
             "_rpc_reportConnectedApplicationList:": self._handle_report_connected_application_list,
@@ -364,6 +364,21 @@ class WebinspectorService(LockdownService):
         :param page_id: The target page identifier.
         """
         await self._forward_did_close(session_id, app_id, page_id)
+        self.wir_events.pop(session_id, None)
+
+    def session_events(self, session_id: str) -> list[Any]:
+        """The queue of events `webinspectord` forwarded to one session's socket.
+
+        Events carry no id, so a consumer cannot tell its own from another's by content, and
+        WebKit allows one inspector session per page but several across pages. `webinspectord`
+        tags every forwarded message with the session it belongs to, so they are queued per
+        session: concurrent sessions - two DevTools tabs, two JSContexts - would otherwise
+        consume each other's events.
+
+        :param session_id: The session identifier the socket was set up with.
+        :returns: The session's queue; consumers pop from it in place.
+        """
+        return self.wir_events.setdefault(session_id, [])
 
     def find_page_id(self, page_id: str) -> tuple[Application, Page]:
         """Look up the application and page for a known page identifier.
@@ -437,7 +452,7 @@ class WebinspectorService(LockdownService):
         if "id" in response:
             self.wir_message_results[response["id"]] = response
         else:
-            self.wir_events.append(response)
+            self.session_events(arg.get("WIRDestinationKey", "")).append(response)
 
     async def _handle_application_disconnected(self, arg: dict[str, Any]):
         self.connected_application.pop(arg["WIRApplicationIdentifierKey"], None)

--- a/tests/services/test_inspector_session.py
+++ b/tests/services/test_inspector_session.py
@@ -11,7 +11,11 @@ from pymobiledevice3.services.web_protocol.inspector_session import InspectorSes
 
 @pytest.fixture()
 async def session():
-    protocol = SimpleNamespace(inspector=SimpleNamespace(wir_events=[]))
+    events: dict[str, list[dict[str, Any]]] = {}
+    protocol = SimpleNamespace(
+        id_="session-1",
+        inspector=SimpleNamespace(session_events=lambda session_id: events.setdefault(session_id, [])),
+    )
     session = InspectorSession(protocol, target_id="page-1")  # pyright: ignore[reportArgumentType]
     yield session
     session._receive_task.cancel()
@@ -123,7 +127,7 @@ async def test_console_enable_completion_switches_to_live_output(
     session.protocol.send_command = send_command  # pyright: ignore[reportAttributeAccessIssue]
     task = asyncio.create_task(session.console_enable())
     # deliver the Console.enable response (inner id 1) so console_enable completes
-    session.protocol.inspector.wir_events.append(_wrap_target_event({"id": 1, "result": {}}))
+    session.protocol.inspector.session_events(session.protocol.id_).append(_wrap_target_event({"id": 1, "result": {}}))
     await asyncio.wait_for(task, timeout=5)
     event = _console_message_added("4", [{"type": "number", "value": 4, "description": "4"}])
     # console_enable itself must have switched the session out of replay state

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import itertools
 import json
+import uuid
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any, Optional
@@ -14,16 +15,15 @@ from wsproto.events import Request as WsRequest
 from pymobiledevice3.exceptions import WebInspectorNotEnabledError
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.services.web_protocol.cdp_server import app
+from pymobiledevice3.services.web_protocol.cdp_target import JS_CONTEXT_EXECUTION_ID
 from pymobiledevice3.services.webinspector import SAFARI, WebinspectorService
 
 TIMEOUT = 30
 
 
 @asynccontextmanager
-async def cdp_server_with_safari_page(
-    lockdown: LockdownClient,
-) -> AsyncGenerator[tuple[int, list[dict[str, Any]]], None]:
-    """Run the CDP server against the device and yield (port, listed Safari targets)."""
+async def cdp_server(lockdown: LockdownClient) -> AsyncGenerator[tuple[int, WebinspectorService], None]:
+    """Run the CDP server against the device and yield (port, inspector)."""
     inspector = WebinspectorService(lockdown=lockdown)
     try:
         await inspector.connect()
@@ -36,22 +36,30 @@ async def cdp_server_with_safari_page(
         while not server.started:
             assert not serve_task.done()
             await asyncio.sleep(0.1)
-        port = server.servers[0].sockets[0].getsockname()[1]
-        await inspector.open_app(SAFARI)
-        targets = []
-        for _ in range(TIMEOUT):
-            targets = await http_get_json(port, "/json/list")
-            if targets:
-                break
-            await asyncio.sleep(1)
-        assert targets, "no inspectable Safari page was listed"
-        yield port, targets
+        yield server.servers[0].sockets[0].getsockname()[1], inspector
     finally:
         # force_exit skips uvicorn's graceful wait so a wedged debugger session can't hang the test
         server.should_exit = True
         server.force_exit = True
         await asyncio.wait_for(serve_task, TIMEOUT)
         await inspector.close()
+
+
+@asynccontextmanager
+async def cdp_server_with_safari_page(
+    lockdown: LockdownClient,
+) -> AsyncGenerator[tuple[int, list[dict[str, Any]]], None]:
+    """Run the CDP server against the device and yield (port, listed Safari targets)."""
+    async with cdp_server(lockdown) as (port, inspector):
+        await inspector.open_app(SAFARI)
+        targets = []
+        for _ in range(TIMEOUT):
+            targets = [target for target in await http_get_json(port, "/json/list") if target["type"] == "page"]
+            if targets:
+                break
+            await asyncio.sleep(1)
+        assert targets, "no inspectable Safari page was listed"
+        yield port, targets
 
 
 async def http_get_json(port: int, path: str) -> Any:
@@ -149,6 +157,79 @@ async def testp_cdp_server_end_to_end(lockdown: LockdownClient) -> None:
         # without which webinspectord never delivers target events to a reconnecting client.
         await evaluate_in_new_session()
         await evaluate_in_new_session()
+
+
+async def testp_cdp_server_drives_a_javascript_context(lockdown: LockdownClient) -> None:
+    """
+    A JSContext debuggable (any process that called -[JSContext setInspectable:YES]) implements
+    only JavaScriptCore's side of the protocol: no Target domain, so no target is announced on
+    attach, messages are exchanged un-multiplexed, and its console output needs Console.enable -
+    which Chrome's JavaScript-only frontend never sends. The bridge must cover all of it.
+    """
+    async with cdp_server(lockdown) as (port, _):
+        targets = [target for target in await http_get_json(port, "/json/list") if target["type"] == "node"]
+        if not targets:
+            pytest.skip("no inspectable JSContext on the device")
+        assert targets[0]["devtoolsFrontendUrl"].startswith("/devtools/js_app.html?"), (
+            "a JSContext must be handed Chrome's JavaScript-only frontend"
+        )
+        # A JSContext only answers the inspector while its host thread services its run loop, so
+        # some of the listed ones may be dormant; any one that answers proves the path.
+        for target in targets:
+            if await evaluate_and_log_in_javascript_context(port, target["id"]):
+                return
+        pytest.skip("no listed JSContext answered the inspector")
+
+
+async def evaluate_and_log_in_javascript_context(port: int, target_id: str) -> bool:
+    """Evaluate an expression that also logs on a JSContext target, asserting both come back.
+
+    :returns: False if the debuggable never answered (a dormant JSContext), True once it did.
+    """
+    # The debuggable replays its buffered console history on attach, so the log this test asserts
+    # on must be distinguishable from whatever ran in the context before.
+    marker = f"pmd3-cdp-{uuid.uuid4()}"
+    client = CdpWebsocketClient(port, target_id)
+    await asyncio.wait_for(client.connect(), TIMEOUT)
+    marked_calls: list[dict[str, Any]] = []
+
+    def collect(message: dict[str, Any]) -> None:
+        if message.get("method") != "Runtime.consoleAPICalled":
+            return
+        if message["params"]["args"][0].get("value") == marker:
+            marked_calls.append(message)
+
+    async def command(id_: int, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """client.command, keeping the console events it would otherwise discard."""
+        await client.send({"id": id_, "method": method, "params": params})
+        while True:
+            message = await client.receive()
+            collect(message)
+            if message.get("id") == id_:
+                return message
+
+    async def next_marked_call() -> dict[str, Any]:
+        while not marked_calls:
+            collect(await client.receive())
+        return marked_calls[0]
+
+    try:
+        try:
+            await asyncio.wait_for(command(1, "Runtime.enable", {}), TIMEOUT)
+        except asyncio.TimeoutError:
+            return False
+        result = await asyncio.wait_for(
+            command(2, "Runtime.evaluate", {"expression": f"console.log({marker!r}); 40+2"}), TIMEOUT
+        )
+        assert result["result"]["result"]["value"] == 42
+        # The console event may trail the evaluate response. It is attributed to the execution
+        # context synthesized on Runtime.enable; without one the frontend refuses to evaluate
+        # anything at all, and WebKit sends no console event before Console.enable.
+        call = await asyncio.wait_for(next_marked_call(), TIMEOUT)
+        assert call["params"]["executionContextId"] == JS_CONTEXT_EXECUTION_ID
+        return True
+    finally:
+        await client.close()
 
 
 async def testp_cdp_server_survives_process_swaps(lockdown: LockdownClient) -> None:

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -14,9 +14,9 @@ from wsproto.events import Request as WsRequest
 
 from pymobiledevice3.exceptions import WebInspectorNotEnabledError
 from pymobiledevice3.lockdown import LockdownClient
-from pymobiledevice3.services.web_protocol.cdp_server import app
+from pymobiledevice3.services.web_protocol.cdp_server import app, targets_html
 from pymobiledevice3.services.web_protocol.cdp_target import JS_CONTEXT_EXECUTION_ID
-from pymobiledevice3.services.webinspector import SAFARI, WebinspectorService
+from pymobiledevice3.services.webinspector import SAFARI, Application, AutomationAvailability, Page, WebinspectorService
 
 TIMEOUT = 30
 
@@ -406,3 +406,74 @@ async def testp_cdp_server_keyboard_input_submits_forms(lockdown: LockdownClient
             await type_and_submit("world", "/fallback")
         finally:
             await client.close()
+
+
+def _inspector_with(pages: dict[str, dict[str, Page]], names: dict[str, str]) -> WebinspectorService:
+    inspector = WebinspectorService.__new__(WebinspectorService)
+    inspector.application_pages = pages
+    inspector.connected_application = {
+        app_id: Application(
+            app_id,
+            "com.example.app",
+            int(app_id.split(":")[1]),
+            name,
+            AutomationAvailability.NOT_AVAILABLE,
+            1,
+            False,
+            True,
+        )
+        for app_id, name in names.items()
+    }
+    return inspector
+
+
+def test_landing_page_links_each_kind_to_its_own_frontend() -> None:
+    """A JSContext gets Chrome's JavaScript-only frontend; a web page gets the full one."""
+    inspector = _inspector_with(
+        {
+            "PID:1": {
+                "1": Page.from_page_dictionary({
+                    "WIRPageIdentifierKey": 1,
+                    "WIRTypeKey": "WIRTypeWeb",
+                    "WIRTitleKey": "Example",
+                    "WIRURLKey": "https://example.com/",
+                })
+            },
+            "PID:2": {
+                "1": Page.from_page_dictionary({
+                    "WIRPageIdentifierKey": 1,
+                    "WIRTypeKey": "WIRTypeJavaScript",
+                    "WIRTitleKey": "JSContext",
+                })
+            },
+        },
+        {"PID:1": "MobileSafari", "PID:2": "myapp"},
+    )
+
+    html = targets_html(inspector, "127.0.0.1:9222")
+
+    assert '<a href="/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/PID:1:1">Example</a>' in html
+    assert '<a href="/devtools/js_app.html?ws=127.0.0.1:9222/devtools/page/PID:2:1">myapp (2): JSContext</a>' in html
+
+
+def test_landing_page_escapes_titles_from_the_device() -> None:
+    """Titles and URLs are whatever the inspected page says they are."""
+    inspector = _inspector_with(
+        {
+            "PID:1": {
+                "1": Page.from_page_dictionary({
+                    "WIRPageIdentifierKey": 1,
+                    "WIRTypeKey": "WIRTypeWeb",
+                    "WIRTitleKey": "</a><script>alert(1)</script>",
+                    "WIRURLKey": "https://example.com/?a=1&b=2",
+                })
+            }
+        },
+        {"PID:1": "MobileSafari"},
+    )
+
+    html = targets_html(inspector, "127.0.0.1:9222")
+
+    assert "<script>" not in html
+    assert "&lt;/a&gt;&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "https://example.com/?a=1&amp;b=2" in html

--- a/tests/services/test_webinspector.py
+++ b/tests/services/test_webinspector.py
@@ -1,11 +1,12 @@
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from typing import Any, cast
 
 import pytest
 
 from pymobiledevice3.exceptions import WebInspectorNotEnabledError
 from pymobiledevice3.lockdown import LockdownClient
-from pymobiledevice3.services.webinspector import SAFARI, WebinspectorService
+from pymobiledevice3.services.webinspector import SAFARI, Page, WebinspectorService, WirTypes, make_target_id
 
 
 @asynccontextmanager
@@ -32,3 +33,33 @@ async def testp_opening_app(lockdown: LockdownClient) -> None:
         pages = await inspector.get_open_pages()
         assert safari.name in pages
         assert pages[safari.name]
+
+
+def test_javascript_page_listing_keeps_its_title() -> None:
+    """A JSContext debuggable is listed with a title but no URL - there is no document behind it."""
+    page = Page.from_page_dictionary({
+        "WIRTitleKey": "JSContext",
+        "WIRTypeKey": "WIRTypeJavaScript",
+        "WIRPageIdentifierKey": 1,
+        "WIROverrideNameKey": "",
+    })
+    assert page.type_ == WirTypes.JAVASCRIPT
+    assert page.web_title == "JSContext"
+    assert page.web_url == ""
+
+
+def test_find_page_id_distinguishes_same_page_of_different_applications() -> None:
+    """Page identifiers are per application - every JSContext debuggable is page 1 of its own
+    process - so the identifier the CDP bridge hands out qualifies them with the application."""
+    inspector = WebinspectorService.__new__(WebinspectorService)
+    listing = {"WIRTitleKey": "JSContext", "WIRTypeKey": "WIRTypeJavaScript", "WIRPageIdentifierKey": 1}
+    inspector.application_pages = {app_id: {"1": Page.from_page_dictionary(listing)} for app_id in ("PID:1", "PID:2")}
+    inspector.connected_application = cast(Any, {app_id: app_id for app_id in ("PID:1", "PID:2")})
+
+    for app_id in ("PID:1", "PID:2"):
+        application, page = inspector.find_page_id(make_target_id(app_id, "1"))
+        assert application == app_id
+        assert page.id_ == 1
+
+    with pytest.raises(KeyError):
+        inspector.find_page_id(make_target_id("PID:3", "1"))

--- a/tests/services/test_webinspector.py
+++ b/tests/services/test_webinspector.py
@@ -49,6 +49,37 @@ def test_javascript_page_listing_keeps_its_title() -> None:
     assert page.web_url == ""
 
 
+def _web_page_listing(app_id: str, pages: dict[str, str]) -> dict[str, Any]:
+    return {
+        "WIRApplicationIdentifierKey": app_id,
+        "WIRListingKey": {
+            page_id: {
+                "WIRPageIdentifierKey": int(page_id),
+                "WIRTypeKey": "WIRTypeWeb",
+                "WIRTitleKey": title,
+                "WIRURLKey": f"https://example.com/{title}",
+            }
+            for page_id, title in pages.items()
+        },
+    }
+
+
+async def test_listing_drops_pages_that_closed() -> None:
+    """A listing is the application's complete set of pages: one missing from it has closed.
+    Merging without dropping those kept every tab ever opened in the listing forever."""
+    inspector = WebinspectorService.__new__(WebinspectorService)
+    inspector.application_pages = {}
+    await inspector._handle_application_sent_listing(_web_page_listing("PID:1", {"1": "kept", "2": "closed"}))
+    kept = inspector.application_pages["PID:1"]["1"]
+
+    await inspector._handle_application_sent_listing(_web_page_listing("PID:1", {"1": "renamed", "3": "opened"}))
+
+    assert set(inspector.application_pages["PID:1"]) == {"1", "3"}
+    # A page that survives is updated in place - sessions hold references to it
+    assert inspector.application_pages["PID:1"]["1"] is kept
+    assert kept.web_title == "renamed"
+
+
 async def test_forwarded_events_are_queued_per_session() -> None:
     """Events carry no id, so a consumer cannot recognize its own by content. `webinspectord` tags
     each with the session it was forwarded to, and they are queued per session - otherwise two

--- a/tests/services/test_webinspector.py
+++ b/tests/services/test_webinspector.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any, cast
@@ -46,6 +47,24 @@ def test_javascript_page_listing_keeps_its_title() -> None:
     assert page.type_ == WirTypes.JAVASCRIPT
     assert page.web_title == "JSContext"
     assert page.web_url == ""
+
+
+async def test_forwarded_events_are_queued_per_session() -> None:
+    """Events carry no id, so a consumer cannot recognize its own by content. `webinspectord` tags
+    each with the session it was forwarded to, and they are queued per session - otherwise two
+    concurrent debugger sessions consume each other's events."""
+    inspector = WebinspectorService.__new__(WebinspectorService)
+    inspector.wir_events = {}
+    inspector.wir_message_results = {}
+    for session_id in ("A", "B"):
+        await inspector._handle_application_sent_data({
+            "WIRApplicationIdentifierKey": "PID:1",
+            "WIRDestinationKey": session_id,
+            "WIRMessageDataKey": json.dumps({"method": "Console.messageAdded", "params": {"of": session_id}}).encode(),
+        })
+
+    for session_id in ("A", "B"):
+        assert [event["params"]["of"] for event in inspector.session_events(session_id)] == [session_id]
 
 
 def test_find_page_id_distinguishes_same_page_of_different_applications() -> None:


### PR DESCRIPTION
`webinspector cdp` listed only WebKit page targets, so an inspectable `JSContext` — one that
`webinspector js-shell` and Safari's own Develop menu both offer — was invisible to it.

Listing it turned out not to be enough. A `JSContext` debuggable is JavaScriptCore's inspector, not
WebKit's, and it differs in four ways that each broke the bridge:

- **No `Target` domain.** Nothing is announced on attach, so `CdpTarget.create` waited forever, and
  messages are exchanged un-multiplexed — replies carry a top-level `id` and arrive on the
  inspector's result table rather than as target events.
- **Colliding identifiers.** Page ids are numbered per application, so every `JSContext` is page 1
  and they all listed under the same id; `find_page_id` always resolved to the first one.
- **No execution context.** JavaScriptCore announces none, and Chrome's frontend refuses to
  evaluate anything until it knows one — the context picker reads "Not selected" and the console
  prompt silently swallows every line.
- **Console output gated.** Chrome's JavaScript-only frontend never sends `Log.enable`/
  `Console.enable` (it expects V8's behaviour, where `Runtime.enable` suffices), but WebKit gates
  `Console.messageAdded` behind `Console.enable`.

`JSContext`s now list as Chrome's `node` target type, titled after the process hosting them
(`myapp (1234): JSContext`) since they all share the name and have no URL, and open with
`js_app.html` — the JavaScript-only DevTools frontend, offering Console, Sources and Memory.

Four defects surfaced while testing this, each committed separately:

- **Concurrent sessions consumed each other's events.** `wir_events` was one shared list every
  receive loop popped from unconditionally. With two sessions open, one client received both
  targets' console output and the other none — reproduced deliberately with two clients logging
  distinct markers. `webinspectord` tags every forwarded message with the session it belongs to
  (`WIRDestinationKey`, present for page targets as well), so events are queued per session. This
  bit two Safari tabs equally before.
- **The landing page never updated.** A tab opened or closed on the device needed a manual reload.
  It now polls the target list and re-renders in place, pausing while it is not the visible tab.
- **The listing only ever grew.** An application's listing is its complete page set, not a delta,
  but it was merged in without dropping what it no longer mentions — every tab ever opened stayed
  listed for the rest of the session, as dead targets that could not be attached to.
- **Every listing request slept half a second.** `/json` blocked on `flush_input(0.5)` waiting for
  listings it had just requested: 503ms of a 506ms response. `webinspectord` pushes a fresh listing
  on its own whenever a page opens, closes or navigates, so the cached state is already live —
  answering from it takes ~2ms.

Rendering the listing client-side also takes the device-reported titles and URLs out of the markup;
they are escaped in the server-rendered list too (a page titled `</a><script>…` used to land there
verbatim).

## Testing

Verified against a device running iOS 26.1:

- Chrome DevTools attached to a `JSContext` evaluates (`1234+5678` → `6912`), renders
  `console.warn('…', obj)` with an expandable object, and lists JavaScript-only panels.
- The landing page picks up a tab opened on the device, and drops it again when it closes, without
  a reload.
- `/json` measured at 0.503s before, 0.0017s after.

New tests: a device test driving a `JSContext` end to end (skips when the device has none), plus
device-free tests for the listing shape, the application-qualified identifier, per-session event
routing, stale-page removal, and the landing page's markup.

The existing Safari coverage (end-to-end, process swaps, screencast, keyboard input) passes
unchanged.
