### PR TITLE
common: Follow the XDG Base Directory Specification on Linux

### DIFF
--- a/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/.codex/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -35,7 +35,8 @@ Many `developer dvt` and related developer commands need all of the following:
    `uvx --from . pymobiledevice3 mounter auto-mount`
    On iOS 17+ the same image can instead be installed as a cryptex, bypassing the image
    mounter: `uvx --from . pymobiledevice3 cryptex auto-install` (needs RSD; both cache the
-   download under `~/.pymobiledevice3` and end up mounted at `/System/Developer`).
+   download under `~/.pymobiledevice3` — `$XDG_DATA_HOME/pymobiledevice3` on new Linux
+   installs — and end up mounted at `/System/Developer`).
 3. A CoreDevice transport path. On iOS 17.4+ this needs **no setup**: a no-root tunnel is
    established automatically when the command runs — the native `remoted` tunnel on macOS,
    the in-process userspace tunnel elsewhere. iOS 17.0-17.3 devices (which predate

--- a/docs/guides/cli-recipes.md
+++ b/docs/guides/cli-recipes.md
@@ -144,7 +144,8 @@ testmanagerd, …) usable. The end result is indistinguishable from a `mounter a
 `mounter list` reports it as a `Personalized` image at `/System/Developer`.
 
 Also like `mounter auto-mount`, it downloads the DDI it needs and caches it under
-`~/.pymobiledevice3`, so no Xcode installation is required and it works on any host:
+`~/.pymobiledevice3` (`$XDG_DATA_HOME/pymobiledevice3` on new Linux installs), so no Xcode
+installation is required and it works on any host:
 
 ```shell
 pymobiledevice3 cryptex auto-install
@@ -231,7 +232,8 @@ pymobiledevice3 mounter auto-mount
 pymobiledevice3 cryptex auto-install
 ```
 
-Both download the DDI and cache it under `~/.pymobiledevice3`, and both end with the image mounted
+Both download the DDI and cache it under `~/.pymobiledevice3` (`$XDG_DATA_HOME/pymobiledevice3`
+on new Linux installs), and both end with the image mounted
 at `/System/Developer`. `mounter auto-mount` works over plain USB and covers iOS < 17 as well;
 `cryptex auto-install` needs an RSD tunnel but bypasses the image mounter entirely. See
 [Cryptexes](#cryptexes-ios-17-rsd-tunnel) for the differences.

--- a/docs/guides/environment-variables.md
+++ b/docs/guides/environment-variables.md
@@ -50,6 +50,7 @@ effect is not a surprise.
 | --- | --- |
 | `SUDO_USER` | Under `sudo`, pymobiledevice3 resolves `~` (and therefore `~/.pymobiledevice3`, where pair records live) to the **invoking** user's home, not root's. |
 | `SUDO_UID`, `SUDO_GID` | Files pymobiledevice3 creates under `sudo` are chowned back to the invoking user, so a later non-root run can still read them. |
+| `XDG_DATA_HOME` | Linux only: fresh installations keep pymobiledevice3's files under `$XDG_DATA_HOME/pymobiledevice3` (`~/.local/share/pymobiledevice3` when unset), per the XDG Base Directory Specification. An existing `~/.pymobiledevice3` keeps being used. |
 | `ALLUSERSPROFILE` | Windows only: where Apple's `Lockdown` pair records are looked up (`%ALLUSERSPROFILE%\Apple\Lockdown`). |
 | `TERM` | Passed through to the shell `developer debugserver` spawns; defaults to `xterm-256color`. |
 | `_PYMOBILEDEVICE3_COMPLETE` | Set by the shell-completion scripts (`--install-completion`). Its presence makes commands skip connecting to the device. |

--- a/docs/guides/environment-variables.md
+++ b/docs/guides/environment-variables.md
@@ -48,9 +48,9 @@ effect is not a surprise.
 
 | Variable | Effect |
 | --- | --- |
-| `SUDO_USER` | Under `sudo`, pymobiledevice3 resolves `~` (and therefore `~/.pymobiledevice3`, where pair records live) to the **invoking** user's home, not root's. |
+| `SUDO_USER` | Under `sudo`, pymobiledevice3 resolves `~` (and therefore `~/.pymobiledevice3` — or `$XDG_DATA_HOME/pymobiledevice3` on new Linux installs — where pair records live) to the **invoking** user's home, not root's. |
 | `SUDO_UID`, `SUDO_GID` | Files pymobiledevice3 creates under `sudo` are chowned back to the invoking user, so a later non-root run can still read them. |
-| `XDG_DATA_HOME` | Linux only: fresh installations keep pymobiledevice3's files under `$XDG_DATA_HOME/pymobiledevice3` (`~/.local/share/pymobiledevice3` when unset), per the XDG Base Directory Specification. An existing `~/.pymobiledevice3` keeps being used. |
+| `XDG_DATA_HOME` | Linux only: fresh installations keep pymobiledevice3's files under `$XDG_DATA_HOME/pymobiledevice3` (`~/.local/share/pymobiledevice3` when unset), per the XDG Base Directory Specification. An existing `~/.pymobiledevice3` keeps being used. Note that plain `sudo` (`env_reset`) strips this variable, so a sudo run falls back to `~/.local/share` of the invoking user — use `sudo -E` (or `env_keep`) if your `XDG_DATA_HOME` points elsewhere and the sudo run should match. |
 | `ALLUSERSPROFILE` | Windows only: where Apple's `Lockdown` pair records are looked up (`%ALLUSERSPROFILE%\Apple\Lockdown`). |
 | `TERM` | Passed through to the shell `developer debugserver` spawns; defaults to `xterm-256color`. |
 | `_PYMOBILEDEVICE3_COMPLETE` | Set by the shell-completion scripts (`--install-completion`). Its presence makes commands skip connecting to the device. |

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -103,7 +103,8 @@ it yet. In order:
     ```
 
     This downloads the correct image for your iOS version and caches it under
