### PR TITLE
webinspector: answer CDP page requests a target cannot serve

### DIFF
--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -63,6 +63,7 @@ __all__ = [
     "RSDRequiredError",
     "RemoteAutomationNotEnabledError",
     "RemotePairingCompletedError",
+    "ScreencastUnavailableError",
     "SetProhibitedError",
     "StartServiceError",
     "SysdiagnoseTimeoutError",
@@ -268,6 +269,12 @@ class StreamClosedError(ConnectionTerminatedError):
 
 class WebInspectorNotEnabledError(PyMobileDevice3Exception):
     """Raise when Web Inspector is not enabled."""
+
+    pass
+
+
+class ScreencastUnavailableError(PyMobileDevice3Exception):
+    """Raise when a debuggable cannot be screencast (it has no page to capture)."""
 
     pass
 

--- a/pymobiledevice3/services/web_protocol/cdp_screencast.py
+++ b/pymobiledevice3/services/web_protocol/cdp_screencast.py
@@ -8,6 +8,8 @@ from typing import Any, Optional
 
 from PIL import Image
 
+from pymobiledevice3.exceptions import ScreencastUnavailableError
+
 logger = logging.getLogger(__name__)
 
 
@@ -58,7 +60,10 @@ class ScreenCast:
             "window.devicePixelRatio"
         )
         if not isinstance(device_size, str):
-            raise TypeError("device did not report its screen size for the screencast")
+            # A JSContext debuggable has no page to capture: its global object carries no window
+            # or screen, so the evaluation comes back as a thrown ReferenceError rather than the
+            # size. A page that stopped answering lands here too.
+            raise ScreencastUnavailableError("the debuggable did not report a screen size to capture")
         self.device_width, self.device_height, self.page_scale_factor = list(map(int, device_size.split(",")))
         self._run = True
         self.recording_task = asyncio.create_task(self.recording_loop())
@@ -66,7 +71,8 @@ class ScreenCast:
     async def stop(self):
         """Stop sending screenshots to the devtools."""
         self._run = False
-        assert self.recording_task is not None
+        if self.recording_task is None:
+            return
         self.recording_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await self.recording_task

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from functools import partial
 from typing import Any, Callable, Optional, cast
 
+from pymobiledevice3.exceptions import ScreencastUnavailableError
 from pymobiledevice3.services.web_protocol.cdp_screencast import ScreenCast
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
 from pymobiledevice3.services.webinspector import WirTypes
@@ -24,6 +25,15 @@ WIR_RESULT_TIMEOUT = 5
 # timeout so a still-dead target only briefly re-pauses the receive loop.
 UNRESPONSIVE_REPROBE_INTERVAL = 2.0
 UNRESPONSIVE_PROBE_TIMEOUT = 1.5
+
+# A navigation that commits in a new process destroys the target the bridge is talking to, and
+# WebKit never answers what was in flight to it. That is exactly when Chrome's frontend asks for
+# the resource tree and when a screencast starts, so those requests wait here for the replacement
+# target to become current and ask it instead of failing. The events that commit the swap are
+# applied by the receive loop, which is paused for the whole of every request wait - the yield
+# below is what lets them through.
+SWAP_COMMIT_TIMEOUT = 5.0
+SWAP_COMMIT_POLL_INTERVAL = 0.05
 
 # sourceURL stamped onto the bridge's own internal evaluations (screencast offsets, synthesized
 # input, navigation) so their Debugger.scriptParsed events can be recognized and dropped instead
@@ -425,7 +435,12 @@ class CdpTarget:
                 message = events[i]
                 if message["method"] == "Target.targetDestroyed":
                     # Only give up the wait; the event stays queued for the receive loop.
-                    if message["params"]["targetId"] == target_id:
+                    if target_id is not None and message["params"]["targetId"] == target_id:
+                        # Record it here too: the receive loop is paused until this wait returns,
+                        # so its own bookkeeping runs too late for the caller to tell a destroyed
+                        # target from one that went quiet (it used to report "stopped responding"
+                        # and back off on a target that had simply been swapped out).
+                        self._destroyed_targets.add(target_id)
                         return None
                     continue
                 if message["method"] != "Target.dispatchMessageFromTarget":
@@ -483,6 +498,36 @@ class CdpTarget:
             return result
         finally:
             self._waiting_for_id -= 1
