### PR TITLE
cli: Let --reconnect accept any device via PYMOBILEDEVICE3_RECONNECT_ANY

### DIFF
--- a/docs/guides/environment-variables.md
+++ b/docs/guides/environment-variables.md
@@ -13,6 +13,7 @@ Each one is a default: the matching command-line option always wins.
 | Variable | Value | Effect |
 | --- | --- | --- |
 | `PYMOBILEDEVICE3_UDID` | device UDID | Default for `--udid` — the device every command targets. |
+| `PYMOBILEDEVICE3_RECONNECT_ANY` | any non-empty value | With `--reconnect`: after a mid-command disconnect, reconnect to the **first available** device even when its UDID differs from the device the command originally targeted. A warning is printed and the re-invocation targets the newly connected device. |
 | `PYMOBILEDEVICE3_USBMUX` | unix socket path or `HOST:PORT` | Default for `--usbmux` — where `usbmuxd` is listening. |
 | `USBMUXD_SOCKET_ADDRESS` | unix socket path or `HOST:PORT` | Same as above; honored for compatibility with `libimobiledevice`. |
 

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -28,6 +28,7 @@ import pymobiledevice3._lazy_imports  # noqa: F401
 from pymobiledevice3.cli.cli_common import (
     FORCE_TUNNEL_ENV_VAR,
     NATIVE_ENV_VAR,
+    RECONNECT_ANY_ENV_VAR,
     TUNNEL_ENV_VAR,
     UDID_ENV_VAR,
     USERSPACE_ENV_VAR,
@@ -285,7 +286,10 @@ def _root(
         bool,
         typer.Option(
             "--reconnect",
-            help="Automatically reconnect if the device disconnects mid-command.",
+            help=(
+                "Automatically reconnect if the device disconnects mid-command "
+                f"(set {RECONNECT_ANY_ENV_VAR} to accept any device, not just the original one)."
+            ),
             show_default=False,
         ),
     ] = False,
@@ -467,6 +471,17 @@ def invoke_cli_with_error_handling() -> bool:
     return False
 
 
+def _retarget_reconnect_udid(udid: str) -> None:
+    """Point the `--reconnect` re-invocation at ``udid``: an explicit ``--udid`` on argv wins over
+    the env var, so rewrite both."""
+    for i, arg in enumerate(sys.argv):
+        if arg == "--udid" and i + 1 < len(sys.argv):
+            sys.argv[i + 1] = udid
+        elif arg.startswith("--udid="):
+            sys.argv[i] = f"--udid={udid}"
+    os.environ[UDID_ENV_VAR] = udid
+
+
 def main() -> None:
     # Retry to invoke the CLI
     while invoke_cli_with_error_handling():
@@ -478,10 +493,23 @@ def main() -> None:
             logger.info("Waiting for the device to be available again")
             # Wait for the device the command targeted, not just any device. The target is the
             # explicit --udid / env value, or whichever device the command's dependency resolved
-            # to (auto-pick or interactive prompt).
+            # to (auto-pick or interactive prompt). RECONNECT_ANY_ENV_VAR opts out: accept the
+            # first available device even when its UDID differs from the original target.
             serial = _cli_udid() or resolved_udid()
-            lockdown = asyncio.run(retry_create_using_usbmux(serial=serial))
-            if serial is not None and not os.getenv(UDID_ENV_VAR):
+            accept_any = bool(os.getenv(RECONNECT_ANY_ENV_VAR))
+            if accept_any and serial is not None:
+                logger.warning(
+                    f"{RECONNECT_ANY_ENV_VAR} is set: accepting the first available device, "
+                    f"even if its UDID differs from {serial}"
+                )
+            lockdown = asyncio.run(retry_create_using_usbmux(serial=None if accept_any else serial))
+            if accept_any and lockdown.udid:
+                if serial is not None and lockdown.udid != serial:
+                    logger.warning(f"Reconnected to a different device: {lockdown.udid} (was {serial})")
+                serial = lockdown.udid
+                # Retarget the re-invocation at the device that actually connected.
+                _retarget_reconnect_udid(serial)
+            elif serial is not None and not os.getenv(UDID_ENV_VAR):
                 # Stamp the target so the re-invocation resolves the same device instead of
                 # prompting again (or silently auto-picking another attached device).
                 os.environ[UDID_ENV_VAR] = serial

--- a/pymobiledevice3/cli/cli_common.py
+++ b/pymobiledevice3/cli/cli_common.py
@@ -36,6 +36,9 @@ from pymobiledevice3.tunneld.api import TUNNELD_DEFAULT_ADDRESS, TunneldAddress,
 from pymobiledevice3.utils import ask_prompt, get_asyncio_loop
 
 UDID_ENV_VAR = "PYMOBILEDEVICE3_UDID"
+# With `--reconnect`: accept the first available device on reconnect, even when its UDID differs
+# from the device the command originally targeted.
+RECONNECT_ANY_ENV_VAR = "PYMOBILEDEVICE3_RECONNECT_ANY"
 TUNNEL_ENV_VAR = "PYMOBILEDEVICE3_TUNNEL"
 USERSPACE_ENV_VAR = "PYMOBILEDEVICE3_USERSPACE"
 # macOS only: piggyback Apple's remoted tunnel via remotepairingd (no root, no Xcode).

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -234,6 +234,50 @@ def test_reconnect_waits_for_the_target_device(monkeypatch):
     assert captured.get("serial") == "TARGET-UDID"
 
 
+def test_reconnect_any_accepts_first_available_device(monkeypatch, caplog):
+    """With RECONNECT_ANY_ENV_VAR set, `--reconnect` must accept the first available device (no
+    serial filter), warn about the UDID mismatch, and retarget the re-invocation at it."""
+    import logging
+    import os
+
+    from pymobiledevice3.cli import cli_common
+
+    _patch_isolated_asyncio_run(monkeypatch)
+    captured: dict[str, str] = {}
+
+    async def fake_retry_create_using_usbmux(*args, **kwargs):
+        captured.update(kwargs)
+
+        class _FakeLockdown:
+            udid = "OTHER-UDID"
+
+            async def close(self) -> None:
+                pass
+
+        return _FakeLockdown()
+
+    invocations = iter([True, False])
+    monkeypatch.setattr(__main__, "invoke_cli_with_error_handling", lambda: next(invocations))
+    monkeypatch.setattr(__main__, "RECONNECT", True)
+    monkeypatch.setattr(__main__, "retry_create_using_usbmux", fake_retry_create_using_usbmux)
+    argv = ["pymobiledevice3", "--reconnect", "afc", "webdav", "--udid", "TARGET-UDID"]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(os, "environ", dict(os.environ))  # isolate env mutations done by main()
+    os.environ[cli_common.RECONNECT_ANY_ENV_VAR] = "1"
+
+    with caplog.at_level(logging.WARNING, logger=__main__.logger.name):
+        __main__.main()
+
+    # No serial filter: any device is accepted.
+    assert captured.get("serial") is None
+    # The re-invocation is retargeted at the device that actually connected (argv --udid wins over
+    # the env var, so both must be rewritten).
+    assert argv[argv.index("--udid") + 1] == "OTHER-UDID"
+    assert os.environ[cli_common.UDID_ENV_VAR] == "OTHER-UDID"
+    # The mismatch is warned about.
+    assert any("OTHER-UDID" in record.message and "TARGET-UDID" in record.message for record in caplog.records)
+
+
 def test_device_not_found_is_a_reconnectable_failure(monkeypatch):
     """A device-not-found failure must keep the `--reconnect` retry loop alive: after a disconnect,
     the target device may still be enumerating while other devices are attached."""


### PR DESCRIPTION
## What

`--reconnect` currently waits for the exact device the command targeted (explicit `--udid`/env, or the interactively/auto-picked one). This adds an opt-in escape hatch: with the `PYMOBILEDEVICE3_RECONNECT_ANY` environment variable set (any non-empty value), the reconnect loop accepts the **first available** device, even when its UDID differs from the original target.

## Behavior

- A warning is printed when the fallback engages, and another when the connected device's UDID actually differs from the original target.
- The re-invocation is retargeted at the newly connected device: both the `--udid` value on argv and `PYMOBILEDEVICE3_UDID` are rewritten (an explicit `--udid` wins over the env var, so rewriting the env var alone would not be enough).
- Without the env var, behavior is unchanged.

## Docs & tests

- Documented in `docs/guides/environment-variables.md` and in the `--reconnect` option help.
- New test `test_reconnect_any_accepts_first_available_device` covers the no-serial wait, the argv/env retargeting, and the warning.