### PR TITLE
webinspector cdp: Support Playwright connectOverCDP against a WKWebView

### DIFF
--- a/pymobiledevice3/services/web_protocol/cdp_browser.py
+++ b/pymobiledevice3/services/web_protocol/cdp_browser.py
@@ -37,6 +37,12 @@ PAGE_LOCK_TIMEOUT = 5
 # others would trade one silent failure for another. Only a session wedged mid-teardown reaches it.
 PAGE_HANDOVER_TIMEOUT = 30
 
+# Playwright's CRBrowser asserts every attached page's targetInfo carries a browserContextId
+# before it will adopt the page. It only uses the value to look the browser context up, falling
+# back to its default context when the id is unrecognized, so a single stable id is enough - the
+# bridge exposes no browser-context concept of its own. Chrome's own DevTools frontend ignores it.
+DEFAULT_BROWSER_CONTEXT_ID = "pymobiledevice3-default-context"
+
 # WebKit supports a single inspector session per page, so sessions are serialized per page:
 # a new debugger connection waits until the previous session's WIR socket teardown completed
 # (otherwise its socket setup races the teardown and webinspectord ignores it). Shared between
@@ -292,6 +298,7 @@ class CdpBrowser:
                     "url": page.web_url or "",
                     "attached": page_id in self._attached_pages,
                     "canAccessOpener": False,
+                    "browserContextId": DEFAULT_BROWSER_CONTEXT_ID,
                 }
                 if is_new and self._discover:
                     await self._send_event("Target.targetCreated", {"targetInfo": self._known_targets[page_id]})

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -264,7 +264,12 @@ async def _frontend_base() -> Optional[str]:
         return app.state.frontend_base
 
 
+# Both spellings: Chrome's DevTools HTTP endpoint answers /json/version and /json/version/
+# identically, and Playwright's connectOverCDP fetches the trailing-slash form. Without the second
+# route it falls through to the /json catch-all below and gets the target list (no
+# webSocketDebuggerUrl), so connectOverCDP fails with "Invalid URL: undefined".
 @app.get("/json/version")
