### PR TITLE
cdp: Show who is debugging each target, highlight, filter and group the landing page

### DIFF
--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -33,6 +33,11 @@ the duration of the debugging session.
 Open <http://127.0.0.1:9222/> in Google Chrome and pick a page. Prefer this landing
 page over `chrome://inspect` — see the command's `--help` for why.
 
+Debuggables are grouped by the process that owns them, with its icon, name, bundle
+identifier and pid as the device reports them; click a process header to fold its
+group. A badge next to a debuggable says whether it is paused, or who is already
+debugging it.
+
 The listing keeps itself current: a tab opened, closed or navigated on the device
 appears there within a couple of seconds, with no reload. Leave it open in a
 background tab and it stops polling until you come back to it.
@@ -255,7 +260,9 @@ already existed when a client attached keep running, as in Safari.
   Playwright) do not take pages over: a page held by another session is skipped after
   a short wait. A page held over a *different* Web Inspector connection (Safari's own
   Web Inspector, a second `pymobiledevice3`) cannot be taken; the bridge logs which
-  connection holds it — detach that client first. A single client may open as many CDP
+  connection holds it — detach that client first. The landing page shows who holds
+  each debuggable: **attached here** for a session of this bridge (opening it takes it
+  over), **held elsewhere** for another Web Inspector connection. A single client may open as many CDP
   sessions onto a page as it likes (Playwright does this when a script also opens a raw
   `newCDPSession`); those share the one underlying session.
 - The page listing is polled as a fallback, so a tab the device did not announce on

--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -35,8 +35,12 @@ page over `chrome://inspect` — see the command's `--help` for why.
 
 Debuggables are grouped by the process that owns them, with its icon, name, bundle
 identifier and pid as the device reports them; click a process header to fold its
-group. A badge next to a debuggable says whether it is paused, or who is already
-debugging it.
+group. A process that accepts Remote Automation sessions carries an **automation**
+badge, and one that runs web content for another (a proxy) names the app it runs
+in. A badge next to a debuggable says whether it is paused, or who is already
+debugging it. Hovering a page highlights its view on the device screen, as Safari's
+Develop menu does, and the filter box narrows the list to targets matching every
+word typed, by title, URL, process name, bundle identifier or pid.
 
 The listing keeps itself current: a tab opened, closed or navigated on the device
 appears there within a couple of seconds, with no reload. Leave it open in a

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -36,7 +36,13 @@ from pymobiledevice3.services.web_protocol.cdp_browser import (
 )
 from pymobiledevice3.services.web_protocol.cdp_target import CdpTarget
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
-from pymobiledevice3.services.webinspector import Application, Page, WebinspectorService, WirTypes
+from pymobiledevice3.services.webinspector import (
+    Application,
+    AutomationAvailability,
+    Page,
+    WebinspectorService,
+    WirTypes,
+)
 
 # chrome://inspect routes a network target's DevTools through Chrome's browser-process relay,
 # which deadlocks after sustained console traffic (the console/screen freeze). Serving the DevTools
@@ -121,15 +127,36 @@ def target_label(page: Page) -> str:
     return page.web_title or page.web_url or f"page {page.id_}"
 
 
-def application_info(application: Application) -> dict[str, Any]:
-    """The process a debuggable belongs to, as the landing page shows it."""
+def application_info(inspector: WebinspectorService, application: Application) -> dict[str, Any]:
+    """The process a debuggable belongs to, as the landing page shows it: identity, icon, the
+    application hosting it when it is a proxy for one (web content running out of process), and
+    whether it accepts Remote Automation sessions."""
+    host = inspector.connected_application.get(application.host) if application.proxy else None
     return {
         "id": application.id_,
         "name": application.name,
         "pid": application.pid,
         "bundle": application.bundle,
         "icon": f"/icon/{application.id_}" if application.icon else "",
+        "host": host.name if host is not None and host is not application else "",
+        "automation": application.availability == AutomationAvailability.AVAILABLE,
     }
+
+
+AUTOMATION_TITLE = "Accepts Remote Automation sessions (Settings > Safari > Advanced > Remote Automation)."
+INDICATE_TITLE = "Hover to highlight this page on the device."
+FILTER_PLACEHOLDER = "Filter by title, URL, process, bundle or pid"
+
+
+def search_text(application: Application, page: Page) -> str:
+    """What the landing page's filter box matches a target against."""
+    return " ".join((
+        target_label(page),
+        target_url(application, page),
+        application.name,
+        application.bundle,
+        str(application.pid),
+    )).lower()
 
 
 def debugged_by(inspector: WebinspectorService, page: Page) -> str:
@@ -212,6 +239,13 @@ li.target small { color: var(--muted); font-size: 11.5px; overflow-wrap: anywher
   border-radius: 999px; background: var(--paused); color: var(--paused-text); vertical-align: 1px;
 }
 .badge.held { background: var(--held); color: var(--held-text); }
