### PR TITLE
webinspector: fix proxy handling for the CDP DevTools frontend, and unwedge reattachment

### DIFF
--- a/pymobiledevice3/services/web_protocol/cdp_browser.py
+++ b/pymobiledevice3/services/web_protocol/cdp_browser.py
@@ -347,7 +347,18 @@ class CdpBrowser:
         try:
             target = await asyncio.wait_for(CdpTarget.create(protocol), TARGET_CREATION_TIMEOUT)
         except (asyncio.TimeoutError, TimeoutError):
-            logger.error(f"page {page_id}: device did not report an inspection target in time")
+            # A page already being debugged over another Web Inspector connection - a second
+            # pymobiledevice3, Safari's own Web Inspector, or a client that exited without
+            # detaching - never reports a target, and the listing says who holds it. Naming them
+            # beats "the device did not answer", which sends people looking at the device.
+            holder = page.web_connection_id
+            if holder and holder != self.inspector.connection_id:
+                logger.error(
+                    f"page {page_id}: already being debugged over Web Inspector connection {holder}; "
+                    "close that debugger, or the process that left it attached, and reconnect"
+                )
+            else:
+                logger.error(f"page {page_id}: device did not report an inspection target in time")
             await self.inspector.teardown_inspector_socket(wir_session_id, application.id_, page.id_)
             lock.release()
             return None

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -7,10 +7,12 @@ import tempfile
 import uuid
 from contextlib import asynccontextmanager
 from html import escape
+from ipaddress import ip_address
 from pathlib import Path
 from string import Template
 from typing import Any, Optional
-from urllib.request import urlopen
+from urllib.parse import urlsplit
+from urllib.request import ProxyHandler, build_opener, urlopen
 
 from fastapi import FastAPI, Request, WebSocket
 from fastapi.logger import logger
@@ -39,6 +41,13 @@ from pymobiledevice3.services.webinspector import Page, WebinspectorService, Wir
 DEVTOOLS_FRONTEND_REV = "0fcdce5f4fdec8d442d7df760cb541f1ca6e446d"
 DEVTOOLS_FRONTEND_HOST = "chrome-devtools-frontend.appspot.com"
 _frontend_cache: dict[str, tuple[bytes, str]] = {}
+
+# The local Chrome's assets must be fetched without a proxy. urllib applies proxy configuration
+# to loopback addresses as well - neither the no_proxy/ExceptionsList defaults nor macOS'
+# "exclude simple hostnames" cover 127.0.0.1 - so on a proxied network every asset request for
+# the fallback frontend would be sent to the proxy and come back empty, leaving a blank DevTools
+# window. Browsers bypass loopback implicitly; this opener does the same.
+_DIRECT_OPENER = build_opener(ProxyHandler({}))
 
 # Names/locations for the Chrome/Chromium binary used for the offline frontend fallback.
 _CHROME_BINARY_NAMES = (
@@ -153,11 +162,22 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 
+def _is_loopback(url: str) -> bool:
+    """Whether url addresses this machine, and so must be fetched without going through a proxy."""
+    host = urlsplit(url).hostname or ""
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return host == "localhost" or host.endswith(".localhost")
+
+
 async def _fetch(url: str) -> Optional[tuple[bytes, str]]:
     """Fetch a frontend asset off the event loop; None on any failure."""
 
     def _get() -> tuple[bytes, str]:
-        with urlopen(url, timeout=20) as response:
+        # Anything on this machine - the fallback Chrome - is fetched directly; see _DIRECT_OPENER.
+        opener = _DIRECT_OPENER.open if _is_loopback(url) else urlopen
+        with opener(url, timeout=20) as response:
             return response.read(), response.headers.get_content_type()
 
     try:

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -433,7 +433,18 @@ async def page_debugger(websocket: WebSocket, page_id: str):
             # bad state), fail the connection instead of keeping a zombie handler alive forever.
             target = await asyncio.wait_for(CdpTarget.create(protocol), TARGET_CREATION_TIMEOUT)
         except (asyncio.TimeoutError, TimeoutError):
-            logger.error(f"page {page_id}: device did not report an inspection target in time")
+            # A page already being debugged over another Web Inspector connection - a second
+            # pymobiledevice3, Safari's own Web Inspector, or a client that exited without
+            # detaching - never reports a target, and the listing says who holds it. Naming them
+            # beats "the device did not answer", which sends people looking at the device.
+            holder = page.web_connection_id
+            if holder and holder != app.state.inspector.connection_id:
+                logger.error(
+                    f"page {page_id}: already being debugged over Web Inspector connection {holder}; "
+                    "close that debugger, or the process that left it attached, and reconnect"
+                )
+            else:
+                logger.error(f"page {page_id}: device did not report an inspection target in time")
             await app.state.inspector.teardown_inspector_socket(session_id, application.id_, page.id_)
             await websocket.close()
             return

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -146,17 +146,24 @@ def find_chrome(explicit: Optional[str] = None) -> Optional[str]:
     return None
 
 
+def _reap_local_frontend() -> None:
+    """Tear down the fallback Chrome and its throwaway profile, if one is running."""
+    proc: Optional[subprocess.Popen[bytes]] = getattr(app.state, "local_chrome_proc", None)
+    if proc is not None:
+        proc.terminate()
+        app.state.local_chrome_proc = None
+    profile: Optional[str] = getattr(app.state, "local_chrome_profile", None)
+    if profile:
+        shutil.rmtree(profile, ignore_errors=True)
+        app.state.local_chrome_profile = None
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     app.state.frontend_lock = asyncio.Lock()
     await app.state.inspector.connect()
     yield
-    proc: Optional[subprocess.Popen[bytes]] = getattr(app.state, "local_chrome_proc", None)
-    if proc is not None:
-        proc.terminate()
-    profile: Optional[str] = getattr(app.state, "local_chrome_profile", None)
-    if profile:
-        shutil.rmtree(profile, ignore_errors=True)
+    _reap_local_frontend()
 
 
 app = FastAPI(lifespan=lifespan)
@@ -196,6 +203,7 @@ async def _launch_local_frontend() -> Optional[str]:
             "was found. Install Chrome/Chromium or pass --chrome <path>."
         )
         return None
