### PR TITLE
cdp: Add the Fetch domain over WebKit interception, for request mocking and Basic auth (#1920)

### DIFF
--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -193,6 +193,33 @@ child frames - including cross-origin ones nested several levels deep, through
 Attaching to a page that is *already open* works too: you do not have to be connected
 before it loads.
 
+### Request interception and HTTP Basic auth
+
+Chrome's `Fetch` domain is available, translated onto WebKit's own request
+interception. Arm it and every matching request pauses as `Fetch.requestPaused`,
+which you answer with `Fetch.continueRequest` (optionally rewriting the URL, method,
+headers or body), `Fetch.fulfillRequest` (a canned response) or `Fetch.failRequest`.
+This is how Playwright's `route()` and Puppeteer's `setRequestInterception()` mock,
+block or rewrite requests against a real device.
+
+The practical use is **answering an HTTP Basic auth challenge without the on-device
+credential dialog** — which otherwise needs a person to tap through it once per
+Safari/WebView process, blocking any unattended run. Supply the credentials on the
+request yourself:
+
+```javascript
+await page.route('**/*', (route) => {
+  const headers = { ...route.request().headers(), authorization: 'Basic ' + btoa('user:pass') };
+  route.continue({ headers });
+});
+await page.goto('https://example.com/behind-basic-auth');  // no dialog
+```
+
+One WebKit limitation to know: it surfaces no auth-challenge event of its own (the OS
+dialog owns the challenge), so Playwright's reactive `httpCredentials` option — which
+waits for a `401` and answers it — does not fire. Supplying the `Authorization` header
+proactively on the request, as above, answers the challenge before it is ever raised.
+
 Notes worth knowing when scripting against a device:
 
 - The first interaction with a newly created frame takes a few seconds while the

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -1875,17 +1875,22 @@ class CdpTarget:
             tree = await self.send_message_with_result("Page.getResourceTree", {})
             frame_tree = tree.get("result", {}).get("frameTree")
             self._map_frame_tree_ids(frame_tree)
-            owner = self._frame_of_object(cast(str, object_id))
-            index = info.get("index")
-            frame_id: Optional[str] = None
-            if owner is not None and isinstance(index, int):
-                frame_id = self._child_frame_at(frame_tree, owner, index)
+            # Correlate the element with the frame it hosts. Prefer the name it was given or the
+            # URL it loaded, which identify the frame outright: iOS 26 orders a document's entries
+            # in the frame tree by when each frame was created, not by where its <iframe> sits in
+            # the document, so pairing the nth <iframe> with the nth tree child (the positional
+            # fallback below) mis-maps every frame whose DOM position differs from its creation
+            # order - which is what left fill()/click() acting on the wrong cross-origin frame.
+            # Positional matching stays as the last resort, for a frame that a unique name or URL
+            # cannot pick out: a srcdoc or about:blank frame, or several sharing a URL.
+            frame_id: Optional[str] = self._find_frame_in_tree(
+                frame_tree, cast(str, info.get("name") or ""), cast(str, info.get("url") or "")
+            )
             if frame_id is None:
-                # Nothing to position against (an object from a context we never saw); fall back
-                # to whatever the element itself identifies the frame by.
-                frame_id = self._find_frame_in_tree(
-                    frame_tree, cast(str, info.get("name") or ""), cast(str, info.get("url") or "")
-                )
+                owner = self._frame_of_object(cast(str, object_id))
+                index = info.get("index")
+                if owner is not None and isinstance(index, int):
+                    frame_id = self._child_frame_at(frame_tree, owner, index)
             if frame_id is not None:
                 node["frameId"] = frame_id
         await self.output_queue.put({"id": message["id"], "result": {"node": node}})

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import hashlib
 import itertools
 import json
@@ -498,6 +499,13 @@ class CdpTarget:
             "Network.loadNetworkResource": self._network_load_network_resource,
             "Network.setAttachDebugStack": partial(self._simple_response, value=None),
             "Network.clearAcceptedEncodingsOverride": partial(self._simple_response, value=None),
+            "Fetch.enable": self._fetch_enable,
+            "Fetch.disable": self._fetch_disable,
+            "Fetch.continueRequest": self._fetch_continue_request,
+            "Fetch.continueResponse": self._fetch_continue_response,
+            "Fetch.continueWithAuth": self._fetch_continue_with_auth,
+            "Fetch.fulfillRequest": self._fetch_fulfill_request,
+            "Fetch.failRequest": self._fetch_fail_request,
             "ServiceWorker.enable": self._service_worker_enable,
             "HeapProfiler.enable": partial(self._simple_response, value=None),
             # Overlay is absent in WebKit; only highlightNode is worth translating, the rest are
@@ -585,6 +593,9 @@ class CdpTarget:
             "Console.messageAdded": self._console_message_added,
             "Network.responseReceived": self._network_response_received,
             "Network.loadingFinished": self._network_loading_finished,
+            "Network.requestWillBeSent": self._network_request_will_be_sent,
+            "Network.requestIntercepted": self._network_request_intercepted,
+            "Network.responseIntercepted": self._network_response_intercepted,
             # WebKit reports a load's progress with the pre-lifecycle events Chrome has long since
             # replaced; each is also turned into the Page.lifecycleEvent modern clients wait on.
             "Page.frameNavigated": self._page_frame_navigated,
@@ -624,6 +635,16 @@ class CdpTarget:
         # and the execution context its keydown was dispatched in (see _input_dispatch_key_event).
         self._key_default_prevented = False
         self._key_context: Optional[int] = None
+        # Chrome's Fetch domain, translated onto WebKit's Network request-interception. When
+        # armed, WebKit pauses each matching request as Network.requestIntercepted, which the
+        # bridge presents to the client as Fetch.requestPaused and answers through
+        # Network.intercept* on the client's continue/fulfill/fail. Injecting an Authorization
+        # header on continueRequest answers HTTP Basic auth without the on-device dialog.
+        self._fetch_enabled = False
+        self._fetch_handle_auth = False
+        # requestId -> {frameId (client), type}, from Network.requestWillBeSent: the fields
+        # Network.requestIntercepted omits but Fetch.requestPaused must carry.
+        self._request_meta: dict[str, dict[str, Any]] = {}
         # execution-context uniqueIds already announced to the frontend, to drop duplicate
         # Runtime.executionContextCreated events (WebKit re-announces contexts) that would
         # otherwise corrupt Chrome's RuntimeModel.
@@ -3386,3 +3407,206 @@ class CdpTarget:
             "timestamp": params["timestamp"],
         }
         await self.output_queue.put(message)
