### PR TITLE
cdp: Attach to new JSContexts before they run and pause them on demand

### DIFF
--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -92,6 +92,54 @@ Configuration notes:
 - Source-map warnings for third-party pages you don't control are harmless; silence
   them with `"sourceMaps": false` if they get noisy.
 
+### JSContexts in VS Code
+
+The landing page at `http://127.0.0.1:9222/` has an **Attach from VS Code** section
+under every target with the configuration that attaches to exactly it; copy it into
+`launch.json`. What those configurations look like, and why:
+
+The `chrome` attach above only takes web pages; js-debug ignores the JSContexts the
+bridge lists (they are advertised as `node` targets). Attach to a JSContext with a
+`node` configuration pointed straight at its websocket:
+
+```json
+{
+    "name": "Attach to JSContext",
+    "type": "node",
+    "request": "attach",
+    "websocketAddress": "ws://127.0.0.1:9222/devtools/page/PID:1234:1"
+}
+```
+
+The address is the `webSocketDebuggerUrl` of the target in
+`http://127.0.0.1:9222/json/list` (the landing page links carry the same
+`PID:<pid>:<page>` id). A plain `"port": 9222` does not work for this: js-debug then
+takes the browser socket from `/json/version`, which is not a JavaScript target.
+
+To browse rather than name one, open the landing page: every JSContext has an
+**Attach from VS Code** block with exactly this config (its own `websocketAddress`),
+ready to copy. js-debug's `chrome` target picker does not list JSContexts - it debugs
+them through the Node path above.
+
+A child session named "Remote Process" appears with the context's scripts; the Debug
+Console evaluates in it. With **Pause new JSContexts on launch** on, a context created
+while the bridge runs comes up stopped on its first statement, so a breakpoint set
+before it runs is hit.
+
+## WebStorm
+
+WebStorm attaches through the same listing: **Run > Edit Configurations > Add >
+Attach to Node.js/Chrome**, host `127.0.0.1`, port `9222`, attach to *Chrome or
+Node.js > 6.3 started with --inspect*. Starting that configuration in Debug opens a
+**Choose Page to Debug** list with every inspectable page and JSContext on the device;
+pick one and the session attaches to it. Breakpoints and the debug console work on a
+Safari page; the bridge answers WebStorm's `Debugger.setSkipAllPauses` with an error
+WebKit does not know the method, which WebStorm tolerates.
+
+WebStorm builds a Node-style target out of a `node` entry's `url`, so JSContexts are
+listed under a `jscontext://<bundle id>/<pid>/<page>` URL. An empty one made WebStorm
+fail with "Malformed URL" as soon as a JSContext was picked.
+
 ## Test automation (Playwright, Puppeteer)
 
 A Chrome-protocol automation framework attaches through the same browser-level
@@ -137,6 +185,59 @@ Notes worth knowing when scripting against a device:
   `promise` subtype, because the bridge recognises built-ins by their class name.
   `await` still behaves; only code that inspects the subtype is affected.
 
+## Attaching before a page or context runs
+
+Safari's Develop menu can attach to every JSContext an app creates, before the
+context runs its first line ("Automatically Show Web Inspector for JSContexts"), and
+optionally stop it there ("Automatically Pause Connecting to JSContexts"). The bridge
+offers the same through the Chrome protocol: a client that enables
+`Target.setAutoAttach` with `waitForDebuggerOnStart` — VS Code, Playwright and
+Puppeteer all do by default — is attached to each new debuggable before it runs.
+
+What happens per kind of debuggable, because WebKit treats them differently:
+
+- **JSContexts** (and service workers) are held by the app itself: it blocks the
+  thread creating the context until the client has attached and released it with
+  `Runtime.runIfWaitingForDebugger`, which the clients above send once their
+  breakpoints are in place. So a breakpoint on the first line of a context's script
+  hits. WebKit gives up on a debugger that does not release the context within ten
+  seconds and lets the app continue.
+- **WKWebView pages** cannot be held before they run: WebKit offers no hook for it.
+  The bridge attaches the moment the device pushes the listing the page appears in
+  (rather than waiting for the next periodic poll), and reports the attachment with
+  `waitingForDebugger: false`. Once attached, a cross-site navigation of that page
+  creates a new process, and the bridge does hold that one — WebKit's
+  `Target.setPauseOnStart` — until the client's debugger state has been replayed
+  into it, so breakpoints hit from the new document's first script on.
+
+While such a client is connected, every app on the device holds each new JSContext
+for it; the bridge switches this off again when the client detaches. Candidates
+nobody can take — for example a page that never made it into the listing — are
+declined immediately so no app waits.
+
+### Pause new JSContexts on launch
+
+Safari's "Automatically Pause Connecting to JSContexts" has a bridge equivalent that
+also works from the landing page, where DevTools cannot attach before a context
+exists: `pymobiledevice3 webinspector cdp --pause-new-targets`, or the
+**Pause new JSContexts on launch** switch at the top of `http://127.0.0.1:9222/`.
+The flag only sets the switch's initial state; it can be turned on and off while the
+bridge runs.
+
+While it is on, the bridge itself accepts every JSContext an app creates, before the
+context runs: it enables the debugger, lets the app continue, and WebKit stops the
+context on its first statement. The context is listed with a **paused** badge; open
+it and DevTools comes up in the Sources panel on that pause, with the scripts it
+parsed so far. Resume from there as usual. A context nobody opens stays paused until
+it is opened or the switch is turned off, which lets every held context go.
+
+Clients that auto-attach (VS Code, Playwright) get the same held sessions, already
+released, and see the pause once their debugger is enabled. Pages cannot be held
+before they run; with the switch on, a page a client auto-attaches is paused on its
+next statement after the client's debugger comes up, and a cross-site navigation of
+an attached page pauses on the new document's first statement. Debuggables that
+already existed when a client attached keep running, as in Safari.
+
 ## Caveats
 
 - WebKit allows a single inspector session per page, so two *separate* debuggers
@@ -145,5 +246,5 @@ Notes worth knowing when scripting against a device:
   skipped after a short wait — detach the other client first. A single client may
   open as many CDP sessions onto a page as it likes (Playwright does this when a
   script also opens a raw `newCDPSession`); those share the one underlying session.
-- The page listing is polled, so tabs opened on the device after the attach are
-  discovered (and auto-attached) within a couple of seconds.
+- The page listing is polled as a fallback, so a tab the device did not announce on
+  its own is still discovered (and auto-attached) within a couple of seconds.

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -396,9 +396,32 @@ async def cdp(
     host: str = "127.0.0.1",
     port: int = 9222,
     chrome: Optional[str] = None,
+    pause_new_targets: Annotated[
+        bool,
+        typer.Option(
+            "--pause-new-targets",
+            help="Attach to every JSContext an app creates before it runs and stop it on its first "
+            'statement (Safari\'s "Automatically Pause Connecting to JSContexts"); open it from the '
+            "landing page to land on the pause. Sets the initial state of the landing page's "
+            '"Pause new JSContexts on launch" switch.',
+        ),
+    ] = False,
 ) -> None:
     """
     Start a CDP server for debugging WebViews and inspectable JSContexts.
+
+    \b
+    A client that auto-attaches with waitForDebuggerOnStart (VS Code, Playwright, Puppeteer)
+    is attached to every JSContext an application creates before the context runs, and holds
+    it until the client releases it - the equivalent of Safari's "Automatically Show Web
+    Inspector for JSContexts". WKWebView pages cannot be held before they run; they are
+    attached the moment they appear, and their cross-site navigations are held until the
+    client's breakpoints reached the new process.
+
+    \b
+    --pause-new-targets (or the switch on the landing page) is Safari's "Automatically Pause
+    Connecting to JSContexts": every new JSContext is stopped on its first statement and
+    listed as paused; opening it lands DevTools on that pause.
 
     \b
     Open the following URL in Google Chrome and pick a page to inspect:
@@ -423,6 +446,7 @@ async def cdp(
     """
     app.state.inspector = WebinspectorService(lockdown=service_provider)
     app.state.chrome_path = find_chrome(chrome)
