### PR TITLE
webinspector cdp: complete the child-frame story — node identity, user gestures, docs

### DIFF
--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -4,7 +4,7 @@
 Chrome DevTools Protocol (CDP), so Chrome-compatible debugger clients can attach to
 Safari tabs and WebViews running on a connected device. One bridge instance serves
 both Chrome DevTools (per-page) and browser-level clients such as VS Code's
-JavaScript debugger.
+JavaScript debugger and test automation frameworks like Playwright and Puppeteer.
 
 ## Device prerequisites
 
@@ -92,10 +92,58 @@ Configuration notes:
 - Source-map warnings for third-party pages you don't control are harmless; silence
   them with `"sourceMaps": false` if they get noisy.
 
+## Test automation (Playwright, Puppeteer)
+
+A Chrome-protocol automation framework attaches through the same browser-level
+endpoint as VS Code, so the page runs on the real device while the test runs on your
+machine. This lets a web test suite drive a `WKWebView` in a real app, rather than a
+simulator or a desktop browser pretending to be one.
+
+```javascript
+const { chromium } = require('playwright');
+
+const browser = await chromium.connectOverCDP('http://127.0.0.1:9222');
+const page = browser.contexts()[0].pages()[0];
+
+await page.goto('https://example.com/');
+await page.locator('#search').fill('hello');
+await page.locator('button[type=submit]').click();
+await page.screenshot({ path: 'device.png' });
+```
+
+Puppeteer attaches the same way with
+`puppeteer.connect({ browserURL: 'http://127.0.0.1:9222' })`.
+
+What works: navigation and its waits (`goto`, `reload`, `waitForNavigation`,
+`waitForLoadState`), reading and evaluating, every text-input API (`fill`,
+`pressSequentially`, `type`, `press`, `keyboard.insertText`), clicking and hovering,
+screenshots, network observation (`page.on('request')`, `page.on('response')`), and
+child frames - including cross-origin ones nested several levels deep, through
+`page.frames()`, `frameLocator()` and `frame.evaluate()`.
+
+Attaching to a page that is *already open* works too: you do not have to be connected
+before it loads.
+
+Notes worth knowing when scripting against a device:
+
+- The first interaction with a newly created frame takes a few seconds while the
+  framework bootstraps its injected script inside that frame over USB. It is not a
+  hang - give the first frame interaction a generous timeout.
+- Everything is a USB round-trip, so per-call latency is far higher than against a
+  local browser. Prefer a few coarse `evaluate()` calls over many fine-grained ones
+  in a hot loop.
+- A page whose framework replaces the global `Promise` and minifies the replacement
+  (Angular with zone.js, for example) reports objects of that class without the
+  `promise` subtype, because the bridge recognises built-ins by their class name.
+  `await` still behaves; only code that inspects the subtype is affected.
+
 ## Caveats
 
-- WebKit allows a single inspector session per page: Chrome DevTools and VS Code can
-  debug different tabs concurrently, but not the same tab. A page already held by
-  another debugger is skipped after a short wait — detach the other client first.
+- WebKit allows a single inspector session per page, so two *separate* debuggers
+  cannot hold the same tab: Chrome DevTools and VS Code can debug different tabs
+  concurrently, but not the same one. A page already held by another debugger is
+  skipped after a short wait — detach the other client first. A single client may
+  open as many CDP sessions onto a page as it likes (Playwright does this when a
+  script also opens a raw `newCDPSession`); those share the one underlying session.
 - The page listing is polled, so tabs opened on the device after the attach are
   discovered (and auto-attached) within a couple of seconds.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Windows, Linux, and macOS.
 - Firmware update, recovery/DFU workflows
 - Notification listen/post
 - Querying and setting SpringBoard options
-- WebInspector automation
+- WebInspector automation, and a Chrome DevTools Protocol bridge for DevTools, VS Code, Playwright and Puppeteer
 - DDI/DVT developer tooling (iOS 17+ over a tunnel)
 - Backup and restore
 

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -354,6 +354,7 @@ class CdpTarget:
             "Runtime.runIfWaitingForDebugger": partial(self._simple_response, value=None),
             "Runtime.enable": self._runtime_enable,
             "Runtime.evaluate": self._runtime_evaluate,
+            "Runtime.callFunctionOn": self._runtime_call_function_on,
             "Runtime.compileScript": self._runtime_compile_script,
             "Runtime.runScript": self._runtime_run_script,
             "Runtime.getIsolateId": self._runtime_get_isolate_id,
