### PR TITLE
docs: Correct the WebView debugging guide and surface the CDP bridge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ It ships both a **command-line tool** and a **Python API**, and runs on Windows,
 
 Highlights: device discovery, port forwarding, syslog/oslog streaming, app & profile management, AFC
 file access, crash reports, PCAP sniffing, firmware update, recovery/DFU, backup/restore, WebInspector
-automation, and DDI/DVT developer tooling (iOS 17+ over a tunnel).
+automation, a [CDP bridge](https://doronz88.github.io/pymobiledevice3/guides/webview-debugging/) that
+lets Chrome DevTools, VS Code and Playwright debug Safari and WebViews on the device, and DDI/DVT
+developer tooling (iOS 17+ over a tunnel).
 
 ## Install
 

--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -140,12 +140,12 @@ Attach to Node.js/Chrome**, host `127.0.0.1`, port `9222`, attach to *Chrome or
 Node.js > 6.3 started with --inspect*. Starting that configuration in Debug opens a
 **Choose Page to Debug** list with every inspectable page and JSContext on the device;
 pick one and the session attaches to it. Breakpoints and the debug console work on a
-Safari page; the bridge answers WebStorm's `Debugger.setSkipAllPauses` with an error
-WebKit does not know the method, which WebStorm tolerates.
+Safari page. WebStorm sends `Debugger.setSkipAllPauses` on attach, which WebKit does not
+have; the bridge translates it into deactivating breakpoints and `debugger` statements.
 
 WebStorm builds a Node-style target out of a `node` entry's `url`, so JSContexts are
-listed under a `jscontext://<bundle id>/<pid>/<page>` URL. An empty one made WebStorm
-fail with "Malformed URL" as soon as a JSContext was picked.
+listed under a `jscontext://<bundle id>/<pid>/<page>` URL (WebStorm rejects a `node`
+entry with an empty URL as malformed).
 
 ## Test automation (Playwright, Puppeteer)
 
@@ -249,9 +249,14 @@ already existed when a client attached keep running, as in Safari.
 
 - WebKit allows a single inspector session per page, so two *separate* debuggers
   cannot hold the same tab: Chrome DevTools and VS Code can debug different tabs
-  concurrently, but not the same one. A page already held by another debugger is
-  skipped after a short wait — detach the other client first. A single client may
-  open as many CDP sessions onto a page as it likes (Playwright does this when a
-  script also opens a raw `newCDPSession`); those share the one underlying session.
+  concurrently, but not the same one. Opening a page from the landing page takes it
+  over from whichever session of this bridge holds it (a DevTools tab left open
+  elsewhere, for example), which is then disconnected. Browser-level clients (VS Code,
+  Playwright) do not take pages over: a page held by another session is skipped after
+  a short wait. A page held over a *different* Web Inspector connection (Safari's own
+  Web Inspector, a second `pymobiledevice3`) cannot be taken; the bridge logs which
+  connection holds it — detach that client first. A single client may open as many CDP
+  sessions onto a page as it likes (Playwright does this when a script also opens a raw
+  `newCDPSession`); those share the one underlying session.
 - The page listing is polled as a fallback, so a tab the device did not announce on
   its own is still discovered (and auto-attached) within a couple of seconds.


### PR DESCRIPTION
## Summary

- `docs/guides/webview-debugging.md`: the WebStorm section still claimed the bridge answers `Debugger.setSkipAllPauses` with an error (it translates it into deactivating breakpoints and `debugger` statements now), and narrated the "Malformed URL" bug behind the `jscontext://` URL instead of stating the behaviour. The caveat on held pages only described browser-level clients; it now covers the landing-page takeover, the browser-level skip, and pages held over a different Web Inspector connection.
- `README.md`: the highlights line only said "WebInspector automation"; add a clause for the Chrome DevTools / VS Code / Playwright bridge linking to the guide.

Every other claim in the guide was cross-checked against the current server routes, target ids, `node` target type, launch.json snippets, pause switch and mkdocs nav.

## Test plan

- [x] Docs-only change; mkdocs nav unchanged, link matches the site's `/guides/<name>/` scheme.