+
+    # --- Fetch domain (Chrome) over Network interception (WebKit) --------------------------------
+
+    @staticmethod
+    def _fetch_headers_to_object(headers: Any) -> dict[str, str]:
+        """Chrome carries headers as a [{name, value}] list; WebKit's intercept* want an object."""
+        result: dict[str, str] = {}
+        if isinstance(headers, list):
+            for entry in cast(list[Any], headers):
+                if isinstance(entry, dict):
+                    name = cast(dict[str, Any], entry).get("name")
+                    value = cast(dict[str, Any], entry).get("value")
+                    if isinstance(name, str):
+                        result[name] = "" if value is None else str(value)
+        elif isinstance(headers, dict):
+            for name, value in cast(dict[str, Any], headers).items():
+                result[str(name)] = "" if value is None else str(value)
+        return result
+
+    @staticmethod
+    def _fetch_pattern_to_regex(url_pattern: str) -> str:
+        """Chrome's Fetch urlPattern is a glob (``*`` any run, ``?`` any char); WebKit takes a regex."""
+        escaped = re.escape(url_pattern)
+        return "^" + escaped.replace("\\*", ".*").replace("\\?", ".") + "$"
+
+    async def _fetch_enable(self, message: dict[str, Any]) -> None:
+        params = message.get("params", {})
+        patterns = params.get("patterns") or [{"urlPattern": "*"}]
+        self._fetch_handle_auth = bool(params.get("handleAuthRequests", False))
+        for pattern in patterns:
+            if not isinstance(pattern, dict):
+                continue
+            spec = cast(dict[str, Any], pattern)
+            url = self._fetch_pattern_to_regex(cast(str, spec.get("urlPattern") or "*"))
+            stage = "response" if str(spec.get("requestStage", "Request")).lower() == "response" else "request"
+            await self._send_message_to_target({
+                "id": self.next_internal_id(),
+                "method": "Network.addInterception",
+                "params": {"url": url, "stage": stage, "isRegex": True},
+            })
+        await self._send_message_to_target({
+            "id": self.next_internal_id(),
+            "method": "Network.setInterceptionEnabled",
+            "params": {"enabled": True},
+        })
+        self._fetch_enabled = True
+        await self._result_response(message, {})
+
+    async def _fetch_disable(self, message: dict[str, Any]) -> None:
+        self._fetch_enabled = False
+        await self._send_message_to_target({
+            "id": self.next_internal_id(),
+            "method": "Network.setInterceptionEnabled",
+            "params": {"enabled": False},
+        })
+        await self._result_response(message, {})
+
+    async def _fetch_continue_request(self, message: dict[str, Any]) -> None:
+        params = message.get("params", {})
+        request_id = params.get("requestId")
+        overrides: dict[str, Any] = {"requestId": request_id}
+        changed = False
+        for key in ("url", "method"):
+            if params.get(key) is not None:
+                overrides[key] = params[key]
+                changed = True
+        if params.get("postData") is not None:
+            overrides["postData"] = params["postData"]
+            changed = True
+        if params.get("headers") is not None:
+            overrides["headers"] = self._fetch_headers_to_object(params["headers"])
+            changed = True
+        if changed:
+            await self._send_message_to_target({
+                "id": self.next_internal_id(),
+                "method": "Network.interceptWithRequest",
+                "params": overrides,
+            })
+        else:
+            await self._send_message_to_target({
+                "id": self.next_internal_id(),
+                "method": "Network.interceptContinue",
+                "params": {"requestId": request_id, "stage": "request"},
+            })
+        await self._result_response(message, {})
+
+    async def _fetch_continue_response(self, message: dict[str, Any]) -> None:
+        await self._send_message_to_target({
+            "id": self.next_internal_id(),
+            "method": "Network.interceptContinue",
+            "params": {"requestId": message.get("params", {}).get("requestId"), "stage": "response"},
+        })
+        await self._result_response(message, {})
+
+    async def _fetch_continue_with_auth(self, message: dict[str, Any]) -> None:
+        # WebKit surfaces no auth-challenge event of its own (the on-device dialog owns it), so this
+        # reactive path is a best effort: with credentials, inject an Authorization header and let
+        # the request go; otherwise just continue it. The reliable way to answer Basic auth here is
+        # proactive - continueRequest with an Authorization header on the matching request.
+        params = message.get("params", {})
+        request_id = params.get("requestId")
+        challenge = cast(dict[str, Any], params.get("authChallengeResponse") or {})
+        if challenge.get("response") == "ProvideCredentials":
+            token = base64.b64encode(
+                f"{challenge.get('username', '')}:{challenge.get('password', '')}".encode()
+            ).decode()
+            await self._send_message_to_target({
+                "id": self.next_internal_id(),
+                "method": "Network.interceptWithRequest",
+                "params": {"requestId": request_id, "headers": {"Authorization": f"Basic {token}"}},
+            })
+        else:
+            await self._send_message_to_target({
+                "id": self.next_internal_id(),
+                "method": "Network.interceptContinue",
+                "params": {"requestId": request_id, "stage": "request"},
+            })
+        await self._result_response(message, {})
+
+    async def _fetch_fulfill_request(self, message: dict[str, Any]) -> None:
+        params = message.get("params", {})
+        headers = self._fetch_headers_to_object(params.get("responseHeaders"))
+        await self._send_message_to_target({
+            "id": self.next_internal_id(),
+            "method": "Network.interceptRequestWithResponse",
+            "params": {
+                "requestId": params.get("requestId"),
+                "content": params.get("body", ""),
+                "base64Encoded": True,
+                "mimeType": headers.get("Content-Type") or headers.get("content-type") or "text/plain",
+                "status": params.get("responseCode", 200),
+                "statusText": params.get("responsePhrase", ""),
+                "headers": headers,
+            },
+        })
+        await self._result_response(message, {})
+
+    async def _fetch_fail_request(self, message: dict[str, Any]) -> None:
+        await self._send_message_to_target({
+            "id": self.next_internal_id(),
+            "method": "Network.interceptRequestWithError",
+            "params": {"requestId": message.get("params", {}).get("requestId"), "errorType": "General"},
+        })
+        await self._result_response(message, {})
+
+    async def _network_request_will_be_sent(self, message: dict[str, Any]) -> None:
+        # Cache what Network.requestIntercepted omits but Fetch.requestPaused needs, then forward
+        # the event as the raw path would have. Bound the cache so a long-lived page cannot grow it.
+        params = message["params"]
+        request_id = params.get("requestId")
+        if isinstance(request_id, str):
+            if len(self._request_meta) > 512:
+                self._request_meta.clear()
+            self._request_meta[request_id] = {
+                "frameId": self._to_client_frame_id(params.get("frameId")),
+                "type": params.get("type"),
+            }
+        self._map_frame_ids_outbound(message)
+        await self.output_queue.put(message)
+
+    async def _network_request_intercepted(self, message: dict[str, Any]) -> None:
+        params = message["params"]
+        if not self._fetch_enabled:
+            # A client driving WebKit's Network interception directly; leave its event untouched.
+            await self.output_queue.put(message)
+            return
+        request_id = params.get("requestId")
+        meta = self._request_meta.get(request_id, {}) if isinstance(request_id, str) else {}
+        resource_type = meta.get("type")
+        await self.output_queue.put({
+            "method": "Fetch.requestPaused",
+            "params": {
+                "requestId": request_id,
+                "request": params.get("request", {}),
+                "frameId": meta.get("frameId") or self.frame_id,
+                "resourceType": resource_type if resource_type in NETWORK_RESOURCE_TYPES else "Other",
+                "networkId": request_id,
+            },
+        })
+
+    async def _network_response_intercepted(self, message: dict[str, Any]) -> None:
+        params = message["params"]
+        if not self._fetch_enabled:
+            await self.output_queue.put(message)
+            return
+        request_id = params.get("requestId")
+        response = params.get("response", {})
+        meta = self._request_meta.get(request_id, {}) if isinstance(request_id, str) else {}
+        resource_type = meta.get("type")
+        headers = response.get("headers", {})
+        await self.output_queue.put({
+            "method": "Fetch.requestPaused",
+            "params": {
+                "requestId": request_id,
+                "request": {"url": response.get("url", ""), "method": "GET", "headers": {}},
+                "frameId": meta.get("frameId") or self.frame_id,
+                "resourceType": resource_type if resource_type in NETWORK_RESOURCE_TYPES else "Other",
+                "networkId": request_id,
+                "responseStatusCode": response.get("status"),
+                "responseStatusText": response.get("statusText", ""),
+                "responseHeaders": [{"name": str(k), "value": str(v)} for k, v in headers.items()],
+            },
+        })

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -977,6 +977,91 @@ async def testp_cdp_server_correlates_frames_by_identity_not_document_order(lock
             await client.close()
 
 
+async def testp_cdp_server_answers_basic_auth_through_the_fetch_domain(lockdown: LockdownClient) -> None:
+    """
+    A client can answer an HTTP Basic auth challenge with no on-device dialog, through Chrome's
+    Fetch domain translated onto WebKit's request interception: arm it with Fetch.enable, receive
+    each request as Fetch.requestPaused, and inject an Authorization header on Fetch.continueRequest.
+    WebKit surfaces no auth event of its own (the dialog owns the challenge), so answering it means
+    supplying the credentials proactively on the request - which is what this proves end to end.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        message_ids = itertools.count(1)
+        credentials = "Basic " + base64.b64encode(b"user:pass").decode()
+        try:
+            # Drive the reads from one place: replies land in a dict, and each paused request is
+            # continued (with the Authorization header for the protected URL) as it arrives.
+            replies: dict[int, dict[str, Any]] = {}
+            paused_urls: list[str] = []
+
+            async def send(method: str, params: dict[str, Any]) -> int:
+                id_ = next(message_ids)
+                await client.send({"id": id_, "method": method, "params": params})
+                return id_
+
+            async def pump(seconds: float) -> None:
+                deadline = asyncio.get_event_loop().time() + seconds
+                while asyncio.get_event_loop().time() < deadline:
+                    try:
+                        message = await asyncio.wait_for(client.receive(), 0.5)
+                    except (asyncio.TimeoutError, TimeoutError):
+                        continue
+                    if message.get("method") == "Fetch.requestPaused":
+                        request = message["params"]
+                        url = request["request"]["url"]
+                        paused_urls.append(url)
+                        if "basic-auth" in url:
+                            headers = [
+                                {"name": name, "value": value}
+                                for name, value in (request["request"].get("headers") or {}).items()
+                            ]
+                            headers.append({"name": "Authorization", "value": credentials})
+                            await send("Fetch.continueRequest", {"requestId": request["requestId"], "headers": headers})
+                        else:
+                            await send("Fetch.continueRequest", {"requestId": request["requestId"]})
+                    elif "id" in message:
+                        replies[message["id"]] = message
+
+            await send("Runtime.enable", {})
+            await send("Page.enable", {})
+            await send("Network.enable", {})
+            await send("Page.navigate", {"url": "https://example.com/"})
+            await pump(4)
+            await send("Fetch.enable", {"patterns": [{"urlPattern": "*"}], "handleAuthRequests": True})
+            await pump(1)
+            await send(
+                "Runtime.evaluate",
+                {
+                    "expression": (
+                        "window.__auth = null;"
+                        " fetch('https://httpbin.org/basic-auth/user/pass', {mode: 'cors'})"
+                        "  .then(r => r.json()).then(j => window.__auth = j)"
+                        "  .catch(e => window.__auth = {error: '' + e});"
+                    ),
+                    "returnByValue": True,
+                },
+            )
+            result: Any = None
+            for _ in range(TIMEOUT):
+                await pump(1)
+                probe = await send("Runtime.evaluate", {"expression": "window.__auth", "returnByValue": True})
+                await pump(0.8)
+                value = replies.get(probe, {}).get("result", {}).get("result", {}).get("value")
+                if value:
+                    result = value
+                    break
+            assert any("basic-auth" in url for url in paused_urls), (
+                f"the protected request must surface as Fetch.requestPaused: {paused_urls}"
+            )
+            assert result == {"authenticated": True, "user": "user"}, (
+                f"the injected Authorization header must answer the Basic auth challenge: {result}"
+            )
+        finally:
+            await client.close()
+
+
 async def testp_cdp_browser_endpoint_gives_each_attachment_its_own_session(lockdown: LockdownClient) -> None:
     """
     A client may attach to one page more than once - Playwright drives a page through the session

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -889,6 +889,94 @@ async def testp_cdp_server_makes_child_frames_reachable(lockdown: LockdownClient
             await client.close()
 
 
+async def testp_cdp_server_correlates_frames_by_identity_not_document_order(lockdown: LockdownClient) -> None:
+    """
+    An <iframe> element must resolve to the frame it actually hosts, whichever order the frames
+    sit in. iOS 26 orders a document's entries in the frame tree by when each frame was created,
+    not by where its element sits in the document; pairing the nth <iframe> with the nth tree
+    child then mis-mapped every frame whose DOM position differed from its creation order, so a
+    client's frameLocator().fill()/click() drove a different cross-origin frame than the one it
+    addressed. The name a frame was given, or the URL it loaded, identifies it regardless of order.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        message_ids = itertools.count(1)
+        try:
+
+            async def command(method: str, params: dict[str, Any]) -> dict[str, Any]:
+                id_ = next(message_ids)
+                await client.send({"id": id_, "method": method, "params": params})
+                while True:
+                    message = await asyncio.wait_for(client.receive(), TIMEOUT)
+                    if message.get("id") == id_:
+                        return message
+
+            await command("Page.enable", {})
+            await command("Runtime.enable", {})
+            await command("Page.navigate", {"url": "https://example.com/"})
+            # Create four named child frames whose document order (d, c, a, b) is deliberately not
+            # the order they were created in (a, b, c, d) - the case that mis-correlated.
+            await command(
+                "Runtime.evaluate",
+                {
+                    "expression": (
+                        "(() => {"
+                        "  const make = (n) => { const f = document.createElement('iframe');"
+                        "    f.name = n; f.src = 'https://example.com/?' + n; return f; };"
+                        "  const a = make('a'), b = make('b');"
+                        "  document.body.append(a, b);"
+                        "  document.body.insertBefore(make('c'), a);"
+                        "  document.body.insertBefore(make('d'), document.body.firstChild);"
+                        "  return 'ok';"
+                        "})()"
+                    ),
+                    "returnByValue": True,
+                },
+            )
+
+            async def child_frame_count() -> int:
+                tree = await command("Page.getFrameTree", {})
+                return len(tree["result"]["frameTree"].get("childFrames") or [])
+
+            for _ in range(TIMEOUT):
+                if await child_frame_count() == 4:
+                    break
+                await asyncio.sleep(0.5)
+            assert await child_frame_count() == 4, "all four child frames must be reported"
+
+            document_order = await command(
+                "Runtime.evaluate",
+                {"expression": "[...document.querySelectorAll('iframe')].map(f => f.name)", "returnByValue": True},
+            )
+            names = document_order["result"]["result"]["value"]
+            assert names == ["d", "c", "a", "b"], names
+
+            for index, name in enumerate(names):
+                element = await command(
+                    "Runtime.evaluate", {"expression": f"document.querySelectorAll('iframe')[{index}]"}
+                )
+                described = await command("DOM.describeNode", {"objectId": element["result"]["result"]["objectId"]})
+                frame_id = described["result"]["node"].get("frameId")
+                assert frame_id, f"the iframe element must resolve to a frame: {described}"
+                # The frame it resolves to must be the one whose document is this element's own
+                # src, proven by reading document.URL inside that frame's own world.
+                world = await command("Page.createIsolatedWorld", {"frameId": frame_id, "worldName": "probe"})
+                url = await command(
+                    "Runtime.evaluate",
+                    {
+                        "expression": "document.URL",
+                        "contextId": world["result"]["executionContextId"],
+                        "returnByValue": True,
+                    },
+                )
+                assert url["result"]["result"]["value"] == f"https://example.com/?{name}", (
+                    f"iframe named {name} must resolve to its own frame, not another's: {url}"
+                )
+        finally:
+            await client.close()
+
+
 async def testp_cdp_browser_endpoint_gives_each_attachment_its_own_session(lockdown: LockdownClient) -> None:
     """
     A client may attach to one page more than once - Playwright drives a page through the session


### PR DESCRIPTION
## Summary

Implements #1920. WebKit has a request-interception API (`Network.addInterception` / `interceptContinue` / `interceptWithRequest` and the `Network.requestIntercepted` event), but Chrome's `Fetch` domain — which every automation framework drives — was unimplemented, so calling it returned `'Fetch' domain was not found`.

This translates `Fetch` onto WebKit's interception:

- **`Fetch.enable`** arms WebKit interception for the given URL patterns (glob → regex), then each paused request surfaces to the client as **`Fetch.requestPaused`**, enriched with the `frameId` and `resourceType` that `Network.requestIntercepted` omits (cached from `Network.requestWillBeSent`).
- **`Fetch.continueRequest`** (optionally rewriting url/method/headers/body), **`Fetch.fulfillRequest`**, **`Fetch.failRequest`** and **`Fetch.continueResponse`** answer it through the matching `Network.intercept*` command.
- A client driving WebKit's native `Network` interception directly still sees its own events untouched.

This is what Playwright's `route()` and Puppeteer's request interception need against a real device.

## The motivating case: HTTP Basic auth without the on-device dialog

The reason #1920 was filed: Basic auth otherwise needs a person to tap through the OS credential dialog once per Safari/WebView process, blocking unattended runs. Now you answer it by supplying the credentials proactively on the request:

```javascript
await page.route('**/*', (route) => {
  const headers = { ...route.request().headers(), authorization: 'Basic ' + btoa('user:pass') };
  route.continue({ headers });
});
await page.goto('https://example.com/behind-basic-auth');  // no dialog
```

**One WebKit limitation, documented:** WebKit surfaces no auth-challenge event of its own (the OS dialog owns the challenge), so Playwright's *reactive* `httpCredentials` option — which waits for a `401` and answers `Fetch.authRequired` — cannot fire. The proactive header injection above answers the challenge before it is raised, which is the supported route.

## Verification

On a physical iPhone (iOS 26.6.1): `Fetch.enable`, then a `fetch()` of an httpbin Basic-auth URL, surfaces as `Fetch.requestPaused`; `Fetch.continueRequest` with an injected `Authorization` header returns `{"authenticated": true, "user": "user"}` — no dialog. Added `testp_cdp_server_answers_basic_auth_through_the_fetch_domain`, and the existing end-to-end / navigation-lifecycle device tests still pass (confirming the new `Network.requestWillBeSent` caching handler doesn't regress event forwarding). ruff and pyright clean; the full non-device suite passes (78).

Independent of #1921 (frame correlation); either can merge first.
