### PR TITLE
cdp: Show the serving version on the landing page, and explain chrome://inspect

### DIFF
--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -31,7 +31,12 @@ the duration of the debugging session.
 ## Chrome DevTools
 
 Open <http://127.0.0.1:9222/> in Google Chrome and pick a page. Prefer this landing
-page over `chrome://inspect` — see the command's `--help` for why.
+page over `chrome://inspect` — see the command's `--help` for why. The page cannot
+link to `chrome://inspect` (Chrome blocks such navigations from web pages, clicked
+or not); if you want it anyway, type `chrome://inspect/#devices` into the address
+bar. Chrome discovers a bridge on `localhost:9222` by itself; any other address goes
+under **Configure...** next to *Discover network targets*. The page's header shows
+the pymobiledevice3 version serving it.
 
 Debuggables are grouped by the process that owns them, with its icon, name, bundle
 identifier and pid as the device reports them; click a process header to fold its

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -143,6 +143,16 @@ def application_info(inspector: WebinspectorService, application: Application) -
     }
 
 
+def bridge_version() -> str:
+    """The running pymobiledevice3's version, or "" when the package was not built (a bare checkout
+    without its generated version module)."""
+    try:
+        from pymobiledevice3._version import __version__
+    except ImportError:
+        return ""
+    return __version__
+
+
 AUTOMATION_TITLE = "Accepts Remote Automation sessions (Settings > Safari > Advanced > Remote Automation)."
 INDICATE_TITLE = "Hover to highlight this page on the device."
 FILTER_PLACEHOLDER = "Filter by title, URL, process, bundle or pid"
@@ -802,6 +812,8 @@ async def index(request: Request) -> HTMLResponse:
     await refresh_listings()
     host = request.headers.get("host", "127.0.0.1:9222")
     checked = " checked" if app.state.holder.running else ""
+    version = bridge_version()
+    product = f"pymobiledevice3 {escape(version)}" if version else "pymobiledevice3"
     return HTMLResponse(
         "<!doctype html><meta charset=utf-8>"
         '<meta name="viewport" content="width=device-width, initial-scale=1">'
@@ -810,7 +822,7 @@ async def index(request: Request) -> HTMLResponse:
         f"<style>{INDEX_STYLE}</style>"
         "<main><header>"
         '<img class="logo" src="/logo.png" alt="">'
-        "<h1>Web Inspector<small>pymobiledevice3 &middot; inspectable pages and JSContexts on the device</small></h1>"
+        f"<h1>Web Inspector<small>{product} &middot; inspectable pages and JSContexts on the device</small></h1>"
         f'<label class="toggle"><input type="checkbox" id="pause-new-targets"{checked}>'
         f'<span class="switch"></span>{PAUSE_NEW_TARGETS_LABEL}</label>'
         '<p class="hint">Attaches to every JSContext an app creates before it runs and stops it on its '
@@ -826,6 +838,14 @@ async def index(request: Request) -> HTMLResponse:
         f"<code>{escape(host.rpartition(':')[2])}</code>, attach to "
         "<i>Chrome or Node.js &gt; 6.3 started with --inspect</i>. Debug it and pick the page or "
         "JSContext from the list WebStorm shows.</p></details>"
+        '<details class="editors"><summary>Using chrome://inspect instead</summary>'
+        "<p>Chrome does not let a web page link to <code>chrome://inspect</code>, so this page cannot "
+        "open it for you: type <code>chrome://inspect/#devices</code> into the address bar. Chrome "
+        "looks for a bridge at <code>localhost:9222</code> on its own; for any other address, add "
+        f"<code>{escape(host)}</code> under <b>Configure...</b> next to <i>Discover network targets</i>. "
+        "Prefer this page when you can: chrome://inspect routes DevTools through Chrome's "
+        "browser-process relay, which deadlocks under sustained console traffic and freezes the "
+        "console and screen, whereas the links below connect to the bridge directly.</p></details>"
         f'<input class="filter" id="filter" type="search" placeholder="{FILTER_PLACEHOLDER}" '
         'aria-label="Filter targets" autocomplete="off">'
         "</header>"

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -8,6 +8,7 @@ import urllib.request
 import uuid
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
+from html import escape
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Optional, cast
 from urllib.parse import urlsplit
@@ -28,6 +29,7 @@ from pymobiledevice3.services.web_protocol.cdp_server import (
     _fetch,
     _frontend_base,
     app,
+    bridge_version,
     targets_html,
 )
 from pymobiledevice3.services.web_protocol.cdp_target import JS_CONTEXT_EXECUTION_ID, CdpTarget
@@ -1950,6 +1952,22 @@ def _landing_page_app() -> Any:
     app.state.inspector = _Inspector()
     app.state.holder = _Holder()
     return app
+
+
+@pytest.mark.asyncio
+async def test_landing_page_names_its_version_and_explains_chrome_inspect() -> None:
+    """The header says which pymobiledevice3 is serving the page, and a note tells people how to
+    reach chrome://inspect - the page cannot link to it, Chrome blocks such navigations."""
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=_landing_page_app()), base_url="http://t") as client:
+        html = (await client.get("/")).text
+
+    version = bridge_version()
+    assert version
+    assert f"<small>pymobiledevice3 {escape(version)} &middot; inspectable pages" in html
+    assert "<summary>Using chrome://inspect instead</summary>" in html
+    assert "<code>chrome://inspect/#devices</code>" in html
+    # The bridge's own address, for Chrome's discovery list when it is not the default one.
+    assert "add <code>t</code> under <b>Configure...</b>" in html
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two additions to the CDP bridge's landing page (`pymobiledevice3 webinspector cdp`):

- **Version in the header.** The subtitle now reads `pymobiledevice3 <version> · inspectable pages and JSContexts on the device`, from the package's generated version module. A bare checkout without that module shows the name alone.
- **A note on chrome://inspect.** Chrome refuses every navigation to a `chrome://` URL that originates in a web page, so the page cannot link or redirect there. A collapsed "Using chrome://inspect instead" section tells people to type `chrome://inspect/#devices`, that Chrome discovers a bridge on `localhost:9222` on its own, where any other address goes (the bridge's own host:port is filled in), and repeats why the landing page is preferred: chrome://inspect routes DevTools through Chrome's browser-process relay, which freezes under sustained console traffic.

The WebView debugging guide gets the same two facts.

## Verification

- Chrome blocks the navigation: plain links to `chrome://inspect/#devices` on an https page, clicked with trusted input events (same tab and new tab), and `window.open`/`location.href` assignments all stayed put and logged `Not allowed to load local resource: chrome://inspect/#devices`.
- Discovery: `chrome://inspect/#devices` listed a bridge running on `localhost:9222` with no configuration.
- Header and note render on a local bridge; `test_cdp_server` + `test_cdp_wait_for_debugger`: 76 passed. ruff and pyright clean.