@@ -2130,6 +2131,7 @@ class CdpTarget:
         # through - refusing them would kill autocomplete. Only the eager preview (no completion
         # objectGroup) is refused.
         params = message["params"]
+        self._translate_user_gesture(params)
         if self._flat:
             # The context the frontend targets is the one synthesized in _runtime_enable, which the
             # debuggable knows nothing about; addressing it explicitly would fail the lookup. It has
@@ -2184,6 +2186,23 @@ class CdpTarget:
                 },
             })
             return
+        await self._send_message_to_target(message)
+
+    @staticmethod
+    def _translate_user_gesture(params: dict[str, Any]) -> None:
+        """Carry a client's "this is a user gesture" flag across to the name WebKit knows.
+
+        Chrome calls it `userGesture`, WebKit `emulateUserGesture`, and an unrecognized parameter
+        is simply ignored - so the call ran with no gesture behind it. That is not cosmetic: an
+        element inside a cross-origin frame cannot be focused without one, so a client's fill()
+        (which focuses the field, then types into whatever holds the focus) quietly typed
+        nowhere and left the field empty.
+        """
+        if "userGesture" in params:
+            params["emulateUserGesture"] = bool(params.pop("userGesture"))
+
+    async def _runtime_call_function_on(self, message: dict[str, Any]):
+        self._translate_user_gesture(message.setdefault("params", {}))
         await self._send_message_to_target(message)
 
     async def _runtime_compile_script(self, message: dict[str, Any]):

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -47,6 +47,10 @@ MAX_FRAME_DESCENT = 5
 # allocated here, well clear of anything the device would produce.
 _FRAME_OWNER_NODE_IDS = itertools.count(0x60000000)
 
+# backendNodeIds minted for nodes a client asked about with DOM.describeNode, so it can name the
+# same node again later (DOM.resolveNode) - which is how it moves an element between worlds.
+_DESCRIBED_NODE_IDS = itertools.count(0x70000000)
+
 # sourceURL stamped onto the bridge's own internal evaluations (screencast offsets, synthesized
 # input, navigation) so their Debugger.scriptParsed events can be recognized and dropped instead
 # of polluting Chrome's script model. WebKit-inspector-internal scripts (its injected script
@@ -281,6 +285,9 @@ class CdpTarget:
         self._announced_frames: set[str] = set()
         # Minted backendNodeId -> the (frame, index) of the <iframe> element it stands for.
         self._frame_owner_nodes: dict[int, tuple[str, int]] = {}
+        # Minted backendNodeId -> the remote object a client was told about. WebKit has no node
+        # identity that outlives a description, so one is kept here (see _dom_describe_node).
+        self._described_nodes: dict[int, str] = {}
         # World names the client registered through Page.addScriptToEvaluateOnNewDocument. Chrome
         # creates a world of that name in every document that loads; the bridge does the same, so
         # a frame that appears later still gets the world its client expects to evaluate in.
@@ -1562,9 +1569,11 @@ class CdpTarget:
             await self._error_response(message, {"code": -32000, "message": "Node is detached from document"})
             return
         info = cast(dict[str, Any], value)
