### PR TITLE
tunneld: Add /connect websocket endpoint exposing the tunnel over HTTP

### DIFF
--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -109,6 +109,26 @@ sudo python3 -m pymobiledevice3 remote tunneld --uds /var/run/tunneld.sock
 python3 -m pymobiledevice3 developer dvt ls / --tunnel ':/var/run/tunneld.sock'
 ```
 
+When the client cannot reach the tunnel interface `tunneld` created — for example, `tunneld` runs
+in a different docker network stack, or on a different host altogether — the RSD addresses reported
+over `GET /` are unreachable. The `/connect` websocket endpoint bridges into the tunnel through the
+HTTP API instead: binary websocket messages are forwarded as-is over a TCP connection opened on the
+device's tunnel address (to `?port=`, defaulting to the RSD port), and vice versa:
+
+```python
+import websockets  # any websocket client works
+
+async with websockets.connect(f'ws://127.0.0.1:49151/connect?udid={udid}') as websocket:
+    # speak RSD (RemoteXPC) over the websocket, or pass ?port=<service-port>
+    # to reach any other service published over the tunnel
+    ...
+```
+
+!!! warning
+    Like the rest of the `tunneld` HTTP API, `/connect` is unauthenticated — anyone able to reach
+    the listener gains access to the services exposed over the tunnel, so only bind non-loopback
+    addresses on trusted networks.
+
 To make `tunneld` the **default** fallback — so commands route to it automatically without passing
 `--tunnel`, restoring the pre-userspace-default behavior — set
 `PYMOBILEDEVICE3_DEFAULT_FALLBACK=tunneld`:

--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -129,6 +129,11 @@ async with websockets.connect(f'ws://127.0.0.1:49151/connect?udid={udid}') as we
     the listener gains access to the services exposed over the tunnel, so only bind non-loopback
     addresses on trusted networks.
 
+!!! note
+    `/connect` only bridges into tunnels established by this `tunneld` instance. A device that
+    appears in `GET /` through a registered upstream `tunneld` is not reachable through this
+    instance's `/connect` — connect to the upstream's own `/connect` endpoint instead.
+
 To make `tunneld` the **default** fallback — so commands route to it automatically without passing
 `--tunnel`, restoring the pre-userspace-default behavior — set
 `PYMOBILEDEVICE3_DEFAULT_FALLBACK=tunneld`:

--- a/pymobiledevice3/tunneld/server.py
+++ b/pymobiledevice3/tunneld/server.py
@@ -78,7 +78,7 @@ OSUTILS = get_os_utils()
 # Timeout for opening the TCP connection over the tunnel from the /connect websocket endpoint
 CONNECT_TCP_TIMEOUT = 10
 
-# Maximum concurrent /connect bridges (mirrors TcpForwarderBase.MAX_FORWARDED_CONNECTIONS)
+# Maximum concurrent /connect bridges
 CONNECT_MAX_BRIDGES = 200
 
 # Read chunk size used when proxying tunnel traffic over the /connect websocket endpoint
@@ -102,6 +102,16 @@ def _fetch_upstream(url: str) -> dict[str, Any]:
     resp = requests.get(url, timeout=_UPSTREAM_FETCH_TIMEOUT)
     resp.raise_for_status()
     return resp.json()
+
+
+async def _close_quietly(websocket: fastapi.WebSocket, code: int = 1000, reason: Optional[str] = None) -> None:
+    """Close the websocket, tolerating a client that already disconnected.
+
+    Closing after the client dropped raises WebSocketDisconnect (starlette re-raises it
+    from OSError); RuntimeError covers a close that was already sent.
+    """
+    with suppress(RuntimeError, fastapi.WebSocketDisconnect):
+        await websocket.close(code=code, reason=reason)
 
 
 @dataclasses.dataclass
@@ -147,16 +157,19 @@ class TunneldCore:
         if self.mobdev2_monitor:
             self.tasks.append(asyncio.create_task(self.monitor_mobdev2_task(), name="monitor-mobdev2-task"))
 
-    def tunnel_exists_for_udid(self, udid: str) -> bool:
+    def get_tunnel(self, udid: str) -> Optional[TunnelResult]:
         for task in self.tunnel_tasks.values():
             # Linux implementations of `usbmuxd` may report an incorrect value of UDID, dismissing the `-` character.
             # For such cases, we also check for a UDID without it.
             # See: <https://github.com/doronz88/pymobiledevice3/issues/1388#issuecomment-2782249770>
             task_udid = task.udid or ""
             if ((task_udid == udid) or (task_udid.replace("-", "") == udid)) and (task.tunnel is not None):
-                return True
+                return task.tunnel
 
-        return False
+        return None
+
+    def tunnel_exists_for_udid(self, udid: str) -> bool:
+        return self.get_tunnel(udid) is not None
 
     @asyncio_print_traceback
     async def monitor_usb_task(self) -> None:
@@ -781,7 +794,9 @@ class TunneldRunner:
             """
             await websocket.accept()
             if self._connect_bridge_count >= CONNECT_MAX_BRIDGES:
-                await websocket.close(code=WS_CLOSE_TRY_AGAIN_LATER, reason="too many concurrent /connect bridges")
+                await _close_quietly(
+                    websocket, code=WS_CLOSE_TRY_AGAIN_LATER, reason="too many concurrent /connect bridges"
+                )
                 return
             self._connect_bridge_count += 1
             try:
@@ -790,13 +805,10 @@ class TunneldRunner:
                 self._connect_bridge_count -= 1
 
     async def _bridge_websocket(self, websocket: fastapi.WebSocket, udid: str, port: Optional[int]) -> None:
-        udid_tunnels = [
-            t.tunnel for t in self._tunneld_core.tunnel_tasks.values() if t.udid == udid and t.tunnel is not None
-        ]
-        if len(udid_tunnels) == 0:
-            await websocket.close(code=WS_CLOSE_NO_TUNNEL, reason=f"no tunnel exists for udid: {udid}")
+        tunnel = self._tunneld_core.get_tunnel(udid)
+        if tunnel is None:
+            await _close_quietly(websocket, code=WS_CLOSE_NO_TUNNEL, reason=f"no tunnel exists for udid: {udid}")
             return
-        tunnel = udid_tunnels[0]
         if port is None:
             port = tunnel.port
         try:
@@ -804,9 +816,10 @@ class TunneldRunner:
                 asyncio.open_connection(tunnel.address, port), timeout=CONNECT_TCP_TIMEOUT
             )
         except (OSError, asyncio.TimeoutError) as e:
-            await websocket.close(
+            await _close_quietly(
+                websocket,
                 code=WS_CLOSE_CONNECT_FAILED,
-                reason=f"failed to connect to [{tunnel.address}]:{port}: {e or 'timed out'}",
+                reason=f"failed to connect to [{tunnel.address}]:{port}: {str(e) or 'timed out'}",
             )
             return
 
@@ -818,8 +831,8 @@ class TunneldRunner:
                 data = message.get("bytes")
                 if data is None:
                     # a text frame on what is strictly a binary bridge
-                    await websocket.close(
-                        code=WS_CLOSE_UNSUPPORTED_DATA, reason="only binary websocket messages are supported"
+                    await _close_quietly(
+                        websocket, code=WS_CLOSE_UNSUPPORTED_DATA, reason="only binary websocket messages are supported"
                     )
                     return
                 writer.write(data)
@@ -837,30 +850,28 @@ class TunneldRunner:
             asyncio.create_task(forward_tcp_to_websocket(), name=f"connect-tcp-to-websocket-{udid}-{port}"),
         ]
         try:
-            _done, pending = await asyncio.wait(forwarders, return_when=asyncio.FIRST_COMPLETED)
-            for forwarder in pending:
-                forwarder.cancel()
-            if pending:
-                await asyncio.wait(pending)
-            for forwarder in forwarders:
-                if forwarder.cancelled():
-                    continue
-                # disconnections from either side are expected; log anything else at debug
-                exception = forwarder.exception()
-                if exception is not None and not isinstance(exception, (fastapi.WebSocketDisconnect, OSError)):
-                    logger.debug(f"unexpected error in {forwarder.get_name()}", exc_info=exception)
+            await asyncio.wait(forwarders, return_when=asyncio.FIRST_COMPLETED)
         finally:
+            # the cleanup lives in the finally so a cancellation aimed at this task
+            # (e.g. server shutdown) can't orphan the forwarders
+            for forwarder in forwarders:
+                forwarder.cancel()
+            results = await asyncio.gather(*forwarders, return_exceptions=True)
+            for forwarder, result in zip(forwarders, results):
+                # disconnections from either side are expected; log anything else at debug
+                if isinstance(result, Exception) and not isinstance(result, (fastapi.WebSocketDisconnect, OSError)):
+                    logger.debug(f"unexpected error in {forwarder.get_name()}", exc_info=result)
             writer.close()
             with suppress(OSError):
                 await writer.wait_closed()
-            with suppress(RuntimeError, fastapi.WebSocketDisconnect):
-                # closing after the client already disconnected raises WebSocketDisconnect
-                # (starlette re-raises it from OSError); RuntimeError covers a close that
-                # was already sent
-                await websocket.close()
+            await _close_quietly(websocket)
 
     def _run_app(self) -> None:
+        # per-message deflate would burn CPU compressing the mostly-encrypted tunnel
+        # traffic bridged over /connect
         if self.uds is not None:
-            uvicorn.run(self._app, uds=self.uds, loop="asyncio", ws="wsproto")
+            uvicorn.run(self._app, uds=self.uds, loop="asyncio", ws="wsproto", ws_per_message_deflate=False)
         else:
-            uvicorn.run(self._app, host=self.host, port=self.port, loop="asyncio", ws="wsproto")
+            uvicorn.run(
+                self._app, host=self.host, port=self.port, loop="asyncio", ws="wsproto", ws_per_message_deflate=False
+            )

--- a/pymobiledevice3/tunneld/server.py
+++ b/pymobiledevice3/tunneld/server.py
@@ -75,6 +75,13 @@ USB_MONITOR_RESCAN_INTERVAL = 30
 USBMUX_INTERVAL = 2
 OSUTILS = get_os_utils()
 
+# Read chunk size used when proxying tunnel traffic over the /connect websocket endpoint
+CONNECT_CHUNK_SIZE = 65536
+
+# Application-specific websocket close codes (4000-4999) used by the /connect endpoint
+WS_CLOSE_NO_TUNNEL = 4404
+WS_CLOSE_CONNECT_FAILED = 4502
+
 _UPSTREAM_FETCH_TIMEOUT = 2.0
 
 
@@ -747,8 +754,71 @@ class TunneldRunner:
                     status_code=404, content=json.dumps({"error": "something went wrong during tunnel creation"})
                 )
 
+        @self._app.websocket("/connect")
+        async def connect(websocket: fastapi.WebSocket, udid: str, port: Optional[int] = None) -> None:
+            """Bridge a websocket client into the tunnel interface of a given device.
+
+            Binary websocket messages are forwarded as-is into a TCP connection opened over the
+            device's tunnel — to the requested ``port``, defaulting to the RSD port — and vice
+            versa, allowing clients without direct access to the tunnel interface (e.g. a
+            different docker network stack, or a different host altogether) to reach the tunnel
+            services through the tunneld HTTP API.
+            """
+            await websocket.accept()
+            udid_tunnels = [
+                t.tunnel for t in self._tunneld_core.tunnel_tasks.values() if t.udid == udid and t.tunnel is not None
+            ]
+            if len(udid_tunnels) == 0:
+                await websocket.close(code=WS_CLOSE_NO_TUNNEL, reason=f"no tunnel exists for udid: {udid}")
+                return
+            tunnel = udid_tunnels[0]
+            if port is None:
+                port = tunnel.port
+            try:
+                reader, writer = await asyncio.open_connection(tunnel.address, port)
+            except OSError as e:
+                await websocket.close(
+                    code=WS_CLOSE_CONNECT_FAILED, reason=f"failed to connect to [{tunnel.address}]:{port}: {e}"
+                )
+                return
+
+            async def forward_websocket_to_tcp() -> None:
+                while True:
+                    data = await websocket.receive_bytes()
+                    writer.write(data)
+                    await writer.drain()
+
+            async def forward_tcp_to_websocket() -> None:
+                while True:
+                    data = await reader.read(CONNECT_CHUNK_SIZE)
+                    if not data:
+                        break
+                    await websocket.send_bytes(data)
+
+            forwarders = [
+                asyncio.create_task(forward_websocket_to_tcp(), name=f"connect-websocket-to-tcp-{udid}-{port}"),
+                asyncio.create_task(forward_tcp_to_websocket(), name=f"connect-tcp-to-websocket-{udid}-{port}"),
+            ]
+            try:
+                done, pending = await asyncio.wait(forwarders, return_when=asyncio.FIRST_COMPLETED)
+                for forwarder in pending:
+                    forwarder.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await forwarder
+                for forwarder in done:
+                    # surface unexpected errors; disconnections from either side are expected
+                    with suppress(fastapi.WebSocketDisconnect, OSError):
+                        forwarder.result()
+            finally:
+                writer.close()
+                with suppress(OSError):
+                    await writer.wait_closed()
+                with suppress(RuntimeError):
+                    # closing after the client already disconnected raises RuntimeError
+                    await websocket.close()
+
     def _run_app(self) -> None:
         if self.uds is not None:
-            uvicorn.run(self._app, uds=self.uds, loop="asyncio")
+            uvicorn.run(self._app, uds=self.uds, loop="asyncio", ws="wsproto")
         else:
-            uvicorn.run(self._app, host=self.host, port=self.port, loop="asyncio")
+            uvicorn.run(self._app, host=self.host, port=self.port, loop="asyncio", ws="wsproto")

--- a/pymobiledevice3/tunneld/server.py
+++ b/pymobiledevice3/tunneld/server.py
@@ -75,12 +75,22 @@ USB_MONITOR_RESCAN_INTERVAL = 30
 USBMUX_INTERVAL = 2
 OSUTILS = get_os_utils()
 
+# Timeout for opening the TCP connection over the tunnel from the /connect websocket endpoint
+CONNECT_TCP_TIMEOUT = 10
+
+# Maximum concurrent /connect bridges (mirrors TcpForwarderBase.MAX_FORWARDED_CONNECTIONS)
+CONNECT_MAX_BRIDGES = 200
+
 # Read chunk size used when proxying tunnel traffic over the /connect websocket endpoint
 CONNECT_CHUNK_SIZE = 65536
 
 # Application-specific websocket close codes (4000-4999) used by the /connect endpoint
 WS_CLOSE_NO_TUNNEL = 4404
 WS_CLOSE_CONNECT_FAILED = 4502
+
+# Standard websocket close codes used by the /connect endpoint
+WS_CLOSE_UNSUPPORTED_DATA = 1003
+WS_CLOSE_TRY_AGAIN_LATER = 1013
 
 _UPSTREAM_FETCH_TIMEOUT = 2.0
 
@@ -554,6 +564,7 @@ class TunneldRunner:
         self.port = port
         self.uds = uds
         self.protocol = protocol
+        self._connect_bridge_count = 0
         self._app = FastAPI(lifespan=lifespan)
         self._tunneld_core = TunneldCore(
             protocol=protocol,
@@ -755,7 +766,11 @@ class TunneldRunner:
                 )
 
         @self._app.websocket("/connect")
-        async def connect(websocket: fastapi.WebSocket, udid: str, port: Optional[int] = None) -> None:
+        async def connect(
+            websocket: fastapi.WebSocket,
+            udid: str,
+            port: Optional[int] = fastapi.Query(default=None, ge=1, le=65535),
+        ) -> None:
             """Bridge a websocket client into the tunnel interface of a given device.
 
             Binary websocket messages are forwarded as-is into a TCP connection opened over the
@@ -765,57 +780,84 @@ class TunneldRunner:
             services through the tunneld HTTP API.
             """
             await websocket.accept()
-            udid_tunnels = [
-                t.tunnel for t in self._tunneld_core.tunnel_tasks.values() if t.udid == udid and t.tunnel is not None
-            ]
-            if len(udid_tunnels) == 0:
-                await websocket.close(code=WS_CLOSE_NO_TUNNEL, reason=f"no tunnel exists for udid: {udid}")
+            if self._connect_bridge_count >= CONNECT_MAX_BRIDGES:
+                await websocket.close(code=WS_CLOSE_TRY_AGAIN_LATER, reason="too many concurrent /connect bridges")
                 return
-            tunnel = udid_tunnels[0]
-            if port is None:
-                port = tunnel.port
+            self._connect_bridge_count += 1
             try:
-                reader, writer = await asyncio.open_connection(tunnel.address, port)
-            except OSError as e:
-                await websocket.close(
-                    code=WS_CLOSE_CONNECT_FAILED, reason=f"failed to connect to [{tunnel.address}]:{port}: {e}"
-                )
-                return
-
-            async def forward_websocket_to_tcp() -> None:
-                while True:
-                    data = await websocket.receive_bytes()
-                    writer.write(data)
-                    await writer.drain()
-
-            async def forward_tcp_to_websocket() -> None:
-                while True:
-                    data = await reader.read(CONNECT_CHUNK_SIZE)
-                    if not data:
-                        break
-                    await websocket.send_bytes(data)
-
-            forwarders = [
-                asyncio.create_task(forward_websocket_to_tcp(), name=f"connect-websocket-to-tcp-{udid}-{port}"),
-                asyncio.create_task(forward_tcp_to_websocket(), name=f"connect-tcp-to-websocket-{udid}-{port}"),
-            ]
-            try:
-                done, pending = await asyncio.wait(forwarders, return_when=asyncio.FIRST_COMPLETED)
-                for forwarder in pending:
-                    forwarder.cancel()
-                    with suppress(asyncio.CancelledError):
-                        await forwarder
-                for forwarder in done:
-                    # surface unexpected errors; disconnections from either side are expected
-                    with suppress(fastapi.WebSocketDisconnect, OSError):
-                        forwarder.result()
+                await self._bridge_websocket(websocket, udid, port)
             finally:
-                writer.close()
-                with suppress(OSError):
-                    await writer.wait_closed()
-                with suppress(RuntimeError):
-                    # closing after the client already disconnected raises RuntimeError
-                    await websocket.close()
+                self._connect_bridge_count -= 1
+
+    async def _bridge_websocket(self, websocket: fastapi.WebSocket, udid: str, port: Optional[int]) -> None:
+        udid_tunnels = [
+            t.tunnel for t in self._tunneld_core.tunnel_tasks.values() if t.udid == udid and t.tunnel is not None
+        ]
+        if len(udid_tunnels) == 0:
+            await websocket.close(code=WS_CLOSE_NO_TUNNEL, reason=f"no tunnel exists for udid: {udid}")
+            return
+        tunnel = udid_tunnels[0]
+        if port is None:
+            port = tunnel.port
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(tunnel.address, port), timeout=CONNECT_TCP_TIMEOUT
+            )
+        except (OSError, asyncio.TimeoutError) as e:
+            await websocket.close(
+                code=WS_CLOSE_CONNECT_FAILED,
+                reason=f"failed to connect to [{tunnel.address}]:{port}: {e or 'timed out'}",
+            )
+            return
+
+        async def forward_websocket_to_tcp() -> None:
+            while True:
+                message = await websocket.receive()
+                if message["type"] == "websocket.disconnect":
+                    raise fastapi.WebSocketDisconnect(int(message.get("code") or 1000), message.get("reason"))
+                data = message.get("bytes")
+                if data is None:
+                    # a text frame on what is strictly a binary bridge
+                    await websocket.close(
+                        code=WS_CLOSE_UNSUPPORTED_DATA, reason="only binary websocket messages are supported"
+                    )
+                    return
+                writer.write(data)
+                await writer.drain()
+
+        async def forward_tcp_to_websocket() -> None:
+            while True:
+                data = await reader.read(CONNECT_CHUNK_SIZE)
+                if not data:
+                    break
+                await websocket.send_bytes(data)
+
+        forwarders = [
+            asyncio.create_task(forward_websocket_to_tcp(), name=f"connect-websocket-to-tcp-{udid}-{port}"),
+            asyncio.create_task(forward_tcp_to_websocket(), name=f"connect-tcp-to-websocket-{udid}-{port}"),
+        ]
+        try:
+            _done, pending = await asyncio.wait(forwarders, return_when=asyncio.FIRST_COMPLETED)
+            for forwarder in pending:
+                forwarder.cancel()
+            if pending:
+                await asyncio.wait(pending)
+            for forwarder in forwarders:
+                if forwarder.cancelled():
+                    continue
+                # disconnections from either side are expected; log anything else at debug
+                exception = forwarder.exception()
+                if exception is not None and not isinstance(exception, (fastapi.WebSocketDisconnect, OSError)):
+                    logger.debug(f"unexpected error in {forwarder.get_name()}", exc_info=exception)
+        finally:
+            writer.close()
+            with suppress(OSError):
+                await writer.wait_closed()
+            with suppress(RuntimeError, fastapi.WebSocketDisconnect):
+                # closing after the client already disconnected raises WebSocketDisconnect
+                # (starlette re-raises it from OSError); RuntimeError covers a close that
+                # was already sent
+                await websocket.close()
 
     def _run_app(self) -> None:
         if self.uds is not None:

--- a/tests/test_tunneld_connect.py
+++ b/tests/test_tunneld_connect.py
@@ -6,13 +6,14 @@ import threading
 import time
 from collections import deque
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Optional, Union
 
 import pytest
 from wsproto import ConnectionType, WSConnection
-from wsproto.events import AcceptConnection, BytesMessage, CloseConnection, Event, Ping, Pong, Request
+from wsproto.events import AcceptConnection, BytesMessage, CloseConnection, Event, Ping, Pong, Request, TextMessage
 
-from pymobiledevice3.tunneld.server import WS_CLOSE_CONNECT_FAILED, WS_CLOSE_NO_TUNNEL
+from pymobiledevice3.tunneld.server import WS_CLOSE_CONNECT_FAILED, WS_CLOSE_NO_TUNNEL, WS_CLOSE_UNSUPPORTED_DATA
 
 UDID = "00008120-0000000000000000"
 
@@ -63,29 +64,36 @@ def echo_port() -> Iterator[int]:
 
 
 @pytest.fixture(scope="module")
-def tunneld_port(echo_port: int) -> Iterator[int]:
+def tunneld_stderr(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Path collecting the tunneld server's stderr, so tests can assert it stayed clean."""
+    return tmp_path_factory.mktemp("tunneld") / "stderr.log"
+
+
+@pytest.fixture(scope="module")
+def tunneld_port(echo_port: int, tunneld_stderr: Path) -> Iterator[int]:
     """A real tunneld server (uvicorn) whose fake tunnel RSD port is the echo server's port."""
     port = _unused_port()
-    proc = subprocess.Popen(
-        [sys.executable, "-c", TUNNELD_SCRIPT, str(port), str(echo_port), UDID],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-    try:
-        deadline = time.monotonic() + 30
-        while True:
-            try:
-                with socket.create_connection(("127.0.0.1", port), timeout=1):
-                    break
-            except OSError:
-                assert proc.poll() is None, "tunneld server exited prematurely"
-                assert time.monotonic() < deadline, "tunneld server did not come up"
-                time.sleep(0.1)
-        yield port
-    finally:
-        # the injected fake TunnelTask has no real asyncio task, so skip graceful shutdown
-        proc.kill()
-        proc.wait(timeout=10)
+    with open(tunneld_stderr, "wb") as stderr:
+        proc = subprocess.Popen(
+            [sys.executable, "-c", TUNNELD_SCRIPT, str(port), str(echo_port), UDID],
+            stdout=subprocess.DEVNULL,
+            stderr=stderr,
+        )
+        try:
+            deadline = time.monotonic() + 30
+            while True:
+                try:
+                    with socket.create_connection(("127.0.0.1", port), timeout=1):
+                        break
+                except OSError:
+                    assert proc.poll() is None, "tunneld server exited prematurely"
+                    assert time.monotonic() < deadline, "tunneld server did not come up"
+                    time.sleep(0.1)
+            yield port
+        finally:
+            # the injected fake TunnelTask has no real asyncio task, so skip graceful shutdown
+            proc.kill()
+            proc.wait(timeout=10)
 
 
 class _WebsocketClient:
@@ -95,9 +103,13 @@ class _WebsocketClient:
         self._sock = socket.create_connection(("127.0.0.1", port), timeout=10)
         self._ws = WSConnection(ConnectionType.CLIENT)
         self._events: deque[Event] = deque()
-        self._send(Request(host=f"127.0.0.1:{port}", target=target))
-        event = self.next_event()
-        assert isinstance(event, AcceptConnection), f"websocket handshake failed: {event}"
+        try:
+            self._send(Request(host=f"127.0.0.1:{port}", target=target))
+            event = self.next_event()
+            assert isinstance(event, AcceptConnection), f"websocket handshake failed: {event}"
+        except BaseException:
+            self._sock.close()
+            raise
 
     def __enter__(self) -> "_WebsocketClient":
         return self
@@ -121,6 +133,9 @@ class _WebsocketClient:
 
     def send_bytes(self, data: bytes) -> None:
         self._send(BytesMessage(data=data))
+
+    def send_text(self, data: str) -> None:
+        self._send(TextMessage(data=data))
 
     def recv_bytes(self, count: int) -> bytes:
         """Receive exactly ``count`` payload bytes, reassembling message fragments."""
@@ -173,3 +188,20 @@ def test_connect_parallel_connections(tunneld_port: int) -> None:
         second.send_bytes(b"second")
         assert second.recv_bytes(6) == b"second"
         assert first.recv_bytes(5) == b"first"
+
+
+def test_connect_rejects_text_frames(tunneld_port: int) -> None:
+    with _connect(tunneld_port) as websocket:
+        websocket.send_text("not binary")
+        assert websocket.recv_close().code == WS_CLOSE_UNSUPPORTED_DATA
+
+
+def test_connect_rejects_out_of_range_port(tunneld_port: int) -> None:
+    # request validation rejects the handshake before the bridge handler ever runs
+    with pytest.raises(AssertionError, match="websocket handshake failed"):
+        _connect(tunneld_port, port=70000)
+
+
+def test_no_asgi_exceptions_logged(tunneld_port: int, tunneld_stderr: Path) -> None:
+    """Must run last: every scenario above must leave the server log free of tracebacks."""
+    assert "Exception in ASGI application" not in tunneld_stderr.read_text()

--- a/tests/test_tunneld_connect.py
+++ b/tests/test_tunneld_connect.py
@@ -1,0 +1,175 @@
+import socket
+import socketserver
+import subprocess
+import sys
+import threading
+import time
+from collections import deque
+from collections.abc import Iterator
+from typing import Optional, Union
+
+import pytest
+from wsproto import ConnectionType, WSConnection
+from wsproto.events import AcceptConnection, BytesMessage, CloseConnection, Event, Ping, Pong, Request
+
+from pymobiledevice3.tunneld.server import WS_CLOSE_CONNECT_FAILED, WS_CLOSE_NO_TUNNEL
+
+UDID = "00008120-0000000000000000"
+
+# Runs a tunneld server with all monitors disabled and a single fake established tunnel whose
+# address points at localhost instead of a device, so /connect proxies into local TCP servers.
+TUNNELD_SCRIPT = (
+    "import sys\n"
+    "from typing import Any, cast\n"
+    "from pymobiledevice3.remote.common import TunnelProtocol\n"
+    "from pymobiledevice3.remote.tunnel_service import TunnelResult\n"
+    "from pymobiledevice3.tunneld.server import TunneldRunner, TunnelTask\n"
+    "runner = TunneldRunner('127.0.0.1', int(sys.argv[1]), usb_monitor=False, wifi_monitor=False, "
+    "usbmux_monitor=False, mobdev2_monitor=False)\n"
+    "runner._tunneld_core.tunnel_tasks['fake-interface'] = TunnelTask(\n"
+    "    task=cast(Any, None), udid=sys.argv[3],\n"
+    "    tunnel=TunnelResult(interface='fake-interface', address='127.0.0.1', port=int(sys.argv[2]),\n"
+    "                        protocol=TunnelProtocol.TCP, client=cast(Any, None)))\n"
+    "runner._run_app()\n"
+)
+
+
+class _EchoHandler(socketserver.BaseRequestHandler):
+    def handle(self) -> None:
+        while True:
+            data = self.request.recv(65536)
+            if not data:
+                break
+            self.request.sendall(data)
+
+
+def _unused_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def echo_port() -> Iterator[int]:
+    """A TCP echo server on 127.0.0.1, standing in for a service on the device tunnel address."""
+    with socketserver.ThreadingTCPServer(("127.0.0.1", 0), _EchoHandler) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            yield server.server_address[1]
+        finally:
+            server.shutdown()
+            thread.join(timeout=10)
+
+
+@pytest.fixture(scope="module")
+def tunneld_port(echo_port: int) -> Iterator[int]:
+    """A real tunneld server (uvicorn) whose fake tunnel RSD port is the echo server's port."""
+    port = _unused_port()
+    proc = subprocess.Popen(
+        [sys.executable, "-c", TUNNELD_SCRIPT, str(port), str(echo_port), UDID],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 30
+        while True:
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=1):
+                    break
+            except OSError:
+                assert proc.poll() is None, "tunneld server exited prematurely"
+                assert time.monotonic() < deadline, "tunneld server did not come up"
+                time.sleep(0.1)
+        yield port
+    finally:
+        # the injected fake TunnelTask has no real asyncio task, so skip graceful shutdown
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+class _WebsocketClient:
+    """Minimal wsproto-based websocket client for exercising the /connect endpoint."""
+
+    def __init__(self, port: int, target: str) -> None:
+        self._sock = socket.create_connection(("127.0.0.1", port), timeout=10)
+        self._ws = WSConnection(ConnectionType.CLIENT)
+        self._events: deque[Event] = deque()
+        self._send(Request(host=f"127.0.0.1:{port}", target=target))
+        event = self.next_event()
+        assert isinstance(event, AcceptConnection), f"websocket handshake failed: {event}"
+
+    def __enter__(self) -> "_WebsocketClient":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self._sock.close()
+
+    def _send(self, event: Event) -> None:
+        self._sock.sendall(self._ws.send(event))
+
+    def next_event(self) -> Event:
+        while not self._events:
+            data = self._sock.recv(65536)
+            self._ws.receive_data(data if data else None)
+            for event in self._ws.events():
+                if isinstance(event, Ping):
+                    self._send(Pong(payload=event.payload))
+                    continue
+                self._events.append(event)
+        return self._events.popleft()
+
+    def send_bytes(self, data: bytes) -> None:
+        self._send(BytesMessage(data=data))
+
+    def recv_bytes(self, count: int) -> bytes:
+        """Receive exactly ``count`` payload bytes, reassembling message fragments."""
+        received = b""
+        while len(received) < count:
+            event = self.next_event()
+            assert isinstance(event, BytesMessage), f"expected a bytes message, got: {event}"
+            received += event.data
+        return received
+
+    def recv_close(self) -> CloseConnection:
+        event = self.next_event()
+        assert isinstance(event, CloseConnection), f"expected a close, got: {event}"
+        return event
+
+
+def _connect(tunneld_port: int, udid: str = UDID, port: Optional[Union[int, str]] = None) -> _WebsocketClient:
+    target = f"/connect?udid={udid}"
+    if port is not None:
+        target += f"&port={port}"
+    return _WebsocketClient(tunneld_port, target)
+
+
+def test_connect_no_tunnel_for_udid(tunneld_port: int) -> None:
+    with _connect(tunneld_port, udid="non-existing-udid") as websocket:
+        assert websocket.recv_close().code == WS_CLOSE_NO_TUNNEL
+
+
+def test_connect_tcp_connection_refused(tunneld_port: int) -> None:
+    with _connect(tunneld_port, port=_unused_port()) as websocket:
+        assert websocket.recv_close().code == WS_CLOSE_CONNECT_FAILED
+
+
+def test_connect_forwards_traffic_to_default_rsd_port(tunneld_port: int) -> None:
+    with _connect(tunneld_port) as websocket:
+        for payload in (b"hello over the tunnel", b"\x00\x01\x02\xff" * 25000):
+            websocket.send_bytes(payload)
+            assert websocket.recv_bytes(len(payload)) == payload
+
+
+def test_connect_forwards_traffic_to_explicit_port(tunneld_port: int, echo_port: int) -> None:
+    with _connect(tunneld_port, port=echo_port) as websocket:
+        websocket.send_bytes(b"ping")
+        assert websocket.recv_bytes(4) == b"ping"
+
+
+def test_connect_parallel_connections(tunneld_port: int) -> None:
+    with _connect(tunneld_port) as first, _connect(tunneld_port) as second:
+        first.send_bytes(b"first")
+        second.send_bytes(b"second")
+        assert second.recv_bytes(6) == b"second"
+        assert first.recv_bytes(5) == b"first"

--- a/tests/test_tunneld_connect.py
+++ b/tests/test_tunneld_connect.py
@@ -165,8 +165,13 @@ def test_connect_no_tunnel_for_udid(tunneld_port: int) -> None:
 
 
 def test_connect_tcp_connection_refused(tunneld_port: int) -> None:
-    with _connect(tunneld_port, port=_unused_port()) as websocket:
-        assert websocket.recv_close().code == WS_CLOSE_CONNECT_FAILED
+    # holding the port bound (but not listening) guarantees an RST and prevents another
+    # process from grabbing it mid-test
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as holder:
+        holder.bind(("127.0.0.1", 0))
+        refused_port = holder.getsockname()[1]
+        with _connect(tunneld_port, port=refused_port) as websocket:
+            assert websocket.recv_close().code == WS_CLOSE_CONNECT_FAILED
 
 
 def test_connect_forwards_traffic_to_default_rsd_port(tunneld_port: int) -> None:
@@ -190,6 +195,13 @@ def test_connect_parallel_connections(tunneld_port: int) -> None:
         assert first.recv_bytes(5) == b"first"
 
 
+def test_connect_accepts_dashless_udid(tunneld_port: int) -> None:
+    # Linux usbmuxd may report the UDID without the dash; the lookup tolerates it
+    with _connect(tunneld_port, udid=UDID.replace("-", "")) as websocket:
+        websocket.send_bytes(b"ping")
+        assert websocket.recv_bytes(4) == b"ping"
+
+
 def test_connect_rejects_text_frames(tunneld_port: int) -> None:
     with _connect(tunneld_port) as websocket:
         websocket.send_text("not binary")
@@ -204,4 +216,21 @@ def test_connect_rejects_out_of_range_port(tunneld_port: int) -> None:
 
 def test_no_asgi_exceptions_logged(tunneld_port: int, tunneld_stderr: Path) -> None:
     """Must run last: every scenario above must leave the server log free of tracebacks."""
-    assert "Exception in ASGI application" not in tunneld_stderr.read_text()
+
+    def read_log() -> str:
+        # utf-8 explicitly: the locale encoding on the Windows matrix would turn a stray
+        # traceback byte into a UnicodeDecodeError instead of the real assertion
+        return tunneld_stderr.read_text(encoding="utf-8", errors="replace")
+
+    # let the log settle so a traceback provoked by the previous test's teardown
+    # can't land just after a single read
+    content = read_log()
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        time.sleep(0.5)
+        latest = read_log()
+        if latest == content:
+            break
+        content = latest
+
+    assert "Exception in ASGI application" not in content


### PR DESCRIPTION
Fixes #1648

## What

Adds a `/connect` websocket endpoint (the name suggested in the issue) to the `tunneld` HTTP API, bridging clients into the tunnel interface so they can reach the services exposed over the tunnel even when they can't access the interface directly — e.g. `tunneld` running in a different docker network stack, or on a different host altogether.

- **`WS /connect?udid=<UDID>[&port=<PORT>]`** — accepts a websocket, looks up the established tunnel for `udid`, opens a TCP connection over the tunnel to the device's tunnel address (`port` defaults to the tunnel's RSD port) and forwards binary websocket messages as-is in both directions until either side disconnects.
- Application close codes on failure: `4404` (no tunnel for that UDID), `4502` (TCP connection over the tunnel failed).
- `uvicorn` now runs tunneld with `ws='wsproto'` — no new dependency (`wsproto` is already a runtime dependency, and this is already how the webinspector CLI serves websockets), and no behavior change for the existing plain-HTTP endpoints.

Example client:

```python
import websockets  # any websocket client works

