### PR TITLE
mobile_image_mounter: survive the CopyDevices hangup on legacy devices

### DIFF
--- a/pymobiledevice3/services/mobile_image_mounter.py
+++ b/pymobiledevice3/services/mobile_image_mounter.py
@@ -55,6 +55,7 @@ class MobileImageMounterService(LockdownService):
             super().__init__(lockdown, self.SERVICE_NAME)
         else:
             super().__init__(lockdown, self.RSD_SERVICE_NAME)
+        self._copy_devices_unsupported = False
 
     async def _send_recv(self, request: dict[str, Any]) -> dict[str, Any]:
         return await self.service.send_recv_plist(request)
@@ -121,9 +122,16 @@ class MobileImageMounterService(LockdownService):
         # LookupImage may return an empty ImageSignature for a Personalized image that IS mounted
         # (observed on iOS 27.0), in which case MountImage would fail with "already mounted".
         # CopyDevices does list such an image, so consult it as well.
+        if self._copy_devices_unsupported:
+            return False
         try:
             devices = await self.copy_devices()
         except MessageNotSupportedError:
+            # Legacy mobile_storage_proxy (observed on iOS 12.5.7) hangs up the connection after
+            # answering an unknown command, so drop it for the next command to reconnect, and
+            # don't provoke the hangup again.
+            self._copy_devices_unsupported = True
+            await self.close()
             return False
         return any(device.get("DiskImageType") == image_type for device in devices)
 

--- a/tests/services/test_mobile_image_mounter.py
+++ b/tests/services/test_mobile_image_mounter.py
@@ -1,6 +1,11 @@
+from typing import Any, cast
+
 import pytest
 
+from pymobiledevice3.exceptions import NotMountedError
 from pymobiledevice3.lockdown import LockdownClient
+from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
+from pymobiledevice3.service_connection import ServiceConnection
 from pymobiledevice3.services.mobile_image_mounter import MobileImageMounterService
 
 
@@ -12,3 +17,57 @@ async def test_is_image_mounted_agrees_with_copy_devices(lockdown: LockdownClien
         mounted_types = {device.get("DiskImageType") for device in await mounter.copy_devices()}
         for image_type in ("Developer", "Personalized"):
             assert await mounter.is_image_mounted(image_type) == (image_type in mounted_types)
+
+
+class _LegacyConnection:
+    """mobile_storage_proxy as seen on legacy iOS (observed on iOS 12.5.7): LookupImage works,
+    but an unknown command such as CopyDevices is answered with UnknownCommand and the daemon
+    then hangs up the connection."""
+
+    def __init__(self) -> None:
+        self.hung_up = False
+        self.commands: list[str] = []
+
+    async def send_recv_plist(self, data: dict[str, Any]) -> dict[str, Any]:
+        if self.hung_up:
+            raise ConnectionResetError("Connection lost")
+        command = data["Command"]
+        self.commands.append(command)
+        if command == "LookupImage":
+            return {"ImagePresent": False}
+        self.hung_up = True
+        return {"Error": "UnknownCommand"}
+
+    async def close(self) -> None:
+        pass
+
+
+class _LegacyLockdown:
+    def __init__(self) -> None:
+        self.connections: list[_LegacyConnection] = []
+
+    async def start_lockdown_service(self, name: str, include_escrow_bag: bool = False) -> ServiceConnection:
+        connection = _LegacyConnection()
+        self.connections.append(connection)
+        return cast(ServiceConnection, connection)
+
+
+@pytest.mark.asyncio
+async def test_is_image_mounted_survives_copy_devices_hangup() -> None:
+    # Regression: the CopyDevices fallback left the mounter on a connection the legacy daemon
+    # had hung up on, so the next command (e.g. upload_image's ReceiveBytes) failed with
+    # ConnectionResetError('Connection lost')
+    lockdown = _LegacyLockdown()
+    mounter = MobileImageMounterService(lockdown=cast(LockdownServiceProvider, lockdown))
+    assert not await mounter.is_image_mounted("Developer")
+
+    # the next command must not run on the hung-up connection
+    with pytest.raises(NotMountedError):
+        await mounter.lookup_image("Developer")
+
+    # and further mounted-checks must not provoke the hangup again
+    assert not await mounter.is_image_mounted("Developer")
+    copy_devices_sent = [
+        command for connection in lockdown.connections for command in connection.commands if command == "CopyDevices"
+    ]
+    assert len(copy_devices_sent) == 1


### PR DESCRIPTION
Fixes #1897.

The `is_image_mounted()` CopyDevices fallback (introduced in 9a09145c for the iOS 27.0 empty-`ImageSignature` quirk, first shipped in v10.10.0) broke Developer image mounting on legacy devices. Their `mobile_storage_proxy` (observed on iOS 12.5.7) answers the unknown `CopyDevices` command with `UnknownCommand` and then hangs up the connection. The fallback swallowed that as "not supported", but left the mounter on the dead socket, so the next command — `upload_image()`'s `ReceiveBytes` — failed with `ConnectionResetError('Connection lost')`. (The reported traceback pins this down: both `LookupImage` and `CopyDevices` completed full round trips, and the transport was already marked lost when `ReceiveBytes` was sent.)

The fix: when `CopyDevices` turns out unsupported, drop the hung-up connection (`close()`) so the lazy service proxy transparently reconnects for the next command, and memoize that the command is unsupported so the second mounted-check inside `mount_image()` does not provoke the hangup again.

Verified:
- New device-free regression test simulating the legacy daemon (answers `UnknownCommand`, then hangs up): fails with `ConnectionResetError: Connection lost` before the fix, passes after.
- Existing real-device test `test_is_image_mounted_agrees_with_copy_devices` passes against an iPhone 11 on iOS 27.0, confirming the iOS 27 fallback behavior is unchanged where `CopyDevices` is supported.
- `ruff check` and `pyright@1.1.411 --venvpath .` clean.