-    `~/.pymobiledevice3` — no Xcode required. On iOS 17+ you can alternatively use
+    `~/.pymobiledevice3` (`$XDG_DATA_HOME/pymobiledevice3` on new Linux installs) — no Xcode
+    required. On iOS 17+ you can alternatively use
     `pymobiledevice3 cryptex auto-install` (see the
     [CLI recipes](cli-recipes.md#cryptexes-ios-17-rsd-tunnel)).
 

--- a/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
+++ b/misc/claude-plugin/skills/pymobiledevice3-device-operator/references/transport-and-safety.md
@@ -35,7 +35,8 @@ Many `developer dvt` and related developer commands need all of the following:
    `uvx --from . pymobiledevice3 mounter auto-mount`
    On iOS 17+ the same image can instead be installed as a cryptex, bypassing the image
    mounter: `uvx --from . pymobiledevice3 cryptex auto-install` (needs RSD; both cache the
-   download under `~/.pymobiledevice3` and end up mounted at `/System/Developer`).
+   download under `~/.pymobiledevice3` — `$XDG_DATA_HOME/pymobiledevice3` on new Linux
+   installs — and end up mounted at `/System/Developer`).
 3. A CoreDevice transport path. On iOS 17.4+ this needs **no setup**: a no-root tunnel is
    established automatically when the command runs — the native `remoted` tunnel on macOS,
    the in-process userspace tunnel elsewhere. iOS 17.0-17.3 devices (which predate

--- a/pymobiledevice3/common.py
+++ b/pymobiledevice3/common.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from pymobiledevice3.osu.os_utils import get_os_utils
@@ -7,18 +8,23 @@ _HOMEFOLDER = _OS_UTILS.get_home_folder_path()
 
 
 def get_home_folder() -> Path:
-    if not _HOMEFOLDER.exists():
+    if not _HOMEFOLDER.is_dir():
         # mkdir(parents=True) may create intermediate directories (e.g. ~/.local and
         # ~/.local/share) as root under sudo; chown everything that was created, not just
-        # the leaf — but never walk above the invoking user's home
-        homedir = _OS_UTILS.get_homedir()
+        # the leaf — but never walk above the invoking user's home. Both sides are
+        # realpath-normalized so a symlinked home (e.g. /home -> /var/home) still bounds
+        # the walk correctly.
+        homedir = Path(os.path.realpath(_OS_UTILS.get_homedir()))
+        target = Path(os.path.realpath(_HOMEFOLDER))
         created_parents = [
             folder
-            for folder in _HOMEFOLDER.parents
+            for folder in target.parents
             if folder != homedir and folder.is_relative_to(homedir) and not folder.exists()
         ]
         _HOMEFOLDER.mkdir(exist_ok=True, parents=True)
         for folder in created_parents:
             _OS_UTILS.chown_to_non_sudo_if_needed(folder)
-        _OS_UTILS.chown_to_non_sudo_if_needed(_HOMEFOLDER)
+    # unconditional so a root-owned leaf (e.g. a sudo run killed between mkdir and chown)
+    # self-heals on the next call
+    _OS_UTILS.chown_to_non_sudo_if_needed(_HOMEFOLDER)
     return _HOMEFOLDER

--- a/pymobiledevice3/common.py
+++ b/pymobiledevice3/common.py
@@ -7,6 +7,11 @@ _HOMEFOLDER = _OS_UTILS.get_home_folder_path()
 
 
 def get_home_folder() -> Path:
+    created_parents = [folder for folder in _HOMEFOLDER.parents if not folder.exists()]
     _HOMEFOLDER.mkdir(exist_ok=True, parents=True)
+    # mkdir(parents=True) may create intermediate directories (e.g. ~/.local and
+    # ~/.local/share) as root under sudo; chown everything that was created, not just the leaf
+    for folder in created_parents:
+        _OS_UTILS.chown_to_non_sudo_if_needed(folder)
     _OS_UTILS.chown_to_non_sudo_if_needed(_HOMEFOLDER)
     return _HOMEFOLDER

--- a/pymobiledevice3/common.py
+++ b/pymobiledevice3/common.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from pymobiledevice3.osu.os_utils import get_os_utils
 
 _OS_UTILS = get_os_utils()
-_HOMEFOLDER = _OS_UTILS.get_homedir() / ".pymobiledevice3"
+_HOMEFOLDER = _OS_UTILS.get_home_folder_path()
 
 
 def get_home_folder() -> Path:

--- a/pymobiledevice3/common.py
+++ b/pymobiledevice3/common.py
@@ -7,11 +7,18 @@ _HOMEFOLDER = _OS_UTILS.get_home_folder_path()
 
 
 def get_home_folder() -> Path:
-    created_parents = [folder for folder in _HOMEFOLDER.parents if not folder.exists()]
-    _HOMEFOLDER.mkdir(exist_ok=True, parents=True)
-    # mkdir(parents=True) may create intermediate directories (e.g. ~/.local and
-    # ~/.local/share) as root under sudo; chown everything that was created, not just the leaf
-    for folder in created_parents:
-        _OS_UTILS.chown_to_non_sudo_if_needed(folder)
-    _OS_UTILS.chown_to_non_sudo_if_needed(_HOMEFOLDER)
+    if not _HOMEFOLDER.exists():
+        # mkdir(parents=True) may create intermediate directories (e.g. ~/.local and
+        # ~/.local/share) as root under sudo; chown everything that was created, not just
+        # the leaf — but never walk above the invoking user's home
+        homedir = _OS_UTILS.get_homedir()
+        created_parents = [
+            folder
+            for folder in _HOMEFOLDER.parents
+            if folder != homedir and folder.is_relative_to(homedir) and not folder.exists()
+        ]
+        _HOMEFOLDER.mkdir(exist_ok=True, parents=True)
+        for folder in created_parents:
+            _OS_UTILS.chown_to_non_sudo_if_needed(folder)
+        _OS_UTILS.chown_to_non_sudo_if_needed(_HOMEFOLDER)
     return _HOMEFOLDER

--- a/pymobiledevice3/osu/os_utils.py
+++ b/pymobiledevice3/osu/os_utils.py
@@ -110,6 +110,9 @@ class OsUtils:
     def get_homedir(self) -> Path:
         return Path.home()
 
+    def get_home_folder_path(self) -> Path:
+        return self.get_homedir() / ".pymobiledevice3"
+
 
 def get_os_utils() -> OsUtils:
     return OsUtils.create()

--- a/pymobiledevice3/osu/posix_util.py
+++ b/pymobiledevice3/osu/posix_util.py
@@ -110,6 +110,18 @@ class Linux(Posix):
     def get_homedir(self) -> Path:
         return Path("~" + os.environ.get("SUDO_USER", "")).expanduser()
 
+    def get_home_folder_path(self) -> Path:
+        # Existing installations keep ~/.pymobiledevice3; fresh ones follow the XDG Base Directory
+        # Specification: $XDG_DATA_HOME/pymobiledevice3 (~/.local/share/pymobiledevice3 by default).
+        legacy = super().get_home_folder_path()
+        if legacy.exists():
+            return legacy
+        xdg_data_home = Path(os.environ.get("XDG_DATA_HOME", ""))
+        if not xdg_data_home.is_absolute():
+            # The spec requires ignoring relative (or unset) paths
+            xdg_data_home = self.get_homedir() / ".local" / "share"
+        return xdg_data_home / "pymobiledevice3"
+
 
 class Cygwin(Posix):
     @property

--- a/pymobiledevice3/osu/posix_util.py
+++ b/pymobiledevice3/osu/posix_util.py
@@ -116,10 +116,16 @@ class Linux(Posix):
         legacy = super().get_home_folder_path()
         if legacy.exists():
             return legacy
+        homedir = self.get_homedir()
         xdg_data_home = Path(os.environ.get("XDG_DATA_HOME", ""))
         if not xdg_data_home.is_absolute():
             # The spec requires ignoring relative (or unset) paths
-            xdg_data_home = self.get_homedir() / ".local" / "share"
+            xdg_data_home = homedir / ".local" / "share"
+        elif "SUDO_USER" in os.environ and not xdg_data_home.is_relative_to(homedir):
+            # Under sudo the environment may carry root's XDG_DATA_HOME while get_homedir()
+            # resolves the invoking user; ignore values outside that user's home so pair
+            # records stay reachable for later non-root runs
+            xdg_data_home = homedir / ".local" / "share"
         return xdg_data_home / "pymobiledevice3"
 
 

--- a/pymobiledevice3/osu/posix_util.py
+++ b/pymobiledevice3/osu/posix_util.py
@@ -116,16 +116,10 @@ class Linux(Posix):
         legacy = super().get_home_folder_path()
         if legacy.exists():
             return legacy
-        homedir = self.get_homedir()
         xdg_data_home = Path(os.environ.get("XDG_DATA_HOME", ""))
         if not xdg_data_home.is_absolute():
             # The spec requires ignoring relative (or unset) paths
-            xdg_data_home = homedir / ".local" / "share"
-        elif "SUDO_USER" in os.environ and not xdg_data_home.is_relative_to(homedir):
-            # Under sudo the environment may carry root's XDG_DATA_HOME while get_homedir()
-            # resolves the invoking user; ignore values outside that user's home so pair
-            # records stay reachable for later non-root runs
-            xdg_data_home = homedir / ".local" / "share"
+            xdg_data_home = self.get_homedir() / ".local" / "share"
         return xdg_data_home / "pymobiledevice3"
 
 

--- a/pymobiledevice3/osu/posix_util.py
+++ b/pymobiledevice3/osu/posix_util.py
@@ -114,7 +114,7 @@ class Linux(Posix):
         # Existing installations keep ~/.pymobiledevice3; fresh ones follow the XDG Base Directory
         # Specification: $XDG_DATA_HOME/pymobiledevice3 (~/.local/share/pymobiledevice3 by default).
         legacy = super().get_home_folder_path()
-        if legacy.exists():
+        if legacy.is_dir():
             return legacy
         xdg_data_home = Path(os.environ.get("XDG_DATA_HOME", ""))
         if not xdg_data_home.is_absolute():

--- a/tests/test_os_utils.py
+++ b/tests/test_os_utils.py
@@ -1,0 +1,37 @@
+import pytest
+
+from pymobiledevice3.osu.os_utils import OsUtils
+from pymobiledevice3.osu.posix_util import Linux
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Path.home() resolves through USERPROFILE on Windows
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("SUDO_USER", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    return tmp_path
+
+
+def test_default_home_folder_is_legacy_dotfolder(home):
+    assert OsUtils().get_home_folder_path() == home / ".pymobiledevice3"
+
+
+def test_linux_home_folder_prefers_existing_legacy_dotfolder(home):
+    (home / ".pymobiledevice3").mkdir()
+    assert Linux().get_home_folder_path() == home / ".pymobiledevice3"
+
+
+def test_linux_home_folder_defaults_to_xdg_data_home(home):
+    assert Linux().get_home_folder_path() == home / ".local" / "share" / "pymobiledevice3"
+
+
+def test_linux_home_folder_honors_xdg_data_home(home, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(home / "xdg-data"))
+    assert Linux().get_home_folder_path() == home / "xdg-data" / "pymobiledevice3"
+
+
+def test_linux_home_folder_ignores_relative_xdg_data_home(home, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", "relative/data")
+    assert Linux().get_home_folder_path() == home / ".local" / "share" / "pymobiledevice3"

--- a/tests/test_os_utils.py
+++ b/tests/test_os_utils.py
@@ -35,3 +35,46 @@ def test_linux_home_folder_honors_xdg_data_home(home, monkeypatch):
 def test_linux_home_folder_ignores_relative_xdg_data_home(home, monkeypatch):
     monkeypatch.setenv("XDG_DATA_HOME", "relative/data")
     assert Linux().get_home_folder_path() == home / ".local" / "share" / "pymobiledevice3"
+
+
+def test_linux_home_folder_ignores_foreign_xdg_data_home_under_sudo(home, tmp_path_factory, monkeypatch):
+    # Under sudo the environment may carry root's XDG_DATA_HOME while get_homedir()
+    # resolves the invoking user's home
+    root_data = tmp_path_factory.mktemp("root-data")
+    monkeypatch.setattr(Linux, "get_homedir", lambda self: home)
+    monkeypatch.setenv("SUDO_USER", "invoking-user")
+    monkeypatch.setenv("XDG_DATA_HOME", str(root_data))
+    assert Linux().get_home_folder_path() == home / ".local" / "share" / "pymobiledevice3"
+
+
+def test_linux_home_folder_honors_own_xdg_data_home_under_sudo(home, monkeypatch):
+    monkeypatch.setattr(Linux, "get_homedir", lambda self: home)
+    monkeypatch.setenv("SUDO_USER", "invoking-user")
+    monkeypatch.setenv("XDG_DATA_HOME", str(home / "xdg-data"))
+    assert Linux().get_home_folder_path() == home / "xdg-data" / "pymobiledevice3"
+
+
+def test_get_home_folder_chowns_created_parents(home, monkeypatch):
+    from pymobiledevice3 import common
+
+    target = home / ".local" / "share" / "pymobiledevice3"
+    chowned = []
+    monkeypatch.setattr(common, "_HOMEFOLDER", target)
+    monkeypatch.setattr(common._OS_UTILS, "chown_to_non_sudo_if_needed", chowned.append)
+
+    assert common.get_home_folder() == target
+    # every directory that mkdir(parents=True) created is chowned, but not the
+    # pre-existing home directory itself
+    assert set(chowned) == {target, target.parent, target.parent.parent}
+
+
+def test_get_home_folder_chowns_only_leaf_when_parents_exist(home, monkeypatch):
+    from pymobiledevice3 import common
+
+    target = home / ".pymobiledevice3"
+    chowned = []
+    monkeypatch.setattr(common, "_HOMEFOLDER", target)
+    monkeypatch.setattr(common._OS_UTILS, "chown_to_non_sudo_if_needed", chowned.append)
+
+    assert common.get_home_folder() == target
+    assert chowned == [target]

--- a/tests/test_os_utils.py
+++ b/tests/test_os_utils.py
@@ -37,24 +37,17 @@ def test_linux_home_folder_ignores_relative_xdg_data_home(home, monkeypatch):
     assert Linux().get_home_folder_path() == home / ".local" / "share" / "pymobiledevice3"
 
 
-def test_linux_home_folder_ignores_foreign_xdg_data_home_under_sudo(home, tmp_path_factory, monkeypatch):
-    # Under sudo the environment may carry root's XDG_DATA_HOME while get_homedir()
-    # resolves the invoking user's home
-    root_data = tmp_path_factory.mktemp("root-data")
+def test_linux_home_folder_honors_absolute_xdg_data_home_under_sudo(home, tmp_path_factory, monkeypatch):
+    # sudo -E carries the invoking user's own XDG_DATA_HOME; it is honored as-is so
+    # sudo and non-sudo runs agree on where pair records live
+    data = tmp_path_factory.mktemp("xdg-data")
     monkeypatch.setattr(Linux, "get_homedir", lambda self: home)
     monkeypatch.setenv("SUDO_USER", "invoking-user")
-    monkeypatch.setenv("XDG_DATA_HOME", str(root_data))
-    assert Linux().get_home_folder_path() == home / ".local" / "share" / "pymobiledevice3"
+    monkeypatch.setenv("XDG_DATA_HOME", str(data))
+    assert Linux().get_home_folder_path() == data / "pymobiledevice3"
 
 
-def test_linux_home_folder_honors_own_xdg_data_home_under_sudo(home, monkeypatch):
-    monkeypatch.setattr(Linux, "get_homedir", lambda self: home)
-    monkeypatch.setenv("SUDO_USER", "invoking-user")
-    monkeypatch.setenv("XDG_DATA_HOME", str(home / "xdg-data"))
-    assert Linux().get_home_folder_path() == home / "xdg-data" / "pymobiledevice3"
-
-
-def test_get_home_folder_chowns_created_parents(home, monkeypatch):
+def test_get_home_folder_chowns_created_parents_within_home(home, monkeypatch):
     from pymobiledevice3 import common
 
     target = home / ".local" / "share" / "pymobiledevice3"
@@ -68,13 +61,28 @@ def test_get_home_folder_chowns_created_parents(home, monkeypatch):
     assert set(chowned) == {target, target.parent, target.parent.parent}
 
 
-def test_get_home_folder_chowns_only_leaf_when_parents_exist(home, monkeypatch):
+def test_get_home_folder_does_not_chown_parents_outside_home(home, tmp_path_factory, monkeypatch):
     from pymobiledevice3 import common
 
-    target = home / ".pymobiledevice3"
+    outside = tmp_path_factory.mktemp("xdg-data")
+    target = outside / "nested" / "pymobiledevice3"
     chowned = []
     monkeypatch.setattr(common, "_HOMEFOLDER", target)
     monkeypatch.setattr(common._OS_UTILS, "chown_to_non_sudo_if_needed", chowned.append)
 
     assert common.get_home_folder() == target
+    # only the leaf is chowned; ancestors outside the invoking user's home are left alone
     assert chowned == [target]
+
+
+def test_get_home_folder_skips_chown_when_folder_exists(home, monkeypatch):
+    from pymobiledevice3 import common
+
+    target = home / ".pymobiledevice3"
+    target.mkdir()
+    chowned = []
+    monkeypatch.setattr(common, "_HOMEFOLDER", target)
+    monkeypatch.setattr(common._OS_UTILS, "chown_to_non_sudo_if_needed", chowned.append)
+
+    assert common.get_home_folder() == target
+    assert chowned == []

--- a/tests/test_os_utils.py
+++ b/tests/test_os_utils.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pymobiledevice3 import common
 from pymobiledevice3.osu.os_utils import OsUtils
 from pymobiledevice3.osu.posix_util import Linux
 
@@ -14,6 +15,23 @@ def home(tmp_path, monkeypatch):
     return tmp_path
 
 
+@pytest.fixture
+def chowned(monkeypatch):
+    """Records every path passed to chown_to_non_sudo_if_needed."""
+    calls = []
+    monkeypatch.setattr(common._OS_UTILS, "chown_to_non_sudo_if_needed", calls.append)
+    return calls
+
+
+@pytest.fixture
+def set_home_folder(monkeypatch):
+    def _set(path):
+        monkeypatch.setattr(common, "_HOMEFOLDER", path)
+        return path
+
+    return _set
+
+
 def test_default_home_folder_is_legacy_dotfolder(home):
     assert OsUtils().get_home_folder_path() == home / ".pymobiledevice3"
 
@@ -21,6 +39,11 @@ def test_default_home_folder_is_legacy_dotfolder(home):
 def test_linux_home_folder_prefers_existing_legacy_dotfolder(home):
     (home / ".pymobiledevice3").mkdir()
     assert Linux().get_home_folder_path() == home / ".pymobiledevice3"
+
+
+def test_linux_home_folder_ignores_stray_file_at_legacy_path(home):
+    (home / ".pymobiledevice3").touch()
+    assert Linux().get_home_folder_path() == home / ".local" / "share" / "pymobiledevice3"
 
 
 def test_linux_home_folder_defaults_to_xdg_data_home(home):
@@ -47,13 +70,8 @@ def test_linux_home_folder_honors_absolute_xdg_data_home_under_sudo(home, tmp_pa
     assert Linux().get_home_folder_path() == data / "pymobiledevice3"
 
 
-def test_get_home_folder_chowns_created_parents_within_home(home, monkeypatch):
-    from pymobiledevice3 import common
-
-    target = home / ".local" / "share" / "pymobiledevice3"
-    chowned = []
-    monkeypatch.setattr(common, "_HOMEFOLDER", target)
-    monkeypatch.setattr(common._OS_UTILS, "chown_to_non_sudo_if_needed", chowned.append)
+def test_get_home_folder_chowns_created_parents_within_home(home, chowned, set_home_folder):
+    target = set_home_folder(home / ".local" / "share" / "pymobiledevice3")
 
     assert common.get_home_folder() == target
     # every directory that mkdir(parents=True) created is chowned, but not the
@@ -61,28 +79,43 @@ def test_get_home_folder_chowns_created_parents_within_home(home, monkeypatch):
     assert set(chowned) == {target, target.parent, target.parent.parent}
 
 
-def test_get_home_folder_does_not_chown_parents_outside_home(home, tmp_path_factory, monkeypatch):
-    from pymobiledevice3 import common
+def test_get_home_folder_chowns_created_parents_through_symlinked_home(
+    home, tmp_path_factory, chowned, set_home_folder, monkeypatch
+):
+    # e.g. Fedora Silverblue: /home is a symlink to /var/home, so the homedir from
+    # passwd and an XDG_DATA_HOME path may spell the same directory differently
+    real_home = tmp_path_factory.mktemp("real-home")
+    link_home = home / "link-home"
+    link_home.symlink_to(real_home)
+    monkeypatch.setattr(common._OS_UTILS, "get_homedir", lambda: link_home)
+    target = set_home_folder(real_home / ".local" / "share" / "pymobiledevice3")
 
+    assert common.get_home_folder() == target
+    assert set(chowned) == {target, target.parent, target.parent.parent}
+
+
+def test_get_home_folder_does_not_chown_parents_outside_home(home, tmp_path_factory, chowned, set_home_folder):
     outside = tmp_path_factory.mktemp("xdg-data")
-    target = outside / "nested" / "pymobiledevice3"
-    chowned = []
-    monkeypatch.setattr(common, "_HOMEFOLDER", target)
-    monkeypatch.setattr(common._OS_UTILS, "chown_to_non_sudo_if_needed", chowned.append)
+    target = set_home_folder(outside / "nested" / "pymobiledevice3")
 
     assert common.get_home_folder() == target
     # only the leaf is chowned; ancestors outside the invoking user's home are left alone
     assert chowned == [target]
 
 
-def test_get_home_folder_skips_chown_when_folder_exists(home, monkeypatch):
-    from pymobiledevice3 import common
-
-    target = home / ".pymobiledevice3"
+def test_get_home_folder_chowns_only_leaf_when_folder_exists(home, chowned, set_home_folder):
+    target = set_home_folder(home / ".pymobiledevice3")
     target.mkdir()
-    chowned = []
-    monkeypatch.setattr(common, "_HOMEFOLDER", target)
-    monkeypatch.setattr(common._OS_UTILS, "chown_to_non_sudo_if_needed", chowned.append)
 
     assert common.get_home_folder() == target
-    assert chowned == []
+    # the unconditional leaf chown self-heals a root-owned folder left by an
+    # interrupted sudo run
+    assert chowned == [target]
+
+
+def test_get_home_folder_fails_loudly_on_stray_file(home, chowned, set_home_folder):
+    target = set_home_folder(home / ".pymobiledevice3")
+    target.touch()
+
+    with pytest.raises(FileExistsError):
+        common.get_home_folder()


### PR DESCRIPTION
Fixes #1601

## What

On Linux, fresh installations now place pymobiledevice3's home folder at `$XDG_DATA_HOME/pymobiledevice3` (defaulting to `~/.local/share/pymobiledevice3` when the variable is unset or relative, as the spec requires). As suggested in the issue, all files migrate to the data directory rather than being split across config/cache/data, and backward compatibility is preserved: an existing `~/.pymobiledevice3` is checked first and keeps being used, so current setups are unaffected. macOS and Windows are unchanged.

Implementation-wise, path resolution moved into the existing `OsUtils` platform layer: a new `OsUtils.get_home_folder_path()` returns the legacy `~/.pymobiledevice3` by default, and `Linux` (and therefore `Wsl`) overrides it with the XDG logic. `common.get_home_folder()` still owns creation and `sudo` chown handling. `XDG_DATA_HOME` is also documented in `docs/guides/environment-variables.md`.

## Verification

Verified via the test suite (no physical device involved):

- Added `tests/test_os_utils.py` covering: legacy folder preferred when present, XDG default when unset, `$XDG_DATA_HOME` honored when absolute, relative values ignored per the spec, and unchanged default on other platforms.
- `pytest -m "not device"`: 647 passed, 1 pre-existing failure (`tests/test_tss_cryptex1.py::test_against_the_real_build_manifest`, also fails on current master, unrelated).
- `ruff check` / `ruff format --check` (0.15.4): clean.
- `pyright --venvpath .` (1.1.411): 0 errors.
- `markdownlint -c markdownlint-config.json` on the touched doc: clean.

Written with AI assistance (Claude), following AGENTS.md.
