### PR TITLE
packaging: Require typer-injector >= 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
     "pyiosbackup>=0.2.4",
     "typer>=0.23.2,<0.24.0; python_version < '3.10'",
     "typer>=0.25; python_version >= '3.10'",
-    "typer-injector>=0.2.0",
+    "typer-injector>=0.3.0",
     "defusedxml",
     "pywin32; platform_system == 'Windows'",
     "av>=14.0.0; platform_system != 'Darwin'",


### PR DESCRIPTION
## Summary

Since d667c442 (v10.2.2), typer-injector < 0.2.2 fails at import time, so the whole `developer` and `lockdown` groups stop loading:

    ParameterNameConflictError: parameter 'ctx' from Depends(make_rsd_dependency.<locals>.rsd_dependency)
        from parameter 'rsd_service_provider' in Depends(any_service_provider_dependency)
            from parameter 'service_provider' in send_signal
    conflicts with parameter 'ctx' from send_signal

Only 0.2.2 and later merge duplicate `typer.Context` parameters.

The lower bound stayed at >=0.2.0, so upgrading pymobiledevice3 in an environment that already had 0.2.0 keeps the broken pair; CI never sees it because a fresh install resolves to the latest release. Require 0.3.0, the current release.

## Testing

Fresh venvs (Python 3.13):

- `pip install pymobiledevice3==10.2.2 typer-injector==0.2.0` then `pymobiledevice3 developer --help` / `lockdown --help`: `ParameterNameConflictError`. Same with 10.2.1: works, so the regression is d667c442.
- `pip install pymobiledevice3==11.3.1` on top of a working 10.2.1 env: typer-injector stays 0.2.0, same failure (the upgrade path users hit).
- Installing this branch into that broken env: typer-injector upgraded to 0.3.0, both groups load again.
- `pip install --dry-run .` in an env holding 0.2.0: `Would install typer-injector-0.3.0`.
- `pytest tests/cli -m "not device"` with typer-injector 0.3.0: 303 passed.

## AI Assistance

Claude Code (Claude Fable 5.1) did the root-cause investigation, the one-line change, the commit message and the test runs above. I reviewed the diff and the commit message, chose the 0.3.0 bound, and requested and reviewed the isolated-environment reproduction.