+    _reap_local_frontend()
     profile = tempfile.mkdtemp(prefix="pmd3-devtools-frontend-")
     app.state.local_chrome_profile = profile
     app.state.local_chrome_proc = subprocess.Popen(
@@ -224,25 +232,28 @@ async def _launch_local_frontend() -> Optional[str]:
 
 
 async def _frontend_base() -> Optional[str]:
-    """Base URL to serve the DevTools frontend from, decided once per run: the hosted build when
-    reachable, otherwise a locally launched Chrome. None if neither is available."""
+    """Base URL to serve the DevTools frontend from: the hosted build when reachable, otherwise a
+    locally launched Chrome. Resolved once per run and kept, but a failure is deliberately not
+    remembered - the causes are transient (a network that comes back, a Chrome that lost the race
+    to publish its port), and remembering one served 404s, and so a blank DevTools window, for the
+    rest of the session."""
     base = getattr(app.state, "frontend_base", None)
-    if base is not None:
-        return base or None
+    if base:
+        return base
     async with app.state.frontend_lock:
         base = getattr(app.state, "frontend_base", None)
-        if base is not None:
-            return base or None
+        if base:
+            return base
         rev = getattr(app.state, "frontend_rev", DEVTOOLS_FRONTEND_REV)
         hosted = f"https://{DEVTOOLS_FRONTEND_HOST}/serve_rev/@{rev}"
         if await _fetch(f"{hosted}/inspector.html") is not None:
             app.state.frontend_base = hosted
         else:
             local = await _launch_local_frontend()
-            app.state.frontend_base = f"{local}/devtools" if local else ""
+            app.state.frontend_base = f"{local}/devtools" if local else None
             if local:
                 logger.info("serving the DevTools frontend from a local Chrome (hosted build unreachable)")
-        return app.state.frontend_base or None
+        return app.state.frontend_base
 
 
 @app.get("/json/version")

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -161,6 +161,14 @@ def _reap_local_frontend() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     app.state.frontend_lock = asyncio.Lock()
+    # Per-page state belongs to one run of the bridge. An asyncio primitive binds to the event loop
+    # that created it, and a page handler killed without unwinding - a forced shutdown, a loop torn
+    # down under it - leaves its lock held. Either one carried into a later run in the same process
+    # (a second asyncio.run, a test) wedges every connection to that page: it waits out
+    # PAGE_HANDOVER_TIMEOUT for a lock nobody is left to release, then fails outright because the
+    # lock belongs to a loop that is gone.
+    PAGE_LOCKS.clear()
+    PAGE_TAKEOVERS.clear()
     await app.state.inspector.connect()
     yield
     _reap_local_frontend()

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -213,6 +213,25 @@ class WebinspectorService(LockdownService):
             if event.get("Name") == WEBINSPECTORD_DISABLED_NOTIFICATION:
                 raise WebInspectorNotEnabledError
 
+    async def _connect_service(self) -> None:
+        """Connect to webinspectord, waiting out the gate it puts on consecutive sessions.
+
+        A new session is admitted only about ten seconds after the previous one started: until
+        then webinspectord accepts the connection but never completes the TLS handshake. That is a
+        hair longer than DEFAULT_SSL_HANDSHAKE_TIMEOUT, so reattaching right after a session ended
+        - restarting the CDP bridge, or opening an automation session once inspection is done -
+        aborted the handshake and, since a disabled device also terminates the connection, was
+        reported as "Web Inspector is disabled". The attempt that timed out has already waited the
+        gate out, so a second one goes through.
+        """
+        try:
+            await super().connect()
+        except ConnectionTerminatedError as e:
+            if not isinstance(e.__cause__, ConnectionAbortedError):
+                # Terminated by the device rather than by our own handshake timeout.
+                raise
+            await super().connect()
+
     async def _connect_or_raise_disabled(self) -> None:
         async with NotificationProxyService(self.lockdown) as notification_proxy:
             await notification_proxy.notify_register_dispatch(WEBINSPECTORD_DISABLED_NOTIFICATION)
@@ -220,7 +239,7 @@ class WebinspectorService(LockdownService):
             try:
                 # Keep the disabled notification watcher active for the full WebInspector handshake. A disabled
                 # device may report either the explicit notification or an abrupt service termination.
-                await self._await_or_raise_disabled(super().connect(), disabled_task)
+                await self._await_or_raise_disabled(self._connect_service(), disabled_task)
                 await self._await_or_raise_disabled(self._report_identifier(), disabled_task)
                 await self._handle_recv(await self._await_or_raise_disabled(self._recv_message(), disabled_task))
             finally:

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -69,6 +69,10 @@ class Page:
     type_: WirTypes
     web_url: str = ""
     web_title: str = ""
+    # The Web Inspector connection currently debugging this page, when there is one. WebKit serves
+    # a single inspector session per debuggable, so a page listed with somebody else's connection
+    # identifier cannot be attached to until they let go.
+    web_connection_id: str = ""
     automation_is_paired_key: bool = False
     automation_name: str = ""
     automation_version: str = ""
@@ -81,6 +85,7 @@ class Page:
         if p.type_ in (WirTypes.WEB, WirTypes.WEB_PAGE):
             p.web_title = page_dict["WIRTitleKey"]
             p.web_url = page_dict["WIRURLKey"]
+            p.web_connection_id = page_dict.get("WIRConnectionIdentifierKey", "")
         if p.type_ == WirTypes.JAVASCRIPT:
             # A JSContext debuggable is listed with a title (its name, "JSContext" by default) but
             # no URL - there is no document behind it.

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -1,10 +1,15 @@
 import asyncio
 import itertools
 import json
+import socket
+import threading
+import urllib.request
 import uuid
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
+from collections.abc import AsyncGenerator, Generator
+from contextlib import asynccontextmanager, contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Optional
+from urllib.parse import urlsplit
 
 import pytest
 import uvicorn
@@ -15,7 +20,7 @@ from wsproto.events import Request as WsRequest
 from pymobiledevice3.exceptions import WebInspectorNotEnabledError
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.services.web_protocol.cdp_browser import PAGE_LOCKS, PAGE_TAKEOVERS
-from pymobiledevice3.services.web_protocol.cdp_server import app, targets_html
+from pymobiledevice3.services.web_protocol.cdp_server import _fetch, app, targets_html
 from pymobiledevice3.services.web_protocol.cdp_target import JS_CONTEXT_EXECUTION_ID
 from pymobiledevice3.services.webinspector import SAFARI, Application, AutomationAvailability, Page, WebinspectorService
 
@@ -515,3 +520,52 @@ def test_landing_page_escapes_titles_from_the_device() -> None:
     assert "<script>" not in html
     assert "&lt;/a&gt;&lt;script&gt;alert(1)&lt;/script&gt;" in html
     assert "https://example.com/?a=1&amp;b=2" in html
+
+
+@contextmanager
+def _local_asset_server(payload: bytes) -> Generator[str, None, None]:
+    """Serve payload from loopback, standing in for the fallback Chrome's bundled frontend."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        # Named to match BaseHTTPRequestHandler's keyword parameter; silences the request log.
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/devtools/inspector.html"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(TIMEOUT)
+
+
+def _refused_address() -> str:
+    """An address nothing listens on, so routing to it fails immediately instead of hanging."""
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return f"http://127.0.0.1:{probe.getsockname()[1]}"
+
+
+async def test_frontend_assets_are_fetched_without_a_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """urllib routes loopback through a configured proxy as readily as anything else, and the
+    fallback frontend lives on loopback: without a bypass, a proxied network serves a blank
+    DevTools window because every asset request goes to the proxy instead of the local Chrome."""
+    monkeypatch.setenv("http_proxy", _refused_address())
+    monkeypatch.delenv("no_proxy", raising=False)
+    # urlopen builds its default opener once and caches the proxies it read; drop it so the
+    # environment set above is the one in effect.
+    monkeypatch.setattr(urllib.request, "_opener", None, raising=False)
+
+    with _local_asset_server(b"<html>frontend</html>") as url:
+        assert urlsplit(url).hostname == "127.0.0.1"
+        assert await _fetch(url) == (b"<html>frontend</html>", "text/html")

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -20,7 +20,14 @@ from wsproto.events import Request as WsRequest
 from pymobiledevice3.exceptions import WebInspectorNotEnabledError
 from pymobiledevice3.lockdown import LockdownClient
 from pymobiledevice3.services.web_protocol.cdp_browser import PAGE_LOCKS, PAGE_TAKEOVERS
-from pymobiledevice3.services.web_protocol.cdp_server import _fetch, app, targets_html
+from pymobiledevice3.services.web_protocol.cdp_server import (
+    DEVTOOLS_FRONTEND_HOST,
+    DEVTOOLS_FRONTEND_REV,
+    _fetch,
+    _frontend_base,
+    app,
+    targets_html,
+)
 from pymobiledevice3.services.web_protocol.cdp_target import JS_CONTEXT_EXECUTION_ID
 from pymobiledevice3.services.webinspector import SAFARI, Application, AutomationAvailability, Page, WebinspectorService
 
@@ -569,3 +576,25 @@ async def test_frontend_assets_are_fetched_without_a_proxy(monkeypatch: pytest.M
     with _local_asset_server(b"<html>frontend</html>") as url:
         assert urlsplit(url).hostname == "127.0.0.1"
         assert await _fetch(url) == (b"<html>frontend</html>", "text/html")
+
+
+async def test_a_frontend_that_could_not_be_resolved_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remembering a failed lookup served 404s - a blank DevTools window - for the rest of the
+    session, even after the cause (an unreachable network, a Chrome that lost the race to publish
+    its port) had passed."""
+    app.state.frontend_lock = asyncio.Lock()
+    monkeypatch.delattr(app.state, "frontend_base", raising=False)
+    # No Chrome to fall back to, so the first attempt cannot resolve a frontend at all.
+    monkeypatch.setattr(app.state, "chrome_path", None, raising=False)
+    probes: list[str] = []
+
+    async def probe(url: str) -> Optional[tuple[bytes, str]]:
+        probes.append(url)
+        # The hosted build is unreachable at first, then comes back.
+        return (b"<html>", "text/html") if len(probes) > 1 else None
+
+    monkeypatch.setattr("pymobiledevice3.services.web_protocol.cdp_server._fetch", probe)
+
+    assert await _frontend_base() is None
+    assert await _frontend_base() == f"https://{DEVTOOLS_FRONTEND_HOST}/serve_rev/@{DEVTOOLS_FRONTEND_REV}"
+    assert len(probes) == 2

--- a/tests/services/test_webinspector.py
+++ b/tests/services/test_webinspector.py
@@ -49,6 +49,28 @@ def test_javascript_page_listing_keeps_its_title() -> None:
     assert page.web_url == ""
 
 
+def test_web_page_listing_reports_the_debugger_holding_it() -> None:
+    """WebKit serves one inspector session per page, and the listing names the connection that has
+    it. Without that, a page held by another debugger looked exactly like a device not answering."""
+    held = Page.from_page_dictionary({
+        "WIRPageIdentifierKey": 1,
+        "WIRTypeKey": "WIRTypeWebPage",
+        "WIRTitleKey": "Example Domain",
+        "WIRURLKey": "https://example.com/",
+        "WIRConnectionIdentifierKey": "98FC0F20-4680-4E8D-A3C9-AB19296BCE96",
+    })
+    assert held.web_connection_id == "98FC0F20-4680-4E8D-A3C9-AB19296BCE96"
+
+    # The key is absent altogether while nobody is debugging the page.
+    free = Page.from_page_dictionary({
+        "WIRPageIdentifierKey": 1,
+        "WIRTypeKey": "WIRTypeWebPage",
+        "WIRTitleKey": "Example Domain",
+        "WIRURLKey": "https://example.com/",
+    })
+    assert free.web_connection_id == ""
+
+
 def _web_page_listing(app_id: str, pages: dict[str, str]) -> dict[str, Any]:
     return {
         "WIRApplicationIdentifierKey": app_id,

--- a/tests/services/test_webinspector.py
+++ b/tests/services/test_webinspector.py
@@ -113,3 +113,20 @@ def test_find_page_id_distinguishes_same_page_of_different_applications() -> Non
 
     with pytest.raises(KeyError):
         inspector.find_page_id(make_target_id("PID:3", "1"))
+
+
+async def testp_reattaching_immediately_after_a_session_succeeds(lockdown: LockdownClient) -> None:
+    """webinspectord admits a new session only about ten seconds after the previous one started,
+    and until then never completes the TLS handshake - a hair past our handshake timeout. Every
+    reattach that came too soon (a restarted CDP bridge, an automation session opened once
+    inspection was done) therefore failed, and was reported as Web Inspector being disabled."""
+    async with webinspector_service(lockdown):
+        pass
+
+    # No delay: this is the reattach that used to abort.
+    reattached = WebinspectorService(lockdown=lockdown)
+    await reattached.connect()
+    try:
+        assert reattached.connection_id
+    finally:
+        await reattached.close()


### PR DESCRIPTION
Fixes proxy handling in the CDP bridge's DevTools frontend, and the reattachment wedges found while stress-testing it against a device.

## Proxy handling

When the frontend is served from a locally launched Chrome, that Chrome is reached over loopback — and the fetch went through whatever proxy was configured.

`_fetch` used a bare `urlopen`, and urllib applies proxy configuration to loopback as readily as to anything else: `proxy_bypass_environment` consults only `no_proxy`, and `_proxy_bypass_macosx_sysconf` only the `ExceptionsList` plus "exclude simple hostnames", which cannot match `127.0.0.1` — the very form `_launch_local_frontend` returns. So with a proxy set, the bridge dialled it to reach a Chrome running on the same machine, every asset came back empty, and DevTools opened blank. The browser side never showed it, because browsers bypass loopback implicitly.

Loopback now goes through an opener with an empty `ProxyHandler`; the hosted build stays on the default opener, so a proxy genuinely needed to reach it is still used.

The frontend fallback itself was fine — the local Chrome serves a frontend byte-identical to the pinned revision, verified over the full 1101-asset import graph.

A second failure made this stick: `_frontend_base` cached failure as `""` and short-circuited on it, so one unlucky lookup served 404s for the rest of the session. Only a resolved base is kept now, and a retry reaps the previous fallback Chrome instead of leaking it.

## Reattachment

`webinspectord` admits a new session only ~10.15s after the previous one *started* — measured from the start, so closing early does not help; until then it accepts the connection but never finishes the TLS handshake. That is a hair past `DEFAULT_SSL_HANDSHAKE_TIMEOUT`, so restarting the bridge, opening an automation session after inspecting, or just running these tests in sequence failed — and since a disabled device also terminates the connection, it was reported as "Web inspector is not enabled", pointing at a Settings toggle that was never off. The attempt that timed out has itself waited the gate out, so it retries once, only for our own handshake timeout.

With that fixed, `testp_cdp_server_takes_a_held_page_over` ran in a full-suite context for the first time — and hung at 100% CPU. `PAGE_LOCKS`/`PAGE_TAKEOVERS` are process-global, but their asyncio primitives belong to the loop that created them, and a handler killed without unwinding leaves its lock held; carried into a later run, every connection to that page waited out `PAGE_HANDOVER_TIMEOUT` and then failed with "is bound to a different event loop". Both are cleared at lifespan startup.

Finally, a page held by another Web Inspector connection never reports a target, and both attach paths blamed the device for it. The listing carries `WIRConnectionIdentifierKey` all along — kept for web pages now, the way automation targets already keep it, and named in the error.

## Verification

Against an iPhone 11 on iOS 27.0, restarted first:

- 3 rounds of the Web Inspector + CDP suites, each followed immediately by the automation-session suites (driver + element) to check that starting automation right after inspection is clean: CDP 3/3 green (16 passed, 1 skipped, ~78s, no wedges), automation sessions started and drove fine in all 3.
- Each commit audited in a clean worktree: `ruff check`, `ruff format --check`, and device-free tests on 3.9 and on the default interpreter. `pyright --venvpath .` is clean at the tip.

Two things found along the way that are *not* addressed here, since both are pre-existing and outside this area:

- `test_driver.py::test_back` is flaky (failed 2 of 3 focused runs): after `back()`, `get_current_url()` still returns the pre-back URL, so the automation navigation commands look like they can return before the navigation settles.
- One device-free run on 3.9 hung once in the audit worktree and did not reproduce on two reruns of the same commit; nothing in these commits is reachable from it.