+        backend_node_id = next(_DESCRIBED_NODE_IDS)
+        self._described_nodes[backend_node_id] = cast(str, object_id)
         node: dict[str, Any] = {
             "nodeId": 0,
-            "backendNodeId": 0,
+            "backendNodeId": backend_node_id,
             "nodeType": 1,
             "nodeName": info.get("nodeName", ""),
             "localName": info.get("localName", ""),
@@ -1639,6 +1648,26 @@ class CdpTarget:
         """Resolve a node back to an object. Only the frame-owner ids minted above are handled
         here; anything else is WebKit's own and is passed through."""
         backend_node_id = message.get("params", {}).get("backendNodeId")
+        if isinstance(backend_node_id, int):
+            described = self._described_nodes.get(backend_node_id)
+            if described is not None:
+                # A client resolves a node to move it between worlds. The worlds this bridge
+                # hands out are all backed by the frame's one real context (see
+                # _page_create_isolated_world), so the node needs no moving - but it does need a
+                # handle of its own: the client releases the handle it described from, and
+                # answering with that same one hands back a reference it has already dropped.
+                fresh = await self.send_message_with_result(
+                    "Runtime.callFunctionOn",
+                    {"objectId": described, "functionDeclaration": "function() { return this; }"},
+                )
+                remote_object = fresh.get("result", {}).get("result")
+                if not isinstance(remote_object, dict) or "objectId" not in cast(dict[str, Any], remote_object):
+                    await self._error_response(message, {"code": -32000, "message": "No node with given id found"})
+                    return
+                node_object = cast(dict[str, Any], remote_object)
+                node_object.setdefault("subtype", "node")
+                await self.output_queue.put({"id": message["id"], "result": {"object": node_object}})
+                return
         owner = self._frame_owner_nodes.get(backend_node_id) if isinstance(backend_node_id, int) else None
         if owner is None:
             await self._send_message_to_target(message)

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -1012,6 +1012,70 @@ async def testp_cdp_server_resolves_a_node_back_to_a_handle(lockdown: LockdownCl
             await client.close()
 
 
+async def testp_cdp_server_carries_a_user_gesture_through(lockdown: LockdownClient) -> None:
+    """
+    A client marks the calls it makes on the user's behalf as a user gesture. Chrome names that
+    `userGesture` and WebKit `emulateUserGesture`, and an unrecognized parameter is ignored - so
+    every such call ran with no gesture behind it.
+
+    That is not cosmetic. Anything the platform gates behind a gesture silently did nothing,
+    including focusing an element inside a cross-origin frame - which is what a client's fill()
+    does before typing, so it typed nowhere and left the field empty while reporting success.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        message_ids = itertools.count(1)
+        try:
+
+            async def command(method: str, params: dict[str, Any]) -> dict[str, Any]:
+                return await client.command(next(message_ids), method, params)
+
+            await command("Page.enable", {})
+            await command("Runtime.enable", {})
+            await command("Page.navigate", {"url": "https://example.com/"})
+
+            # execCommand('copy') is refused without a user gesture and allowed with one, so it
+            # reports whether the gesture actually reached the page.
+            gesture_probe = (
+                "(function () {"
+                "  const field = document.createElement('textarea');"
+                "  field.value = 'x';"
+                "  document.body.appendChild(field);"
+                "  field.select();"
+                "  const allowed = document.execCommand('copy');"
+                "  field.remove();"
+                "  return allowed;"
+                "})()"
+            )
+
+            async def probe(**extra: Any) -> Any:
+                response = await command(
+                    "Runtime.evaluate", {"expression": gesture_probe, "returnByValue": True, **extra}
+                )
+                return response.get("result", {}).get("result", {}).get("value")
+
+            assert await probe() is False, "a call with no gesture must not be treated as one"
+            assert await probe(userGesture=True) is True, "a call marked as a user gesture must reach the page as one"
+            # Runtime.callFunctionOn carries the same flag, and is what a client actually uses to
+            # run its own helpers against an element.
+            window = await command("Runtime.evaluate", {"expression": "window"})
+            with_gesture = await command(
+                "Runtime.callFunctionOn",
+                {
+                    "objectId": window["result"]["result"]["objectId"],
+                    "functionDeclaration": f"function() {{ return {gesture_probe}; }}",
+                    "returnByValue": True,
+                    "userGesture": True,
+                },
+            )
+            assert with_gesture["result"]["result"]["value"] is True, (
+                f"Runtime.callFunctionOn must carry the gesture too: {with_gesture}"
+            )
+        finally:
+            await client.close()
+
+
 async def testp_cdp_server_drives_a_javascript_context(lockdown: LockdownClient) -> None:
     """
     A JSContext debuggable (any process that called -[JSContext setInspectable:YES]) implements

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -955,6 +955,63 @@ async def testp_cdp_browser_endpoint_gives_each_attachment_its_own_session(lockd
             await client.close()
 
 
+async def testp_cdp_server_resolves_a_node_back_to_a_handle(lockdown: LockdownClient) -> None:
+    """
+    A client moves an element between execution contexts by describing it to get a backendNodeId
+    and resolving that id back to an object - which is what every locator-driven interaction with
+    something inside a child frame goes through. WebKit has no node identity that outlives a
+    description, so DOM.describeNode reported no usable id and the resolve that followed found
+    nothing: the action retried until it timed out, with nothing explaining why.
+
+    The resolve must also answer with a handle of its own. A client releases the handle it
+    described from, so answering with that same handle returns a reference it has already dropped.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        message_ids = itertools.count(1)
+        try:
+
+            async def command(method: str, params: dict[str, Any]) -> dict[str, Any]:
+                return await client.command(next(message_ids), method, params)
+
+            await command("Page.enable", {})
+            await command("Runtime.enable", {})
+            await command("Page.navigate", {"url": "https://example.com/"})
+
+            element = await command("Runtime.evaluate", {"expression": "document.body"})
+            object_id = element["result"]["result"]["objectId"]
+            described = await command("DOM.describeNode", {"objectId": object_id})
+            backend_node_id = described["result"]["node"].get("backendNodeId")
+            assert isinstance(backend_node_id, int) and backend_node_id, (
+                f"a described node must carry an id the client can name it by again: {described}"
+            )
+
+            resolved = await command("DOM.resolveNode", {"backendNodeId": backend_node_id})
+            assert "result" in resolved, f"a described node must resolve back: {resolved.get('error')}"
+            resolved_object_id = resolved["result"]["object"]["objectId"]
+            assert resolved_object_id != object_id, (
+                "resolving must answer with a handle of its own, not the one already described from"
+            )
+
+            # Releasing the original handle must leave the resolved one usable - that is the whole
+            # point of it being a separate handle.
+            await command("Runtime.releaseObject", {"objectId": object_id})
+            still_usable = await command(
+                "Runtime.callFunctionOn",
+                {
+                    "objectId": resolved_object_id,
+                    "functionDeclaration": "function() { return this.tagName; }",
+                    "returnByValue": True,
+                },
+            )
+            assert still_usable["result"]["result"]["value"] == "BODY", (
+                f"the resolved handle must still address the node: {still_usable}"
+            )
+        finally:
+            await client.close()
+
+
 async def testp_cdp_server_drives_a_javascript_context(lockdown: LockdownClient) -> None:
     """
     A JSContext debuggable (any process that called -[JSContext setInspectable:YES]) implements


### PR DESCRIPTION
Fixes #1910, and closes out the two things v11.4.0 shipped as known limitations. **Both turned out to be bugs here, not platform limits.**

## 1. Locator interaction inside a child frame (#1910)

Acting on an element through a locator goes through **node identity**: a client describes the element to get a `backendNodeId`, then resolves that id back to an object. `DOM.describeNode` reported `backendNodeId: 0` for every node, so the resolve found nothing and every locator-driven interaction inside a child frame retried until it timed out.

I had written this off as needing Chrome's whole node identity model. That was more than is actually required, because of something specific to this bridge: **the isolated worlds it hands out are all backed by the frame's one real execution context** (WebKit has none, so they are synthesized). There is no adoption between worlds to perform — only the identity was missing.

Resolving must also answer with a **fresh** handle: a client releases the handle it described from, so returning that same one hands back a reference it has already dropped. That detail was the difference between `Execution context was destroyed` and success.

## 2. `fill()` into a cross-origin frame — was never a platform limit

Chrome names the user-gesture flag `userGesture`, WebKit names it `emulateUserGesture`, and an unrecognized parameter is ignored — so every call a client marked as a user gesture reached the page with no gesture behind it. An element inside a cross-origin frame **cannot be focused without one**, and `fill()` focuses the field and then types into whatever holds the focus. So it typed nowhere and left the field empty while reporting success.

I documented this as a platform limitation in the v11.4.0 notes. It was this missing translation, and it is now fixed.

## Verified against a device

Against a replica of the page from #1908 — two origins, three cross-origin iframes, one nested a further level down:

```
frames discovered (3 levels, cross-origin)  : 5
cross-origin frame.evaluate / 3-level deep  : correct URLs
cross-origin frame.fill                     : 4111    (was: empty)
frameLocator(...).innerText()               : correct
frameLocator(...).fill()                    : 4222    (was: empty)
frameLocator(...).click()                   : the child page's own title changed
frameLocator(...).locator(...).evaluate()   : correct (was: timeout)
re-attach - fresh connection sees frames    : 5
```

The cross-origin click is confirmed by the *child* document's title changing, not just by the call returning.

## Docs

The WebView debugging guide covered Chrome DevTools and VS Code but not automation, which is now the larger reason to use the bridge. Adds a Playwright/Puppeteer section with a runnable example, what is supported, and the three things worth knowing when scripting over USB. Also corrects the single-session caveat: WebKit allows one inspector session per page, but a single client may open several CDP sessions onto it. Docs build clean under `mkdocs build --strict`.

## Testing

Two new device tests — one for the node identity round-trip (including that the resolved handle survives the original being released), one for the user gesture reaching the page (`execCommand('copy')` is refused without a gesture and allowed with one). Both verified to fail without their fix.

Device suite: **24 passed, 2 skipped**. pyright and ruff clean.

## Remaining known limitation

A page whose framework replaces the global `Promise` and minifies the replacement (Angular with zone.js) reports objects of that class without the `promise` subtype, since built-ins are recognised by class name. `await` still behaves; only code inspecting the subtype is affected. Documented in the guide.