+    app.state.pause_new_targets = pause_new_targets
     print(f"Web Inspector ready. Open in Google Chrome: http://{host}:{port}/")
     server = uvicorn.Server(
         uvicorn.Config(

--- a/pymobiledevice3/services/web_protocol/cdp_browser.py
+++ b/pymobiledevice3/services/web_protocol/cdp_browser.py
@@ -9,7 +9,14 @@ from fastapi import WebSocket
 
 from pymobiledevice3.services.web_protocol.cdp_target import CdpTarget
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
-from pymobiledevice3.services.webinspector import Application, Page, WebinspectorService, WirTypes, make_target_id
+from pymobiledevice3.services.webinspector import (
+    Application,
+    AutomaticInspectionCandidate,
+    Page,
+    WebinspectorService,
+    WirTypes,
+    make_target_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +37,11 @@ PAGE_LISTING_FLUSH = 0.5
 TARGET_CREATION_TIMEOUT = 30
 # Seconds between page-listing refreshes while target discovery/auto-attach is active
 TARGET_POLL_INTERVAL = 2.0
+# Seconds a JSContext that appeared in a listing is left to its automatic-inspection candidate
+# before being attached as an already-running target. The device pushes the listing a few
+# milliseconds ahead of the candidate; a context that never gets one (made inspectable before
+# automatic inspection reached its process) is picked up by the poll after this.
+CANDIDATE_GRACE = 3.0
 # Seconds to wait for another debugger session on the same page to tear down before skipping it
 PAGE_LOCK_TIMEOUT = 5
 # Seconds a page-endpoint connection waits for the page after asking the session holding it to hand
@@ -57,6 +69,19 @@ PAGE_LOCKS: dict[str, asyncio.Lock] = {}
 # old session's WIR teardown still completes before the new one's socket setup.
 PAGE_TAKEOVERS: dict[str, asyncio.Event] = {}
 
+# Debuggables the bridge itself attached to before they ran and is keeping paused for whichever
+# frontend opens them (see HeldTargets), by page id. Both endpoints adopt from here before
+# setting up a session of their own.
+HELD_TARGETS: dict[str, CdpTarget] = {}
+
+
+def adopt_held_target(page_id: str) -> Optional[CdpTarget]:
+    """Take the session the bridge is holding for a page, if any, to attach a frontend to it."""
+    target = HELD_TARGETS.pop(page_id, None)
+    if target is not None:
+        target.adopt()
+    return target
+
 
 def iter_inspectable(inspector: WebinspectorService) -> "Iterator[tuple[str, Application, Page]]":
     """Walk every debuggable the bridge can attach to, as (target id, application, page).
@@ -64,11 +89,17 @@ def iter_inspectable(inspector: WebinspectorService) -> "Iterator[tuple[str, App
     The target id qualifies the page with its application (see `make_target_id`); the bare page
     identifier would collide, most visibly across JSContexts.
     """
-    for app_id, pages in inspector.application_pages.items():
-        application = inspector.connected_application.get(app_id)
-        if application is None:
-            continue
-        for page_id, page in pages.items():
+    # The device reports a process's pages in whatever order it holds them (3, 1, 4, 2, 5 for
+    # JSContexts); list applications by name and each one's pages by number.
+    applications = sorted(
+        ((application, app_id) for app_id, application in inspector.connected_application.items()),
+        key=lambda item: (item[0].name.lower(), item[0].pid),
+    )
+    for application, app_id in applications:
+        pages = inspector.application_pages.get(app_id, {})
+        for page_id, page in sorted(
+            pages.items(), key=lambda item: (not item[0].isdigit(), int(item[0]) if item[0].isdigit() else 0, item[0])
+        ):
             if page.type_ in INSPECTABLE_TYPES:
                 yield make_target_id(app_id, page_id), application, page
 
@@ -78,11 +109,20 @@ def target_type(page: Page) -> str:
     return JS_TARGET_TYPE if page.type_ == WirTypes.JAVASCRIPT else "page"
 
 
+def target_url(application: Application, page: Page) -> str:
+    """URL to advertise a debuggable under. A JSContext has no document; name it after its
+    process instead of leaving the field empty - WebStorm builds its Node-style target from
+    this field and fails with "Malformed URL" on an empty one."""
+    if page.type_ == WirTypes.JAVASCRIPT:
+        return f"jscontext://{application.bundle}/{application.pid}/{page.id_}"
+    return page.web_url
+
+
 def target_title(application: Application, page: Page) -> str:
     """Title to advertise a debuggable under. JSContexts are all named "JSContext" and have no URL
-    to tell them apart, so name their process instead."""
+    to tell them apart, so name their process and their number instead."""
     if page.type_ == WirTypes.JAVASCRIPT:
-        return f"{application.name} ({application.pid}): {page.web_title or 'JSContext'}"
+        return f"{application.name} ({application.pid}): {page.web_title or 'JSContext'} #{page.id_}"
     return page.web_title or ""
 
 
@@ -123,11 +163,32 @@ class CdpBrowser:
     Target.setDiscoverTargets -> Target.targetCreated -> Target.attachToTarget, with every
     per-page message carrying the attachment's sessionId. Each attached page is backed by an
     ordinary CdpTarget whose messages are tagged/untagged with that sessionId here.
+
+    Target.setAutoAttach with waitForDebuggerOnStart attaches debuggables before they run: the
+    bridge enables webinspectord's automatic inspection, so an application creating a JSContext
+    (or service worker) blocks until this client has attached and released it with
+    Runtime.runIfWaitingForDebugger - Safari's "Automatically Show Web Inspector for JSContexts".
+    WebKit offers no such hold for a WKWebView's page; those are attached the moment the device
+    pushes the listing they appear in, and the navigation-created targets of an attached page
+    are held (Target.setPauseOnStart) until the client's debugger setup reached them.
+
+    :param pause_on_start: Also stop every auto-attached debuggable on its first statement -
+        Safari's "Automatically Pause Connecting to JSContexts" (see CdpTarget.pause_on_start).
     """
 
-    def __init__(self, inspector: WebinspectorService, websocket: WebSocket) -> None:
+    def __init__(self, inspector: WebinspectorService, websocket: WebSocket, pause_on_start: bool = False) -> None:
         self.inspector = inspector
         self.websocket = websocket
+        self._pause_on_start = pause_on_start
+        # Target.setAutoAttach(waitForDebuggerOnStart): attach before the debuggable runs.
+        self._wait_for_debugger = False
+        self._automatic_inspection_enabled = False
+        self._candidates: Optional[asyncio.Queue[AutomaticInspectionCandidate]] = None
+        self._candidate_task: Optional[asyncio.Task[None]] = None
+        self._listings: Optional[asyncio.Queue[str]] = None
+        self._listing_task: Optional[asyncio.Task[None]] = None
+        # JSContexts left to their candidate: page_id -> loop time to stop waiting for one
+        self._awaiting_candidate: dict[str, float] = {}
         # sessionIds handed out by Target.attachToBrowserTarget; commands arriving under them are
         # browser-level commands, not page messages
         self._browser_sessions: set[str] = set()
@@ -168,8 +229,80 @@ class CdpBrowser:
             self._poll_task.cancel()
             await asyncio.gather(self._poll_task, return_exceptions=True)
             self._poll_task = None
+        await self._stop_waiting_for_new_targets()
         for attachment in list(self._attachments.values()):
             await self._close_attachment(attachment, notify=False)
+
+    async def _start_waiting_for_new_targets(self) -> None:
+        """Take automatic-inspection candidates and pushed listings as they come."""
+        # With the pause flag on, the bridge's own holder takes every candidate (HeldTargets) and
+        # this client adopts the held session when the context shows up in a listing.
+        if self._candidates is None and not self._pause_on_start:
+            self._candidates = self.inspector.subscribe_automatic_inspection()
+            self._candidate_task = asyncio.create_task(self._consume_candidates(self._candidates))
+        if self._listings is None:
+            self._listings = self.inspector.subscribe_listings()
+            self._listing_task = asyncio.create_task(self._consume_listings(self._listings))
+        if not self._automatic_inspection_enabled:
+            self._automatic_inspection_enabled = True
+            await self.inspector.set_automatic_inspection_enabled(True)
+
+    async def _stop_waiting_for_new_targets(self) -> None:
+        for task in (self._candidate_task, self._listing_task):
+            if task is not None:
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+        self._candidate_task = self._listing_task = None
+        if self._candidates is not None:
+            self.inspector.unsubscribe_automatic_inspection(self._candidates)
+            # Candidates offered but not yet taken would otherwise keep their apps waiting.
+            while not self._candidates.empty():
+                await self.inspector.reject_automatic_inspection(self._candidates.get_nowait())
+            self._candidates = None
+        if self._listings is not None:
+            self.inspector.unsubscribe_listings(self._listings)
+            self._listings = None
+        if self._automatic_inspection_enabled:
+            self._automatic_inspection_enabled = False
+            await self.inspector.set_automatic_inspection_enabled(False)
+
+    async def _consume_candidates(self, candidates: "asyncio.Queue[AutomaticInspectionCandidate]") -> None:
+        while True:
+            candidate = await candidates.get()
+            try:
+                await self._take_candidate(candidate)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception(f"failed taking automatic inspection candidate {candidate}")
+                await self.inspector.reject_automatic_inspection(candidate)
+
+    async def _take_candidate(self, candidate: AutomaticInspectionCandidate) -> None:
+        """Attach to a debuggable its application is holding for us, or decline it."""
+        page_id = make_target_id(candidate.app_id, str(candidate.page_id))
+        self._awaiting_candidate.pop(page_id, None)
+        # The application pushed its listing right before the candidate was reported, so the
+        # page is already known; announce it to the client, then attach.
+        await self._sync_targets(attach=False)
+        if page_id not in self._known_targets:
+            logger.warning(f"declining automatic inspection of {page_id}: not in the application's listing")
+            await self.inspector.reject_automatic_inspection(candidate)
+            return
+        if not await self._auto_attach_page(page_id, waiting_for_debugger=True):
+            await self.inspector.reject_automatic_inspection(candidate)
+
+    async def _consume_listings(self, listings: "asyncio.Queue[str]") -> None:
+        while True:
+            await listings.get()
+            # One pass covers every listing that arrived meanwhile.
+            while not listings.empty():
+                listings.get_nowait()
+            try:
+                await self._sync_targets()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("target sync failed")
 
     async def _send(self, message: dict[str, Any]) -> None:
         logger.debug(f"BROWSER CDP OUTPUT: {message}")
@@ -240,11 +373,22 @@ class CdpBrowser:
         await self._reply(message, {})
 
     async def _target_set_auto_attach(self, message: dict[str, Any]) -> None:
-        self._auto_attach = bool(message.get("params", {}).get("autoAttach"))
+        params = message.get("params", {})
+        self._auto_attach = bool(params.get("autoAttach"))
+        wait_for_debugger = self._auto_attach and bool(params.get("waitForDebuggerOnStart"))
         if self._auto_attach:
             self._events_session = message.get("sessionId")
+            # The debuggables that exist now are already running: attach them as such, before
+            # new JSContexts start being left to their candidates.
             await self._refresh_targets()
             self._ensure_poll()
+        self._wait_for_debugger = wait_for_debugger
+        if wait_for_debugger:
+            for attachment in self._attachments.values():
+                await attachment.target.hold_new_targets()
+            await self._start_waiting_for_new_targets()
+        else:
+            await self._stop_waiting_for_new_targets()
         await self._reply(message, {})
 
     async def _target_get_targets(self, message: dict[str, Any]) -> None:
@@ -302,9 +446,15 @@ class CdpBrowser:
         return {target_id: (application, page) for target_id, application, page in iter_inspectable(self.inspector)}
 
     async def _refresh_targets(self) -> None:
+        """Ask every application for its listing, then bring the client's target list up to date."""
+        await self.inspector.get_open_pages()
+        await self.inspector.flush_input(PAGE_LISTING_FLUSH)
+        await self._sync_targets()
+
+    async def _sync_targets(self, attach: bool = True) -> None:
+        """Bring the client's target list in line with the listings already received: announce
+        new pages, destroy gone ones and, unless `attach` is off, auto-attach the new ones."""
         async with self._refresh_lock:
-            await self.inspector.get_open_pages()
-            await self.inspector.flush_input(PAGE_LISTING_FLUSH)
             pages = self._list_pages()
             for page_id in [known for known in self._known_targets if known not in pages]:
                 await self._destroy_target(page_id)
@@ -321,11 +471,34 @@ class CdpBrowser:
                 }
                 if is_new and self._discover:
                     await self._send_event("Target.targetCreated", {"targetInfo": self._known_targets[page_id]})
-                if self._auto_attach and page_id not in self._attachments:
+                if attach and self._auto_attach and page_id not in self._attachments:
+                    if self._left_to_its_candidate(page_id, page):
+                        continue
                     await self._auto_attach_page(page_id)
+
+    def _left_to_its_candidate(self, page_id: str, page: Page) -> bool:
+        """Whether a listed JSContext is to be attached from its automatic-inspection candidate
+        rather than from the listing - like Safari, which only ever attaches on the candidate.
+
+        The listing lands a few milliseconds ahead of the candidate; attaching from it would
+        adopt the context as running and the candidate would find it already attached, leaving
+        the application waiting for a release that never comes. Give up after CANDIDATE_GRACE.
+        """
+        if not self._wait_for_debugger or page.type_ != WirTypes.JAVASCRIPT or page_id in HELD_TARGETS:
+            return False
+        now = asyncio.get_event_loop().time()
+        deadline = self._awaiting_candidate.get(page_id)
+        if deadline is None:
+            self._awaiting_candidate[page_id] = now + CANDIDATE_GRACE
+            return True
+        if now < deadline:
+            return True
+        del self._awaiting_candidate[page_id]
+        return False
 
     async def _destroy_target(self, page_id: str) -> None:
         self._known_targets.pop(page_id, None)
+        self._awaiting_candidate.pop(page_id, None)
         attachment = self._attachments.get(page_id)
         if attachment is not None:
             await self._close_attachment(attachment, notify=True)
@@ -338,26 +511,35 @@ class CdpBrowser:
             event["sessionId"] = self._events_session
         await self._send(event)
 
-    async def _auto_attach_page(self, page_id: str) -> None:
-        session_id = await self._attach_page(page_id)
+    async def _auto_attach_page(self, page_id: str, waiting_for_debugger: bool = False) -> bool:
+        """Attach and announce the attachment.
+
+        :param waiting_for_debugger: The debuggable is held until the client releases it with
+            Runtime.runIfWaitingForDebugger (an automatic-inspection candidate).
+        :returns: Whether the page was attached.
+        """
+        session_id = await self._attach_page(page_id, waiting_for_debugger)
         if session_id is None:
-            return
+            return False
         await self._send_event(
             "Target.attachedToTarget",
             {
                 "sessionId": session_id,
                 "targetInfo": self._known_targets[page_id],
-                "waitingForDebugger": False,
+                "waitingForDebugger": waiting_for_debugger,
             },
         )
+        return True
 
-    async def _attach_page(self, page_id: str) -> Optional[str]:
+    async def _attach_page(self, page_id: str, waiting_for_debugger: bool = False) -> Optional[str]:
         """Attach to a page and return the CDP sessionId of this attachment.
 
         Attaching to a page that is already attached opens an additional session onto the same
         target rather than handing back the existing one: a client keeps its own request ids per
         session, and giving two of them the same session id makes each receive the other's
         answers - which trips an assertion in the client and takes the whole connection down.
+
+        :param waiting_for_debugger: The debuggable is held for us (see _auto_attach_page).
         """
         attachment = self._attachments.get(page_id)
         if attachment is not None:
@@ -373,10 +555,44 @@ class CdpBrowser:
         except (asyncio.TimeoutError, TimeoutError):
             logger.warning(f"page {page_id}: busy with another debugger session, not attaching")
             return None
+        held = adopt_held_target(page_id)
+        if held is not None:
+            # The bridge attached before the context ran and has kept it paused; the client gets
+            # that session, already released, and sees the pause once its debugger is on.
+            target = held
+            waiting_for_debugger = False
+        else:
+            target = await self._create_target(page_id, application, page, waiting_for_debugger, lock)
+            if target is None:
+                return None
+        target.waiting_for_debugger = waiting_for_debugger
+        # Pause mode is for debuggables created while the client waits for new ones; the ones
+        # that already existed when it enabled auto-attach (attached before _wait_for_debugger
+        # is set) are running and stay that way.
+        target.pause_on_start = self._pause_on_start and self._wait_for_debugger
+        if self._wait_for_debugger:
+            await target.hold_new_targets()
+        attachment = _PageAttachment(page_id, target, lock)
+        attachment.pump = asyncio.create_task(self._pump(attachment))
+        self._attachments[page_id] = attachment
+        if page_id in self._known_targets:
+            self._known_targets[page_id]["attached"] = True
+        return self._open_session(attachment)
+
+    async def _create_target(
+        self, page_id: str, application: Application, page: Page, waiting_for_debugger: bool, lock: asyncio.Lock
+    ) -> Optional[CdpTarget]:
+        """Set up a fresh inspector session on a page. Releases `lock` and returns None if the
+        device never reports the target."""
         wir_session_id = str(uuid.uuid4()).upper()
         protocol = SessionProtocol(self.inspector, wir_session_id, application, page, method_prefix="")
         try:
-            target = await asyncio.wait_for(CdpTarget.create(protocol), TARGET_CREATION_TIMEOUT)
+            # A held debuggable is paused by WebKit itself on release when asked to; anything
+            # else the bridge pauses once its debugger is enabled (see CdpTarget.pause_on_start).
+            return await asyncio.wait_for(
+                CdpTarget.create(protocol, automatically_pause=waiting_for_debugger and self._pause_on_start),
+                TARGET_CREATION_TIMEOUT,
+            )
         except (asyncio.TimeoutError, TimeoutError):
             # A page already being debugged over another Web Inspector connection - a second
             # pymobiledevice3, Safari's own Web Inspector, or a client that exited without
@@ -393,12 +609,6 @@ class CdpBrowser:
             await self.inspector.teardown_inspector_socket(wir_session_id, application.id_, page.id_)
             lock.release()
             return None
-        attachment = _PageAttachment(page_id, target, lock)
-        attachment.pump = asyncio.create_task(self._pump(attachment))
-        self._attachments[page_id] = attachment
-        if page_id in self._known_targets:
-            self._known_targets[page_id]["attached"] = True
-        return self._open_session(attachment)
 
     def _open_session(self, attachment: _PageAttachment) -> str:
         """Register one more CDP session onto an attached page."""
@@ -463,3 +673,117 @@ class CdpBrowser:
                     "Target.detachedFromTarget",
                     {"sessionId": session_id, "targetId": attachment.page_id},
                 )
+
+
+class HeldTargets:
+    """The bridge's own automatic-inspection debugger: `cdp --pause-new-targets` for frontends
+    that cannot be attached before a debuggable exists - DevTools opened from the landing page.
+
+    What Safari does with both Develop-menu options on: every JSContext (or service worker) an
+    application creates is accepted before it runs, its session initialized so WebKit stops it on
+    its first statement, and the session kept - listed as paused - until a frontend opens it and
+    adopts the session (see adopt_held_target), finding it paused where it was stopped. The
+    application itself resumes right away, blocked only for the milliseconds the setup takes.
+    """
+
+    def __init__(self, inspector: WebinspectorService) -> None:
+        self.inspector = inspector
+        self._candidates: Optional[asyncio.Queue[AutomaticInspectionCandidate]] = None
+        self._listings: Optional[asyncio.Queue[str]] = None
+        self._tasks: list[asyncio.Task[None]] = []
+
+    @property
+    def running(self) -> bool:
+        return self._candidates is not None
+
+    async def start(self) -> None:
+        if self.running:
+            return
+        self._candidates = self.inspector.subscribe_automatic_inspection()
+        self._listings = self.inspector.subscribe_listings()
+        self._tasks = [
+            asyncio.create_task(self._consume_candidates(self._candidates)),
+            asyncio.create_task(self._consume_listings(self._listings)),
+        ]
+        await self.inspector.set_automatic_inspection_enabled(True)
+
+    async def stop(self) -> None:
+        """Let go of every held session and stop being offered new ones."""
+        if not self.running:
+            return
+        for task in self._tasks:
+            task.cancel()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks = []
+        if self._candidates is not None:
+            self.inspector.unsubscribe_automatic_inspection(self._candidates)
+            while not self._candidates.empty():
+                await self.inspector.reject_automatic_inspection(self._candidates.get_nowait())
+            self._candidates = None
+        if self._listings is not None:
+            self.inspector.unsubscribe_listings(self._listings)
+            self._listings = None
+        for page_id in list(HELD_TARGETS):
+            await self._drop(page_id)
+        await self.inspector.set_automatic_inspection_enabled(False)
+
+    async def _consume_candidates(self, candidates: "asyncio.Queue[AutomaticInspectionCandidate]") -> None:
+        while True:
+            candidate = await candidates.get()
+            try:
+                await self._hold(candidate)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception(f"failed holding automatic inspection candidate {candidate}")
+                await self.inspector.reject_automatic_inspection(candidate)
+
+    async def _hold(self, candidate: AutomaticInspectionCandidate) -> None:
+        page_id = make_target_id(candidate.app_id, str(candidate.page_id))
+        try:
+            application, page = self.inspector.find_page_id(page_id)
+        except KeyError:
+            logger.warning(f"declining automatic inspection of {page_id}: not in the application's listing")
+            await self.inspector.reject_automatic_inspection(candidate)
+            return
+        lock = PAGE_LOCKS.setdefault(page_id, asyncio.Lock())
+        if page.type_ not in INSPECTABLE_TYPES or lock.locked() or page_id in HELD_TARGETS:
+            await self.inspector.reject_automatic_inspection(candidate)
+            return
+        # Held only while the session is set up: a frontend adopting the session takes the lock
+        # for itself the usual way, and finds the session in HELD_TARGETS once it has it.
+        async with lock:
+            protocol = SessionProtocol(self.inspector, str(uuid.uuid4()).upper(), application, page, method_prefix="")
+            try:
+                target = await asyncio.wait_for(
+                    CdpTarget.create(protocol, automatically_pause=True), TARGET_CREATION_TIMEOUT
+                )
+            except (asyncio.TimeoutError, TimeoutError):
+                logger.error(f"page {page_id}: device did not report an inspection target in time")
+                await self.inspector.teardown_inspector_socket(protocol.id_, application.id_, page.id_)
+                await self.inspector.reject_automatic_inspection(candidate)
+                return
+            target.waiting_for_debugger = True
+            target.pause_on_start = True
+            target.start_holding()
+            # The debugger must be on for the pause to land; then let the application go - WebKit
+            # stops the context on its first statement (the socket was set up to pause).
+            await target.enable_debugger()
+            await target.release_debugger()
+            HELD_TARGETS[page_id] = target
+        logger.info(f"holding {page_id} paused on its first statement")
+
+    async def _consume_listings(self, listings: "asyncio.Queue[str]") -> None:
+        while True:
+            await listings.get()
+            while not listings.empty():
+                listings.get_nowait()
+            listed = {page_id for page_id, _, _ in iter_inspectable(self.inspector)}
+            for page_id in [held for held in HELD_TARGETS if held not in listed]:
+                # The context went away (its process exited) with nobody ever having opened it.
+                await self._drop(page_id)
+
+    async def _drop(self, page_id: str) -> None:
+        target = HELD_TARGETS.pop(page_id, None)
+        if target is not None:
+            await target.close()

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -19,18 +19,22 @@ from fastapi.logger import logger
 from fastapi.responses import HTMLResponse, Response
 
 from pymobiledevice3.services.web_protocol.cdp_browser import (
+    HELD_TARGETS,
     PAGE_HANDOVER_TIMEOUT,
     PAGE_LOCKS,
     PAGE_TAKEOVERS,
     TARGET_CREATION_TIMEOUT,
     CdpBrowser,
+    HeldTargets,
+    adopt_held_target,
     iter_inspectable,
     target_title,
     target_type,
+    target_url,
 )
 from pymobiledevice3.services.web_protocol.cdp_target import CdpTarget
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
-from pymobiledevice3.services.webinspector import Page, WebinspectorService, WirTypes
+from pymobiledevice3.services.webinspector import Application, Page, WebinspectorService, WirTypes
 
 # chrome://inspect routes a network target's DevTools through Chrome's browser-process relay,
 # which deadlocks after sustained console traffic (the console/screen freeze). Serving the DevTools
@@ -78,7 +82,7 @@ _CHROME_DEFAULT_PATHS: dict[str, tuple[str, ...]] = {
 
 
 NO_TARGETS_MESSAGE = "No inspectable pages. Open a page in Safari."
-NO_TARGETS_MESSAGE_HTML = f"<p>{NO_TARGETS_MESSAGE}</p>"
+NO_TARGETS_MESSAGE_HTML = f'<p class="empty">{NO_TARGETS_MESSAGE}</p>'
 
 # How often the landing page re-reads the target list. Serving one is a read of already-pushed
 # state (see refresh_listings), so this can be short enough that a tab opened or closed on the
@@ -86,39 +90,194 @@ NO_TARGETS_MESSAGE_HTML = f"<p>{NO_TARGETS_MESSAGE}</p>"
 # polling while it is not the visible tab.
 INDEX_POLL_INTERVAL_MS = 750
 
+# Label of the landing page's pause-on-launch switch (see pause_new_targets endpoints).
+PAUSE_NEW_TARGETS_LABEL = "Pause new JSContexts on launch"
+
+INDEX_STYLE = """
+:root {
+  color-scheme: light dark;
+  --bg: #f5f5f7; --card: #ffffff; --text: #1d1d1f; --muted: #6e6e73; --line: #e5e5ea;
+  --accent: #0a84ff; --page: #dbeafe; --page-text: #1e40af; --js: #fef3c7; --js-text: #92400e;
+  --paused: #fde68a; --paused-text: #78350f; --switch: #c7c7cc;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1c1c1e; --card: #2c2c2e; --text: #f5f5f7; --muted: #98989d; --line: #3a3a3c;
+    --page: #1e3a8a; --page-text: #bfdbfe; --js: #78350f; --js-text: #fde68a;
+    --paused: #92400e; --paused-text: #fef3c7; --switch: #48484a;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--bg); color: var(--text);
+  font: 13px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+main { max-width: 760px; margin: 0 auto; padding: 18px 16px 32px; }
+header { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 20px; margin-bottom: 12px; }
+h1 { font-size: 17px; font-weight: 600; margin: 0; flex: 1 1 auto; }
+h1 small { display: block; font-size: 12px; font-weight: 400; color: var(--muted); }
+.toggle { display: inline-flex; align-items: center; gap: 8px; cursor: pointer; user-select: none; font-size: 13px; }
+.toggle input { position: absolute; opacity: 0; width: 0; height: 0; }
+.switch {
+  position: relative; width: 34px; height: 20px; border-radius: 10px; background: var(--switch);
+  transition: background .15s;
+}
+.switch::after {
+  content: ""; position: absolute; top: 2px; left: 2px; width: 16px; height: 16px; border-radius: 50%;
+  background: #fff; box-shadow: 0 1px 3px rgba(0,0,0,.3); transition: transform .15s;
+}
+.toggle input:checked + .switch { background: var(--accent); }
+.toggle input:checked + .switch::after { transform: translateX(14px); }
+.toggle input:focus-visible + .switch { outline: 2px solid var(--accent); outline-offset: 2px; }
+.hint { flex-basis: 100%; margin: 0; font-size: 12px; color: var(--muted); }
+ul.targets { list-style: none; margin: 0; padding: 0; display: grid; gap: 6px; }
+li.target {
+  background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 7px 12px;
+  display: grid; grid-template-columns: auto 1fr; grid-template-rows: auto auto auto; column-gap: 10px; row-gap: 0;
+  align-items: center;
+}
+.kind {
+  grid-row: 1 / span 3; font-size: 10px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+  padding: 2px 7px; border-radius: 999px; white-space: nowrap;
+}
+.kind.page { background: var(--page); color: var(--page-text); }
+.kind.jscontext { background: var(--js); color: var(--js-text); }
+li.target a { color: var(--accent); font-weight: 500; text-decoration: none; overflow-wrap: anywhere; }
+li.target a:hover { text-decoration: underline; }
+li.target small { color: var(--muted); font-size: 11.5px; overflow-wrap: anywhere; }
+.badge {
+  display: inline-block; margin-left: 6px; font-size: 10px; font-weight: 600; padding: 1px 7px;
+  border-radius: 999px; background: var(--paused); color: var(--paused-text); vertical-align: 1px;
+}
+details.attach { grid-column: 2; margin-top: 2px; font-size: 12px; }
+details.attach summary, details.editors summary { cursor: pointer; color: var(--muted); }
+details.attach summary:hover, details.editors summary:hover { color: var(--text); }
+.snippet { position: relative; margin-top: 6px; }
+details.attach pre {
+  margin: 0; padding: 8px 10px; border-radius: 6px; background: var(--bg); border: 1px solid var(--line);
+  font: 11.5px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; overflow-x: auto; user-select: all;
+}
+button.copy {
+  position: absolute; top: 5px; right: 5px; font: 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 2px 7px; border-radius: 5px; border: 1px solid var(--line); background: var(--card); color: var(--text);
+  cursor: pointer; opacity: 0; transition: opacity .15s;
+}
+.snippet:hover button.copy, button.copy:focus-visible, button.copy.done { opacity: 1; }
+button.copy:hover { border-color: var(--accent); }
+button.copy.done { color: var(--accent); border-color: var(--accent); }
+details.editors { flex-basis: 100%; font-size: 12px; color: var(--muted); }
+details.editors p { margin: 6px 0 0; }
+details.editors code { font: 11.5px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--text); }
+p.empty { color: var(--muted); text-align: center; padding: 28px 0; }
+"""
+
 INDEX_SCRIPT = Template("""
 (function () {
   const container = document.getElementById('targets');
+  const toggle = document.getElementById('pause-new-targets');
   let rendered = null;
   function render(targets) {
     container.textContent = '';
     if (!targets.length) {
       const empty = document.createElement('p');
+      empty.className = 'empty';
       empty.textContent = $empty;
       container.appendChild(empty);
       return;
     }
     const list = document.createElement('ul');
+    list.className = 'targets';
     for (const target of targets) {
+      const kind = document.createElement('span');
+      kind.className = 'kind ' + (target.type === 'node' ? 'jscontext' : 'page');
+      kind.textContent = target.type === 'node' ? 'JSContext' : 'Page';
+      const title = document.createElement('span');
       const link = document.createElement('a');
       link.href = target.devtoolsFrontendUrl;
       link.textContent = target.title || target.url || ('page ' + target.id);
+      title.appendChild(link);
+      if (target.paused) {
+        const badge = document.createElement('span');
+        badge.className = 'badge';
+        badge.textContent = 'paused';
+        title.appendChild(badge);
+      }
       const url = document.createElement('small');
       url.textContent = target.url;
+      const attach = document.createElement('details');
+      attach.className = 'attach';
+      const summary = document.createElement('summary');
+      summary.textContent = 'Attach from VS Code';
+      const config = document.createElement('pre');
+      config.textContent = JSON.stringify(target.attach, null, 4);
+      const copy = document.createElement('button');
+      copy.type = 'button';
+      copy.className = 'copy';
+      copy.title = 'Copy to clipboard';
+      copy.textContent = 'Copy';
+      const snippet = document.createElement('div');
+      snippet.className = 'snippet';
+      snippet.append(copy, config);
+      attach.append(summary, snippet);
       const item = document.createElement('li');
-      item.append(link, document.createElement('br'), url);
+      item.className = 'target';
+      item.append(kind, title, url, attach);
       list.appendChild(item);
     }
     container.appendChild(list);
   }
+  container.addEventListener('click', async (event) => {
+    const button = event.target.closest('button.copy');
+    if (!button) {
+      return;
+    }
+    const text = button.parentElement.querySelector('pre').textContent;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (error) {
+      // No clipboard API (a non-loopback host over plain http): fall back to a selection copy.
+      const range = document.createRange();
+      range.selectNodeContents(button.parentElement.querySelector('pre'));
+      const selection = getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+      document.execCommand('copy');
+      selection.removeAllRanges();
+    }
+    button.textContent = 'Copied';
+    button.classList.add('done');
+    setTimeout(() => {
+      button.textContent = 'Copy';
+      button.classList.remove('done');
+    }, 1500);
+  });
+  let pending = false;
+  toggle.addEventListener('change', async () => {
+    pending = true;
+    try {
+      const response = await fetch('/pause-new-targets', {
+        method: 'POST',
+        headers: {'content-type': 'application/json'},
+        body: JSON.stringify({enabled: toggle.checked}),
+      });
+      toggle.checked = (await response.json()).enabled;
+    } catch (error) {
+      toggle.checked = !toggle.checked;
+    } finally {
+      pending = false;
+    }
+  });
   async function poll() {
     if (!document.hidden) {
       try {
-        const targets = await (await fetch('/json/list', {cache: 'no-store'})).json();
-        const serialized = JSON.stringify(targets);
+        const listing = await (await fetch('/api/targets', {cache: 'no-store'})).json();
+        const serialized = JSON.stringify(listing.targets);
         if (serialized !== rendered) {
           rendered = serialized;
-          render(targets);
+          render(listing.targets);
+        }
+        if (!pending) {
+          toggle.checked = listing.pause_new_targets;
         }
       } catch (error) {
         // The bridge is momentarily busy or gone; leave the list as it is and try again.
@@ -169,9 +328,18 @@ async def lifespan(app: FastAPI):
     # lock belongs to a loop that is gone.
     PAGE_LOCKS.clear()
     PAGE_TAKEOVERS.clear()
+    HELD_TARGETS.clear()
     await app.state.inspector.connect()
-    yield
-    _reap_local_frontend()
+    # The bridge's own automatic-inspection debugger (`--pause-new-targets`); toggled from the
+    # landing page as well, so it exists either way and is merely started or not.
+    app.state.holder = HeldTargets(app.state.inspector)
+    if getattr(app.state, "pause_new_targets", False):
+        await app.state.holder.start()
+    try:
+        yield
+    finally:
+        await app.state.holder.stop()
+        _reap_local_frontend()
 
 
 app = FastAPI(lifespan=lifespan)
@@ -304,11 +472,76 @@ async def available_targets(request: Request, _: str):
             "id": target_id,
             "title": target_title(application, page),
             "type": target_type(page),
-            "url": page.web_url,
+            "url": target_url(application, page),
             "webSocketDebuggerUrl": f"ws://{host}/devtools/page/{target_id}",
             "devtoolsFrontendUrl": f"{_frontend_url(page)}?ws={host}/devtools/page/{target_id}",
         })
     return targets
+
+
+def attach_config(application: Application, page: Page, host: str, target_id: str) -> dict[str, Any]:
+    """The VS Code launch.json configuration that attaches to exactly this debuggable.
+
+    js-debug's `chrome` attach takes web pages only and picks them by URL; a JSContext (a
+    `node` target) is reached by its websocket address directly.
+    """
+    title = target_title(application, page)
+    if page.type_ == WirTypes.JAVASCRIPT:
+        return {
+            "name": f"Attach to {title}",
+            "type": "node",
+            "request": "attach",
+            "websocketAddress": f"ws://{host}/devtools/page/{target_id}",
+        }
+    address, _, port = host.rpartition(":")
+    return {
+        "name": f"Attach to {title or page.web_url}",
+        "type": "chrome",
+        "request": "attach",
+        "address": address or host,
+        "port": int(port) if port.isdigit() else 9222,
+        "urlFilter": page.web_url,
+        "webRoot": "${workspaceFolder}",
+    }
+
+
+@app.get("/api/targets")
+async def landing_targets(request: Request) -> dict[str, Any]:
+    """What the landing page renders: the /json/list targets plus what only the bridge knows -
+    which of them it is holding paused, and whether it is taking new ones (the page's switch)."""
+    await refresh_listings()
+    host = request.headers.get("host", "127.0.0.1:9222")
+    targets: list[dict[str, Any]] = []
+    for target_id, application, page in iter_inspectable(app.state.inspector):
+        targets.append({
+            "id": target_id,
+            "title": target_title(application, page),
+            "type": target_type(page),
+            "url": target_url(application, page),
+            "paused": target_id in HELD_TARGETS,
+            "webSocketDebuggerUrl": f"ws://{host}/devtools/page/{target_id}",
+            "devtoolsFrontendUrl": f"{_frontend_url(page)}?ws={host}/devtools/page/{target_id}",
+            "attach": attach_config(application, page, host, target_id),
+        })
+    return {"targets": targets, "pause_new_targets": app.state.holder.running}
+
+
+@app.get("/pause-new-targets")
+async def get_pause_new_targets() -> dict[str, bool]:
+    """Whether the bridge attaches to and pauses every JSContext an app creates (see HeldTargets)."""
+    return {"enabled": app.state.holder.running}
+
+
+@app.post("/pause-new-targets")
+async def set_pause_new_targets(request: Request) -> dict[str, bool]:
+    """Switch pause-on-launch on or off at runtime - the landing page's toggle. Off lets go of
+    every context still held, and stops webinspectord from offering new ones."""
+    body = await request.json()
+    if bool(body.get("enabled")):
+        await app.state.holder.start()
+    else:
+        await app.state.holder.stop()
+    return {"enabled": app.state.holder.running}
 
 
 def _frontend_url(page: Page) -> str:
@@ -328,12 +561,34 @@ async def index(request: Request) -> HTMLResponse:
     the page was loaded appears without reloading it by hand."""
     await refresh_listings()
     host = request.headers.get("host", "127.0.0.1:9222")
+    checked = " checked" if app.state.holder.running else ""
     return HTMLResponse(
-        f"<!doctype html><meta charset=utf-8><title>pymobiledevice3 Web Inspector</title>"
-        f"<h2>pymobiledevice3 Web Inspector</h2>"
+        "<!doctype html><meta charset=utf-8>"
+        '<meta name="viewport" content="width=device-width, initial-scale=1">'
+        "<title>pymobiledevice3 Web Inspector</title>"
+        f"<style>{INDEX_STYLE}</style>"
+        "<main><header>"
+        "<h1>Web Inspector<small>pymobiledevice3 &middot; inspectable pages and JSContexts on the device</small></h1>"
+        f'<label class="toggle"><input type="checkbox" id="pause-new-targets"{checked}>'
+        f'<span class="switch"></span>{PAUSE_NEW_TARGETS_LABEL}</label>'
+        '<p class="hint">Attaches to every JSContext an app creates before it runs and stops it on its '
+        "first statement; open it from the list to land on the pause. "
+        "Pages cannot be held before they run.</p>"
+        '<details class="editors"><summary>Attach from an editor</summary>'
+        "<p><b>VS Code</b>: expand a target below and put its configuration into "
+        "<code>.vscode/launch.json</code> (js-debug is built in). A page configuration attaches "
+        "to that page by URL; a JSContext configuration attaches to that context by its "
+        "websocket address, so it is specific to the process listed.</p>"
+        "<p><b>WebStorm</b>: Run &gt; Edit Configurations &gt; Add &gt; <b>Attach to Node.js/Chrome</b>, "
+        f"host <code>{escape(host.rpartition(':')[0] or host)}</code>, port "
+        f"<code>{escape(host.rpartition(':')[2])}</code>, attach to "
+        "<i>Chrome or Node.js &gt; 6.3 started with --inspect</i>. Debug it and pick the page or "
+        "JSContext from the list WebStorm shows.</p></details>"
+        "</header>"
         # Rendered server-side once so the list is there before any script runs, then kept up to
         # date in place by INDEX_SCRIPT.
         f'<div id="targets">{targets_html(app.state.inspector, host)}</div>'
+        "</main>"
         f"<script>{INDEX_SCRIPT}</script>"
     )
 
@@ -344,12 +599,23 @@ def targets_html(inspector: WebinspectorService, host: str) -> str:
     for target_id, application, page in iter_inspectable(inspector):
         frontend = f"{_frontend_url(page)}?ws={host}/devtools/page/{target_id}"
         title = target_title(application, page) or page.web_url or f"page {target_id}"
+        is_jscontext = page.type_ == WirTypes.JAVASCRIPT
+        kind = f'<span class="kind {"jscontext" if is_jscontext else "page"}">{"JSContext" if is_jscontext else "Page"}</span>'
+        # Attached before it ran and stopped on its first statement; opening it lands there.
+        badge = '<span class="badge">paused</span>' if target_id in HELD_TARGETS else ""
+        config = json.dumps(attach_config(application, page, host, target_id), indent=4)
+        attach = (
+            '<details class="attach"><summary>Attach from VS Code</summary>'
+            '<div class="snippet"><button type="button" class="copy" title="Copy to clipboard">Copy</button>'
+            f"<pre>{escape(config, quote=False)}</pre></div></details>"
+        )
         items.append(
-            f'<li><a href="{escape(frontend)}">{escape(title)}</a><br><small>{escape(page.web_url)}</small></li>'
+            f'<li class="target">{kind}<span><a href="{escape(frontend)}">{escape(title)}</a>{badge}</span>'
+            f"<small>{escape(target_url(application, page))}</small>{attach}</li>"
         )
     if not items:
         return NO_TARGETS_MESSAGE_HTML
-    return "<ul>" + "".join(items) + "</ul>"
+    return '<ul class="targets">' + "".join(items) + "</ul>"
 
 
 @app.get("/devtools/{path:path}")
@@ -387,7 +653,7 @@ async def browser_debugger(websocket: WebSocket, connection_id: str):
     """Browser-level endpoint (the one /json/version advertises): flat-session Target-domain
     debugging for Chrome-compatible clients such as VS Code's js-debug and Puppeteer."""
     await websocket.accept()
-    browser = CdpBrowser(app.state.inspector, websocket)
+    browser = CdpBrowser(app.state.inspector, websocket, pause_on_start=getattr(app.state, "pause_new_targets", False))
     try:
         await browser.run()
     finally:
@@ -433,10 +699,17 @@ async def page_debugger(websocket: WebSocket, page_id: str):
     taken_over = asyncio.Event()
     PAGE_TAKEOVERS[page_id] = taken_over
     try:
+        held = adopt_held_target(page_id)
         try:
-            # Bound the wait: if the device never reports the target (e.g. webinspectord is in a
-            # bad state), fail the connection instead of keeping a zombie handler alive forever.
-            target = await asyncio.wait_for(CdpTarget.create(protocol), TARGET_CREATION_TIMEOUT)
+            if held is not None:
+                # The bridge attached before the context ran and kept it paused on its first
+                # statement for exactly this: the frontend takes that session over and, once its
+                # debugger is on, is shown the pause.
+                target = held
+            else:
+                # Bound the wait: if the device never reports the target (e.g. webinspectord is
+                # in a bad state), fail the connection instead of keeping a zombie handler alive.
+                target = await asyncio.wait_for(CdpTarget.create(protocol), TARGET_CREATION_TIMEOUT)
         except (asyncio.TimeoutError, TimeoutError):
             # A page already being debugged over another Web Inspector connection - a second
             # pymobiledevice3, Safari's own Web Inspector, or a client that exited without

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -3,6 +3,7 @@ import hashlib
 import itertools
 import json
 import logging
+import re
 from collections.abc import Awaitable
 from datetime import datetime
 from functools import partial
@@ -239,9 +240,20 @@ DEBUGGER_PAUSED_REASON = {
     "exception": "exception",
     "assert": "assert",
     "CSPViolation": "CSPViolation",
-    "DebuggerStatement": "debugCommand",
-    "Breakpoint": "instrumentation",
-    "PauseOnNextStatement": "instrumentation",
+    # A `debugger;` statement. V8/Chrome report this as "other", and that is what editors treat
+    # as a genuine suspend to hold. "debugCommand" is Chrome's reason for a pause the client
+    # itself requested via Debugger.pause; WebStorm, seeing it without having asked, took the
+    # pause for spurious and resumed on its own - so `debugger` never stopped it on a JSContext.
+    "DebuggerStatement": "other",
+    # A hit on a source breakpoint. V8/Chrome report this as "other" with hitBreakpoints set;
+    # "instrumentation" is Chrome's reason for its instrumentation breakpoints (DOM/event/...),
+    # which carry data an editor looks for and, not finding, discards the pause - so a breakpoint
+    # a user set on a JSContext line was reached but never surfaced.
+    "Breakpoint": "other",
+    # Chrome's reason for its own pause button. "instrumentation" is reserved for the frontend's
+    # instrumentation breakpoints, which carry breakpoint data; without it the frontend drops
+    # the pause silently and stays at "Not paused".
+    "PauseOnNextStatement": "other",
     "Microtask": "other",
     "BlackboxedScript": "other",
     "other": "other",
@@ -337,6 +349,7 @@ class CdpTarget:
             "Emulation.setEmitTouchEventsForMouse": partial(self._simple_response, value=None),
             "Debugger.setAsyncCallStackDepth": partial(self._simple_response, value=True),
             "Debugger.enable": self._debugger_enable,
+            "Debugger.setSkipAllPauses": self._debugger_set_skip_all_pauses,
             "Debugger.setBreakpointsActive": self._debugger_set_breakpoints_active,
             "Debugger.setBlackboxPatterns": self._debugger_set_blackbox_patterns,
             "Debugger.setBreakpointByUrl": self._debugger_set_breakpoint_by_url,
@@ -351,7 +364,7 @@ class CdpTarget:
             # Overlay is absent in WebKit; only highlightNode is worth translating, the rest are
             # acknowledged by the NOOP_ABSENT_DOMAINS fallback in _input_loop.
             "Overlay.highlightNode": self._overlay_highlight_node,
-            "Runtime.runIfWaitingForDebugger": partial(self._simple_response, value=None),
+            "Runtime.runIfWaitingForDebugger": self._runtime_run_if_waiting_for_debugger,
             "Runtime.enable": self._runtime_enable,
             "Runtime.evaluate": self._runtime_evaluate,
             "Runtime.callFunctionOn": self._runtime_call_function_on,
@@ -455,6 +468,10 @@ class CdpTarget:
         # scriptId -> url, from Debugger.scriptParsed; used to fill the `url` WebKit omits from the
         # callFrames of Debugger.paused (Chrome's CallFrame requires it).
         self._script_id_to_url: dict[str, str] = {}
+        # For a flat JSContext: the synthetic URL handed to the frontend for a URL-less script ->
+        # the script's id. Lets a URL breakpoint (how editors set breakpoints) be turned into a
+        # scriptId-location breakpoint, the only kind that binds on a URL-less script.
+        self._flat_script_url_to_id: dict[str, str] = {}
         self._eval_side_effect_id = 0
         self._default_execution_id = 0
         self._last_console_api_call: Optional[dict[str, Any]] = None
@@ -488,6 +505,27 @@ class CdpTarget:
         self._setup_sent_targets: set[str] = {target_id}
         # Targets announced as pages - the only kind this session talks to (see _target_created).
         self._page_targets: set[str] = {target_id}
+        # The debuggable was attached before it ran (an automatic-inspection candidate) and the
+        # application is blocked until the frontend reports itself initialized. Released by the
+        # client's Runtime.runIfWaitingForDebugger, or on close.
+        self.waiting_for_debugger = False
+        # Stop the debuggable on its first statement once attached (Safari's "Automatically
+        # Pause Connecting to JSContexts"). A held JSContext is paused by WebKit itself on
+        # release (the socket was set up with WIRAutomaticallyPause); anything else - a page,
+        # the target a process swap creates - is paused by the bridge as soon as its debugger is
+        # enabled (see _debugger_enable and _target_created).
+        self.pause_on_start = False
+        # Hold the page target a cross-site navigation creates until its debugger setup has been
+        # replayed (WebKit's Target.setPauseOnStart); see hold_new_targets.
+        self.hold_navigations = False
+        # Targets the bridge already asked to pause, so each is stopped once.
+        self._paused_targets: set[str] = set()
+        # What the target emitted while the bridge held it with no frontend attached (see
+        # start_holding): handed to the frontend that adopts it once its debugger is on.
+        self.held_events: list[dict[str, Any]] = []
+        self._holding_task: Optional[asyncio.Task[None]] = None
+        # id of the adopting frontend's Debugger.enable; the held events follow its response.
+        self._replay_after_id: Optional[int] = None
 
     def next_internal_id(self) -> int:
         """
@@ -535,11 +573,15 @@ class CdpTarget:
                     frame_d[key] = self._to_client_frame_id(frame_d[key])
 
     @classmethod
-    async def create(cls, protocol: SessionProtocol) -> "CdpTarget":
+    async def create(cls, protocol: SessionProtocol, automatically_pause: bool = False) -> "CdpTarget":
         """
         :param pymobiledevice3.services.web_protocol.session_protocol.SessionProtocol protocol: Session protocol.
+        :param automatically_pause: Have WebKit pause the debuggable on its next statement once the
+            frontend is initialized (see WebinspectorService.setup_inspector_socket).
         """
-        await protocol.inspector.setup_inspector_socket(protocol.id_, protocol.app.id_, protocol.page.id_)
+        await protocol.inspector.setup_inspector_socket(
+            protocol.id_, protocol.app.id_, protocol.page.id_, automatically_pause=automatically_pause
+        )
         if protocol.page.type_ == WirTypes.JAVASCRIPT:
             # A JSContext debuggable has no Target domain, so it announces nothing on attach and
             # there is only ever the one target - synthesize its id instead of waiting forever.
@@ -560,6 +602,67 @@ class CdpTarget:
         # Chrome's schema requires (type/title/url/attached) and crashes the frontend's SDK.
         return cls(protocol, target_id)
 
+    async def hold_new_targets(self) -> None:
+        """Ask WebKit to hold the page target a cross-site navigation creates until it is resumed.
+
+        The one creation-time hold WebKit offers for pages: a WKWebView's page runs from the
+        moment it exists, but a navigation that swaps processes announces its provisional target
+        first, and with Target.setPauseOnStart that target waits for Target.resume before its
+        load commits. The bridge resumes it right after replaying the frontend's setup (see
+        _target_created), so breakpoints reach the new process ahead of its first script.
+        """
+        if self.hold_navigations:
+            return
+        self.hold_navigations = True
+        if not self._flat:
+            await self.protocol.send_command("Target.setPauseOnStart", pauseOnStart=True)
+
+    async def release_debugger(self) -> None:
+        """Let a debuggable attached before it ran start running.
+
+        WebKit blocks the thread creating an automatic-inspection candidate until the frontend
+        sends Inspector.initialized (or ten seconds pass); Chrome clients express the same step
+        as Runtime.runIfWaitingForDebugger. Nothing to do for a target that was not held.
+        """
+        if not self.waiting_for_debugger:
+            return
+        self.waiting_for_debugger = False
+        await self._send_message_to_target(
+            {"id": self.next_internal_id(), "method": "Inspector.initialized", "params": {}}, record=False
+        )
+
+    async def enable_debugger(self) -> None:
+        """Turn the debugger on on the bridge's own behalf (with the same extras a frontend's
+        Debugger.enable gets), before any frontend is attached."""
+        await self._debugger_enable({"id": self.next_internal_id(), "method": "Debugger.enable", "params": {}})
+
+    def start_holding(self) -> None:
+        """Keep the target alive with no frontend attached: whatever it emits meanwhile - the
+        scripts it parsed, the pause it stopped at - is kept for the frontend that adopts it."""
+
+        async def collect() -> None:
+            while True:
+                self.held_events.append(await self.output_queue.get())
+
+        self._holding_task = asyncio.create_task(collect())
+
+    def adopt(self) -> None:
+        """Hand a held target to a frontend. What it missed is replayed once it enables the
+        debugger (see _debugger_enable): a pause only means something to a debugger that is on,
+        and that is the order a fresh backend would have produced."""
+        if self._holding_task is not None:
+            self._holding_task.cancel()
+            self._holding_task = None
+
+    async def _pause_target(self, target_id: str) -> None:
+        """Stop a target on its next statement, once, if the client's debugger is on."""
+        if target_id in self._paused_targets or "Debugger.enable" not in self._setup_messages:
+            return
+        self._paused_targets.add(target_id)
+        await self._send_message_to_target(
+            {"id": self.next_internal_id(), "method": "Debugger.pause", "params": {}}, target_id=target_id, record=False
+        )
+
     async def close(self) -> None:
         """
         Stop the queue-consumer tasks and any running screencast, and tear down the WIR socket.
@@ -567,6 +670,12 @@ class CdpTarget:
         if self.screencast is not None:
             await self.screencast.stop()
             self.screencast = None
+        # A held debuggable must not outlive its debugger: release it before the socket goes.
+        await self.release_debugger()
+        if self._holding_task is not None:
+            self._holding_task.cancel()
+            await asyncio.gather(self._holding_task, return_exceptions=True)
+            self._holding_task = None
         for task in (self._input_task, self._receiving_task, *self._background_tasks):
             task.cancel()
         await asyncio.gather(self._input_task, self._receiving_task, *self._background_tasks, return_exceptions=True)
@@ -1997,6 +2106,9 @@ class CdpTarget:
         await self._send_message_to_target(message)
 
     async def _debugger_enable(self, message: dict[str, Any]):
+        if self.held_events and self._holding_task is None:
+            # An adopting frontend: what the target emitted while held follows this response.
+            self._replay_after_id = message["id"]
         await self._send_message_to_target(message)
         # Two WebKit quirks conspire to make the debugger never stop, and Chrome's frontend papers
         # over neither because its own backend behaves differently:
@@ -2018,6 +2130,32 @@ class CdpTarget:
             "method": "Debugger.setPauseOnDebuggerStatements",
             "params": {"enabled": True},
         })
+        if self.pause_on_start and not self.waiting_for_debugger:
+            # Pause mode on a debuggable that could not be held before it ran: stop it on its
+            # next statement now that the client's debugger is on. A held one is paused by
+            # WebKit itself when released.
+            await self._pause_target(self.target_id)
+
+    async def _debugger_set_skip_all_pauses(self, message: dict[str, Any]) -> None:
+        # WebKit has no setSkipAllPauses (WebStorm sends it on attach); skipping every pause is
+        # what deactivating breakpoints and debugger statements amounts to, and un-skipping is
+        # the state _debugger_enable establishes. Both are replayed onto new targets.
+        skip = bool(message.get("params", {}).get("skip"))
+        await self._send_message_to_target({
+            "id": self.next_internal_id(),
+            "method": "Debugger.setBreakpointsActive",
+            "params": {"active": not skip},
+        })
+        await self._send_message_to_target({
+            "id": self.next_internal_id(),
+            "method": "Debugger.setPauseOnDebuggerStatements",
+            "params": {"enabled": not skip},
+        })
+        await self._result_response(message, {})
+
+    async def _runtime_run_if_waiting_for_debugger(self, message: dict[str, Any]) -> None:
+        await self.release_debugger()
+        await self._simple_response(message, None)
 
     async def _debugger_set_breakpoints_active(self, message: dict[str, Any]):
         # Chrome's "Deactivate breakpoints" toggle also suppresses `debugger;` statements; mirror
@@ -2038,10 +2176,46 @@ class CdpTarget:
         await self._simple_response(message, None)
 
     async def _debugger_set_breakpoint_by_url(self, message: dict[str, Any]):
-        condition = message["params"].pop("condition", "")
+        params = message["params"]
+        if self._flat:
+            script_id = self._flat_breakpoint_script(params)
+            if script_id is not None:
+                # A URL breakpoint does not bind on a URL-less JSContext script; set it by the
+                # script's location instead - the only kind that binds - and answer the frontend
+                # in the shape it expects from setBreakpointByUrl.
+                location: dict[str, Any] = {"scriptId": script_id, "lineNumber": params.get("lineNumber", 0)}
+                if "columnNumber" in params:
+                    location["columnNumber"] = params["columnNumber"]
+                set_params: dict[str, Any] = {"location": location}
+                if params.get("condition"):
+                    set_params["options"] = {"condition": params["condition"]}
+                response = await self.send_message_with_result("Debugger.setBreakpoint", set_params)
+                result = response.get("result", {})
+                breakpoint_id = result.get("breakpointId") or f"url:{params.get('url')}"
+                locations = [result["actualLocation"]] if "actualLocation" in result else []
+                await self._result_response(message, {"breakpointId": breakpoint_id, "locations": locations})
+                return
+        condition = params.pop("condition", "")
         if condition:
-            message["params"]["options"]["condition"] = condition
+            params["options"]["condition"] = condition
         await self._send_message_to_target(message)
+
+    def _flat_breakpoint_script(self, params: dict[str, Any]) -> Optional[str]:
+        """The JSContext script a URL breakpoint targets: by exact synthetic URL, or by a urlRegex
+        that matches one. None when it targets no known script (then it is forwarded unchanged)."""
+        url = params.get("url")
+        if url and url in self._flat_script_url_to_id:
+            return self._flat_script_url_to_id[url]
+        url_regex = params.get("urlRegex")
+        if url_regex:
+            try:
+                pattern = re.compile(url_regex)
+            except re.error:
+                return None
+            for known_url, script_id in self._flat_script_url_to_id.items():
+                if pattern.search(known_url):
+                    return script_id
+        return None
 
     async def _domdebugger_get_event_listeners(self, message: dict[str, Any]):
         node = {"nodeId": await self.object_id_to_node_id(message["params"]["objectId"])}
@@ -2556,6 +2730,12 @@ class CdpTarget:
         # Network/Page/Console/Debugger event ever arrives again after a process swap and the
         # session appears dead after a couple of link clicks.
         await self._send_setup_to_target(new_target_id)
+        if target_info.get("isPaused", False):
+            # Held by Target.setPauseOnStart (see hold_new_targets) - its setup is in place now,
+            # so let its load commit; in pause mode, stopped on its first statement.
+            if self.pause_on_start:
+                await self._pause_target(new_target_id)
+            await self.protocol.send_command("Target.resume", targetId=new_target_id)
         await self.output_queue.put({
             "method": "Target.targetInfoChanged",
             "params": {
@@ -2670,11 +2850,33 @@ class CdpTarget:
             # Expected protocol-level errors (e.g. element-only DOM queries on text nodes) are
             # already delivered to the frontend, which copes; don't shout about them here.
             logger.debug(f"Target error response: {message}")
+            data = message["error"].get("data")
+            if data is not None and not isinstance(data, str):
+                # WebKit lists the underlying errors under `data`; Chrome's protocol types it as
+                # a string, and WebStorm's reader gives up on the whole response otherwise
+                # ("Expected a string but was BEGIN_ARRAY") - one per domain a JSContext lacks.
+                entries = cast(list[Any], data) if isinstance(data, list) else []
+                details = [
+                    str(cast(dict[str, Any], entry).get("message", "")) for entry in entries if isinstance(entry, dict)
+                ]
+                message["error"]["data"] = "; ".join(detail for detail in details if detail) or json.dumps(data)
+            if "id" in message and str(message["error"].get("message", "")).endswith("domain already enabled"):
+                # Enabled before the frontend asked - by the bridge holding the target, or by WebKit
+                # itself when it paused a released context. Chrome's backend treats a repeated
+                # enable as a no-op, and the frontend gives up on the domain over an error.
+                message = {"id": message["id"], "result": {}}
         if "id" in message:
             self._pending_requests.pop(message["id"], None)
             if message["id"] < 0:
                 # Response to a bridge-internal request (setup replay or an abandoned wait);
                 # forwarding it would hand the frontend an id it never issued.
+                return
+            if message["id"] == self._replay_after_id:
+                self._replay_after_id = None
+                await self.output_queue.put(message)
+                for event in self.held_events:
+                    await self.output_queue.put(event)
+                self.held_events.clear()
                 return
         method = message.get("method", "")
         if method in WEBKIT_ONLY_EVENTS:
@@ -2710,6 +2912,14 @@ class CdpTarget:
         if any(marker in source for marker in WEBKIT_INTERNAL_SCRIPT_MARKERS):
             return
         script_id = params.get("scriptId")
+        if not source and self._flat and script_id is not None:
+            # A JSContext's own scripts carry no URL (nothing gave them a sourceURL). An editor
+            # sets a breakpoint by URL, which cannot match an empty one, so the breakpoint never
+            # binds. Give the script a stable synthetic URL so it is addressable, and translate
+            # the URL breakpoint back to this script (see _debugger_set_breakpoint_by_url).
+            source = f"jscontext:///{script_id}.js"
+            params["url"] = source
+            self._flat_script_url_to_id[source] = script_id
         if script_id is not None:
             self._script_id_to_url[script_id] = source
         await self.output_queue.put(message)

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -146,6 +146,22 @@ class ApplicationPage:
         return f"<{self.application.name}({self.application.pid}) TYPE:{self.page.type_.value} URL:{self.page.web_url}>"
 
 
+@dataclass(frozen=True)
+class AutomaticInspectionCandidate:
+    """A debuggable an application just created and is holding, waiting for a debugger.
+
+    Offered by `webinspectord` (as `_rpc_reportAutomaticInspectionCandidate:`) to every connection
+    that enabled automatic inspection, one connection at a time. The application blocks the thread
+    creating the debuggable until the candidate is either accepted - a socket setup for the page,
+    followed by the frontend's `Inspector.initialized` - or rejected, and gives up on its own
+    after ten seconds. WebKit only offers JSContexts and service workers; web pages never block.
+    """
+
+    app_id: str
+    page_id: int
+    session_id: str
+
+
 class WebinspectorService(LockdownService):
     """Client for the `com.apple.webinspector` service (`webinspectord`).
 
@@ -178,8 +194,14 @@ class WebinspectorService(LockdownService):
             "_rpc_applicationConnected:": self._handle_application_connected,
             "_rpc_applicationSentData:": self._handle_application_sent_data,
             "_rpc_applicationDisconnected:": self._handle_application_disconnected,
+            "_rpc_reportAutomaticInspectionCandidate:": self._handle_report_automatic_inspection_candidate,
         }
         self._recv_task: Optional[asyncio.Task[None]] = None
+        # Queues handed out by subscribe_*: the receive task publishes into them without waiting,
+        # so a subscriber that reacts by talking to the device (whose answers arrive through this
+        # same receive task) never deadlocks it.
+        self._candidate_subscribers: list[asyncio.Queue[AutomaticInspectionCandidate]] = []
+        self._listing_subscribers: list[asyncio.Queue[str]] = []
 
     async def connect(self) -> None:
         """Establish the WebInspector session and start the background receive task.
@@ -368,14 +390,81 @@ class WebinspectorService(LockdownService):
         """
         await self._forward_socket_data(session_id, app_id, page_id, data)
 
-    async def setup_inspector_socket(self, session_id: str, app_id: str, page_id: int):
-        """Set up a forwarding socket for an inspector session without auto-pausing the target.
+    async def setup_inspector_socket(
+        self, session_id: str, app_id: str, page_id: int, automatically_pause: bool = False
+    ) -> None:
+        """Set up a forwarding socket for an inspector session.
 
         :param session_id: The session identifier to associate with the socket.
         :param app_id: The target application identifier.
         :param page_id: The target page identifier.
+        :param automatically_pause: Ask WebKit to pause the debuggable on its next statement once
+            the frontend reports itself initialized (`Inspector.initialized`) - Safari's
+            "Automatically Pause Connecting to JSContexts". Honoured by JSContexts, service
+            workers and legacy WebViews; a WKWebView's page ignores it.
         """
-        await self._forward_socket_setup(session_id, app_id, page_id, pause=False)
+        await self._forward_socket_setup(session_id, app_id, page_id, automatically_pause=automatically_pause)
+
+    async def set_automatic_inspection_enabled(self, enabled: bool) -> None:
+        """Ask `webinspectord` to offer this connection every debuggable an application creates,
+        before the application gets to run it (see `AutomaticInspectionCandidate`).
+
+        While any connection has this enabled, every application holds each new JSContext until
+        the candidate is answered; subscribe with `subscribe_automatic_inspection` first, and
+        switch it off again when done.
+
+        :param enabled: Whether to receive candidates.
+        """
+        await self._send_message(
+            "_rpc_forwardAutomaticInspectionConfiguration:", {"WIRAutomaticInspectionEnabledKey": enabled}
+        )
+
+    def subscribe_automatic_inspection(self) -> "asyncio.Queue[AutomaticInspectionCandidate]":
+        """Receive automatic-inspection candidates as they are offered.
+
+        A candidate is accepted by setting up an inspector socket for its page and completing the
+        frontend handshake, or declined with `reject_automatic_inspection`. Candidates offered while
+        nobody is subscribed are declined on the spot, so applications never wait on this client.
+
+        :returns: A queue the candidates are published into; hand it back to
+            `unsubscribe_automatic_inspection` when done.
+        """
+        queue: asyncio.Queue[AutomaticInspectionCandidate] = asyncio.Queue()
+        self._candidate_subscribers.append(queue)
+        return queue
+
+    def unsubscribe_automatic_inspection(self, queue: "asyncio.Queue[AutomaticInspectionCandidate]") -> None:
+        with contextlib.suppress(ValueError):
+            self._candidate_subscribers.remove(queue)
+
+    async def reject_automatic_inspection(self, candidate: AutomaticInspectionCandidate) -> None:
+        """Decline a candidate, letting the application resume (or be offered to the next debugger).
+
+        :param candidate: The candidate as published by `subscribe_automatic_inspection`.
+        """
+        await self._send_message(
+            "_rpc_forwardAutomaticInspectionRejection:",
+            {
+                "WIRApplicationIdentifierKey": candidate.app_id,
+                "WIRPageIdentifierKey": candidate.page_id,
+                "WIRAutomaticInspectionSessionIdentifierKey": candidate.session_id,
+            },
+        )
+
+    def subscribe_listings(self) -> "asyncio.Queue[str]":
+        """Be told whenever an application's page listing arrives - `webinspectord` relays one on
+        its own the moment a page opens, closes or navigates.
+
+        :returns: A queue the identifier of the application whose listing changed is published
+            into; hand it back to `unsubscribe_listings` when done.
+        """
+        queue: asyncio.Queue[str] = asyncio.Queue()
+        self._listing_subscribers.append(queue)
+        return queue
+
+    def unsubscribe_listings(self, queue: "asyncio.Queue[str]") -> None:
+        with contextlib.suppress(ValueError):
+            self._listing_subscribers.remove(queue)
 
     async def teardown_inspector_socket(self, session_id: str, app_id: str, page_id: int):
         """Tear down a forwarding socket previously set up for an inspector session.
@@ -462,6 +551,21 @@ class WebinspectorService(LockdownService):
             else:
                 pages[id_] = Page.from_page_dictionary(page)
         self.application_pages[app_id] = pages
+        for queue in self._listing_subscribers:
+            queue.put_nowait(app_id)
+
+    async def _handle_report_automatic_inspection_candidate(self, arg: dict[str, Any]) -> None:
+        candidate = AutomaticInspectionCandidate(
+            arg["WIRApplicationIdentifierKey"],
+            arg["WIRPageIdentifierKey"],
+            arg["WIRAutomaticInspectionSessionIdentifierKey"],
+        )
+        if not self._candidate_subscribers:
+            # Nobody to take it: decline now rather than let the application wait out its timeout.
+            await self.reject_automatic_inspection(candidate)
+            return
+        for queue in self._candidate_subscribers:
+            queue.put_nowait(candidate)
 
     async def _handle_application_updated(self, arg: dict[str, Any]):
         app = Application.from_application_dictionary(arg)
@@ -509,16 +613,20 @@ class WebinspectorService(LockdownService):
             },
         )
 