+
+    async def _await_target_swap(self, target_id: str, deadline: float) -> bool:
+        """Wait for the target that replaced a destroyed one to become current.
+
+        :param target_id: The target whose answer was lost.
+        :param deadline: Event-loop time to give up at.
+        :returns: True once a different target is current, False if `target_id` was not destroyed
+            in the first place or nothing took over in time.
+        """
+        if target_id not in self._destroyed_targets:
+            return False
+        while self.target_id == target_id:
+            if asyncio.get_event_loop().time() >= deadline:
+                return False
+            # Yields to the receive loop, which applies the targetCreated /
+            # didCommitProvisionalTarget pair that makes the replacement current.
+            await asyncio.sleep(SWAP_COMMIT_POLL_INTERVAL)
+        return True
+
+    async def send_message_with_result_across_swaps(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """send_message_with_result, re-asked of the target that replaces one destroyed mid-request.
+
+        Returns the last (empty) result if no replacement became current in time.
+        """
+        deadline = asyncio.get_event_loop().time() + SWAP_COMMIT_TIMEOUT
+        while True:
+            target_id = self.target_id
+            result = await self.send_message_with_result(method, params)
+            if result or not await self._await_target_swap(target_id, deadline):
+                return result
 
     def _mark_target_responsive(self, target_id: str) -> None:
         """Clear the unresponsive flag once a target answers again."""
@@ -669,6 +714,11 @@ class CdpTarget:
         """Respond with an exact result body, for methods whose response fields the frontend reads."""
         await self.output_queue.put({"id": message["id"], "result": result})
 
+    async def _error_response(self, message: dict[str, Any], error: dict[str, Any]) -> None:
+        """Refuse a frontend request. Chrome's frontends absorb a protocol error - what they cannot
+        absorb is no answer at all, which is what raising out of a translation leaves them with."""
+        await self.output_queue.put({"id": message["id"], "error": error})
+
     async def _audits_enable(self, message: dict[str, Any]):
         # A previous inspector session may have left an audit configured; WebKit then rejects
         # setup with "Must call teardown before calling setup again", so always reset first.
@@ -826,8 +876,26 @@ class CdpTarget:
 
     async def _page_start_screencast(self, message: dict[str, Any]):
         params = message["params"]
-        self.screencast = ScreenCast(self, params["format"], params["quality"], params["maxWidth"], params["maxHeight"])
-        await self.screencast.start()
+        screencast = ScreenCast(self, params["format"], params["quality"], params["maxWidth"], params["maxHeight"])
+        deadline = asyncio.get_event_loop().time() + SWAP_COMMIT_TIMEOUT
+        while True:
+            target_id = self.target_id
+            try:
+                await screencast.start()
+            except ScreencastUnavailableError as e:
+                # The size probe found no page to capture. A process swap swallowed it (DevTools
+                # starts the screencast while the page it just opened is still navigating, and
+                # unlike the resource tree it never asks again - the screen would stay black for
+                # the rest of the session), so re-probe the target that took over.
+                if await self._await_target_swap(target_id, deadline):
+                    continue
+                # Nothing took over: a JSContext debuggable, or a page that went quiet. Refuse
+                # rather than keep a screencast that never started - closing the session would
+                # then fail on it and leave the target's queue-consumer tasks draining the next.
+                await self._error_response(message, {"code": -32000, "message": str(e)})
+                return
+            break
+        self.screencast = screencast
         await self._simple_response(message, None)
 
     async def _page_stop_screencast(self, message: dict[str, Any]):
@@ -842,7 +910,21 @@ class CdpTarget:
         await self._simple_response(message, None)
 
     async def _page_get_resource_tree(self, message: dict[str, Any]):
-        result = await self.send_message_with_result(message["method"], message["params"])
+        result = await self.send_message_with_result_across_swaps(message["method"], message["params"])
+        if "result" not in result:
+            # No frame tree to report: a JSContext debuggable implements no Page domain and says
+            # so, and a target that stopped answering yields nothing at all. Relay that - a real
+            # Node target answers Chrome's frontends with the same error and they carry on.
+            await self._error_response(
+                message,
+                result.get("error")
+                or (
+                    dict(TARGET_CLOSED_ERROR)
+                    if self.target_id in self._destroyed_targets
+                    else {"code": -32000, "message": f"the device did not answer {message['method']}"}
+                ),
+            )
+            return
         self.frame = result["result"]["frameTree"]["frame"]
         # result carries our internal request id; answer the frontend with its own id.
         await self.output_queue.put({"id": message["id"], "result": result["result"]})

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -245,6 +245,74 @@ async def evaluate_and_log_in_javascript_context(port: int, target_id: str) -> b
         await client.close()
 
 
+async def testp_cdp_server_rejects_the_page_domain_on_a_javascript_context(lockdown: LockdownClient) -> None:
+    """
+    A JSContext debuggable implements no Page domain and its global object has no window, but
+    Chrome's frontends still ask for a resource tree and a screencast. Both must come back as
+    protocol errors the frontend can absorb. Raising out of their translation instead loses the
+    response, and a screencast kept on the target although it never started took the session's
+    teardown down with it - leaking the queue-consumer tasks that then drained the next
+    session's events.
+    """
+    async with cdp_server(lockdown) as (port, _):
+        targets = await list_targets_of_type(port, "node")
+        if not targets:
+            pytest.skip("no inspectable JSContext on the device")
+        for target in targets:
+            if await page_domain_is_rejected_in_javascript_context(port, target["id"]):
+                return
+        pytest.skip("no listed JSContext answered the inspector")
+
+
+async def list_targets_of_type(port: int, type_: str) -> list[dict[str, Any]]:
+    """Listed targets of one kind. The device reports its debuggables asynchronously after the
+    inspector connects, so an immediate listing is empty even when there are some."""
+    for _ in range(TIMEOUT):
+        targets = [target for target in await http_get_json(port, "/json/list") if target["type"] == type_]
+        if targets:
+            return targets
+        await asyncio.sleep(1)
+    return []
+
+
+async def page_domain_is_rejected_in_javascript_context(port: int, target_id: str) -> bool:
+    """Ask a JSContext target for page-only functionality and assert it is refused cleanly.
+
+    :returns: False if the debuggable never answered (a dormant JSContext), True once it did.
+    """
+    client = CdpWebsocketClient(port, target_id)
+    await asyncio.wait_for(client.connect(), TIMEOUT)
+    try:
+        try:
+            await asyncio.wait_for(client.command(1, "Runtime.enable", {}), TIMEOUT)
+        except asyncio.TimeoutError:
+            return False
+        for id_, method, params in (
+            (2, "Page.getResourceTree", {}),
+            (3, "Page.startScreencast", {"format": "jpeg", "quality": 60, "maxWidth": 480, "maxHeight": 960}),
+        ):
+            response = await client.command(id_, method, params)
+            assert "result" not in response, f"{method} cannot succeed on a JSContext"
+            assert "failed to handle" not in response["error"]["message"], (
+                f"{method} must be refused, not raise out of its translation: {response['error']}"
+            )
+        # Refusing must leave the session usable rather than wedge it.
+        result = await client.command(4, "Runtime.evaluate", {"expression": "40+2"})
+        assert result["result"]["result"]["value"] == 42
+    finally:
+        await client.close()
+    # The teardown of a session that asked for a screencast must complete, or its receive loop
+    # keeps consuming the messages of every later session on the same debuggable.
+    client = CdpWebsocketClient(port, target_id)
+    await asyncio.wait_for(client.connect(), TIMEOUT)
+    try:
+        result = await client.command(1, "Runtime.evaluate", {"expression": "40+2"})
+        assert result["result"]["result"]["value"] == 42
+    finally:
+        await client.close()
+    return True
+
+
 async def testp_cdp_server_takes_a_held_page_over(lockdown: LockdownClient) -> None:
     """
     A DevTools tab left attached to a page must not brick every later connection to it.
@@ -378,6 +446,64 @@ async def testp_cdp_server_screencast_survives_navigation(lockdown: LockdownClie
             for url in ("https://example.com/", "https://www.apple.com/") * 2:
                 await command("Page.navigate", {"url": url})
                 await wait_for_frame()
+        finally:
+            await client.close()
+
+
+async def testp_cdp_server_answers_page_requests_across_a_process_swap(lockdown: LockdownClient) -> None:
+    """
+    A navigation that commits in a new process destroys the target the bridge is talking to, and
+    WebKit never answers what was in flight to it - which is exactly when Chrome's frontend asks
+    for the resource tree and starts a screencast. Both used to blow up on the answer that never
+    came (a KeyError on the missing result, and "did not report its screen size"), and the
+    screencast is the damaging one: the frontend never asks again, so the screen stays black for
+    the rest of the session. Both must be re-asked of the target that took over.
+
+    A live screencast runs throughout: its snapshot round-trips pause the receive loop, which is
+    what keeps the targetDestroyed event queued long enough for the requests below to be routed
+    to a target that is already gone.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        message_ids = itertools.count(1)
+        try:
+
+            async def command(method: str, params: dict[str, Any]) -> dict[str, Any]:
+                """client.command, acking the screencast frames it would otherwise leave unacked
+                (the encoder stops after one unacked frame)."""
+                id_ = next(message_ids)
+                await client.send({"id": id_, "method": method, "params": params})
+
+                async def wait_for_response() -> dict[str, Any]:
+                    while True:
+                        message = await client.receive()
+                        if message.get("method") == "Page.screencastFrame":
+                            await client.send({
+                                "id": next(message_ids),
+                                "method": "Page.screencastFrameAck",
+                                "params": {"sessionId": message["params"]["sessionId"]},
+                            })
+                        if message.get("id") == id_:
+                            return message
+
+                return await asyncio.wait_for(wait_for_response(), TIMEOUT)
+
+            await command("Page.enable", {})
+            await command("Runtime.enable", {})
+            screencast_params = {"format": "jpeg", "quality": 60, "maxWidth": 480, "maxHeight": 960}
+            assert "result" in await command("Page.startScreencast", screencast_params)
+            # Alternating origins force the swaps. The target is destroyed somewhere in the
+            # couple of seconds after the navigate is issued, so keep asking across that window
+            # rather than once - a single well-timed request slips through on its own.
+            for url in ("https://example.com/", "https://www.apple.com/") * 3:
+                await command("Page.navigate", {"url": url})
+                for _ in range(6):
+                    tree = await command("Page.getResourceTree", {})
+                    assert "result" in tree, f"resource tree lost to the swap into {url}: {tree.get('error')}"
+                    restarted = await command("Page.startScreencast", screencast_params)
+                    assert "result" in restarted, f"screencast lost to the swap into {url}: {restarted.get('error')}"
+                    await asyncio.sleep(0.3)
         finally:
             await client.close()
 


### PR DESCRIPTION
`Page.getResourceTree` and `Page.startScreencast` both assumed the device answers, and raised out of their translation when it did not:

```
ERROR Failed handling DevTools message: Page.getResourceTree
  File "pymobiledevice3/services/web_protocol/cdp_target.py", line 846, in _page_get_resource_tree
    self.frame = result["result"]["frameTree"]["frame"]
KeyError: 'result'

ERROR Failed handling DevTools message: Page.startScreencast
  File "pymobiledevice3/services/web_protocol/cdp_screencast.py", line 61, in start
    raise TypeError("device did not report its screen size for the screencast")
```

`startScreencast` additionally kept a `ScreenCast` that never started, so `close()` tripped `assert self.recording_task is not None` and took the whole WebSocket handler down with it - skipping the rest of `target.close()` and leaving the target's queue-consumer tasks draining the events of every later session on that page.

## Root cause

Two situations leave `send_message_with_result` with nothing to return.

**A process swap.** A navigation that commits in a new process destroys the target the bridge is talking to, and WebKit never answers what was in flight to it. Instrumented against a real Safari page, alternating origins:

```
PROBE abandon id -253: queued targetDestroyed for page-1261
PROBE no answer for Page.getResourceTree sent to page-1261; current target is now page-1261; destroyed=False
PROBE abandon id -326: queued targetDestroyed for page-1266
PROBE no answer for Runtime.evaluate sent to page-1266; current target is now page-1266; destroyed=False
```

The second pair is the screencast's `window.innerWidth` probe - both reported symptoms, one cause. It is not a timeout: raising `WIR_RESULT_TIMEOUT` to 30 s did not help, 3 of 6 rounds still lost their answer. `self.target_id` still points at the dead target at that moment, and `_destroyed_targets` still says `False`, because the events that commit the swap sit queued behind the receive loop - which is paused for the whole of every request wait. That is also where the misleading `target ... stopped responding; backing off` came from.

This is worst where navigations fail or stall (an offline environment), since swaps are then frequent and the window is wide.

**A JSContext debuggable.** It implements no `Page` domain and its global object has no `window`, so neither request can ever succeed:

```
RAW getResourceTree reply: {'error': {'code': -32601, 'message': "'Page' domain was not found"}, 'id': -2}
Evaluated: {'result': {'result': {'subtype': 'error', 'className': 'ReferenceError',
            'description': "ReferenceError: Can't find variable: window"}, 'wasThrown': True}}
```

## Changes

- `wait_for_event_id` records the destroyed target as it abandons the wait, so callers can tell a swapped-out target from one that went quiet (and stop backing off on it).
- `send_message_with_result_across_swaps` re-asks the target that took over; `Page.getResourceTree` uses it.
- `Page.startScreencast` re-probes across the swap before refusing. Unlike the resource tree, the frontend never asks again - without this the screen stays black for the rest of the session.
- Where nothing can serve the request, both answer with a protocol error instead of raising: the device's own error for the resource tree (what a real Node target gives Chrome), and a new `ScreencastUnavailableError` for the screencast.
- `ScreenCast` is stored only after a successful `start()`, and `stop()` tolerates a never-started recording.

## Testing

Two device-backed tests:

- `testp_cdp_server_answers_page_requests_across_a_process_swap` - live screencast running (its snapshot round-trips are what keep the receive loop paused), 6 cross-origin navigations, polling across the destroy window. **3/3 runs fail without the fix, 3/3 pass with it.** A standalone probe went from 1-5 lost requests per run to 0/0/0 across three runs.
- `testp_cdp_server_rejects_the_page_domain_on_a_javascript_context` - both requests refused cleanly, the session still usable afterwards, and a second session on the same debuggable still works (the teardown-leak regression).

`tests/services/test_web_protocol/` + `tests/services/test_webinspector.py`: 24 passed against a device (iPhone17,3, iOS 26.1). `pyright --venvpath .` 0 errors; ruff clean.
