### PR TITLE
tests: self-contained WebDriver history tests, and a no-root tunnel by default

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -23,7 +23,7 @@ description: Cut a new pymobiledevice3 release — create the GitHub release (wh
 2. **Review what's shipping** so you can write accurate highlights:
    ```shell
    PREV=$(git tag --sort=-creatordate | head -1)
-   git log $PREV..HEAD --oneline
+   git log --no-merges $PREV..HEAD --oneline
    git show <sha>   # inspect each meaningful change to describe it correctly
    ```
 
@@ -43,9 +43,11 @@ description: Cut a new pymobiledevice3 release — create the GitHub release (wh
 
 5. **Rewrite `## What's Changed` as a commit history**, not the PR-link list `--generate-notes`
    produces. One line per commit since the previous tag, formatted
-   `* <shortsha8> <subject> (#<pr>) (@<committer>)`:
+   `* <shortsha8> <subject> (#<pr>) (@<committer>)`. `--no-merges` is required: a merge commit
+   carries no change of its own, and its subject ("Merge pull request #N from <branch>") names the
+   branch rather than what shipped, which is exactly what these notes exist to spell out.
    ```shell
-   for sha in $(git log $PREV..HEAD --format='%H'); do
+   for sha in $(git log --no-merges $PREV..HEAD --format='%H'); do
      short=$(git rev-parse --short=8 $sha)
      subj=$(git show -s --format='%s' $sha)
      login=$(gh api repos/doronz88/pymobiledevice3/commits/$sha --jq '.author.login')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from pymobiledevice3.exceptions import (
 )
 from pymobiledevice3.lockdown import UsbmuxLockdownClient, create_using_usbmux
 from pymobiledevice3.remote.remote_service_discovery import RemoteServiceDiscoveryService
+from pymobiledevice3.remote.rsd_tunnel import PreferredRsdTunnel
 from pymobiledevice3.services.dvt.instruments.dvt_provider import DvtProvider
 from pymobiledevice3.services.dvt.testmanaged.xcuitest import XCUITestService
 from pymobiledevice3.tunneld.api import get_tunneld_devices
@@ -64,7 +65,9 @@ def _skip_unless_tunneled(item: pytest.Item, e: InvalidServiceError) -> None:
     provider = funcargs.get("service_provider") or funcargs.get("lockdown")
     if isinstance(provider, RemoteServiceDiscoveryService):
         raise e
-    pytest.skip(f"Service requires an RSD tunnel (rerun with --rsd/--tunnel): {e}")
+    # service_provider brings a tunnel up on its own, so reaching here means none was available
+    # for this device at all - not that the run forgot to ask for one.
+    pytest.skip(f"Service requires an RSD tunnel, and none could be established: {e}")
 
 
 @pytest.hookimpl(wrapper=True)
@@ -145,8 +148,25 @@ async def service_provider(
             for rsd in rsds:
                 await rsd.close()
     else:
-        async with await _create_usbmux_client() as client:
-            yield client
+        # No transport asked for: establish one. Every RSD-requiring service is reachable
+        # in-process without root - the native tunnel on macOS, the userspace tunnel elsewhere -
+        # so those tests run by default instead of skipping until someone supplies tunneld.
+        # Per test rather than per session on purpose: the tunnel's asyncio objects belong to the
+        # loop that opened them, and the suite runs each test on a loop of its own.
+        tunnel = PreferredRsdTunnel()
+        try:
+            rsd = await tunnel.aopen()
+        except Exception:
+            # No tunnel for this device (pre-iOS 17, unpaired, no usable transport). Lockdown
+            # services still work over usbmux; the RSD-only ones skip as they did before.
+            await tunnel.aclose()
+            async with await _create_usbmux_client() as client:
+                yield client
+        else:
+            try:
+                yield rsd
+            finally:
+                await tunnel.aclose()
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/tests/services/test_web_protocol/common.py
+++ b/tests/services/test_web_protocol/common.py
@@ -3,3 +3,11 @@ LINK_HTML = (
     "the text obviously"
     "</a>"
 )
+
+# Navigation targets for the history tests. Self-contained on purpose: a real site needs the
+# device to be online, and loads at its own pace - back() intermittently still reported the page
+# it was leaving, because the navigation had not been reflected in the browsing context yet. A
+# data: URL settles synchronously and is reported back verbatim, so the history is exactly what
+# the test put there.
+PAGE_ONE = "data:text/html,<title>one</title><h1>one</h1>"
+PAGE_TWO = "data:text/html,<title>two</title><h1>two</h1>"

--- a/tests/services/test_web_protocol/test_driver.py
+++ b/tests/services/test_web_protocol/test_driver.py
@@ -1,27 +1,26 @@
 from pymobiledevice3.services.web_protocol.driver import By
-from tests.services.test_web_protocol.common import LINK_HTML
+from tests.services.test_web_protocol.common import LINK_HTML, PAGE_ONE, PAGE_TWO
 
 
 async def test_back(webdriver):
-    await webdriver.get("https://www.google.com")
-    await webdriver.get("https://github.com")
+    await webdriver.get(PAGE_ONE)
+    await webdriver.get(PAGE_TWO)
     await webdriver.back()
-    assert (await webdriver.get_current_url()).rstrip("/") == "https://www.google.com"
+    assert await webdriver.get_current_url() == PAGE_ONE
 
 
 async def test_current_url(webdriver):
     assert not await webdriver.get_current_url()
-    url = "https://www.google.com"
-    await webdriver.get(url)
-    assert (await webdriver.get_current_url()).rstrip("/") == url
+    await webdriver.get(PAGE_ONE)
+    assert await webdriver.get_current_url() == PAGE_ONE
 
 
 async def test_forward(webdriver):
-    await webdriver.get("https://www.google.com")
-    await webdriver.get("https://github.com")
+    await webdriver.get(PAGE_ONE)
+    await webdriver.get(PAGE_TWO)
     await webdriver.back()
     await webdriver.forward()
-    assert (await webdriver.get_current_url()).rstrip("/") == "https://github.com"
+    assert await webdriver.get_current_url() == PAGE_TWO
 
 
 async def test_find_element(webdriver):


### PR DESCRIPTION
Three independent changes, one commit each.

## The WebDriver history tests no longer need the device online

`test_back`, `test_current_url` and `test_forward` drove Safari to `google.com` and `github.com`, so they needed the *device* to have internet — and they were flaky even when it did. `back()` intermittently reported the page it was leaving rather than the one it returned to: roughly one navigation in five over the network, and never once across the same number of local navigations. A real page settles at its own pace, and the browsing context is read as soon as the automation command returns.

They navigate `data:` URLs now: no network, settle synchronously, reported back verbatim, so the history under test is exactly what the test put there.

The underlying timing question in `back()`/`forward()` is deliberately left alone. It only shows against network-backed pages, and it wants a fix in the driver rather than a test that papers over it — worth its own change once it can be pinned down.

## RSD tests bring up their own tunnel

Every RSD-requiring service is reachable in-process without root — the native tunnel on macOS, the userspace tunnel elsewhere — so a test needing one no longer has to be handed `--rsd` or a privileged `tunneld`. `service_provider` establishes the tunnel itself when neither was supplied.

Per test rather than per session, on purpose: the tunnel's asyncio objects belong to the loop that opened them, and the suite gives every test a loop of its own. Through the native path that costs about 0.3s per test.

`lockdown` is untouched and still usbmux-only, so usbmux-specific tests keep exercising that transport. A device with no tunnel available (pre-iOS 17, unpaired, no usable transport) falls back to usbmux exactly as before; the RSD-only tests still skip there, with a message that no longer tells the runner to pass a flag it no longer needs.

## Release notes drop merge commits

The `What's Changed` recipe walked every commit since the previous tag, so a release cut from merged PRs led with `Merge pull request #N from <branch>` — a line carrying no change of its own, naming the branch instead of what shipped. `--no-merges` now, in the review step too, so the commits being described and the commits being listed are the same set.

## Verification

Against the same iPhone 11 on iOS 27.0, reached over Wi-Fi (RemoteXPC, no USB, no root):

- `test_driver.py` 3 rounds, 12 executions, all green — the previous version failed 2 of 3 focused runs.
- `tests/services/instruments/` with no flags at all: 25 passed, 2 skipped (both for their own documented reasons). Before this change those needed `--rsd`/`tunneld`.
- Each commit audited in a clean worktree: `ruff check`, `ruff format --check`, device-free tests on 3.9 and on the default interpreter. `pyright --venvpath .` clean at the tip.

One note on how the first item was verified: the phone is currently on Wi-Fi only, and the `webdriver` fixture builds on `lockdown`, which stays usbmux-only here — so for those runs I pointed that fixture at `service_provider` temporarily and reverted it before committing. Moving `webdriver` (and the other Web Inspector tests) onto `service_provider` permanently would let them run over either transport; that seemed beyond what this change should decide.