-    async def _forward_socket_setup(self, session_id: str, app_id: str, page_id: int, pause: bool = True):
-        message: dict[str, Any] = {
-            "WIRApplicationIdentifierKey": app_id,
-            "WIRPageIdentifierKey": page_id,
-            "WIRSenderKey": session_id,
-            "WIRMessageDataTypeChunkSupportedKey": 0,
-        }
-        if not pause:
-            message["WIRAutomaticallyPause"] = False
-        await self._send_message("_rpc_forwardSocketSetup:", message)
+    async def _forward_socket_setup(
+        self, session_id: str, app_id: str, page_id: int, automatically_pause: bool = False
+    ) -> None:
+        await self._send_message(
+            "_rpc_forwardSocketSetup:",
+            {
+                "WIRApplicationIdentifierKey": app_id,
+                "WIRPageIdentifierKey": page_id,
+                "WIRSenderKey": session_id,
+                "WIRMessageDataTypeChunkSupportedKey": 0,
+                # Read by inspection targets only; an automation target's setup ignores it.
+                "WIRAutomaticallyPause": automatically_pause,
+            },
+        )
 
     async def _forward_socket_data(self, session_id: str, app_id: str, page_id: int, data: dict[str, Any]):
         await self._send_message(

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -1536,7 +1536,8 @@ def test_landing_page_links_each_kind_to_its_own_frontend() -> None:
     html = targets_html(inspector, "127.0.0.1:9222")
 
     assert '<a href="/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/PID:1:1">Example</a>' in html
-    assert '<a href="/devtools/js_app.html?ws=127.0.0.1:9222/devtools/page/PID:2:1">myapp (2): JSContext</a>' in html
+    # Every JSContext of a process is titled "JSContext"; the context number tells them apart.
+    assert '<a href="/devtools/js_app.html?ws=127.0.0.1:9222/devtools/page/PID:2:1">myapp (2): JSContext #1</a>' in html
 
 
 def test_landing_page_escapes_titles_from_the_device() -> None:

--- a/tests/services/test_web_protocol/test_cdp_wait_for_debugger.py
+++ b/tests/services/test_web_protocol/test_cdp_wait_for_debugger.py
@@ -1,0 +1,967 @@
+"""Attaching to debuggables before they run: Target.setAutoAttach(waitForDebuggerOnStart).
+
+Everything here runs without a device: the inspector service is wired to a fake webinspectord
+connection that records what the bridge sends it, and the messages webinspectord would relay
+from an app are fed straight into the service's receive handlers in their wire format.
+"""
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import Any, Optional, cast
+
+import httpx
+import pytest
+
+from pymobiledevice3.services.web_protocol import cdp_browser
+from pymobiledevice3.services.web_protocol.cdp_browser import (
+    HELD_TARGETS,
+    CdpBrowser,
+    HeldTargets,
+    adopt_held_target,
+    iter_inspectable,
+)
+from pymobiledevice3.services.web_protocol.cdp_server import app, targets_html
+from pymobiledevice3.services.web_protocol.cdp_target import CdpTarget
+from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
+from pymobiledevice3.services.webinspector import Application, AutomationAvailability, Page, WebinspectorService
+
+APP_ID = "PID:42"
+CANDIDATE_SESSION = "9D0D3D1E-2C5B-4B69-8E4F-2A6A0B8E1C11"
+TIMEOUT = 5
+
+
+class FakeWebinspectord:
+    """The service connection a WebinspectorService talks over, recording every plist sent."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def send_plist(self, plist: dict[str, Any]) -> None:
+        self.sent.append(plist)
+
+    def selectors(self) -> list[str]:
+        return [message["__selector"] for message in self.sent]
+
+    def arguments(self, selector: str) -> list[dict[str, Any]]:
+        return [message["__argument"] for message in self.sent if message["__selector"] == selector]
+
+    def socket_data(self) -> list[dict[str, Any]]:
+        """The inspector-protocol messages forwarded to debuggables, decoded."""
+        return [json.loads(argument["WIRSocketDataKey"]) for argument in self.arguments("_rpc_forwardSocketData:")]
+
+
+class FakeWebSocket:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def send_json(self, message: dict[str, Any]) -> None:
+        self.sent.append(message)
+
+    def events(self, method: str) -> list[dict[str, Any]]:
+        return [message for message in self.sent if message.get("method") == method]
+
+
+async def eventually(condition: Any, timeout: float = TIMEOUT) -> None:
+    """Wait for `condition()` to hold; the bridge's target tasks run in the background."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while not condition():
+        if asyncio.get_event_loop().time() >= deadline:
+            raise AssertionError("condition not met in time")
+        await asyncio.sleep(0.01)
+
+
+def application_connected(app_id: str = APP_ID) -> dict[str, Any]:
+    return {
+        "__selector": "_rpc_applicationConnected:",
+        "__argument": {
+            "WIRApplicationIdentifierKey": app_id,
+            "WIRApplicationBundleIdentifierKey": "com.example.app",
+            "WIRApplicationNameKey": "Example",
+            "WIRAutomationAvailabilityKey": "WIRAutomationAvailabilityNotAvailable",
+            "WIRIsApplicationActiveKey": 1,
+            "WIRIsApplicationProxyKey": False,
+            "WIRIsApplicationReadyKey": True,
+        },
+    }
+
+
+def jscontext_listing(page_id: int, app_id: str = APP_ID) -> dict[str, Any]:
+    return {
+        "__selector": "_rpc_applicationSentListing:",
+        "__argument": {
+            "WIRApplicationIdentifierKey": app_id,
+            "WIRListingKey": {
+                str(page_id): {
+                    "WIRPageIdentifierKey": page_id,
+                    "WIRTypeKey": "WIRTypeJavaScript",
+                    "WIRTitleKey": "JSContext",
+                    "WIROverrideNameKey": "",
+                }
+            },
+        },
+    }
+
+
+def web_page_listing(page_id: int, app_id: str = APP_ID) -> dict[str, Any]:
+    return {
+        "__selector": "_rpc_applicationSentListing:",
+        "__argument": {
+            "WIRApplicationIdentifierKey": app_id,
+            "WIRListingKey": {
+                str(page_id): {
+                    "WIRPageIdentifierKey": page_id,
+                    "WIRTypeKey": "WIRTypeWebPage",
+                    "WIRTitleKey": "Example",
+                    "WIRURLKey": "https://example.com/",
+                }
+            },
+        },
+    }
+
+
+def automatic_inspection_candidate(page_id: int, app_id: str = APP_ID) -> dict[str, Any]:
+    return {
+        "__selector": "_rpc_reportAutomaticInspectionCandidate:",
+        "__argument": {
+            "WIRApplicationIdentifierKey": app_id,
+            "WIRPageIdentifierKey": page_id,
+            "WIRAutomaticInspectionSessionIdentifierKey": CANDIDATE_SESSION,
+        },
+    }
+
+
+def application_sent_data(session_id: str, message: dict[str, Any], app_id: str = APP_ID) -> dict[str, Any]:
+    return {
+        "__selector": "_rpc_applicationSentData:",
+        "__argument": {
+            "WIRApplicationIdentifierKey": app_id,
+            "WIRDestinationKey": session_id,
+            "WIRMessageDataKey": json.dumps(message).encode(),
+        },
+    }
+
+
+@asynccontextmanager
+async def offline_browser(
+    pause_on_start: bool = False,
+) -> AsyncGenerator[tuple[CdpBrowser, FakeWebinspectord, FakeWebSocket], None]:
+    inspector = WebinspectorService(lockdown=cast(Any, object()))
+    connection = FakeWebinspectord()
+    inspector._service = cast(Any, connection)
+    websocket = FakeWebSocket()
+    browser = CdpBrowser(inspector, cast(Any, websocket), pause_on_start=pause_on_start)
+    await inspector._handle_recv(application_connected())
+    connection.sent.clear()
+    try:
+        yield browser, connection, websocket
+    finally:
+        await browser.close()
+
+
+async def enable_auto_attach(browser: CdpBrowser, wait_for_debugger: bool = True) -> None:
+    await browser._handle({
+        "id": 1,
+        "method": "Target.setAutoAttach",
+        "params": {"autoAttach": True, "waitForDebuggerOnStart": wait_for_debugger, "flatten": True},
+    })
+
+
+async def announce_jscontext(browser: CdpBrowser, page_id: int) -> None:
+    """What webinspectord relays when an app creates an inspectable JSContext while automatic
+    inspection is on: the app pushes its listing, then the candidate is reported."""
+    await browser.inspector._handle_recv(jscontext_listing(page_id))
+    await browser.inspector._handle_recv(automatic_inspection_candidate(page_id))
+
+
+async def attached_session(websocket: FakeWebSocket) -> str:
+    await eventually(lambda: websocket.events("Target.attachedToTarget"))
+    return websocket.events("Target.attachedToTarget")[-1]["params"]["sessionId"]
+
+
+async def test_wait_for_debugger_on_start_enables_automatic_inspection_on_the_device() -> None:
+    """Only a debugger that asked webinspectord for automatic inspection is offered new contexts."""
+    async with offline_browser() as (browser, connection, _):
+        await enable_auto_attach(browser)
+
+        configurations = connection.arguments("_rpc_forwardAutomaticInspectionConfiguration:")
+        assert [c["WIRAutomaticInspectionEnabledKey"] for c in configurations] == [True]
+
+
+async def test_auto_attach_without_waiting_leaves_automatic_inspection_off() -> None:
+    async with offline_browser() as (browser, connection, _):
+        await enable_auto_attach(browser, wait_for_debugger=False)
+
+        assert "_rpc_forwardAutomaticInspectionConfiguration:" not in connection.selectors()
+
+
+async def test_a_new_jscontext_is_attached_before_it_runs() -> None:
+    """The candidate is accepted with a socket setup, and the client is told the target waits."""
+    async with offline_browser() as (browser, connection, websocket):
+        await enable_auto_attach(browser)
+        await announce_jscontext(browser, page_id=1)
+
+        session_id = await attached_session(websocket)
+        setups = connection.arguments("_rpc_forwardSocketSetup:")
+        assert [(s["WIRApplicationIdentifierKey"], s["WIRPageIdentifierKey"]) for s in setups] == [(APP_ID, 1)]
+        assert setups[0]["WIRAutomaticallyPause"] is False
+        attached = websocket.events("Target.attachedToTarget")[0]["params"]
+        assert attached["waitingForDebugger"] is True
+        assert attached["targetInfo"]["type"] == "node"
+        assert session_id
+        assert "_rpc_forwardAutomaticInspectionRejection:" not in connection.selectors()
+
+
+async def test_a_jscontext_whose_listing_lands_first_is_still_attached_as_waiting() -> None:
+    """The device pushes the listing a few milliseconds before it reports the candidate. Reacting
+    to the listing alone attached the context as already running, so the candidate only opened a
+    second session on it and the application was never released."""
+    async with offline_browser() as (browser, connection, websocket):
+        await enable_auto_attach(browser)
+        await browser.inspector._handle_recv(jscontext_listing(page_id=1))
+        # Let the listing consumer act on the push before the candidate is even received.
+        for _ in range(20):
+            await asyncio.sleep(0)
+        await browser.inspector._handle_recv(automatic_inspection_candidate(page_id=1))
+
+        await attached_session(websocket)
+        await asyncio.sleep(0.05)
+        setups = connection.arguments("_rpc_forwardSocketSetup:")
+        assert [s["WIRPageIdentifierKey"] for s in setups] == [1]
+        attached = websocket.events("Target.attachedToTarget")
+        assert [a["params"]["waitingForDebugger"] for a in attached] == [True]
+        assert "_rpc_forwardAutomaticInspectionRejection:" not in connection.selectors()
+
+
+async def test_a_jscontext_that_is_never_offered_is_attached_after_the_grace_period(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Not every JSContext in a pushed listing comes with a candidate (one made inspectable
+    before automatic inspection reached its process, say). Hold off for the candidate briefly,
+    then attach it as a running target."""
+    monkeypatch.setattr(cdp_browser, "CANDIDATE_GRACE", 0.05)
+    async with offline_browser() as (browser, connection, websocket):
+        await enable_auto_attach(browser)
+
+        await browser.inspector._handle_recv(jscontext_listing(page_id=1))
+
+        await asyncio.sleep(0.02)
+        assert "_rpc_forwardSocketSetup:" not in connection.selectors()
+        await asyncio.sleep(0.05)
+        await browser._sync_targets()
+        session_id = await attached_session(websocket)
+        assert websocket.events("Target.attachedToTarget")[0]["params"]["waitingForDebugger"] is False
+        assert session_id
+
+
+async def test_run_if_waiting_for_debugger_releases_the_jscontext() -> None:
+    """WebKit holds the context until the frontend reports itself initialized; that is what
+    Runtime.runIfWaitingForDebugger means to a Chrome client."""
+    async with offline_browser() as (browser, connection, websocket):
+        await enable_auto_attach(browser)
+        await announce_jscontext(browser, page_id=1)
+        session_id = await attached_session(websocket)
+        assert "Inspector.initialized" not in [m["method"] for m in connection.socket_data()]
+
+        await browser._handle({"id": 7, "sessionId": session_id, "method": "Runtime.runIfWaitingForDebugger"})
+
+        await eventually(lambda: "Inspector.initialized" in [m["method"] for m in connection.socket_data()])
+        await eventually(lambda: any(m.get("id") == 7 for m in websocket.sent))
+        assert "result" in next(m for m in websocket.sent if m.get("id") == 7)
+
+
+async def test_pause_mode_leaves_debuggables_that_already_existed_running() -> None:
+    """Safari's automatic pause applies to contexts created while it is on; a context that was
+    already running when the client attached is not stopped in its tracks."""
+    async with offline_browser(pause_on_start=True) as (browser, connection, websocket):
+        await browser.inspector._handle_recv(jscontext_listing(page_id=1))
+        await enable_auto_attach(browser)
+        session_id = await attached_session(websocket)
+
+        await browser._handle({"id": 5, "sessionId": session_id, "method": "Debugger.enable", "params": {}})
+
+        await eventually(
+            lambda: "Debugger.setPauseOnDebuggerStatements" in [m["method"] for m in connection.socket_data()]
+        )
+        assert "Debugger.pause" not in [m["method"] for m in connection.socket_data()]
+
+
+async def test_a_candidate_nobody_waits_for_is_rejected() -> None:
+    """An unanswered candidate stalls the app for ten seconds; decline it right away instead."""
+    inspector = WebinspectorService(lockdown=cast(Any, object()))
+    connection = FakeWebinspectord()
+    inspector._service = cast(Any, connection)
+    await inspector._handle_recv(application_connected())
+
+    await inspector._handle_recv(automatic_inspection_candidate(page_id=1))
+
+    rejections = connection.arguments("_rpc_forwardAutomaticInspectionRejection:")
+    assert len(rejections) == 1
+    assert rejections[0]["WIRApplicationIdentifierKey"] == APP_ID
+    assert rejections[0]["WIRPageIdentifierKey"] == 1
+    assert rejections[0]["WIRAutomaticInspectionSessionIdentifierKey"] == CANDIDATE_SESSION
+
+
+async def test_a_candidate_that_cannot_be_attached_is_rejected() -> None:
+    """A candidate whose page never made it into the listing cannot be set up; decline it."""
+    async with offline_browser() as (browser, connection, _):
+        await enable_auto_attach(browser)
+
+        await browser.inspector._handle_recv(automatic_inspection_candidate(page_id=5))
+
+        await eventually(lambda: connection.arguments("_rpc_forwardAutomaticInspectionRejection:"))
+        assert "_rpc_forwardSocketSetup:" not in connection.selectors()
+
+
+async def test_closing_the_browser_releases_and_switches_automatic_inspection_off() -> None:
+    """A held context must not outlive the debugger that held it, and webinspectord must stop
+    offering candidates to a connection that no longer takes them."""
+    async with offline_browser() as (browser, connection, websocket):
+        await enable_auto_attach(browser)
+        await announce_jscontext(browser, page_id=1)
+        await attached_session(websocket)
+
+        await browser.close()
+
+        assert "Inspector.initialized" in [m["method"] for m in connection.socket_data()]
+        configurations = connection.arguments("_rpc_forwardAutomaticInspectionConfiguration:")
+        assert [c["WIRAutomaticInspectionEnabledKey"] for c in configurations] == [True, False]
+
+
+async def test_a_pushed_listing_attaches_a_new_page_without_waiting_for_the_poll() -> None:
+    """webinspectord relays an app's listing the moment a page appears; auto-attach acts on that
+    push rather than on the next periodic refresh. A page cannot be held before it runs, so the
+    client is told it is not waiting."""
+    async with offline_browser() as (browser, connection, websocket):
+        await enable_auto_attach(browser)
+
+        await browser.inspector._handle_recv(web_page_listing(page_id=3))
+
+        await eventually(lambda: connection.arguments("_rpc_forwardSocketSetup:"))
+        setup = connection.arguments("_rpc_forwardSocketSetup:")[0]
+        assert setup["WIRPageIdentifierKey"] == 3
+        # The page answers its socket setup by announcing its inspection target.
+        await browser.inspector._handle_recv(
+            application_sent_data(
+                setup["WIRSenderKey"],
+                {"method": "Target.targetCreated", "params": {"targetInfo": {"targetId": "page-3-1", "type": "page"}}},
+            )
+        )
+        session_id = await attached_session(websocket)
+        attached = websocket.events("Target.attachedToTarget")[0]["params"]
+        assert attached["waitingForDebugger"] is False
+        assert attached["targetInfo"]["type"] == "page"
+        assert session_id
+
+
+@asynccontextmanager
+async def offline_holder() -> AsyncGenerator[tuple[HeldTargets, FakeWebinspectord], None]:
+    """The bridge-level acceptor `--pause-new-targets` runs: it takes every candidate itself."""
+    HELD_TARGETS.clear()
+    inspector = WebinspectorService(lockdown=cast(Any, object()))
+    connection = FakeWebinspectord()
+    inspector._service = cast(Any, connection)
+    await inspector._handle_recv(application_connected())
+    holder = HeldTargets(inspector)
+    await holder.start()
+    try:
+        yield holder, connection
+    finally:
+        await holder.stop()
+        HELD_TARGETS.clear()
+
+
+async def test_the_pause_flag_holds_a_new_jscontext_paused_on_its_first_statement() -> None:
+    """Like Safari with both Develop-menu options on: the bridge accepts the candidate itself,
+    initializes the session so WebKit pauses the context on its first statement, and keeps the
+    session for whichever frontend opens it later."""
+    async with offline_holder() as (holder, connection):
+        assert [
+            c["WIRAutomaticInspectionEnabledKey"]
+            for c in connection.arguments("_rpc_forwardAutomaticInspectionConfiguration:")
+        ] == [True]
+        await holder.inspector._handle_recv(jscontext_listing(page_id=1))
+        await holder.inspector._handle_recv(automatic_inspection_candidate(page_id=1))
+
+        page_id = f"{APP_ID}:1"
+        await eventually(lambda: page_id in HELD_TARGETS)
+        await eventually(lambda: "Inspector.initialized" in [m["method"] for m in connection.socket_data()])
+        assert connection.arguments("_rpc_forwardSocketSetup:")[0]["WIRAutomaticallyPause"] is True
+        methods = [m["method"] for m in connection.socket_data()]
+        assert methods.index("Debugger.enable") < methods.index("Inspector.initialized")
+        assert "_rpc_forwardAutomaticInspectionRejection:" not in connection.selectors()
+
+        target = adopt_held_target(page_id)
+        assert target is not None
+        assert adopt_held_target(page_id) is None
+        await target.close()
+
+
+async def test_a_held_target_is_dropped_when_its_context_goes_away() -> None:
+    async with offline_holder() as (holder, connection):
+        await holder.inspector._handle_recv(jscontext_listing(page_id=1))
+        await holder.inspector._handle_recv(automatic_inspection_candidate(page_id=1))
+        page_id = f"{APP_ID}:1"
+        await eventually(lambda: page_id in HELD_TARGETS)
+
+        await holder.inspector._handle_recv({
+            "__selector": "_rpc_applicationSentListing:",
+            "__argument": {"WIRApplicationIdentifierKey": APP_ID, "WIRListingKey": {}},
+        })
+
+        await eventually(lambda: page_id not in HELD_TARGETS)
+        # The session is torn down right after it is dropped from the registry, on the holder's
+        # own task - give it its turn rather than assert on the same tick.
+        await eventually(lambda: "_rpc_forwardDidClose:" in connection.selectors())
+
+
+async def test_stopping_the_holder_releases_and_switches_automatic_inspection_off() -> None:
+    async with offline_holder() as (holder, connection):
+        await holder.inspector._handle_recv(jscontext_listing(page_id=1))
+        await holder.inspector._handle_recv(automatic_inspection_candidate(page_id=1))
+        await eventually(lambda: f"{APP_ID}:1" in HELD_TARGETS)
+
+        await holder.stop()
+
+        assert "_rpc_forwardDidClose:" in connection.selectors()
+        assert HELD_TARGETS == {}
+        configurations = connection.arguments("_rpc_forwardAutomaticInspectionConfiguration:")
+        assert [c["WIRAutomaticInspectionEnabledKey"] for c in configurations] == [True, False]
+
+
+async def test_a_candidate_the_holder_cannot_attach_is_rejected() -> None:
+    async with offline_holder() as (holder, connection):
+        await holder.inspector._handle_recv(automatic_inspection_candidate(page_id=9))
+
+        await eventually(lambda: connection.arguments("_rpc_forwardAutomaticInspectionRejection:"))
+        assert "_rpc_forwardSocketSetup:" not in connection.selectors()
+
+
+def _offline_jscontext_target(connection: FakeWebinspectord) -> CdpTarget:
+    inspector = WebinspectorService(lockdown=cast(Any, object()))
+    inspector._service = cast(Any, connection)
+    page = Page.from_page_dictionary({
+        "WIRPageIdentifierKey": 1,
+        "WIRTypeKey": "WIRTypeJavaScript",
+        "WIRTitleKey": "JSContext",
+        "WIROverrideNameKey": "",
+    })
+    application = Application(
+        APP_ID, "com.example.app", 42, "Example", AutomationAvailability.NOT_AVAILABLE, 1, False, True
+    )
+    return CdpTarget(SessionProtocol(inspector, "HELD", application, page, method_prefix=""), f"jscontext:{APP_ID}:1")
+
+
+async def _next_output(target: CdpTarget) -> dict[str, Any]:
+    return await asyncio.wait_for(target.receive(), TIMEOUT)
+
+
+async def test_a_frontend_adopting_a_held_target_sees_its_pause_after_enabling_the_debugger() -> None:
+    """The context paused while nobody was looking. A frontend that opens it later enables the
+    debugger as usual; WebKit answers that the domain is already on (the bridge enabled it), which
+    is turned into a success, and the scripts and the pause the frontend missed follow - the order
+    a fresh backend would have produced."""
+    connection = FakeWebinspectord()
+    target = _offline_jscontext_target(connection)
+    try:
+        target.start_holding()
+        events = target.protocol.inspector.session_events("HELD")
+        events.append({"method": "Debugger.scriptParsed", "params": {"scriptId": "2", "url": ""}})
+        events.append({"method": "Debugger.paused", "params": {"reason": "PauseOnNextStatement", "callFrames": []}})
+        await eventually(lambda: len(target.held_events) == 2)
+
+        target.adopt()
+        await target.send({"id": 3, "method": "Debugger.enable", "params": {}})
+        await eventually(lambda: any(m["method"] == "Debugger.enable" for m in connection.socket_data()))
+        wire_id = next(m["id"] for m in connection.socket_data() if m["method"] == "Debugger.enable")
+        target.protocol.inspector.wir_message_results[wire_id] = {
+            "id": wire_id,
+            "error": {"code": -32000, "message": "Debugger domain already enabled"},
+        }
+
+        assert await _next_output(target) == {"id": 3, "result": {}}
+        assert (await _next_output(target))["method"] == "Debugger.scriptParsed"
+        assert (await _next_output(target))["method"] == "Debugger.paused"
+    finally:
+        await target.close()
+
+
+async def test_error_data_reaches_the_frontend_as_a_string() -> None:
+    """WebKit's error responses carry `data` as a list of error objects; Chrome's protocol
+    types it as a string. WebStorm's reader threw "Expected a string but was BEGIN_ARRAY" on
+    every such response - one per domain a JSContext lacks - and lost the session's pauses."""
+    connection = FakeWebinspectord()
+    target = _offline_jscontext_target(connection)
+    try:
+        await target.send({"id": 4, "method": "Page.enable", "params": {}})
+        await eventually(lambda: connection.socket_data())
+        wire_id = connection.socket_data()[0]["id"]
+        target.protocol.inspector.wir_message_results[wire_id] = {
+            "id": wire_id,
+            "error": {
+                "code": -32601,
+                "message": "'Page' domain was not found",
+                "data": [{"code": -32601, "message": "'Page' domain was not found"}],
+            },
+        }
+
+        reply = await _next_output(target)
+
+        assert reply["id"] == 4
+        assert reply["error"]["code"] == -32601
+        assert reply["error"]["message"] == "'Page' domain was not found"
+        assert isinstance(reply["error"]["data"], str)
+    finally:
+        await target.close()
+
+
+async def test_skip_all_pauses_is_translated_to_what_webkit_has() -> None:
+    """WebStorm sends Debugger.setSkipAllPauses on attach; WebKit has no such method. Its
+    meaning is covered by deactivating breakpoints and debugger statements, so translate it
+    instead of handing the editor an error for its first debugger request."""
+    connection = FakeWebinspectord()
+    target = _offline_jscontext_target(connection)
+    try:
+        await target.send({"id": 4, "method": "Debugger.setSkipAllPauses", "params": {"skip": True}})
+
+        assert await _next_output(target) == {"id": 4, "result": {}}
+        await eventually(lambda: len(connection.socket_data()) == 2)
+        assert [(m["method"], m["params"]) for m in connection.socket_data()] == [
+            ("Debugger.setBreakpointsActive", {"active": False}),
+            ("Debugger.setPauseOnDebuggerStatements", {"enabled": False}),
+        ]
+    finally:
+        await target.close()
+
+
+async def test_a_url_less_jscontext_script_gets_a_synthetic_url() -> None:
+    """A JSContext's own scripts carry no URL. Give each a stable synthetic one so an editor can
+    address it (and set a breakpoint on it)."""
+    connection = FakeWebinspectord()
+    target = _offline_jscontext_target(connection)
+    try:
+        await target._debugger_script_parsed({
+            "method": "Debugger.scriptParsed",
+            "params": {"scriptId": "7", "url": "", "startLine": 0},
+        })
+        assert (await _next_output(target))["params"]["url"] == "jscontext:///7.js"
+    finally:
+        await target.close()
+
+
+async def test_a_url_breakpoint_on_a_jscontext_binds_by_location() -> None:
+    """An editor sets a breakpoint by URL; that never binds on a URL-less JSContext script. The
+    bridge turns it into a scriptId-location breakpoint - the only kind that binds - and answers
+    in the shape setBreakpointByUrl callers expect."""
+    connection = FakeWebinspectord()
+    target = _offline_jscontext_target(connection)
+    try:
+        await target._debugger_script_parsed({
+            "method": "Debugger.scriptParsed",
+            "params": {"scriptId": "7", "url": "", "startLine": 0},
+        })
+        await _next_output(target)
+
+        await target.send({
+            "id": 40,
+            "method": "Debugger.setBreakpointByUrl",
+            "params": {"lineNumber": 2, "url": "jscontext:///7.js"},
+        })
+        await eventually(lambda: any(m.get("method") == "Debugger.setBreakpoint" for m in connection.socket_data()))
+        sent = next(m for m in connection.socket_data() if m.get("method") == "Debugger.setBreakpoint")
+        assert sent["params"]["location"] == {"scriptId": "7", "lineNumber": 2}
+        # The device answers; the frontend gets a setBreakpointByUrl-shaped reply.
+        wire_id = sent["id"]
+        target.protocol.inspector.wir_message_results[wire_id] = {
+            "id": wire_id,
+            "result": {
+                "breakpointId": "7:2:0",
+                "actualLocation": {"scriptId": "7", "lineNumber": 2, "columnNumber": 2},
+            },
+        }
+        reply = await _next_output(target)
+        assert reply["id"] == 40
+        assert reply["result"]["breakpointId"] == "7:2:0"
+        assert reply["result"]["locations"] == [{"scriptId": "7", "lineNumber": 2, "columnNumber": 2}]
+    finally:
+        await target.close()
+
+
+async def test_a_breakpoint_hit_is_reported_as_other_with_hit_breakpoints() -> None:
+    """A source-breakpoint hit is reason "other" with hitBreakpoints in V8/Chrome. WebKit calls
+    it "Breakpoint"; forwarding it as "instrumentation" (Chrome's reason for DOM/event breakpoints)
+    made editors discard the pause, so a breakpoint set on a JSContext line was reached but never
+    surfaced."""
+    connection = FakeWebinspectord()
+    target = _offline_jscontext_target(connection)
+    try:
+        await target._debugger_paused({
+            "method": "Debugger.paused",
+            "params": {"reason": "Breakpoint", "data": {"breakpointId": "2:1:0"}, "callFrames": []},
+        })
+
+        paused = (await _next_output(target))["params"]
+        assert paused["reason"] == "other"
+        assert paused["hitBreakpoints"] == ["2:1:0"]
+    finally:
+        await target.close()
+
+
+async def test_a_debugger_statement_is_reported_as_other_like_v8() -> None:
+    """V8 reports a `debugger;` statement as reason "other", and editors hold that. WebKit calls
+    it "DebuggerStatement"; forwarding it as "debugCommand" (Chrome's reason for a client-issued
+    Debugger.pause) made WebStorm resume on its own, so `debugger` never stopped it on a
+    JSContext, while node - reporting "other" - did stop."""
+    connection = FakeWebinspectord()
+    target = _offline_jscontext_target(connection)
+    try:
+        await target._debugger_paused({
+            "method": "Debugger.paused",
+            "params": {"reason": "DebuggerStatement", "callFrames": []},
+        })
+
+        assert (await _next_output(target))["params"]["reason"] == "other"
+    finally:
+        await target.close()
+
+
+async def test_a_pause_on_the_next_statement_is_reported_as_a_plain_pause() -> None:
+    """WebKit's PauseOnNextStatement is what Chrome reports as "other" (its own pause button).
+    Reported as "instrumentation", Chrome's frontend takes it for one of its instrumentation
+    breakpoints, looks for the breakpoint data that is not there, and drops the pause on the
+    floor: the Sources panel stays at "Not paused" while the context sits stopped."""
+    connection = FakeWebinspectord()
+    target = _offline_jscontext_target(connection)
+    try:
+        await target._debugger_paused({
+            "method": "Debugger.paused",
+            "params": {"reason": "PauseOnNextStatement", "callFrames": []},
+        })
+
+        assert (await _next_output(target))["params"]["reason"] == "other"
+    finally:
+        await target.close()
+
+
+async def test_the_browser_endpoint_adopts_a_held_jscontext_instead_of_attaching() -> None:
+    """With the flag on, the bridge already holds every new context; a client auto-attaching
+    gets that session (already released and paused) rather than a second socket setup."""
+    async with offline_browser(pause_on_start=True) as (browser, connection, websocket):
+        await enable_auto_attach(browser)
+        held = _offline_jscontext_target(FakeWebinspectord())
+        held.start_holding()
+        HELD_TARGETS[f"{APP_ID}:1"] = held
+        try:
+            await browser.inspector._handle_recv(jscontext_listing(page_id=1))
+
+            session_id = await attached_session(websocket)
+            assert websocket.events("Target.attachedToTarget")[0]["params"]["waitingForDebugger"] is False
+            assert "_rpc_forwardSocketSetup:" not in connection.selectors()
+            assert HELD_TARGETS == {}
+            assert session_id
+        finally:
+            HELD_TARGETS.clear()
+
+
+async def test_with_the_pause_flag_the_browser_leaves_candidates_to_the_holder() -> None:
+    async with offline_browser(pause_on_start=True) as (browser, connection, _):
+        await enable_auto_attach(browser)
+
+        await announce_jscontext(browser, page_id=1)
+
+        await asyncio.sleep(0.05)
+        assert "_rpc_forwardSocketSetup:" not in connection.selectors()
+        # Nobody held it (no holder in this test), so the service declined it on the spot.
+        assert connection.arguments("_rpc_forwardAutomaticInspectionRejection:")
+
+
+def _listed_inspector(connection: FakeWebinspectord) -> WebinspectorService:
+    inspector = WebinspectorService(lockdown=cast(Any, object()))
+    inspector._service = cast(Any, connection)
+    inspector.connected_application = {
+        APP_ID: Application(
+            APP_ID, "com.example.app", 42, "Example", AutomationAvailability.NOT_AVAILABLE, 1, False, True
+        )
+    }
+    inspector.application_pages = {
+        APP_ID: {
+            "1": Page.from_page_dictionary({
+                "WIRPageIdentifierKey": 1,
+                "WIRTypeKey": "WIRTypeJavaScript",
+                "WIRTitleKey": "JSContext",
+                "WIROverrideNameKey": "",
+            })
+        }
+    }
+    return inspector
+
+
+def test_landing_page_marks_held_targets_paused() -> None:
+    inspector = _listed_inspector(FakeWebinspectord())
+    HELD_TARGETS[f"{APP_ID}:1"] = cast(Any, object())
+    try:
+        html = targets_html(inspector, "127.0.0.1:9222")
+        assert "paused" in html
+        # The link itself stays as it was: the title, nothing else, is its text.
+        assert (
+            '<a href="/devtools/js_app.html?ws=127.0.0.1:9222/devtools/page/PID:42:1">Example (42): JSContext #1</a>'
+            in html
+        )
+    finally:
+        HELD_TARGETS.clear()
+
+
+@asynccontextmanager
+async def bridge_client(
+    monkeypatch: pytest.MonkeyPatch, pause_new_targets: bool = False
+) -> AsyncGenerator[tuple[httpx.AsyncClient, FakeWebinspectord], None]:
+    """The bridge's HTTP surface over a fake device connection."""
+    connection = FakeWebinspectord()
+    inspector = _listed_inspector(connection)
+
+    async def connect() -> None:
+        pass
+
+    monkeypatch.setattr(inspector, "connect", connect)
+    app.state.inspector = inspector
+    app.state.pause_new_targets = pause_new_targets
+    try:
+        # Not a parenthesized `with`: that is 3.10+ syntax and the repository runs on 3.9.
+        async with AsyncExitStack() as stack:
+            await stack.enter_async_context(app.router.lifespan_context(app))
+            client = await stack.enter_async_context(
+                httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://bridge")
+            )
+            yield client, connection
+    finally:
+        HELD_TARGETS.clear()
+
+
+async def test_the_landing_page_toggle_starts_and_stops_holding_new_targets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pause-on-launch can be switched from the landing page: on enables automatic inspection
+    on the device (the bridge starts taking candidates), off stops it and lets held targets go."""
+    async with bridge_client(monkeypatch) as (client, connection):
+        assert (await client.get("/pause-new-targets")).json() == {"enabled": False}
+
+        assert (await client.post("/pause-new-targets", json={"enabled": True})).json() == {"enabled": True}
+        assert (await client.get("/pause-new-targets")).json() == {"enabled": True}
+        assert (await client.post("/pause-new-targets", json={"enabled": False})).json() == {"enabled": False}
+
+        configurations = connection.arguments("_rpc_forwardAutomaticInspectionConfiguration:")
+        assert [c["WIRAutomaticInspectionEnabledKey"] for c in configurations] == [True, False]
+
+
+async def test_the_flag_sets_the_toggles_initial_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    async with bridge_client(monkeypatch, pause_new_targets=True) as (client, connection):
+        assert (await client.get("/pause-new-targets")).json() == {"enabled": True}
+        assert 'id="pause-new-targets" checked' in (await client.get("/")).text
+        configurations = connection.arguments("_rpc_forwardAutomaticInspectionConfiguration:")
+        assert [c["WIRAutomaticInspectionEnabledKey"] for c in configurations] == [True]
+
+
+async def test_a_jscontext_is_listed_with_a_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A JSContext has no document, and an empty url broke WebStorm: it builds its Node-style
+    target from the url field and fails on "" with "Malformed URL". Name the context instead."""
+    async with bridge_client(monkeypatch) as (client, _):
+        listed = (await client.get("/json/list")).json()[0]
+        api = (await client.get("/api/targets")).json()["targets"][0]
+
+        assert listed["url"] == "jscontext://com.example.app/42/1"
+        assert api["url"] == "jscontext://com.example.app/42/1"
+        assert api["webSocketDebuggerUrl"] == "ws://bridge/devtools/page/PID:42:1"
+
+
+async def test_the_landing_page_offers_an_attach_config_per_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Instead of hand-writing a launch.json with a pid and page number, each target on the
+    landing page comes with the VS Code configuration that attaches to exactly it."""
+    async with bridge_client(monkeypatch) as (client, _):
+        html = (await client.get("/")).text
+
+        assert '"websocketAddress": "ws://bridge/devtools/page/PID:42:1"' in html
+        assert '"type": "node"' in html
+        assert "Attach to Node.js/Chrome" in html
+
+
+def test_targets_are_listed_in_order() -> None:
+    """The device reports a process's contexts in whatever order it holds them (3, 1, 4, 2, 5);
+    the bridge lists applications by name and each one's targets by number."""
+    inspector = _listed_inspector(FakeWebinspectord())
+    inspector.connected_application["PID:7"] = Application(
+        "PID:7", "com.apple.mobilesafari", 7, "Safari", AutomationAvailability.NOT_AVAILABLE, 1, False, True
+    )
+    inspector.application_pages = {
+        "PID:7": {
+            "12": Page.from_page_dictionary({
+                "WIRPageIdentifierKey": 12,
+                "WIRTypeKey": "WIRTypeWebPage",
+                "WIRTitleKey": "b",
+                "WIRURLKey": "https://b/",
+            }),
+            "2": Page.from_page_dictionary({
+                "WIRPageIdentifierKey": 2,
+                "WIRTypeKey": "WIRTypeWebPage",
+                "WIRTitleKey": "a",
+                "WIRURLKey": "https://a/",
+            }),
+        },
+        APP_ID: {
+            str(n): Page.from_page_dictionary({
+                "WIRPageIdentifierKey": n,
+                "WIRTypeKey": "WIRTypeJavaScript",
+                "WIRTitleKey": "JSContext",
+            })
+            for n in (3, 1, 10, 2)
+        },
+    }
+
+    listed = [target_id for target_id, _, _ in iter_inspectable(inspector)]
+
+    assert listed == ["PID:42:1", "PID:42:2", "PID:42:3", "PID:42:10", "PID:7:2", "PID:7:12"]
+
+
+def test_each_attach_snippet_has_a_copy_button() -> None:
+    """Like a GitHub code snippet: one click puts the configuration on the clipboard."""
+    inspector = _listed_inspector(FakeWebinspectord())
+
+    html = targets_html(inspector, "127.0.0.1:9222")
+
+    assert html.count('<button type="button" class="copy"') == 1
+    assert html.index('class="copy"') < html.index("<pre>")
+
+
+def test_a_page_target_gets_a_chrome_attach_config() -> None:
+    inspector = _listed_inspector(FakeWebinspectord())
+    inspector.application_pages[APP_ID]["2"] = Page.from_page_dictionary({
+        "WIRPageIdentifierKey": 2,
+        "WIRTypeKey": "WIRTypeWebPage",
+        "WIRTitleKey": "Example",
+        "WIRURLKey": "https://example.com/path?q=1",
+    })
+
+    html = targets_html(inspector, "127.0.0.1:9222")
+
+    assert '"type": "chrome"' in html
+    assert '"urlFilter": "https://example.com/path?q=1"' in html
+    assert '"port": 9222' in html
+
+
+async def test_the_landing_page_api_reports_held_targets(monkeypatch: pytest.MonkeyPatch) -> None:
+    async with bridge_client(monkeypatch) as (client, _):
+        HELD_TARGETS[f"{APP_ID}:1"] = cast(Any, object())
+
+        listing = (await client.get("/api/targets")).json()
+
+        assert listing["pause_new_targets"] is False
+        assert [(t["id"], t["type"], t["paused"]) for t in listing["targets"]] == [(f"{APP_ID}:1", "node", True)]
+        assert listing["targets"][0]["devtoolsFrontendUrl"].startswith("/devtools/js_app.html?ws=")
+
+
+def _offline_page_target(
+    connection: FakeWebinspectord, target_id: str = "page-1", pause_on_start: bool = False
+) -> CdpTarget:
+    inspector = WebinspectorService(lockdown=cast(Any, object()))
+    inspector._service = cast(Any, connection)
+    page = Page.from_page_dictionary({
+        "WIRPageIdentifierKey": 1,
+        "WIRTypeKey": "WIRTypeWebPage",
+        "WIRTitleKey": "Example",
+        "WIRURLKey": "https://example.com/",
+    })
+    application = Application(
+        APP_ID, "com.example.app", 42, "Example", AutomationAvailability.NOT_AVAILABLE, 1, False, True
+    )
+    target = CdpTarget(SessionProtocol(inspector, "SESSION", application, page, method_prefix=""), target_id)
+    target.pause_on_start = pause_on_start
+    # The frontend had enabled the debugger; a target that takes over gets it replayed.
+    target._setup_messages["Debugger.enable"] = {}
+    return target
+
+
+def _target_created(target_id: str, **extra: Any) -> dict[str, Any]:
+    return {
+        "method": "Target.targetCreated",
+        "params": {"targetInfo": {"targetId": target_id, "type": "page", **extra}},
+    }
+
+
+def _inner_methods(connection: FakeWebinspectord) -> list[tuple[str, Optional[str]]]:
+    """(method, targetId) of every message sent, unwrapping Target.sendMessageToTarget."""
+    methods: list[tuple[str, Optional[str]]] = []
+    for message in connection.socket_data():
+        if message["method"] == "Target.sendMessageToTarget":
+            methods.append((json.loads(message["params"]["message"])["method"], message["params"]["targetId"]))
+        else:
+            methods.append((message["method"], message.get("params", {}).get("targetId")))
+    return methods
+
+
+async def test_holding_navigations_asks_webkit_to_pause_new_targets() -> None:
+    """WebKit's Target.setPauseOnStart holds the page target a cross-site navigation creates
+    until it is resumed - the one creation-time hold WebKit offers for pages."""
+    connection = FakeWebinspectord()
+    target = _offline_page_target(connection)
+    try:
+        await target.hold_new_targets()
+
+        assert connection.socket_data()[-1] == {
+            "id": connection.socket_data()[-1]["id"],
+            "method": "Target.setPauseOnStart",
+            "params": {"pauseOnStart": True},
+        }
+    finally:
+        await target.close()
+
+
+async def test_a_paused_provisional_target_is_set_up_and_then_resumed() -> None:
+    """The point of holding it: the frontend's debugger state reaches the new process before its
+    first script runs. Setup goes first, then the resume."""
+    connection = FakeWebinspectord()
+    target = _offline_page_target(connection)
+    try:
+        await target._target_created(_target_created("page-2", isProvisional=True, isPaused=True))
+
+        assert _inner_methods(connection) == [("Debugger.enable", "page-2"), ("Target.resume", "page-2")]
+    finally:
+        await target.close()
+
+
+async def test_a_paused_provisional_target_is_paused_on_its_first_statement_in_pause_mode() -> None:
+    connection = FakeWebinspectord()
+    target = _offline_page_target(connection, pause_on_start=True)
+    try:
+        await target._target_created(_target_created("page-2", isProvisional=True, isPaused=True))
+
+        assert _inner_methods(connection) == [
+            ("Debugger.enable", "page-2"),
+            ("Debugger.pause", "page-2"),
+            ("Target.resume", "page-2"),
+        ]
+    finally:
+        await target.close()
+
+
+async def test_a_target_that_is_not_paused_is_not_resumed() -> None:
+    connection = FakeWebinspectord()
+    target = _offline_page_target(connection)
+    try:
+        await target._target_created(_target_created("page-2"))
+
+        assert _inner_methods(connection) == [("Debugger.enable", "page-2")]
+    finally:
+        await target.close()
+
+
+async def test_pause_mode_pauses_a_page_once_its_debugger_is_enabled() -> None:
+    """A page cannot be held at creation, so the closest to Safari's automatic pause is stopping
+    it on its next statement as soon as the client's debugger is on."""
+    connection = FakeWebinspectord()
+    target = _offline_page_target(connection, pause_on_start=True)
+    try:
+        await target.send({"id": 3, "method": "Debugger.enable", "params": {}})
+
+        await eventually(lambda: ("Debugger.pause", "page-1") in _inner_methods(connection))
+        methods = [method for method, _ in _inner_methods(connection)]
+        assert methods.index("Debugger.enable") < methods.index("Debugger.pause")
+    finally:
+        await target.close()

--- a/tests/services/test_webinspector.py
+++ b/tests/services/test_webinspector.py
@@ -89,8 +89,7 @@ def _web_page_listing(app_id: str, pages: dict[str, str]) -> dict[str, Any]:
 async def test_listing_drops_pages_that_closed() -> None:
     """A listing is the application's complete set of pages: one missing from it has closed.
     Merging without dropping those kept every tab ever opened in the listing forever."""
-    inspector = WebinspectorService.__new__(WebinspectorService)
-    inspector.application_pages = {}
+    inspector = WebinspectorService(lockdown=cast(Any, object()))
     await inspector._handle_application_sent_listing(_web_page_listing("PID:1", {"1": "kept", "2": "closed"}))
     kept = inspector.application_pages["PID:1"]["1"]
 


### PR DESCRIPTION
## What

Safari's Develop menu can attach to every JSContext an app creates before it runs ("Automatically Show Web Inspector for JSContexts") and stop it on its first statement ("Automatically Pause Connecting to JSContexts"). This brings both to the CDP bridge, over the same `webinspectord` automatic-inspection protocol Safari uses (verified against WebKit source and the Mac WebInspector/Safari frameworks):

- host enables it with `_rpc_forwardAutomaticInspectionConfiguration:`
- the app blocks on creation while `_rpc_reportAutomaticInspectionCandidate:` is answered with a socket setup (optionally `WIRAutomaticallyPause`) or `_rpc_forwardAutomaticInspectionRejection:`
- the frontend's `Inspector.initialized` releases it

## Changes

- **WebinspectorService**: automatic-inspection configuration, candidate handling and rejection; listing and candidate subscriptions; `WIRAutomaticallyPause` is now actually sent on socket setup (the previous `pause` parameter never emitted `true`).
- **Browser endpoint**: `Target.setAutoAttach` honours `waitForDebuggerOnStart` — new JSContexts are attached before they run and reported `waitingForDebugger: true`; `Runtime.runIfWaitingForDebugger` releases them. This is what VS Code js-debug, Playwright and Puppeteer do by default, so breakpoints hit from a context's first line. Pages are attached on the device's pushed listing instead of the 2 s poll, and cross-site navigations of an attached page are held with `Target.setPauseOnStart` until the debugger setup is replayed into the new process.
- **`--pause-new-targets`** and a **"Pause new JSContexts on launch"** switch on the landing page: the bridge itself accepts every new JSContext, pauses it on its first statement and keeps the session until a frontend opens it; DevTools then comes up in Sources on the pause. The flag only sets the switch's initial state.
- **Landing page** restyled (type badges, paused badge, dark mode) on top of two small endpoints, `/api/targets` and `/pause-new-targets`.
- **Fix**: WebKit's `PauseOnNextStatement` was reported to Chrome as reason `instrumentation`, which the frontend silently drops without breakpoint data ("Not paused"). It is now `other`, Chrome's own reason for a pause button pause.

WKWebView pages cannot be held before they run: WebKit never offers them as candidates (`WebPageDebuggable` has no `automaticInspectionAllowed`) and `WebPageInspectorController::connectFrontend` drops the pause flags.

## Verification

- 35 new offline tests (fake `webinspectord` transport, real service/bridge code), pyright and pre-commit clean.
- On a device (iOS 26.6.1): a fresh JSContext was attached exactly once as waiting and `setInspectable:` blocked for exactly the 3 s the client delayed its release; with the pause switch on, DevTools opened from the landing page lands on line 1 with "Debugger paused", and Resume lets the app's `evaluateScript:` return.
- Existing device tests for the browser endpoint (Playwright-style attach, process swaps, multi-session) pass.
- Also fixes a race found on the device: the listing lands a few ms before the candidate, and attaching from it left the app blocked for good. JSContexts are now left to their candidate, with a short grace fallback.

Docs: `docs/guides/webview-debugging.md`, "Attaching before a page or context runs".
