### PR TITLE
webinspector: take a held CDP page over instead of waiting behind it

### DIFF
--- a/pymobiledevice3/services/web_protocol/cdp_browser.py
+++ b/pymobiledevice3/services/web_protocol/cdp_browser.py
@@ -31,12 +31,24 @@ TARGET_CREATION_TIMEOUT = 30
 TARGET_POLL_INTERVAL = 2.0
 # Seconds to wait for another debugger session on the same page to tear down before skipping it
 PAGE_LOCK_TIMEOUT = 5
+# Seconds a page-endpoint connection waits for the page after asking the session holding it to hand
+# it over. Far longer than PAGE_LOCK_TIMEOUT: the handover itself is quick, but several connections
+# to one page are served one after another, and dropping a client that is merely queued behind the
+# others would trade one silent failure for another. Only a session wedged mid-teardown reaches it.
+PAGE_HANDOVER_TIMEOUT = 30
 
 # WebKit supports a single inspector session per page, so sessions are serialized per page:
 # a new debugger connection waits until the previous session's WIR socket teardown completed
 # (otherwise its socket setup races the teardown and webinspectord ignores it). Shared between
 # the page endpoint and browser-endpoint attachments.
 PAGE_LOCKS: dict[str, asyncio.Lock] = {}
+
+# Page-endpoint sessions that can be superseded, by page id. A DevTools tab left attached holds
+# its page for as long as it stays open, so without this every later connection to that page waits
+# behind it - its websocket already accepted, which is what a blank, unresponsive frontend is. A
+# new connection sets the event to hand the page over, then waits for PAGE_LOCKS as usual so the
+# old session's WIR teardown still completes before the new one's socket setup.
+PAGE_TAKEOVERS: dict[str, asyncio.Event] = {}
 
 
 def iter_inspectable(inspector: WebinspectorService) -> "Iterator[tuple[str, Application, Page]]":

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -17,7 +17,9 @@ from fastapi.logger import logger
 from fastapi.responses import HTMLResponse, Response
 
 from pymobiledevice3.services.web_protocol.cdp_browser import (
+    PAGE_HANDOVER_TIMEOUT,
     PAGE_LOCKS,
+    PAGE_TAKEOVERS,
     TARGET_CREATION_TIMEOUT,
     CdpBrowser,
     iter_inspectable,
@@ -363,7 +365,30 @@ async def page_debugger(websocket: WebSocket, page_id: str):
     # Accept before the device-side target setup: DevTools drops the connection if the
     # websocket handshake stalls behind the WIR socket establishment.
     await websocket.accept()
-    async with PAGE_LOCKS.setdefault(page_id, asyncio.Lock()):
+    # WebKit serves one inspector session per debuggable, so sessions are serialized per page.
+    # Ask whoever holds this one to hand it over: a DevTools tab left attached (in a background
+    # tab, another window, a frontend the user never closed) holds the page for as long as it
+    # lives, and waiting it out behind PAGE_LOCKS is invisible to the newcomer - its websocket is
+    # already accepted, so the frontend just comes up blank and swallows everything typed into it.
+    # Most visible on JSContexts, whose debuggable outlives every page that ever inspected it.
+    superseded = PAGE_TAKEOVERS.get(page_id)
+    if superseded is not None:
+        logger.info(f"page {page_id}: taking the page over from the session holding it")
+        superseded.set()
+    # The lock is still taken, so the old session's WIR teardown completes before this one's
+    # socket setup (webinspectord ignores a setup that races a teardown). Only the session holding
+    # the page when this one arrived is asked to step aside - connections that are merely queued
+    # here alongside it are left to run in turn, so a burst of them still all get served.
+    lock = PAGE_LOCKS.setdefault(page_id, asyncio.Lock())
+    try:
+        await asyncio.wait_for(lock.acquire(), PAGE_HANDOVER_TIMEOUT)
+    except (asyncio.TimeoutError, TimeoutError):
+        logger.error(f"page {page_id}: the session holding it did not release it in time")
+        await websocket.close()
+        return
+    taken_over = asyncio.Event()
+    PAGE_TAKEOVERS[page_id] = taken_over
+    try:
         try:
             # Bound the wait: if the device never reports the target (e.g. webinspectord is in a
             # bad state), fail the connection instead of keeping a zombie handler alive forever.
@@ -373,16 +398,26 @@ async def page_debugger(websocket: WebSocket, page_id: str):
             await app.state.inspector.teardown_inspector_socket(session_id, application.id_, page.id_)
             await websocket.close()
             return
-        tasks: list[asyncio.Task[None]] = [
+        tasks: list[asyncio.Task[Any]] = [
             asyncio.create_task(from_cdp(target, websocket)),
             asyncio.create_task(to_cdp(target, websocket)),
+            asyncio.create_task(taken_over.wait()),
         ]
         try:
-            # from_cdp ends when the client disconnects; tear everything down so the target's
-            # queue-consumer tasks don't keep draining wir_events of future sessions.
+            # from_cdp ends when the client disconnects, taken_over when a newer connection claims
+            # the page; tear everything down so the target's queue-consumer tasks don't keep
+            # draining wir_events of future sessions.
             await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         finally:
             for task in tasks:
                 task.cancel()
             await asyncio.gather(*tasks, return_exceptions=True)
             await target.close()
+            if taken_over.is_set():
+                # Close rather than leave it hanging: the superseded frontend shows a disconnect
+                # instead of silently going dead.
+                await websocket.close()
+    finally:
+        if PAGE_TAKEOVERS.get(page_id) is taken_over:
+            del PAGE_TAKEOVERS[page_id]
+        lock.release()

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -14,6 +14,7 @@ from wsproto.events import Request as WsRequest
 
 from pymobiledevice3.exceptions import WebInspectorNotEnabledError
 from pymobiledevice3.lockdown import LockdownClient
+from pymobiledevice3.services.web_protocol.cdp_browser import PAGE_LOCKS, PAGE_TAKEOVERS
 from pymobiledevice3.services.web_protocol.cdp_server import app, targets_html
 from pymobiledevice3.services.web_protocol.cdp_target import JS_CONTEXT_EXECUTION_ID
 from pymobiledevice3.services.webinspector import SAFARI, Application, AutomationAvailability, Page, WebinspectorService
@@ -230,6 +231,43 @@ async def evaluate_and_log_in_javascript_context(port: int, target_id: str) -> b
         return True
     finally:
         await client.close()
+
+
+async def testp_cdp_server_takes_a_held_page_over(lockdown: LockdownClient) -> None:
+    """
+    A DevTools tab left attached to a page must not brick every later connection to it.
+
+    WebKit serves a single inspector session per debuggable, so sessions are serialized per page.
+    A second connection used to wait out the first one - with its websocket already accepted, so
+    the frontend rendered an empty window and swallowed everything typed into it, indefinitely.
+    The newcomer takes the page over instead, the way Safari's own Web Inspector does.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        page_id = targets[0]["id"]
+        held = CdpWebsocketClient(port, page_id)
+        await asyncio.wait_for(held.connect(), TIMEOUT)
+        try:
+            first = await held.command(1, "Runtime.evaluate", {"expression": "40+2"})
+            assert first["result"]["result"]["value"] == 42
+            # The first session is still attached and is never closed by the test.
+            taking_over = CdpWebsocketClient(port, page_id)
+            await asyncio.wait_for(taking_over.connect(), TIMEOUT)
+            try:
+                second = await taking_over.command(1, "Runtime.evaluate", {"expression": "40+2"})
+                assert second["result"]["result"]["value"] == 42
+            finally:
+                await taking_over.close()
+        finally:
+            await held.close()
+        # Both sessions are gone: the page must be left claimable, not pinned by a registration
+        # that outlived them (which would make the next connection wait out the whole handover
+        # budget before being refused).
+        for _ in range(TIMEOUT):
+            if page_id not in PAGE_TAKEOVERS and not PAGE_LOCKS[page_id].locked():
+                break
+            await asyncio.sleep(1)
+        assert page_id not in PAGE_TAKEOVERS, "the page stayed registered after both sessions ended"
+        assert not PAGE_LOCKS[page_id].locked(), "the page lock was not released"
 
 
 async def testp_cdp_server_survives_process_swaps(lockdown: LockdownClient) -> None:


### PR DESCRIPTION
Fixes the CDP bridge coming up blank - most often on a JSContext - and swallowing everything typed into the console.

## The bug

WebKit serves a single inspector session per debuggable, so the bridge serializes sessions per page with `PAGE_LOCKS`. `page_debugger` accepted the websocket **before** acquiring that lock, then waited on it with **no timeout**. A second connection to a page that already had a session therefore blocked forever - with a successfully accepted websocket, which is exactly what a blank, unresponsive DevTools window is.

A DevTools tab left open in a background tab or another window holds its page for as long as it lives, so this is not a narrow race. JSContexts take the worst of it: the debuggable outlives every frontend that ever inspected it, and `js_app.html` is nothing but the console, so a blocked session shows up as a completely empty window.

`CdpBrowser._attach_page` already bounded this wait; the page endpoint never did.

## The fix

Hand the page over, the way Safari's own Web Inspector does. A new connection signals the holder through a new `PAGE_TAKEOVERS` registry, then still waits on `PAGE_LOCKS` so the old session's WIR teardown completes before the new one's socket setup (`webinspectord` ignores a setup that races a teardown). The superseded frontend gets its websocket closed, so it shows a disconnect rather than going quietly dead.

Only the session holding the page *on arrival* is asked to step aside, so a burst of connections that arrive together is still served one after another instead of evicting each other. The wait is bounded by `PAGE_HANDOVER_TIMEOUT` rather than `PAGE_LOCK_TIMEOUT`: the handover itself is immediate, but a connection queued behind several others is legitimate, and dropping it would trade one silent failure for another.

## Verification

Against a physical iPhone (26.1), page endpoint, both web pages and JSContexts.

Baseline on `master`, second session on a page that already has one:

```
sequential takeovers: {'takeover:dead': 3, 'holder:survived': 3}
```

With the fix:

```
sequential takeovers: {'takeover:ok': 60, 'holder:evicted': 60}
final health:         all pages ok
```

- 60-round soak: 60/60 newcomers served, 60/60 holders evicted, every page still healthy afterwards.
- Concurrent bursts of 2, 3 and 6 to one page, 9 rounds each: **zero hangs**. Exactly the session holding the page is cleanly evicted; every other arrival succeeds.
- Stale holder attached for 1 s / 10 s before the newcomer arrives: evicted every time, takeover latency under 10 ms.
- Registry-leak guard: after both sessions end, the page must be left unregistered and unlocked (asserted in the new test).

New device test `testp_cdp_server_takes_a_held_page_over` times out against `master` and passes with the fix. `pyright` 0 errors, `ruff` clean.

Note: in a full-file run the new test can land on the suite's existing `xfail("Web Inspector is disabled on the device")` path - running several CDP device tests back to back exhausts `webinspectord`, which happens without this test in the mix too. It passes consistently on its own.
