### PR TITLE
cdp: Correlate an iframe to its frame by identity, not document order (#1919)

### DIFF
--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -1875,17 +1875,22 @@ class CdpTarget:
             tree = await self.send_message_with_result("Page.getResourceTree", {})
             frame_tree = tree.get("result", {}).get("frameTree")
             self._map_frame_tree_ids(frame_tree)
-            owner = self._frame_of_object(cast(str, object_id))
-            index = info.get("index")
-            frame_id: Optional[str] = None
-            if owner is not None and isinstance(index, int):
-                frame_id = self._child_frame_at(frame_tree, owner, index)
+            # Correlate the element with the frame it hosts. Prefer the name it was given or the
+            # URL it loaded, which identify the frame outright: iOS 26 orders a document's entries
+            # in the frame tree by when each frame was created, not by where its <iframe> sits in
+            # the document, so pairing the nth <iframe> with the nth tree child (the positional
+            # fallback below) mis-maps every frame whose DOM position differs from its creation
+            # order - which is what left fill()/click() acting on the wrong cross-origin frame.
+            # Positional matching stays as the last resort, for a frame that a unique name or URL
+            # cannot pick out: a srcdoc or about:blank frame, or several sharing a URL.
+            frame_id: Optional[str] = self._find_frame_in_tree(
+                frame_tree, cast(str, info.get("name") or ""), cast(str, info.get("url") or "")
+            )
             if frame_id is None:
-                # Nothing to position against (an object from a context we never saw); fall back
-                # to whatever the element itself identifies the frame by.
-                frame_id = self._find_frame_in_tree(
-                    frame_tree, cast(str, info.get("name") or ""), cast(str, info.get("url") or "")
-                )
+                owner = self._frame_of_object(cast(str, object_id))
+                index = info.get("index")
+                if owner is not None and isinstance(index, int):
+                    frame_id = self._child_frame_at(frame_tree, owner, index)
             if frame_id is not None:
                 node["frameId"] = frame_id
         await self.output_queue.put({"id": message["id"], "result": {"node": node}})

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -889,6 +889,94 @@ async def testp_cdp_server_makes_child_frames_reachable(lockdown: LockdownClient
             await client.close()
 
 
+async def testp_cdp_server_correlates_frames_by_identity_not_document_order(lockdown: LockdownClient) -> None:
+    """
+    An <iframe> element must resolve to the frame it actually hosts, whichever order the frames
+    sit in. iOS 26 orders a document's entries in the frame tree by when each frame was created,
+    not by where its element sits in the document; pairing the nth <iframe> with the nth tree
+    child then mis-mapped every frame whose DOM position differed from its creation order, so a
+    client's frameLocator().fill()/click() drove a different cross-origin frame than the one it
+    addressed. The name a frame was given, or the URL it loaded, identifies it regardless of order.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        message_ids = itertools.count(1)
+        try:
+
+            async def command(method: str, params: dict[str, Any]) -> dict[str, Any]:
+                id_ = next(message_ids)
+                await client.send({"id": id_, "method": method, "params": params})
+                while True:
+                    message = await asyncio.wait_for(client.receive(), TIMEOUT)
+                    if message.get("id") == id_:
+                        return message
+
+            await command("Page.enable", {})
+            await command("Runtime.enable", {})
+            await command("Page.navigate", {"url": "https://example.com/"})
+            # Create four named child frames whose document order (d, c, a, b) is deliberately not
+            # the order they were created in (a, b, c, d) - the case that mis-correlated.
+            await command(
+                "Runtime.evaluate",
+                {
+                    "expression": (
+                        "(() => {"
+                        "  const make = (n) => { const f = document.createElement('iframe');"
+                        "    f.name = n; f.src = 'https://example.com/?' + n; return f; };"
+                        "  const a = make('a'), b = make('b');"
+                        "  document.body.append(a, b);"
+                        "  document.body.insertBefore(make('c'), a);"
+                        "  document.body.insertBefore(make('d'), document.body.firstChild);"
+                        "  return 'ok';"
+                        "})()"
+                    ),
+                    "returnByValue": True,
+                },
+            )
+
+            async def child_frame_count() -> int:
+                tree = await command("Page.getFrameTree", {})
+                return len(tree["result"]["frameTree"].get("childFrames") or [])
+
+            for _ in range(TIMEOUT):
+                if await child_frame_count() == 4:
+                    break
+                await asyncio.sleep(0.5)
+            assert await child_frame_count() == 4, "all four child frames must be reported"
+
+            document_order = await command(
+                "Runtime.evaluate",
+                {"expression": "[...document.querySelectorAll('iframe')].map(f => f.name)", "returnByValue": True},
+            )
+            names = document_order["result"]["result"]["value"]
+            assert names == ["d", "c", "a", "b"], names
+
+            for index, name in enumerate(names):
+                element = await command(
+                    "Runtime.evaluate", {"expression": f"document.querySelectorAll('iframe')[{index}]"}
+                )
+                described = await command("DOM.describeNode", {"objectId": element["result"]["result"]["objectId"]})
+                frame_id = described["result"]["node"].get("frameId")
+                assert frame_id, f"the iframe element must resolve to a frame: {described}"
+                # The frame it resolves to must be the one whose document is this element's own
+                # src, proven by reading document.URL inside that frame's own world.
+                world = await command("Page.createIsolatedWorld", {"frameId": frame_id, "worldName": "probe"})
+                url = await command(
+                    "Runtime.evaluate",
+                    {
+                        "expression": "document.URL",
+                        "contextId": world["result"]["executionContextId"],
+                        "returnByValue": True,
+                    },
+                )
+                assert url["result"]["result"]["value"] == f"https://example.com/?{name}", (
+                    f"iframe named {name} must resolve to its own frame, not another's: {url}"
+                )
+        finally:
+            await client.close()
+
+
 async def testp_cdp_browser_endpoint_gives_each_attachment_its_own_session(lockdown: LockdownClient) -> None:
     """
     A client may attach to one page more than once - Playwright drives a page through the session


### PR DESCRIPTION
## Summary

Fixes #1919. Resolving an `<iframe>` element to the frame it hosts (`DOM.describeNode`, which is how a client's `frameLocator()`/`contentFrame()` reach into a child frame) paired the nth `<iframe>` in the document with the nth child in the frame tree. On iOS 26 the frame tree orders a document's entries by **when each frame was created**, not by where its element sits in the document, so every frame whose DOM position differed from its creation order resolved to the wrong one. A client's `fill()`/`click()` into a cross-origin frame then drove a *different* frame than the one it addressed, and reported success — exactly the real-Safari `fill()` failure #1919 describes.

The fix prefers the name a frame was given, or the URL it loaded, which identify it outright regardless of order. The code already matched on these, but only as a fallback that positional matching pre-empted; this flips the priority. Positional matching stays as the last resort for a frame that a unique name or URL cannot pick out (a `srcdoc` or `about:blank` frame, or several sharing a URL) — no worse than before for those.

## Verification

On a physical iPhone (iOS 26.6.1), reproduced then fixed. Four child frames created in the order `a,b,c,d` but placed in the document as `d,c,a,b`:

| iframe (document order) | resolved frame's `document.URL` — before | after |
|---|---|---|
| `d` | `?a` (wrong) | `?d` |
| `c` | `?b` (wrong) | `?c` |
| `a` | `?c` (wrong) | `?a` |
| `b` | `?d` (wrong) | `?b` |

Added `testp_cdp_server_correlates_frames_by_identity_not_document_order`, which asserts each element resolves to the frame whose own `document.URL` is that element's `src`. It and the existing frame/node device tests (`makes_child_frames_reachable`, `resolves_a_node_back_to_a_handle`, `carries_a_user_gesture_through`, `keeps_each_frame_in_its_own_execution_context`) pass on device. ruff and pyright clean.