+.badge.auto { background: var(--page); color: var(--page-text); }
+input.filter {
+  flex-basis: 100%; margin-top: 4px; padding: 6px 10px; border-radius: 8px; border: 1px solid var(--line);
+  background: var(--card); color: var(--text); font: 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+input.filter:focus { outline: 2px solid var(--accent); outline-offset: -1px; border-color: transparent; }
+li.target[data-indicate] .kind { cursor: crosshair; }
 details.attach { grid-column: 2; margin-top: 2px; font-size: 12px; }
 details.attach summary, details.editors summary { cursor: pointer; color: var(--muted); }
 details.attach summary:hover, details.editors summary:hover { color: var(--text); }
@@ -237,8 +271,59 @@ p.empty { color: var(--muted); text-align: center; padding: 28px 0; }
 INDEX_SCRIPT = Template("""
 (function () {
   const BADGES = $badges;
+  const AUTOMATION_TITLE = $automation_title;
+  const INDICATE_TITLE = $indicate_title;
   const container = document.getElementById('targets');
   const toggle = document.getElementById('pause-new-targets');
+  const filter = document.getElementById('filter');
+  // Narrow the list to targets mentioning every word typed; a process whose targets are all
+  // hidden goes with them. Re-applied after every rebuild of the list, so it sticks.
+  function applyFilter() {
+    const words = filter.value.toLowerCase().split(/\\s+/).filter(Boolean);
+    for (const group of container.querySelectorAll('details.app')) {
+      let shown = 0;
+      for (const item of group.querySelectorAll('li.target')) {
+        const match = words.every((word) => item.dataset.search.includes(word));
+        item.hidden = !match;
+        shown += match ? 1 : 0;
+      }
+      group.hidden = shown === 0;
+    }
+  }
+  filter.addEventListener('input', applyFilter);
+  // Hovering a page highlights its view on the device, as Safari's Develop menu does.
+  let indicated = null;
+  async function indicate(id, enabled) {
+    try {
+      await fetch('/api/indicate', {
+        method: 'POST',
+        headers: {'content-type': 'application/json'},
+        body: JSON.stringify({id, enabled}),
+      });
+    } catch (error) {
+      // The bridge is momentarily busy or gone; the highlight is cosmetic.
+    }
+  }
+  container.addEventListener('mouseover', (event) => {
+    const item = event.target.closest('li.target');
+    const id = item ? item.dataset.indicate || null : null;
+    if (id === indicated) {
+      return;
+    }
+    if (indicated !== null) {
+      indicate(indicated, false);
+    }
+    indicated = id;
+    if (indicated !== null) {
+      indicate(indicated, true);
+    }
+  });
+  container.addEventListener('mouseleave', () => {
+    if (indicated !== null) {
+      indicate(indicated, false);
+      indicated = null;
+    }
+  });
   // Process groups the user folded; the list is rebuilt whenever it changes, so the fold has to
   // outlive the elements.
   const folded = new Set();
@@ -284,12 +369,21 @@ INDEX_SCRIPT = Template("""
         name.className = 'name';
         name.textContent = target.application.name;
         const details = document.createElement('small');
-        details.textContent = target.application.bundle + ' \u00b7 pid ' + target.application.pid;
+        details.textContent = target.application.bundle + ' \u00b7 pid ' + target.application.pid
+          + (target.application.host ? ' \u00b7 in ' + target.application.host : '');
+        header.append(name, details);
+        if (target.application.automation) {
+          const automation = document.createElement('span');
+          automation.className = 'badge auto';
+          automation.textContent = 'automation';
+          automation.title = AUTOMATION_TITLE;
+          header.appendChild(automation);
+        }
         const count = document.createElement('small');
         count.className = 'count';
         const total = targets.filter((t) => t.application.id === target.application.id).length;
         count.textContent = total + (total === 1 ? ' target' : ' targets');
-        header.append(name, details, count);
+        header.appendChild(count);
         list = document.createElement('ul');
         list.className = 'targets';
         section.append(header, list);
@@ -298,6 +392,9 @@ INDEX_SCRIPT = Template("""
       const kind = document.createElement('span');
       kind.className = 'kind ' + (target.type === 'node' ? 'jscontext' : 'page');
       kind.textContent = target.type === 'node' ? 'JSContext' : 'Page';
+      if (target.type !== 'node') {
+        kind.title = INDICATE_TITLE;
+      }
       const title = document.createElement('span');
       const link = document.createElement('a');
       link.href = target.devtoolsFrontendUrl;
@@ -330,9 +427,14 @@ INDEX_SCRIPT = Template("""
       attach.append(summary, snippet);
       const item = document.createElement('li');
       item.className = 'target';
+      item.dataset.search = target.search;
+      if (target.type !== 'node') {
+        item.dataset.indicate = target.id;
+      }
       item.append(kind, title, url, attach);
       list.appendChild(item);
     }
+    applyFilter();
   }
   container.addEventListener('click', async (event) => {
     const button = event.target.closest('button.copy');
@@ -399,6 +501,8 @@ INDEX_SCRIPT = Template("""
     empty=json.dumps(NO_TARGETS_MESSAGE),
     interval=INDEX_POLL_INTERVAL_MS,
     badges=json.dumps({name: {"text": text, "title": title} for name, (text, title) in BADGES.items()}),
+    automation_title=json.dumps(AUTOMATION_TITLE),
+    indicate_title=json.dumps(INDICATE_TITLE),
 )
 
 
@@ -588,6 +692,9 @@ async def available_targets(request: Request, _: str):
             "webSocketDebuggerUrl": f"ws://{host}/devtools/page/{target_id}",
             "devtoolsFrontendUrl": f"{_frontend_url(page)}?ws={host}/devtools/page/{target_id}",
         })
+        if application.icon:
+            # chrome://inspect renders it next to the target, as it does a page's favicon.
+            targets[-1]["faviconUrl"] = f"http://{host}/icon/{application.id_}"
     return targets
 
 
@@ -632,7 +739,8 @@ async def landing_targets(request: Request) -> dict[str, Any]:
             "label": target_label(page),
             "type": target_type(page),
             "url": target_url(application, page),
-            "application": application_info(application),
+            "application": application_info(app.state.inspector, application),
+            "search": search_text(application, page),
             "paused": target_id in HELD_TARGETS,
             "debugged_by": debugged_by(app.state.inspector, page),
             "webSocketDebuggerUrl": f"ws://{host}/devtools/page/{target_id}",
@@ -640,6 +748,22 @@ async def landing_targets(request: Request) -> dict[str, Any]:
             "attach": attach_config(application, page, host, target_id),
         })
     return {"targets": targets, "pause_new_targets": app.state.holder.running}
+
+
+@app.post("/api/indicate")
+async def indicate_target(request: Request) -> dict[str, bool]:
+    """Highlight a page's view on the device, or clear it: {"id": target id, "enabled": bool}.
+    JSContexts have no view; asking for one is answered with enabled=false and nothing sent."""
+    body = await request.json()
+    try:
+        application, page = app.state.inspector.find_page_id(str(body["id"]))
+    except KeyError:
+        return {"enabled": False}
+    if page.type_ == WirTypes.JAVASCRIPT:
+        return {"enabled": False}
+    enabled = bool(body.get("enabled", True))
+    await app.state.inspector.indicate_web_view(application, page, enabled)
+    return {"enabled": enabled}
 
 
 @app.get("/pause-new-targets")
@@ -702,6 +826,8 @@ async def index(request: Request) -> HTMLResponse:
         f"<code>{escape(host.rpartition(':')[2])}</code>, attach to "
         "<i>Chrome or Node.js &gt; 6.3 started with --inspect</i>. Debug it and pick the page or "
         "JSContext from the list WebStorm shows.</p></details>"
+        f'<input class="filter" id="filter" type="search" placeholder="{FILTER_PLACEHOLDER}" '
+        'aria-label="Filter targets" autocomplete="off">'
         "</header>"
         # Rendered server-side once so the list is there before any script runs, then kept up to
         # date in place by INDEX_SCRIPT.
@@ -721,12 +847,18 @@ def targets_html(inspector: WebinspectorService, host: str) -> str:
     def flush() -> None:
         if current is None or not items:
             return
-        info = application_info(current)
+        info = application_info(inspector, current)
         icon = f'<img class="icon" src="{escape(info["icon"])}" alt="">' if info["icon"] else ""
+        host = f" &middot; in {escape(info['host'])}" if info["host"] else ""
+        automation = (
+            f'<span class="badge auto" title="{escape(AUTOMATION_TITLE)}">automation</span>'
+            if info["automation"]
+            else ""
+        )
         count = f"{len(items)} target{'' if len(items) == 1 else 's'}"
         header = (
             f'<summary class="app-header">{icon}<span class="name">{escape(info["name"])}</span>'
-            f"<small>{escape(info['bundle'])} &middot; pid {info['pid']}</small>"
+            f"<small>{escape(info['bundle'])} &middot; pid {info['pid']}{host}</small>{automation}"
             f'<small class="count">{count}</small></summary>'
         )
         sections.append(f'<details class="app" open>{header}<ul class="targets">{"".join(items)}</ul></details>')
@@ -739,7 +871,13 @@ def targets_html(inspector: WebinspectorService, host: str) -> str:
         frontend = f"{_frontend_url(page)}?ws={host}/devtools/page/{target_id}"
         title = target_label(page)
         is_jscontext = page.type_ == WirTypes.JAVASCRIPT
-        kind = f'<span class="kind {"jscontext" if is_jscontext else "page"}">{"JSContext" if is_jscontext else "Page"}</span>'
+        if is_jscontext:
+            kind = '<span class="kind jscontext">JSContext</span>'
+            attributes = ""
+        else:
+            kind = f'<span class="kind page" title="{escape(INDICATE_TITLE)}">Page</span>'
+            attributes = f' data-indicate="{escape(target_id)}"'
+        attributes += f' data-search="{escape(search_text(application, page))}"'
         # Attached before it ran and stopped on its first statement; opening it lands there.
         # Otherwise, whoever is debugging it now.
         state = "paused" if target_id in HELD_TARGETS else debugged_by(inspector, page)
@@ -755,7 +893,7 @@ def targets_html(inspector: WebinspectorService, host: str) -> str:
             f"<pre>{escape(config, quote=False)}</pre></div></details>"
         )
         items.append(
-            f'<li class="target">{kind}<span><a href="{escape(frontend)}">{escape(title)}</a>{badge}</span>'
+            f'<li class="target"{attributes}>{kind}<span><a href="{escape(frontend)}">{escape(title)}</a>{badge}</span>'
             f"<small>{escape(target_url(application, page))}</small>{attach}</li>"
         )
     flush()

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -98,18 +98,60 @@ LOGO_PNG = (importlib.resources.files(pymobiledevice3.resources) / "webinspector
 # Label of the landing page's pause-on-launch switch (see pause_new_targets endpoints).
 PAUSE_NEW_TARGETS_LABEL = "Pause new JSContexts on launch"
 
+# Badge shown next to a debuggable's title: (text, tooltip). "paused" is a JSContext the bridge is
+# holding on its first statement; the other two say who is debugging it right now - the device
+# reports the Web Inspector connection attached to each debuggable, and WebKit serves one session
+# per debuggable, so anyone else has to wait for that connection to let go.
+BADGES: dict[str, tuple[str, str]] = {
+    "paused": ("paused", "Held by the bridge on its first statement; open it to land on the pause."),
+    "bridge": ("attached here", "Being debugged through this bridge; opening it takes it over from that session."),
+    "other": (
+        "held elsewhere",
+        "Being debugged over another Web Inspector connection (Safari, another pymobiledevice3); "
+        "detach that debugger first.",
+    ),
+}
+
+
+def target_label(page: Page) -> str:
+    """The landing page's link text. It sits under its process's header there, so a JSContext needs
+    only its number (its /json/list title carries the process too, for editors listing targets flat)."""
+    if page.type_ == WirTypes.JAVASCRIPT:
+        return f"{page.web_title or 'JSContext'} #{page.id_}"
+    return page.web_title or page.web_url or f"page {page.id_}"
+
+
+def application_info(application: Application) -> dict[str, Any]:
+    """The process a debuggable belongs to, as the landing page shows it."""
+    return {
+        "id": application.id_,
+        "name": application.name,
+        "pid": application.pid,
+        "bundle": application.bundle,
+        "icon": f"/icon/{application.id_}" if application.icon else "",
+    }
+
+
+def debugged_by(inspector: WebinspectorService, page: Page) -> str:
+    """Who is debugging a page right now: "" for nobody, "bridge" for a session of this bridge, "other"
+    for a different Web Inspector connection."""
+    if not page.web_connection_id:
+        return ""
+    return "bridge" if page.web_connection_id == inspector.connection_id else "other"
+
+
 INDEX_STYLE = """
 :root {
   color-scheme: light dark;
   --bg: #f5f5f7; --card: #ffffff; --text: #1d1d1f; --muted: #6e6e73; --line: #e5e5ea;
   --accent: #0a84ff; --page: #dbeafe; --page-text: #1e40af; --js: #fef3c7; --js-text: #92400e;
-  --paused: #fde68a; --paused-text: #78350f; --switch: #c7c7cc;
+  --paused: #fde68a; --paused-text: #78350f; --held: #fecaca; --held-text: #7f1d1d; --switch: #c7c7cc;
 }
 @media (prefers-color-scheme: dark) {
   :root {
     --bg: #1c1c1e; --card: #2c2c2e; --text: #f5f5f7; --muted: #98989d; --line: #3a3a3c;
     --page: #1e3a8a; --page-text: #bfdbfe; --js: #78350f; --js-text: #fde68a;
-    --paused: #92400e; --paused-text: #fef3c7; --switch: #48484a;
+    --paused: #92400e; --paused-text: #fef3c7; --held: #7f1d1d; --held-text: #fecaca; --switch: #48484a;
   }
 }
 * { box-sizing: border-box; }
@@ -136,6 +178,20 @@ h1 small { display: block; font-size: 12px; font-weight: 400; color: var(--muted
 .toggle input:checked + .switch::after { transform: translateX(14px); }
 .toggle input:focus-visible + .switch { outline: 2px solid var(--accent); outline-offset: 2px; }
 .hint { flex-basis: 100%; margin: 0; font-size: 12px; color: var(--muted); }
+details.app + details.app { margin-top: 16px; }
+.app-header { display: flex; align-items: center; gap: 8px; margin: 0 0 6px 2px; cursor: pointer; list-style: none; }
+.app-header::-webkit-details-marker { display: none; }
+.app-header::before {
+  content: ""; flex: none; width: 6px; height: 6px; margin: 0 2px 2px 0;
+  border-right: 1.5px solid var(--muted); border-bottom: 1.5px solid var(--muted);
+  transform: rotate(45deg); transition: transform .15s;
+}
+details.app:not([open]) > .app-header { margin-bottom: 0; }
+details.app:not([open]) > .app-header::before { transform: rotate(-45deg); margin: 0 0 0 2px; }
+.app-header img.icon { width: 22px; height: 22px; border-radius: 5px; flex: none; }
+.app-header .name { font-size: 13.5px; font-weight: 600; }
+.app-header small { color: var(--muted); font-size: 11.5px; overflow-wrap: anywhere; }
+.app-header small.count { margin-left: auto; white-space: nowrap; }
 ul.targets { list-style: none; margin: 0; padding: 0; display: grid; gap: 6px; }
 li.target {
   background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 7px 12px;
@@ -155,6 +211,7 @@ li.target small { color: var(--muted); font-size: 11.5px; overflow-wrap: anywher
   display: inline-block; margin-left: 6px; font-size: 10px; font-weight: 600; padding: 1px 7px;
   border-radius: 999px; background: var(--paused); color: var(--paused-text); vertical-align: 1px;
 }
+.badge.held { background: var(--held); color: var(--held-text); }
 details.attach { grid-column: 2; margin-top: 2px; font-size: 12px; }
 details.attach summary, details.editors summary { cursor: pointer; color: var(--muted); }
 details.attach summary:hover, details.editors summary:hover { color: var(--text); }
@@ -179,8 +236,23 @@ p.empty { color: var(--muted); text-align: center; padding: 28px 0; }
 
 INDEX_SCRIPT = Template("""
 (function () {
+  const BADGES = $badges;
   const container = document.getElementById('targets');
   const toggle = document.getElementById('pause-new-targets');
+  // Process groups the user folded; the list is rebuilt whenever it changes, so the fold has to
+  // outlive the elements.
+  const folded = new Set();
+  container.addEventListener('toggle', (event) => {
+    const group = event.target;
+    if (!group.classList.contains('app')) {
+      return;
+    }
+    if (group.open) {
+      folded.delete(group.dataset.app);
+    } else {
+      folded.add(group.dataset.app);
+    }
+  }, true);
   let rendered = null;
   function render(targets) {
     container.textContent = '';
@@ -191,21 +263,52 @@ INDEX_SCRIPT = Template("""
       container.appendChild(empty);
       return;
     }
-    const list = document.createElement('ul');
-    list.className = 'targets';
+    let section = null;
+    let list = null;
     for (const target of targets) {
+      if (section === null || section.dataset.app !== target.application.id) {
+        section = document.createElement('details');
+        section.className = 'app';
+        section.dataset.app = target.application.id;
+        section.open = !folded.has(target.application.id);
+        const header = document.createElement('summary');
+        header.className = 'app-header';
+        if (target.application.icon) {
+          const icon = document.createElement('img');
+          icon.className = 'icon';
+          icon.src = target.application.icon;
+          icon.alt = '';
+          header.appendChild(icon);
+        }
+        const name = document.createElement('span');
+        name.className = 'name';
+        name.textContent = target.application.name;
+        const details = document.createElement('small');
+        details.textContent = target.application.bundle + ' \u00b7 pid ' + target.application.pid;
+        const count = document.createElement('small');
+        count.className = 'count';
+        const total = targets.filter((t) => t.application.id === target.application.id).length;
+        count.textContent = total + (total === 1 ? ' target' : ' targets');
+        header.append(name, details, count);
+        list = document.createElement('ul');
+        list.className = 'targets';
+        section.append(header, list);
+        container.appendChild(section);
+      }
       const kind = document.createElement('span');
       kind.className = 'kind ' + (target.type === 'node' ? 'jscontext' : 'page');
       kind.textContent = target.type === 'node' ? 'JSContext' : 'Page';
       const title = document.createElement('span');
       const link = document.createElement('a');
       link.href = target.devtoolsFrontendUrl;
-      link.textContent = target.title || target.url || ('page ' + target.id);
+      link.textContent = target.label;
       title.appendChild(link);
-      if (target.paused) {
+      const state = target.paused ? 'paused' : target.debugged_by;
+      if (state) {
         const badge = document.createElement('span');
-        badge.className = 'badge';
-        badge.textContent = 'paused';
+        badge.className = 'badge' + (state === 'other' ? ' held' : '');
+        badge.textContent = BADGES[state].text;
+        badge.title = BADGES[state].title;
         title.appendChild(badge);
       }
       const url = document.createElement('small');
@@ -230,7 +333,6 @@ INDEX_SCRIPT = Template("""
       item.append(kind, title, url, attach);
       list.appendChild(item);
     }
-    container.appendChild(list);
   }
   container.addEventListener('click', async (event) => {
     const button = event.target.closest('button.copy');
@@ -293,7 +395,11 @@ INDEX_SCRIPT = Template("""
   }
   setTimeout(poll, $interval);
 })();
-""").substitute(empty=json.dumps(NO_TARGETS_MESSAGE), interval=INDEX_POLL_INTERVAL_MS)
+""").substitute(
+    empty=json.dumps(NO_TARGETS_MESSAGE),
+    interval=INDEX_POLL_INTERVAL_MS,
+    badges=json.dumps({name: {"text": text, "title": title} for name, (text, title) in BADGES.items()}),
+)
 
 
 def find_chrome(explicit: Optional[str] = None) -> Optional[str]:
@@ -513,8 +619,9 @@ def attach_config(application: Application, page: Page, host: str, target_id: st
 
 @app.get("/api/targets")
 async def landing_targets(request: Request) -> dict[str, Any]:
-    """What the landing page renders: the /json/list targets plus what only the bridge knows -
-    which of them it is holding paused, and whether it is taking new ones (the page's switch)."""
+    """What the landing page renders: the /json/list targets plus what the listing knows on top -
+    which of them the bridge is holding paused, who is debugging each one, and whether the bridge
+    is taking new ones (the page's switch)."""
     await refresh_listings()
     host = request.headers.get("host", "127.0.0.1:9222")
     targets: list[dict[str, Any]] = []
@@ -522,9 +629,12 @@ async def landing_targets(request: Request) -> dict[str, Any]:
         targets.append({
             "id": target_id,
             "title": target_title(application, page),
+            "label": target_label(page),
             "type": target_type(page),
             "url": target_url(application, page),
+            "application": application_info(application),
             "paused": target_id in HELD_TARGETS,
+            "debugged_by": debugged_by(app.state.inspector, page),
             "webSocketDebuggerUrl": f"ws://{host}/devtools/page/{target_id}",
             "devtoolsFrontendUrl": f"{_frontend_url(page)}?ws={host}/devtools/page/{target_id}",
             "attach": attach_config(application, page, host, target_id),
@@ -602,15 +712,42 @@ async def index(request: Request) -> HTMLResponse:
 
 
 def targets_html(inspector: WebinspectorService, host: str) -> str:
-    """The landing page's target list. Titles and URLs come from the device, so they are escaped."""
+    """The landing page's target list, grouped by process; each group folds on its header. Names,
+    titles and URLs come from the device, so they are escaped."""
+    sections: list[str] = []
     items: list[str] = []
+    current: Optional[Application] = None
+
+    def flush() -> None:
+        if current is None or not items:
+            return
+        info = application_info(current)
+        icon = f'<img class="icon" src="{escape(info["icon"])}" alt="">' if info["icon"] else ""
+        count = f"{len(items)} target{'' if len(items) == 1 else 's'}"
+        header = (
+            f'<summary class="app-header">{icon}<span class="name">{escape(info["name"])}</span>'
+            f"<small>{escape(info['bundle'])} &middot; pid {info['pid']}</small>"
+            f'<small class="count">{count}</small></summary>'
+        )
+        sections.append(f'<details class="app" open>{header}<ul class="targets">{"".join(items)}</ul></details>')
+        items.clear()
+
     for target_id, application, page in iter_inspectable(inspector):
+        if application is not current:
+            flush()
+            current = application
         frontend = f"{_frontend_url(page)}?ws={host}/devtools/page/{target_id}"
-        title = target_title(application, page) or page.web_url or f"page {target_id}"
+        title = target_label(page)
         is_jscontext = page.type_ == WirTypes.JAVASCRIPT
         kind = f'<span class="kind {"jscontext" if is_jscontext else "page"}">{"JSContext" if is_jscontext else "Page"}</span>'
         # Attached before it ran and stopped on its first statement; opening it lands there.
-        badge = '<span class="badge">paused</span>' if target_id in HELD_TARGETS else ""
+        # Otherwise, whoever is debugging it now.
+        state = "paused" if target_id in HELD_TARGETS else debugged_by(inspector, page)
+        badge = ""
+        if state:
+            text, tooltip = BADGES[state]
+            held = " held" if state == "other" else ""
+            badge = f'<span class="badge{held}" title="{escape(tooltip)}">{escape(text)}</span>'
         config = json.dumps(attach_config(application, page, host, target_id), indent=4)
         attach = (
             '<details class="attach"><summary>Attach from VS Code</summary>'
@@ -621,9 +758,10 @@ def targets_html(inspector: WebinspectorService, host: str) -> str:
             f'<li class="target">{kind}<span><a href="{escape(frontend)}">{escape(title)}</a>{badge}</span>'
             f"<small>{escape(target_url(application, page))}</small>{attach}</li>"
         )
-    if not items:
+    flush()
+    if not sections:
         return NO_TARGETS_MESSAGE_HTML
-    return '<ul class="targets">' + "".join(items) + "</ul>"
+    return "".join(sections)
 
 
 @app.get("/logo.png")
@@ -631,6 +769,15 @@ def targets_html(inspector: WebinspectorService, host: str) -> str:
 async def serve_logo() -> Response:
     """The project logo; /favicon.ico as well, for browsers that ask for the default icon path."""
     return Response(content=LOGO_PNG, media_type="image/png")
+
+
+@app.get("/icon/{app_id}")
+async def application_icon(app_id: str) -> Response:
+    """The icon the device reports for a connected process, for the landing page's headers."""
+    application = app.state.inspector.connected_application.get(app_id)
+    if application is None or not application.icon:
+        return Response(status_code=404)
+    return Response(content=application.icon, media_type="image/png", headers={"Cache-Control": "max-age=3600"})
 
 
 @app.get("/devtools/{path:path}")

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -656,9 +656,19 @@ class WebinspectorService(LockdownService):
             },
         )
 
+    async def indicate_web_view(self, app: Application, page: Page, enable: bool) -> None:
+        """Highlight a web page's view on the device screen (a translucent overlay, as Safari's
+        Develop menu does while hovering a page), or clear the highlight.
+
+        :param app: The application owning the page.
+        :param page: The web page to highlight. JSContexts have nothing to highlight.
+        :param enable: Whether to show or clear the highlight.
+        """
+        await self._forward_indicate_web_view(app.id_, page.id_, enable)
+
     async def _forward_indicate_web_view(self, app_id: str, page_id: int, enable: bool):
         await self._send_message(
-            "_rpc_forwardIndicateWebView",
+            "_rpc_forwardIndicateWebView:",
             {
                 "WIRApplicationIdentifierKey": app_id,
                 "WIRPageIdentifierKey": page_id,

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -71,7 +71,8 @@ class Page:
     web_title: str = ""
     # The Web Inspector connection currently debugging this page, when there is one. WebKit serves
     # a single inspector session per debuggable, so a page listed with somebody else's connection
-    # identifier cannot be attached to until they let go.
+    # identifier cannot be attached to until they let go. Reported for every debuggable, JSContexts
+    # included; automation targets carry theirs in `automation_connection_id`.
     web_connection_id: str = ""
     automation_is_paired_key: bool = False
     automation_name: str = ""
@@ -85,11 +86,12 @@ class Page:
         if p.type_ in (WirTypes.WEB, WirTypes.WEB_PAGE):
             p.web_title = page_dict["WIRTitleKey"]
             p.web_url = page_dict["WIRURLKey"]
-            p.web_connection_id = page_dict.get("WIRConnectionIdentifierKey", "")
         if p.type_ == WirTypes.JAVASCRIPT:
             # A JSContext debuggable is listed with a title (its name, "JSContext" by default) but
             # no URL - there is no document behind it.
             p.web_title = page_dict.get("WIRTitleKey", "")
+        if p.type_ != WirTypes.AUTOMATION:
+            p.web_connection_id = page_dict.get("WIRConnectionIdentifierKey", "")
         if p.type_ == WirTypes.AUTOMATION:
             p.automation_is_paired_key = page_dict["WIRAutomationTargetIsPairedKey"]
             p.automation_name = page_dict["WIRAutomationTargetNameKey"]
@@ -121,6 +123,9 @@ class Application:
     proxy: bool
     ready: bool
     host: str = ""
+    # The application's icon as PNG bytes (`WIRApplicationIconKey`); processes without one are
+    # sent a generic placeholder by the device.
+    icon: bytes = b""
 
     @classmethod
     def from_application_dictionary(cls, app_dict: dict[str, Any]) -> "Application":
@@ -134,6 +139,7 @@ class Application:
             app_dict["WIRIsApplicationProxyKey"],
             app_dict["WIRIsApplicationReadyKey"],
             app_dict.get("WIRHostApplicationIdentifierKey", ""),
+            app_dict.get("WIRApplicationIconKey", b""),
         )
 
 

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -9,7 +9,7 @@ import uuid
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, Optional
+from typing import Any, Optional, cast
 from urllib.parse import urlsplit
 
 import httpx
@@ -1584,6 +1584,122 @@ def test_landing_page_groups_targets_by_process() -> None:
     assert sections[1].count("<li") == 2
 
 
+def _listed_app(pages: dict[str, dict[str, Any]], **applications: Application) -> Any:
+    app = _landing_page_app()
+    app.state.inspector.connected_application = dict(applications)
+    app.state.inspector.application_pages = {
+        app_id: {key: Page.from_page_dictionary(listing) for key, listing in listings.items()}
+        for app_id, listings in pages.items()
+    }
+    return app
+
+
+_WEB_PAGE = {"WIRPageIdentifierKey": 1, "WIRTypeKey": "WIRTypeWeb", "WIRTitleKey": "Example", "WIRURLKey": "https://e/"}
+_JS_CONTEXT = {"WIRPageIdentifierKey": 1, "WIRTypeKey": "WIRTypeJavaScript", "WIRTitleKey": "JSContext"}
+
+
+@pytest.mark.asyncio
+async def test_hovering_a_page_highlights_it_on_the_device() -> None:
+    """The landing page forwards a hovered page to the device's indicate message, and clears it
+    when the pointer leaves. A JSContext has no view to highlight; an unknown target is gone."""
+    app = _listed_app(
+        {"PID:1": {"1": _WEB_PAGE}, "PID:2": {"1": _JS_CONTEXT}},
+        **{
+            "PID:1": Application(
+                "PID:1", "com.apple.mobilesafari", 1, "Safari", AutomationAvailability.AVAILABLE, 0, False, True
+            ),
+            "PID:2": Application("PID:2", "com.example.app", 2, "app", AutomationAvailability.UNKNOWN, 0, False, True),
+        },
+    )
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as client:
+        on = await client.post("/api/indicate", json={"id": "PID:1:1", "enabled": True})
+        off = await client.post("/api/indicate", json={"id": "PID:1:1", "enabled": False})
+        jscontext = await client.post("/api/indicate", json={"id": "PID:2:1", "enabled": True})
+        gone = await client.post("/api/indicate", json={"id": "PID:3:1", "enabled": True})
+
+    assert on.json() == {"enabled": True}
+    assert off.json() == {"enabled": False}
+    assert jscontext.json() == {"enabled": False}
+    assert gone.json() == {"enabled": False}
+    assert app.state.inspector.indicated == [("PID:1", 1, True), ("PID:1", 1, False)]
+
+
+@pytest.mark.asyncio
+async def test_chrome_listing_carries_the_process_icon_as_favicon() -> None:
+    """chrome://inspect shows a target's faviconUrl; a process with an icon lends it to its targets."""
+    with_icon = Application(
+        "PID:1", "com.apple.mobilesafari", 1, "Safari", AutomationAvailability.UNKNOWN, 0, False, True
+    )
+    with_icon.icon = b"\x89PNG"
+    without = Application("PID:2", "com.example.app", 2, "app", AutomationAvailability.UNKNOWN, 0, False, True)
+    app = _listed_app(
+        {"PID:1": {"1": _WEB_PAGE}, "PID:2": {"1": _JS_CONTEXT}}, **{"PID:1": with_icon, "PID:2": without}
+    )
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as client:
+        targets = {target["id"]: target for target in (await client.get("/json/list")).json()}
+
+    assert targets["PID:1:1"]["faviconUrl"] == "http://t/icon/PID:1"
+    assert "faviconUrl" not in targets["PID:2:1"]
+
+
+def test_landing_page_names_the_host_of_a_proxy_and_flags_automation() -> None:
+    """A process running web content for another names the app it runs in; a process that accepts
+    Remote Automation sessions is flagged. Neither shows on an ordinary process."""
+    inspector = _inspector_with(
+        {"PID:1": {"1": Page.from_page_dictionary(_WEB_PAGE)}, "PID:2": {"1": Page.from_page_dictionary(_WEB_PAGE)}},
+        {"PID:1": "Safari", "PID:2": "WebContent"},
+    )
+    inspector.connected_application["PID:1"].availability = AutomationAvailability.AVAILABLE
+    inspector.connected_application["PID:2"].proxy = True
+    inspector.connected_application["PID:2"].host = "PID:1"
+
+    html = targets_html(inspector, "127.0.0.1:9222")
+
+    safari, webcontent = html.split('<details class="app" open>')[1:]
+    assert "<small>com.example.app &middot; pid 1</small>" in safari
+    assert 'class="badge auto"' in safari and ">automation</span>" in safari
+    assert "<small>com.example.app &middot; pid 2 &middot; in Safari</small>" in webcontent
+    assert "badge auto" not in webcontent
+
+
+@pytest.mark.asyncio
+async def test_landing_page_has_a_filter_and_targets_carry_what_it_matches() -> None:
+    """The filter box narrows the list client-side; every target carries its searchable text, and
+    web pages (not JSContexts) carry the id the hover highlight is sent for."""
+    app = _listed_app(
+        {"PID:1": {"1": _WEB_PAGE}, "PID:2": {"1": _JS_CONTEXT}},
+        **{
+            "PID:1": Application(
+                "PID:1", "com.apple.mobilesafari", 1, "Safari", AutomationAvailability.UNKNOWN, 0, False, True
+            ),
+            "PID:2": Application("PID:2", "com.example.app", 2, "app", AutomationAvailability.UNKNOWN, 0, False, True),
+        },
+    )
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as client:
+        html = (await client.get("/")).text
+        listing = (await client.get("/api/targets")).json()
+
+    assert '<input class="filter" id="filter" type="search"' in html
+    assert (
+        '<li class="target" data-indicate="PID:1:1" data-search="example https://e/ safari com.apple.mobilesafari 1">'
+        in html
+    )
+    assert (
+        '<li class="target" data-search="jscontext #1 jscontext://com.example.app/2/1 app com.example.app 2">' in html
+    )
+    by_id = {target["id"]: target for target in listing["targets"]}
+    assert by_id["PID:1:1"]["search"] == "example https://e/ safari com.apple.mobilesafari 1"
+    assert by_id["PID:1:1"]["application"] == {
+        "id": "PID:1",
+        "name": "Safari",
+        "pid": 1,
+        "bundle": "com.apple.mobilesafari",
+        "icon": "",
+        "host": "",
+        "automation": False,
+    }
+
+
 @pytest.mark.asyncio
 async def test_process_icons_are_served_from_the_listing() -> None:
     """A process's icon is the PNG the device sent; a process without one, or unknown, is a 404."""
@@ -1814,11 +1930,19 @@ def _landing_page_app() -> Any:
 
     class _Inspector:
         def __init__(self) -> None:
+            self.connection_id = "BRIDGE-CONNECTION"
             self.application_pages: dict[str, dict[str, Page]] = {}
             self.connected_application: dict[str, Application] = {}
+            self.indicated: list[tuple[str, int, bool]] = []
 
         async def get_open_pages(self) -> None:
             pass
+
+        def find_page_id(self, page_id: str) -> tuple[Application, Page]:
+            return WebinspectorService.find_page_id(cast(Any, self), page_id)
+
+        async def indicate_web_view(self, application: Application, page: Page, enable: bool) -> None:
+            self.indicated.append((application.id_, page.id_, enable))
 
     class _Holder:
         running = False

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -1494,6 +1494,7 @@ async def testp_cdp_server_keyboard_input_submits_forms(lockdown: LockdownClient
 
 def _inspector_with(pages: dict[str, dict[str, Page]], names: dict[str, str]) -> WebinspectorService:
     inspector = WebinspectorService.__new__(WebinspectorService)
+    inspector.connection_id = "BRIDGE-CONNECTION"
     inspector.application_pages = pages
     inspector.connected_application = {
         app_id: Application(
@@ -1537,8 +1538,107 @@ def test_landing_page_links_each_kind_to_its_own_frontend() -> None:
     html = targets_html(inspector, "127.0.0.1:9222")
 
     assert '<a href="/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/PID:1:1">Example</a>' in html
-    # Every JSContext of a process is titled "JSContext"; the context number tells them apart.
-    assert '<a href="/devtools/js_app.html?ws=127.0.0.1:9222/devtools/page/PID:2:1">myapp (2): JSContext #1</a>' in html
+    # Every JSContext of a process is titled "JSContext"; the context number tells them apart, and
+    # the process is named by the header the context is listed under.
+    assert '<a href="/devtools/js_app.html?ws=127.0.0.1:9222/devtools/page/PID:2:1">JSContext #1</a>' in html
+
+
+def test_landing_page_groups_targets_by_process() -> None:
+    """Each process gets a header with what the device reports about it - icon, name, bundle, pid -
+    and its debuggables listed under it, in a group that folds on the header. A process without an
+    icon gets no image."""
+    inspector = _inspector_with(
+        {
+            "PID:1": {
+                "1": Page.from_page_dictionary({
+                    "WIRPageIdentifierKey": 1,
+                    "WIRTypeKey": "WIRTypeWeb",
+                    "WIRTitleKey": "Example",
+                    "WIRURLKey": "https://example.com/",
+                })
+            },
+            "PID:2": {
+                str(n): Page.from_page_dictionary({
+                    "WIRPageIdentifierKey": n,
+                    "WIRTypeKey": "WIRTypeJavaScript",
+                    "WIRTitleKey": "JSContext",
+                })
+                for n in (1, 2)
+            },
+        },
+        {"PID:1": "MobileSafari", "PID:2": "myapp"},
+    )
+    inspector.connected_application["PID:1"].icon = b"\x89PNG..."
+
+    html = targets_html(inspector, "127.0.0.1:9222")
+
+    sections = html.split('<details class="app" open>')[1:]
+    assert len(sections) == 2
+    assert (
+        '<summary class="app-header"><img class="icon" src="/icon/PID:1" alt=""><span class="name">MobileSafari</span>'
+        '<small>com.example.app &middot; pid 1</small><small class="count">1 target</small></summary>'
+    ) in sections[0]
+    assert sections[0].count("<li") == 1
+    assert '<summary class="app-header"><span class="name">myapp</span>' in sections[1]
+    assert '<small class="count">2 targets</small>' in sections[1]
+    assert sections[1].count("<li") == 2
+
+
+@pytest.mark.asyncio
+async def test_process_icons_are_served_from_the_listing() -> None:
+    """A process's icon is the PNG the device sent; a process without one, or unknown, is a 404."""
+    app = _landing_page_app()
+    app.state.inspector.connected_application = {
+        "PID:1": Application(
+            "PID:1", "com.example.app", 1, "app", AutomationAvailability.NOT_AVAILABLE, 0, False, True
+        ),
+    }
+    app.state.inspector.connected_application["PID:1"].icon = b"\x89PNG\r\n\x1a\nicon"
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as client:
+        icon = await client.get("/icon/PID:1")
+        missing = await client.get("/icon/PID:2")
+
+    assert icon.status_code == 200
+    assert icon.headers["content-type"] == "image/png"
+    assert icon.content == b"\x89PNG\r\n\x1a\nicon"
+    assert missing.status_code == 404
+
+
+def test_landing_page_says_who_is_debugging_each_target() -> None:
+    """A debuggable already held by a session is flagged, and whose session it is decides what
+    opening it will do: a session of this bridge is taken over, another connection has to let go."""
+    inspector = _inspector_with(
+        {
+            "PID:2": {
+                "1": Page.from_page_dictionary({
+                    "WIRPageIdentifierKey": 1,
+                    "WIRTypeKey": "WIRTypeJavaScript",
+                    "WIRTitleKey": "JSContext",
+                }),
+                "2": Page.from_page_dictionary({
+                    "WIRPageIdentifierKey": 2,
+                    "WIRTypeKey": "WIRTypeJavaScript",
+                    "WIRTitleKey": "JSContext",
+                    "WIRConnectionIdentifierKey": "BRIDGE-CONNECTION",
+                }),
+                "3": Page.from_page_dictionary({
+                    "WIRPageIdentifierKey": 3,
+                    "WIRTypeKey": "WIRTypeJavaScript",
+                    "WIRTitleKey": "JSContext",
+                    "WIRConnectionIdentifierKey": "SAFARI-CONNECTION",
+                }),
+            },
+        },
+        {"PID:2": "myapp"},
+    )
+
+    html = targets_html(inspector, "127.0.0.1:9222")
+
+    free, bridge, other = (html.split("</li>")[i] for i in range(3))
+    assert 'class="app-header"' in free
+    assert "badge" not in free
+    assert 'class="badge"' in bridge and ">attached here</span>" in bridge
+    assert 'class="badge held"' in other and ">held elsewhere</span>" in other
 
 
 def test_landing_page_escapes_titles_from_the_device() -> None:

--- a/tests/services/test_web_protocol/test_cdp_wait_for_debugger.py
+++ b/tests/services/test_web_protocol/test_cdp_wait_for_debugger.py
@@ -703,11 +703,10 @@ def test_landing_page_marks_held_targets_paused() -> None:
     try:
         html = targets_html(inspector, "127.0.0.1:9222")
         assert "paused" in html
-        # The link itself stays as it was: the title, nothing else, is its text.
-        assert (
-            '<a href="/devtools/js_app.html?ws=127.0.0.1:9222/devtools/page/PID:42:1">Example (42): JSContext #1</a>'
-            in html
-        )
+        # The link itself stays as it was: the context's label, nothing else, is its text; its
+        # process is named by the header it is listed under.
+        assert '<span class="name">Example</span>' in html
+        assert '<a href="/devtools/js_app.html?ws=127.0.0.1:9222/devtools/page/PID:42:1">JSContext #1</a>' in html
     finally:
         HELD_TARGETS.clear()
 

--- a/tests/services/test_webinspector.py
+++ b/tests/services/test_webinspector.py
@@ -7,7 +7,14 @@ import pytest
 
 from pymobiledevice3.exceptions import WebInspectorNotEnabledError
 from pymobiledevice3.lockdown import LockdownClient
-from pymobiledevice3.services.webinspector import SAFARI, Page, WebinspectorService, WirTypes, make_target_id
+from pymobiledevice3.services.webinspector import (
+    SAFARI,
+    Application,
+    Page,
+    WebinspectorService,
+    WirTypes,
+    make_target_id,
+)
 
 
 @asynccontextmanager
@@ -47,6 +54,36 @@ def test_javascript_page_listing_keeps_its_title() -> None:
     assert page.type_ == WirTypes.JAVASCRIPT
     assert page.web_title == "JSContext"
     assert page.web_url == ""
+    assert page.web_connection_id == ""
+
+
+def test_javascript_page_listing_reports_the_debugger_holding_it() -> None:
+    """The device names the connection debugging a JSContext exactly as it does for a web page
+    (observed on iOS 26.6.1: the key appears while a session is attached, and only then)."""
+    page = Page.from_page_dictionary({
+        "WIRTitleKey": "JSContext",
+        "WIRTypeKey": "WIRTypeJavaScript",
+        "WIRPageIdentifierKey": 7,
+        "WIRConnectionIdentifierKey": "D0F5501A-3182-492B-AE82-F0F323B02C28",
+        "WIROverrideNameKey": "",
+    })
+    assert page.web_connection_id == "D0F5501A-3182-492B-AE82-F0F323B02C28"
+
+
+def test_application_listing_keeps_its_icon() -> None:
+    """The device sends each process's icon as PNG bytes (a generic one for processes without an
+    icon of their own); the landing page shows it."""
+    application = Application.from_application_dictionary({
+        "WIRApplicationIdentifierKey": "PID:26846",
+        "WIRApplicationBundleIdentifierKey": "com.apple.mobilesafari",
+        "WIRApplicationNameKey": "Safari",
+        "WIRAutomationAvailabilityKey": "WIRAutomationAvailabilityAvailable",
+        "WIRIsApplicationActiveKey": 2,
+        "WIRIsApplicationProxyKey": False,
+        "WIRIsApplicationReadyKey": True,
+        "WIRApplicationIconKey": b"\x89PNG\r\n\x1a\nicon",
+    })
+    assert application.icon == b"\x89PNG\r\n\x1a\nicon"
 
 
 def test_web_page_listing_reports_the_debugger_holding_it() -> None:


### PR DESCRIPTION
## Summary

The CDP bridge's landing page (`pymobiledevice3 webinspector cdp`) now surfaces what the device's Web Inspector listing already reports but the page ignored, plus two conveniences for long lists.

- **Who is debugging each target.** The device puts the attached Web Inspector connection's identifier on every debuggable's listing entry, JSContexts included, but the parser only kept it for web pages and the page rendered it nowhere, so a context someone else was debugging looked free and opening it came up blank. Each target now carries a badge: **attached here** for a session of this bridge (opening it takes it over), **held elsewhere** for another Web Inspector connection (Safari, a second pymobiledevice3).
- **Grouped by process, with the device's icon.** Targets sit under a header per process with the icon the device sends, name, bundle identifier, pid and target count. Web pages previously showed no owning app at all. Groups fold on their header and stay folded while the list refreshes.
- **Hover highlights the page on the device.** The indicate message the service already had a sender for (never called, and missing its trailing colon) tints the page's view blue on the device while a page target is hovered, as Safari's Develop menu does.
- **Filter box.** Narrows the list to targets matching every typed word by title, URL, process name, bundle identifier or pid; re-applied after every refresh.
- **Smaller bits.** A proxy process names the app it runs web content for, a process that accepts Remote Automation carries an **automation** badge, and Chrome's `/json/list` entries carry the process icon as `faviconUrl` for chrome://inspect.

## Verification

On an iPhone running iOS 26.6.1:

- Raw listing probe: `WIRConnectionIdentifierKey` appears on a JSContext entry while a session is attached and is absent otherwise.
- Landing page in Chrome: both badges render live (a DevTools tab through the bridge vs. a separate Web Inspector connection holding a context); Safari's real icon and the generic daemon placeholder both render; folding and the filter survive a list refresh with no reload.
- Indicate: device screenshots show the Safari page tinted while enabled and cleared after the disable.
- `test_webinspector`, `test_cdp_server`, `test_cdp_wait_for_debugger`: 84 passed. ruff and pyright clean.

Not done: the per-app active flag the device reports did not change when Safari was brought to the foreground, so its meaning is unverified and it is not shown.
