### PR TITLE
webinspector: keep the CDP session on its page target

### DIFF
--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -72,6 +72,10 @@ _FLAT_WIRE_IDS = itertools.count(0x40000000)
 JS_CONTEXT_EXECUTION_ID = 1
 JS_CONTEXT_UNIQUE_ID = "jscontext.1"
 
+# Target.TargetInfo.type of the targets this bridge debugs. WebKit announces "frame", "worker"
+# and "service-worker" ones too - see _target_created.
+PAGE_TARGET_TYPE = "page"
+
 # Error synthesized for requests routed to a target that got destroyed before answering
 # (WebKit never answers those). Matches Chrome's own message for the same situation.
 TARGET_CLOSED_ERROR: dict[str, Any] = {"code": -32000, "message": "Inspected target navigated or closed"}
@@ -348,6 +352,8 @@ class CdpTarget:
         # setup (domain enables & co.) the frontend established, replayed onto new targets
         self._setup_messages: dict[Any, dict[str, Any]] = {}
         self._setup_sent_targets: set[str] = {target_id}
+        # Targets announced as pages - the only kind this session talks to (see _target_created).
+        self._page_targets: set[str] = {target_id}
 
     def next_internal_id(self) -> int:
         """
@@ -377,7 +383,9 @@ class CdpTarget:
                 await asyncio.sleep(0)
                 continue
             created = events.pop(0)
-            if "targetInfo" in created.get("params", {}):
+            target_info = created.get("params", {}).get("targetInfo")
+            # Only a page target can serve this session (see _target_created).
+            if target_info is not None and target_info.get("type", PAGE_TARGET_TYPE) == PAGE_TARGET_TYPE:
                 break
         target_id = created["params"]["targetInfo"]["targetId"]
         logger.info(f"Created: {target_id}")
@@ -1348,6 +1356,17 @@ class CdpTarget:
         # SDK); the real url arrives via the device's own Page.frameNavigated.
         target_info = message["params"]["targetInfo"]
         new_target_id = target_info["targetId"]
+        if target_info.get("type", PAGE_TARGET_TYPE) != PAGE_TARGET_TYPE:
+            # Not every announced target is a page: iOS 26 announces one "frame" target per
+            # subframe (and workers as "worker"/"service-worker"). Their backends implement a
+            # much smaller domain set - a site-isolated frame has no Page/Network/Audit, and with
+            # site isolation off it registers no agents at all - so a session that routed its
+            # commands to one answered everything with "'<domain>' domain was not found" and
+            # never recovered: no commit or destroy follows to move it back off. Chrome has no
+            # counterpart for them either.
+            logger.debug(f"ignoring {target_info.get('type')} target {new_target_id}")
+            return
+        self._page_targets.add(new_target_id)
         if not target_info.get("isProvisional", False):
             # A provisional target becomes current only on didCommitProvisionalTarget; routing
             # commands to it earlier loses them if the load never commits.
@@ -1372,6 +1391,12 @@ class CdpTarget:
 
     async def _target_destroyed(self, message: dict[str, Any]):
         destroyed_target_id = message["params"]["targetId"]
+        if destroyed_target_id not in self._page_targets:
+            # A target the session deliberately never adopted (see _target_created). Telling the
+            # frontend the document changed because a subframe or a worker went away would reset
+            # its panels for something it never knew about.
+            return
+        self._page_targets.discard(destroyed_target_id)
         self._destroyed_targets.add(destroyed_target_id)
         self._setup_sent_targets.discard(destroyed_target_id)
         self._mark_target_responsive(destroyed_target_id)
@@ -1459,6 +1484,9 @@ class CdpTarget:
         # frontend's commands to it.
         self.target_id = message["params"]["newTargetId"]
         # Normally already done at targetCreated; covers a commit whose creation we never saw.
+        # Only page targets are ever committed, so recording it here keeps _target_destroyed
+        # recognizing it as one.
+        self._page_targets.add(self.target_id)
         await self._send_setup_to_target(self.target_id)
 
     async def _debugger_script_parsed(self, message: dict[str, Any]):

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -28,7 +28,8 @@ from pymobiledevice3.services.web_protocol.cdp_server import (
     app,
     targets_html,
 )
-from pymobiledevice3.services.web_protocol.cdp_target import JS_CONTEXT_EXECUTION_ID
+from pymobiledevice3.services.web_protocol.cdp_target import JS_CONTEXT_EXECUTION_ID, CdpTarget
+from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
 from pymobiledevice3.services.webinspector import SAFARI, Application, AutomationAvailability, Page, WebinspectorService
 
 TIMEOUT = 30
@@ -724,3 +725,77 @@ async def test_a_frontend_that_could_not_be_resolved_is_retried(monkeypatch: pyt
     assert await _frontend_base() is None
     assert await _frontend_base() == f"https://{DEVTOOLS_FRONTEND_HOST}/serve_rev/@{DEVTOOLS_FRONTEND_REV}"
     assert len(probes) == 2
+
+
+@contextmanager
+def offline_cdp_target(
+    monkeypatch: pytest.MonkeyPatch, target_id: str = "page-1"
+) -> Generator[tuple[CdpTarget, list[dict[str, Any]]], None, None]:
+    """A CdpTarget wired to a stub inspector, for message translation that needs no device.
+
+    Yields the target and the list of messages it sent towards the device.
+    """
+    sent: list[dict[str, Any]] = []
+    inspector = WebinspectorService.__new__(WebinspectorService)
+    inspector.wir_events = {}
+    inspector.wir_message_results = {}
+
+    async def send_socket_data(session_id: str, app_id: str, page_id: int, data: dict[str, Any]) -> None:
+        sent.append(data)
+
+    monkeypatch.setattr(inspector, "send_socket_data", send_socket_data)
+    page = Page.from_page_dictionary({
+        "WIRPageIdentifierKey": 1,
+        "WIRTypeKey": "WIRTypeWeb",
+        "WIRTitleKey": "Example",
+        "WIRURLKey": "https://example.com/",
+    })
+    application = Application(
+        "PID:1", "com.apple.mobilesafari", 1, "MobileSafari", AutomationAvailability.NOT_AVAILABLE, 1, False, True
+    )
+    target = CdpTarget(SessionProtocol(inspector, "SESSION", application, page, method_prefix=""), target_id)
+    # The frontend had enabled a domain; a target that takes over gets it replayed.
+    target._setup_messages["Runtime.enable"] = {}
+    try:
+        yield target, sent
+    finally:
+        for task in (target._input_task, target._receiving_task):
+            task.cancel()
+
+
+def _target_created(target_id: str, type_: str, **extra: Any) -> dict[str, Any]:
+    return {"method": "Target.targetCreated", "params": {"targetInfo": {"targetId": target_id, "type": type_, **extra}}}
+
+
+async def test_a_page_target_takes_over_the_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The committed page target a process swap creates is what commands must be routed to."""
+    with offline_cdp_target(monkeypatch) as (target, sent):
+        await target._target_created(_target_created("page-2", "page"))
+
+        assert target.target_id == "page-2"
+        assert [json.loads(m["params"]["message"])["method"] for m in sent] == ["Runtime.enable"]
+        assert target.output_queue.get_nowait()["method"] == "Target.targetInfoChanged"
+
+
+async def test_a_frame_target_does_not_take_over_the_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WebKit announces site-isolated subframes as "frame" targets. Their backend implements a
+    far smaller domain set than a page's - with site isolation off, no domains at all - so a
+    session that adopted one answered every request with "'<domain>' domain was not found", and
+    never recovered: no didCommitProvisionalTarget or targetDestroyed follows to move it back."""
+    with offline_cdp_target(monkeypatch) as (target, sent):
+        await target._target_created(_target_created("frame-2", "frame"))
+
+        assert target.target_id == "page-1"
+        assert sent == []
+        assert target.output_queue.empty()
+
+
+async def test_a_frame_target_going_away_does_not_reset_the_frontend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A subframe target is not the inspected document; announcing a load and a document update
+    for it would clear panels the frontend filled from the page."""
+    with offline_cdp_target(monkeypatch) as (target, _):
+        await target._target_created(_target_created("frame-2", "frame"))
+        await target._target_destroyed({"method": "Target.targetDestroyed", "params": {"targetId": "frame-2"}})
+
+        assert target.output_queue.empty()
+        assert "frame-2" not in target._destroyed_targets