async with websockets.connect(f'ws://127.0.0.1:49151/connect?udid={udid}') as websocket:
    # speak RSD (RemoteXPC) over the websocket, or pass ?port=<service-port>
    # to reach any other service published over the tunnel
    ...
```

## Design notes

- The issue also floats MASQUE/HTTP3 and SOCKS5; I went with websockets as the smallest HTTP-native option that works with tunneld's existing FastAPI/uvicorn stack and dependency set. Happy to rework the shape if you prefer another transport.
- The issue mentions authentication. The rest of the tunneld API (including `/shutdown` and `/clear_tunnels`) is currently unauthenticated, so this endpoint follows the existing security posture; the docs note warns about binding non-loopback addresses. An auth mechanism would apply to the whole API and seems better addressed separately — happy to take that on as a follow-up if wanted.

## Verification

- New `tests/test_tunneld_connect.py` (5 tests): spawns a real tunneld server subprocess (uvicorn + wsproto, monitors disabled) with a fake established tunnel whose address points at a local TCP echo server, and exercises the endpoint through a raw `wsproto` client — no-tunnel close code, connection-refused close code, default-port roundtrip (100 KB payload), explicit `?port=` roundtrip, and two parallel bridged connections.
- `pytest -m "not device"`: 647 passed, 1 failed — the failure is `tests/test_tss_cryptex1.py::test_against_the_real_build_manifest`, which fails identically on a clean master checkout (pre-existing, unrelated).
- `ruff check` / `ruff format --check` (0.15.4): clean.
- `pyright --venvpath .` (1.1.411): 0 errors.
- Real devices: I don't have an iOS device attached to test the full device path; the bridging path is exercised end-to-end against a real TCP server through the real uvicorn websocket stack.

## Disclosure

This PR was written with AI assistance (Claude Code), per AGENTS.md conventions; a human reviewed the flow before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KAcg7m7GR5XMPhw8k3uzC