+@app.get("/json/version/")
 def version(request: Request):
     host = request.headers.get("host", "localhost:9222")
     return {

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Optional, cast
 from pymobiledevice3.exceptions import ScreencastUnavailableError
 from pymobiledevice3.services.web_protocol.cdp_screencast import ScreenCast
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
-from pymobiledevice3.services.webinspector import WirTypes
+from pymobiledevice3.services.webinspector import WirTypes, make_target_id
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +67,10 @@ WEBKIT_ONLY_EVENTS = frozenset({
 # at 1 in every session - would consume each other's responses and SessionProtocol's. Allocating
 # from a process-wide counter in a range neither of them reaches keeps them apart.
 _FLAT_WIRE_IDS = itertools.count(0x40000000)
+
+# execution-context ids minted for the synthesized isolated worlds (see _page_create_isolated_world).
+# Based well above WebKit's own small per-session context ids so the two never collide.
+_ISOLATED_WORLD_IDS = itertools.count(0x50000000)
 
 # The single execution context synthesized for a JSContext debuggable (see _runtime_enable).
 JS_CONTEXT_EXECUTION_ID = 1
@@ -202,6 +206,20 @@ class CdpTarget:
         self.session_id = protocol.id_
         self.app_id = protocol.app.id_
         self.page_id = protocol.page.id_
+        # Chrome guarantees the top frame's id equals the page's targetId; a Chrome-protocol client
+        # (Playwright's crPage keys its per-page session by targetId, then looks the session up by
+        # the frame's id) relies on it and throws "Frame has been detached" otherwise. WebKit names
+        # the top frame independently ("0.1"), so the bridge maps that id to the id the client
+        # attached with, in both directions, everywhere a frameId crosses the wire.
+        self.frame_id = make_target_id(self.app_id, str(self.page_id))
+        # WebKit's own id for the top frame, learned from the first frame tree / main-world context.
+        self._webkit_frame_id: Optional[str] = None
+        # WebKit's Web Inspector cannot create isolated worlds (Page.createIsolatedWorld). Chrome
+        # clients (Playwright) run their own helpers in one and block until its context is
+        # announced. The bridge synthesizes that context and routes evaluations addressed to it
+        # into the page's real (main) world - the ids handed out for those synthetic contexts are
+        # collected here so their contextId can be rewritten back on the way to the device.
+        self._isolated_world_context_ids: set[int] = set()
         self.output_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self.input_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self.screencast: Optional[ScreenCast] = None
@@ -220,6 +238,12 @@ class CdpTarget:
             "Page.stopScreencast": self._page_stop_screencast,
             "Page.screencastFrameAck": self._page_screencast_frame_ack,
             "Page.getResourceTree": self._page_get_resource_tree,
+            # WebKit implements no Page.getFrameTree (Playwright's connectOverCDP calls it to
+            # learn the frame tree); answer it from the resource tree, whose frameTree carries the
+            # same frame. Nor Page.setLifecycleEventsEnabled - raw-forwarding it errors and rejects
+            # Playwright's page initialization, so acknowledge it.
+            "Page.getFrameTree": self._page_get_resource_tree,
+            "Page.setLifecycleEventsEnabled": partial(self._simple_response, value=None),
             "Emulation.setEmulatedMedia": self._emulation_set_emulated_media,
             "Emulation.setTouchEmulationEnabled": partial(self._simple_response, value=None),
             "Emulation.setFocusEmulationEnabled": partial(self._simple_response, value=None),
@@ -261,6 +285,7 @@ class CdpTarget:
             "Page.navigate": self._page_navigate,
             "Page.setAdBlockingEnabled": partial(self._simple_response, value=None),
             "Page.addScriptToEvaluateOnNewDocument": self._page_add_script_to_evaluate_on_new_document,
+            "Page.createIsolatedWorld": self._page_create_isolated_world,
             "Accessibility.enable": partial(self._simple_response, value=None),
             "Autofill.enable": partial(self._simple_response, value=None),
             "Autofill.setAddresses": partial(self._simple_response, value=None),
@@ -366,6 +391,39 @@ class CdpTarget:
         """
         self._internal_id -= 1
         return self._internal_id
+
+    def _to_client_frame_id(self, frame_id: Any) -> Any:
+        """WebKit's top-frame id -> the id the client attached with (see self.frame_id)."""
+        return self.frame_id if frame_id == self._webkit_frame_id else frame_id
+
+    def _to_device_frame_id(self, frame_id: Any) -> Any:
+        """The client's frame id -> WebKit's, the reverse of _to_client_frame_id."""
+        if frame_id == self.frame_id and self._webkit_frame_id is not None:
+            return self._webkit_frame_id
+        return frame_id
+
+    def _learn_webkit_frame_id(self, frame_id: Any) -> None:
+        """Record WebKit's own id for the top frame the first time it is seen (the frame tree's
+        top frame, or the main-world execution context's frame)."""
+        if self._webkit_frame_id is None and isinstance(frame_id, str):
+            self._webkit_frame_id = frame_id
+
+    def _map_frame_ids_outbound(self, message: dict[str, Any]) -> None:
+        """Rewrite WebKit's top-frame id to the client's in the frameId-bearing fields of an event
+        (Page.frame*, Network.*), so every frame reference the client sees matches its targetId."""
+        params = message.get("params")
+        if not isinstance(params, dict):
+            return
+        params_d = cast(dict[str, Any], params)
+        for key in ("frameId", "parentFrameId"):
+            if key in params_d:
+                params_d[key] = self._to_client_frame_id(params_d[key])
+        frame = params_d.get("frame")
+        if isinstance(frame, dict):
+            frame_d = cast(dict[str, Any], frame)
+            for key in ("id", "parentId"):
+                if key in frame_d:
+                    frame_d[key] = self._to_client_frame_id(frame_d[key])
 
     @classmethod
     async def create(cls, protocol: SessionProtocol) -> "CdpTarget":
@@ -572,6 +630,12 @@ class CdpTarget:
         while True:
             message = await self.input_queue.get()
             try:
+                # The client refers to the top frame by the id it attached with; translate it back
+                # to WebKit's before the request reaches the device.
+                params = message.get("params")
+                if isinstance(params, dict) and "frameId" in params:
+                    params_d = cast(dict[str, Any], params)
+                    params_d["frameId"] = self._to_device_frame_id(params_d["frameId"])
                 if message["method"] in self.from_cdp_special_messages_methods:
                     await self.from_cdp_special_messages_methods[message["method"]](message)
                 elif message["method"].split(".", 1)[0] in NOOP_ABSENT_DOMAINS:
@@ -739,7 +803,7 @@ class CdpTarget:
         """WebKit has no Page.navigate; navigate in-page instead (URL bar / reload in DevTools)."""
         url = json.dumps(message["params"]["url"])
         await self.evaluate_and_result(f"location.href = {url}")
-        await self.output_queue.put({"id": message["id"], "result": {"frameId": self.frame.get("id", "")}})
+        await self.output_queue.put({"id": message["id"], "result": {"frameId": self.frame_id}})
 
     async def _dom_push_nodes_by_backend_ids(self, message: dict[str, Any]):
         await self.output_queue.put({"id": message["id"], "result": {"nodeIds": []}})
@@ -791,6 +855,39 @@ class CdpTarget:
 
     async def _page_add_script_to_evaluate_on_new_document(self, message: dict[str, Any]):
         await self.output_queue.put({"id": message["id"], "result": {"identifier": "1"}})
+
+    async def _page_create_isolated_world(self, message: dict[str, Any]):
+        """
+        WebKit's Web Inspector has no Page.createIsolatedWorld. Chrome clients (Playwright) create
+        an isolated world to run their own helpers off the page's globals and block every evaluate
+        until its execution context is announced - so read APIs (page.title(), locator text) hang
+        forever otherwise.
+
+        Synthesize the world: mint a context id, announce a Runtime.executionContextCreated for it
+        named as requested (so the client binds it to its "utility" world), and answer with that
+        id. WebKit cannot actually isolate it, so evaluations addressed to it are rerouted to the
+        page's real main-world context in _runtime_evaluate. The isolation is only advisory here;
+        reads return correct results, which is what these APIs need.
+        """
+        params = message.get("params", {})
+        # _input_loop already mapped params.frameId back to WebKit's id; report the client's.
+        frame_id = self._to_client_frame_id(params.get("frameId"))
+        world_name = params.get("worldName", "")
+        context_id = next(_ISOLATED_WORLD_IDS)
+        self._isolated_world_context_ids.add(context_id)
+        await self.output_queue.put({
+            "method": "Runtime.executionContextCreated",
+            "params": {
+                "context": {
+                    "id": context_id,
+                    "origin": "",
+                    "name": world_name,
+                    "uniqueId": f"{frame_id}.{context_id}",
+                    "auxData": {"isDefault": False, "type": "isolated", "frameId": frame_id},
+                }
+            },
+        })
+        await self.output_queue.put({"id": message["id"], "result": {"executionContextId": context_id}})
 
     async def _dom_get_box_model(self, message: dict[str, Any]):
         message["method"] = "DOM.highlightNode"
@@ -918,7 +1015,9 @@ class CdpTarget:
         await self._simple_response(message, None)
 
     async def _page_get_resource_tree(self, message: dict[str, Any]):
-        result = await self.send_message_with_result_across_swaps(message["method"], message["params"])
+        # WebKit only has Page.getResourceTree; ask it for that even when the frontend called the
+        # (WebKit-absent) Page.getFrameTree, whose response Chrome reads out of the same frameTree.
+        result = await self.send_message_with_result_across_swaps("Page.getResourceTree", message.get("params", {}))
         if "result" not in result:
             # No frame tree to report: a JSContext debuggable implements no Page domain and says
             # so, and a target that stopped answering yields nothing at all. Relay that - a real
@@ -934,6 +1033,10 @@ class CdpTarget:
             )
             return
         self.frame = result["result"]["frameTree"]["frame"]
+        # The top frame's id must be the id the client attached with (see self.frame_id); learn
+        # WebKit's own id for it and rewrite it in the response the client reads.
+        self._learn_webkit_frame_id(self.frame.get("id"))
+        self.frame["id"] = self._to_client_frame_id(self.frame.get("id"))
         # result carries our internal request id; answer the frontend with its own id.
         await self.output_queue.put({"id": message["id"], "result": result["result"]})
 
@@ -1091,6 +1194,13 @@ class CdpTarget:
             # exactly one context anyway - let it use its default.
             params.pop("contextId", None)
             params.pop("uniqueContextId", None)
+        elif params.get("contextId") in self._isolated_world_context_ids:
+            # A synthesized isolated world (see _page_create_isolated_world) has no real context on
+            # the device; run in the page's main world instead, which WebKit does know.
+            if self._default_execution_id:
+                params["contextId"] = self._default_execution_id
+            else:
+                params.pop("contextId", None)
         if params.get("throwOnSideEffect") and params.get("objectGroup") not in _COMPLETION_OBJECT_GROUPS:
             self._eval_side_effect_id += 1
             error_object = {
@@ -1477,6 +1587,9 @@ class CdpTarget:
         else:
             if method:
                 logger.debug(f"Dispatching: {method}")
+            # Forwarded-as-is events (Page.frame*, ...) still reference the top frame by WebKit's
+            # id; rewrite it to the client's so every frame reference is consistent.
+            self._map_frame_ids_outbound(message)
             await self.output_queue.put(message)
 
     async def _target_did_commit_provisional_target(self, message: dict[str, Any]):
@@ -1557,7 +1670,11 @@ class CdpTarget:
         # results depending on timing. Only the main-world context is forwarded.
         if context["type"] != "normal":
             return
-        unique_id = f"{context['frameId']}.{context['id']}"
+        # The main-world context is the top frame's; learn WebKit's id for it and report the id the
+        # client attached with (see self.frame_id).
+        self._learn_webkit_frame_id(context["frameId"])
+        frame_id = self._to_client_frame_id(context["frameId"])
+        unique_id = f"{frame_id}.{context['id']}"
         if unique_id in self._emitted_context_unique_ids:
             # WebKit re-announces the same context; a duplicate executionContextCreated corrupts
             # Chrome's RuntimeModel (it keys contexts by uniqueId), so emit each at most once.
@@ -1571,6 +1688,12 @@ class CdpTarget:
                 "name": "",
                 # must be unique per context - Chrome keys contexts by it
                 "uniqueId": unique_id,
+                # Chrome carries the frame association in auxData; WebKit reports the frame id at
+                # the top level and omits auxData entirely. A CDP client (Playwright's crPage, and
+                # DevTools' RuntimeModel) finds the context's frame through auxData.frameId and
+                # recognizes the page's main world through auxData.isDefault, so without this the
+                # context is never registered and every evaluate against the page hangs.
+                "auxData": {"isDefault": True, "type": "default", "frameId": frame_id},
             }
         }
         await self.output_queue.put(message)
@@ -1645,7 +1768,7 @@ class CdpTarget:
             },
         }
         if "frameId" in params:
-            message["params"]["frameId"] = params["frameId"]
+            message["params"]["frameId"] = self._to_client_frame_id(params["frameId"])
         await self.output_queue.put(message)
 
     async def _network_loading_finished(self, message: dict[str, Any]):

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -173,6 +173,181 @@ async def testp_cdp_server_end_to_end(lockdown: LockdownClient) -> None:
         await evaluate_in_new_session()
 
 
+class CdpBrowserWebsocketClient(CdpWebsocketClient):
+    """CDP client for the browser endpoint (flat session mode), the way Puppeteer/Playwright's
+    connectOverCDP attaches: it talks to /devtools/browser/<id>, discovers page targets through
+    the Target domain, and tags every per-page message with the attachment's sessionId."""
+
+    async def connect(self) -> None:
+        self.reader, self.writer = await asyncio.open_connection("127.0.0.1", self.port)
+        self.writer.write(
+            self.ws.send(WsRequest(host=f"127.0.0.1:{self.port}", target=f"/devtools/browser/{self.page_id}"))
+        )
+        await self.writer.drain()
+        assert isinstance(await self._next_event(), AcceptConnection)
+
+    async def wait_for_event(self, method: str) -> dict[str, Any]:
+        """Wait for the next event with the given method (ignoring responses and other events)."""
+
+        async def wait() -> dict[str, Any]:
+            while True:
+                message = await self.receive()
+                if "id" not in message and message.get("method") == method:
+                    return message
+
+        return await asyncio.wait_for(wait(), TIMEOUT)
+
+    async def session_command(self, session_id: str, id_: int, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Send a request under a page attachment's sessionId and wait for its response."""
+        await self.send({"id": id_, "sessionId": session_id, "method": method, "params": params})
+
+        async def wait_for_response() -> dict[str, Any]:
+            while True:
+                message = await self.receive()
+                if message.get("id") == id_:
+                    return message
+
+        return await asyncio.wait_for(wait_for_response(), TIMEOUT)
+
+
+async def testp_cdp_browser_endpoint_attaches_playwright_style(lockdown: LockdownClient) -> None:
+    """
+    A Chrome-protocol client attaching over the browser endpoint (Puppeteer/Playwright's
+    connectOverCDP) to a page that was already loaded when it attached must be able to read and
+    evaluate against it - exactly as if it had attached right after a fresh navigation.
+
+    This exercises the whole flat-session handshake Playwright performs, and guards four separate
+    regressions that each silently broke it:
+      * the auto-attached target's targetInfo must carry a browserContextId (CRBrowser asserts on
+        it before adopting the page);
+      * Page.getFrameTree must be answered (Playwright gates page-readiness on its frame tree;
+        WebKit only implements Page.getResourceTree);
+      * Page.setLifecycleEventsEnabled must be accepted (WebKit has no such method, and a raw
+        forward errors and rejects Playwright's initialization);
+      * Runtime.enable must yield an executionContextCreated whose auxData ties the context to its
+        frame and marks it the main world - without it Playwright never registers the context and
+        every evaluate hangs.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        # Playwright's connectOverCDP fetches /json/version with a trailing slash; it must return
+        # the version dict (with webSocketDebuggerUrl), not fall through to the target listing.
+        version = await http_get_json(port, "/json/version/")
+        assert version.get("webSocketDebuggerUrl"), f"/json/version/ must carry a browser ws url: {version}"
+        browser_id = urlsplit(version["webSocketDebuggerUrl"]).path.rsplit("/", 1)[1]
+        page_id = targets[0]["id"]
+        client = CdpBrowserWebsocketClient(port, browser_id)
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        try:
+            # Playwright's connectOverCDP enables auto-attach on the root connection and waits for
+            # the page to be announced as an attached target. The Target.attachedToTarget event is
+            # emitted before the setAutoAttach reply, so watch for it directly rather than through
+            # command() (which would consume and discard it).
+            await client.send({
+                "id": 1,
+                "method": "Target.setAutoAttach",
+                "params": {"autoAttach": True, "waitForDebuggerOnStart": True, "flatten": True},
+            })
+
+            async def wait_for_page_attached() -> dict[str, Any]:
+                while True:
+                    message = await client.receive()
+                    if (
+                        message.get("method") == "Target.attachedToTarget"
+                        and message["params"]["targetInfo"]["targetId"] == page_id
+                    ):
+                        return message
+
+            attached = await asyncio.wait_for(wait_for_page_attached(), TIMEOUT)
+            target_info = attached["params"]["targetInfo"]
+            assert target_info.get("browserContextId"), (
+                f"attached targetInfo must carry a browserContextId; Playwright asserts on it: {target_info}"
+            )
+            session_id = attached["params"]["sessionId"]
+
+            ids = itertools.count(2)
+            await client.session_command(session_id, next(ids), "Page.enable", {})
+
+            # Playwright sends Page.getFrameTree with no params key at all; the handler must not
+            # assume one is present.
+            frame_tree_id = next(ids)
+            await client.send({"id": frame_tree_id, "sessionId": session_id, "method": "Page.getFrameTree"})
+
+            async def wait_for_frame_tree() -> dict[str, Any]:
+                while True:
+                    message = await client.receive()
+                    if message.get("id") == frame_tree_id:
+                        return message
+
+            frame_tree = await asyncio.wait_for(wait_for_frame_tree(), TIMEOUT)
+            assert "result" in frame_tree, f"Page.getFrameTree must be answered, not error: {frame_tree.get('error')}"
+            frame_id = frame_tree["result"]["frameTree"]["frame"]["id"]
+
+            lifecycle = await client.session_command(
+                session_id, next(ids), "Page.setLifecycleEventsEnabled", {"enabled": True}
+            )
+            assert "result" in lifecycle, (
+                f"Page.setLifecycleEventsEnabled must be accepted, not error: {lifecycle.get('error')}"
+            )
+
+            # Playwright sends Page.enable before Runtime.enable; WebKit then retroactively
+            # announces the already-existing context. Capture that event and the enable response.
+            await client.send({"id": next(ids), "sessionId": session_id, "method": "Runtime.enable", "params": {}})
+            context = await client.wait_for_event("Runtime.executionContextCreated")
+            payload = context["params"]["context"]
+            aux = payload.get("auxData", {})
+            assert aux.get("isDefault") is True, f"the main-world context must be marked isDefault: {payload}"
+            assert aux.get("frameId") == frame_id, (
+                f"the context's auxData.frameId must match the frame tree ({frame_id}): {payload}"
+            )
+            # Chrome ties the top frame's id to the page's targetId; Playwright looks the page's
+            # session up by the frame id and throws "Frame has been detached" if they differ.
+            assert frame_id == page_id, f"the top frame id must equal the targetId {page_id}: {frame_id}"
+
+            # The announced context must actually be usable: evaluating in it (as Playwright does,
+            # addressing it by contextId) returns a value rather than hanging or erroring.
+            result = await client.session_command(
+                session_id,
+                next(ids),
+                "Runtime.evaluate",
+                {"expression": "6*7", "contextId": payload["id"], "returnByValue": True},
+            )
+            assert result["result"]["result"]["value"] == 42, result
+
+            # WebKit has no isolated worlds, but Playwright creates one and evaluates page.title()
+            # and locator text in it, blocking until its context is announced. The bridge must
+            # synthesize that world's context and let evaluations against it run (in the page's
+            # real world), or those read APIs hang forever.
+            world_id = next(ids)
+            await client.send({
+                "id": world_id,
+                "sessionId": session_id,
+                "method": "Page.createIsolatedWorld",
+                "params": {"frameId": frame_id, "worldName": "__pmd3_test_world__", "grantUniveralAccess": True},
+            })
+
+            async def wait_for_utility_context() -> dict[str, Any]:
+                while True:
+                    message = await client.receive()
+                    if (
+                        message.get("method") == "Runtime.executionContextCreated"
+                        and message["params"]["context"].get("name") == "__pmd3_test_world__"
+                    ):
+                        return message
+
+            utility = await asyncio.wait_for(wait_for_utility_context(), TIMEOUT)
+            utility_id = utility["params"]["context"]["id"]
+            assert utility["params"]["context"]["auxData"]["frameId"] == page_id, utility
+            in_world = await client.session_command(
+                session_id,
+                next(ids),
+                "Runtime.evaluate",
+                {"expression": "1+2", "contextId": utility_id, "returnByValue": True},
+            )
+            assert in_world["result"]["result"]["value"] == 3, in_world
+        finally:
+            await client.close()
+
+
 async def testp_cdp_server_drives_a_javascript_context(lockdown: LockdownClient) -> None:
     """
     A JSContext debuggable (any process that called -[JSContext setInspectable:YES]) implements


### PR DESCRIPTION
Fixes #1900.

Attaching Playwright (`chromium.connectOverCDP`) to a WKWebView that was already loaded when the debugger attached completed the whole handshake but never issued a `Runtime.evaluate` — `page.title()`, locator reads, and `page.evaluate` all hung until Playwright's client-side timeout.

@ammar01 nailed three of the sub-bugs (thank you for the excellent report and tracing!). Reproducing it end-to-end against a real device turned up three more, plus the deeper reason the execution context never registered:

- **`Page.getFrameTree`** — WebKit only implements `Page.getResourceTree`; now answered from it, and tolerant of the no-`params` form Playwright sends.
- **`Page.setLifecycleEventsEnabled`** — WebKit has no such method; acknowledged instead of raw-forwarded (a raw forward errored and rejected Playwright's init).
- **`browserContextId`** — added to the browser endpoint's target-info, which `CRBrowser` asserts on before adopting a page.
- **`Runtime.executionContextCreated`** — now carries `auxData` (`isDefault` + `frameId`). A CDP client uses `auxData.frameId` to bind the context to its frame and `isDefault` to mark the main world; without it the context was never registered and every evaluate hung.
- **`/json/version/`** (trailing slash, which Playwright's `connectOverCDP` requests) now returns the version dict instead of falling through to the target listing — otherwise `connectOverCDP` fails with `Invalid URL: undefined`.
- **Top frame id ↔ target id** — Chrome guarantees the top frame's id equals the page's `targetId`; Playwright keys its per-page session by `targetId` and looks it up by frame id, throwing *"Frame has been detached"* otherwise. WebKit names the top frame independently (`0.1`), so the bridge now reconciles the two in both directions everywhere a `frameId` crosses the wire.
- **Isolated worlds** — WebKit can't create them (`Page.createIsolatedWorld` → `-32601`), but Playwright runs `page.title()`/locator reads in one. The bridge synthesizes the world and reroutes its evaluations into the page's real main world (isolation is advisory; reads return correct values).

### Verification
Verified with real Playwright 1.62.1 against a physical iPhone (iOS 26.6.1) on an already-loaded page:

```
page.url()                     → https://example.com/...
page.title()                   → "Example Domain"
page.locator('h1').innerText() → "Example Domain"
page.evaluate(() => 6*7)       → 42
```

Adds a device test (`testp_cdp_browser_endpoint_attaches_playwright_style`) exercising the full flat-session handshake, and the existing CDP device suite still passes (no DevTools-path regression). pyright/ruff clean.

@ammar01 — when you get a chance, would you mind pulling this branch and confirming it fixes your Cordova/WKWebView setup too? Your repro was on 11.3.1 with local patches, and I'd love to make sure this covers the real-world case end-to-end before it lands. Thanks again for the thorough write-up!