### PR DESCRIPTION
On iOS 26, clicking a link on a normal web page killed the CDP session: the terminal filled with

```
Evaluating: window.location.href
Evaluated: {'error': {'code': -32601, 'message': "'Runtime' domain was not found", ...}}
```

and nothing worked afterwards — Runtime, Network, Page, CSS, Debugger and Audit all reported as missing.

## Cause

iOS 26 announces a `Target.targetCreated` **per subframe**, with `type: "frame"`, but `_target_created` adopted every announced target as the session's current one. So the session walked off its page target onto the last iframe and stayed there — a frame target is neither committed nor destroyed while its page is fine, which is why the only event in the log is `Target.targetCreated`, with no `didCommitProvisionalTarget` or `targetDestroyed` to move it back.

Unfixed, on the device:

```
### targetCreated {'targetId': 'frame-8589934593', 'type': 'frame'} (current=page-30)
###   -> current target now frame-8589934593
### targetCreated {'targetId': 'frame-12884901889', 'type': 'frame'} (current=frame-8589934593)
###   -> current target now frame-12884901889
```

What the frame target answers depends on site isolation. In-process frames reply `Page domain already enabled` and `Missing node for given nodeId`; a site-isolated one runs `FrameInspectorController`, which has no Page/Network/Audit at all — and with site isolation off registers no agents whatsoever, so every request fails with `-32601 '<domain>' domain was not found`.

Worth keeping apart, measured on-device:

| reply | meaning |
| --- | --- |
| `-32601 "'X' domain was not found"` | the addressed dispatcher has no agent for X |
| `-32000 "Missing target for given targetId"` | the target is gone (already handled) |

## Change

Route the session only to targets announced as pages — in `create()` too, since a frame target is announced as early as attach time and can be the first `targetInfo` a session sees. Track which targets were adopted, so a subframe going away no longer fires a `Page.loadEventFired` and a `DOM.documentUpdated` that reset panels the frontend filled from the page (five frame targets per navigation on the test page).

## Testing

Three offline tests drive synthetic `targetCreated` events — a device cannot be made to emit frame targets on demand. They fail on the unfixed code (the frame target takes over `target_id`, gets the setup replay, and queues a `targetInfoChanged`) and pass after; the third is the positive control that the gate is not too strict.

Reproduced and verified on iPhone99,11 / iOS 26.6.1 with Chrome's DevTools frontend attached to a Safari tab, on a page with cross-origin iframes. With the fix, across two navigations and five announced frame targets, the session stays on `page-30` and DevTools keeps a correct URL, full DOM, populated Styles/Layout and a live screencast.

`test_cdp_server.py`: 13 passed, 2 skipped against the device (both skips environmental — no inspectable JSContext on that device).
