### PR TITLE
cdp: Keep the debugger responsive - free withheld replies, stop the idle spin, fetch big scopes

### DIFF
--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -276,3 +276,7 @@ already existed when a client attached keep running, as in Safari.
   `newCDPSession`); those share the one underlying session.
 - The page listing is polled as a fallback, so a tab the device did not announce on
   its own is still discovered (and auto-attached) within a couple of seconds.
+- The manual pause button (`Debugger.pause`) cannot interrupt JavaScript that is already
+  busy in a tight loop: WebKit handles inspector messages on the page's own JavaScript
+  thread, so the pause lands when the script next yields. Armed while the page is idle it
+  stops the next code that runs, as in Chrome.

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -30,6 +30,26 @@ UNRESPONSIVE_PROBE_TIMEOUT = 1.5
 # CdpTarget._evaluate_key_handler). Typical replies arrive within ~10 ms.
 KEY_HANDLER_WAKE_DELAY = 0.05
 
+# Any forwarded client request hits the same iOS 26 WebKit quirk as the key handlers: its reply -
+# and the events it triggers, such as the Debugger.paused after a step - is occasionally held until
+# the next message reaches the page (see CdpTarget._wake_late_replies). Measured on a large script,
+# half of all step-overs stalled this way, and an evaluate, a stepOver reply and its paused event
+# were each freed by one throwaway message within ~10 ms. While any client reply is outstanding the
+# bridge checks every REPLY_WAKE_TICK and nudges once any reply has waited REPLY_WAKE_INTERVAL - one
+# nudge flushes everything held, so traffic is bounded whatever is pending - and stops tracking a
+# request after REPLY_WAKE_MAX_AGE (a script that never terminates). The interval is well above a
+# normal round-trip (~10 ms), so a prompt reply is never nudged; the finer tick keeps a withheld
+# step-over's stall to ~0.3 s rather than up to two intervals.
+REPLY_WAKE_TICK = 0.1
+REPLY_WAKE_INTERVAL = 0.25
+REPLY_WAKE_MAX_AGE = 20.0
+
+# The receive loop and the internal-reply waits poll their queues. Polling with sleep(0) spun a
+# core flat out whenever nothing was pending - 23% of a CPU measured while a debugger sat idle at
+# a breakpoint. A 1 ms sleep drops that to nothing; a message that is already queued is still
+# handled without sleeping, so throughput under load is unchanged.
+IDLE_POLL_INTERVAL = 0.001
+
 # A navigation that commits in a new process destroys the target the bridge is talking to, and
 # WebKit never answers what was in flight to it. That is exactly when Chrome's frontend asks for
 # the resource tree and when a screencast starts, so those requests wait here for the replacement
@@ -429,6 +449,13 @@ class CdpTarget:
         self._top_frame_commits = 0
         # Detached tasks (a navigation waiting for its commit); cancelled when the session closes.
         self._background_tasks: set[asyncio.Task[None]] = set()
+        # Forwarded client request id -> loop time it was sent, while its reply is outstanding, and the
+        # single watchdog nudging the page for them (see _wake_late_replies).
+        self._reply_wake_pending: dict[int, float] = {}
+        # Client request id -> how to finish that request when its device reply arrives, for
+        # requests forwarded without blocking (see _forward_and_translate).
+        self._reply_translators: dict[int, Callable[[dict[str, Any]], Awaitable[None]]] = {}
+        self._reply_wake_task: Optional[asyncio.Task[None]] = None
         self.output_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self.input_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self.screencast: Optional[ScreenCast] = None
@@ -705,9 +732,9 @@ class CdpTarget:
         events = protocol.inspector.session_events(protocol.id_)
         while True:
             if not events:
-                await asyncio.sleep(0)
+                await asyncio.sleep(IDLE_POLL_INTERVAL)
                 continue
-            created = events.pop(0)
+            created = events.popleft()
             target_info = created.get("params", {}).get("targetInfo")
             # Only a page target can serve this session (see _target_created).
             if target_info is not None and target_info.get("type", PAGE_TARGET_TYPE) == PAGE_TARGET_TYPE:
@@ -851,7 +878,7 @@ class CdpTarget:
                 del events[i]
                 self._pending_requests.pop(id_, None)
                 return message
-            await asyncio.sleep(0)
+            await asyncio.sleep(IDLE_POLL_INTERVAL)
         return None
 
     async def send_message_with_result(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
@@ -994,11 +1021,11 @@ class CdpTarget:
     async def _receive_loop(self):
         while True:
             if self._waiting_for_id:
-                await asyncio.sleep(0)
+                await asyncio.sleep(IDLE_POLL_INTERVAL)
                 continue
             message = self._next_message()
             if message is None:
-                await asyncio.sleep(0)
+                await asyncio.sleep(IDLE_POLL_INTERVAL)
                 continue
             try:
                 if self._flat:
@@ -1023,7 +1050,7 @@ class CdpTarget:
         events = self.protocol.inspector.session_events(self.session_id)
         if not events:
             return None
-        return cast(dict[str, Any], events.pop(0))
+        return cast(dict[str, Any], events.popleft())
 
     async def _to_output_queue(self, message: dict[str, Any]):
         if message["method"] != "Target.dispatchMessageFromTarget":
@@ -1039,6 +1066,15 @@ class CdpTarget:
         resolved_target_id = target_id if target_id is not None else self.target_id
         if "id" in message:
             self._pending_requests[message["id"]] = resolved_target_id
+        message_id = message.get("id")
+        if record and isinstance(message_id, int) and message_id > 0:
+            # A client request whose reply WebKit may withhold until the next message; the watchdog
+            # keeps the page nudged until it answers (see _wake_late_replies).
+            self._reply_wake_pending[message_id] = asyncio.get_event_loop().time()
+            if self._reply_wake_task is None or self._reply_wake_task.done():
+                self._reply_wake_task = asyncio.ensure_future(self._wake_late_replies())
+                self._background_tasks.add(self._reply_wake_task)
+                self._reply_wake_task.add_done_callback(self._background_tasks.discard)
         if record:
             self._record_setup_message(message)
         if self._flat:
@@ -1084,7 +1120,7 @@ class CdpTarget:
             if message is not None:
                 self._pending_requests.pop(id_, None)
                 return message
-            await asyncio.sleep(0)
+            await asyncio.sleep(IDLE_POLL_INTERVAL)
         return None
 
     def _record_setup_message(self, message: dict[str, Any]):
@@ -1184,39 +1220,67 @@ class CdpTarget:
     async def _dom_push_nodes_by_backend_ids(self, message: dict[str, Any]):
         await self.output_queue.put({"id": message["id"], "result": {"nodeIds": []}})
 
+    async def _forward_and_translate(
+        self,
+        message: dict[str, Any],
+        device_message: dict[str, Any],
+        translate: Callable[[dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        """Forward a client request to the device under the client's own id and finish it with
+        `translate` when the reply arrives, instead of waiting for it here.
+
+        Waiting here (send_message_with_result) holds the receive loop for up to WIR_RESULT_TIMEOUT
+        and gives up after it: a reply WebKit needs longer to build - the property list of a
+        large scope, which the Sources panel fetches on every pause - was silently answered
+        with an empty result, and no event reached the client for those five seconds. Forwarding
+        under the client's id also lets the withheld-reply watchdog cover the request.
+        """
+        self._reply_translators[message["id"]] = translate
+        await self._send_message_to_target({"id": message["id"], **device_message})
+
     async def _runtime_get_properties(self, message: dict[str, Any]):
         """
         WebKit answers Runtime.getProperties with a 'properties' array; Chrome's frontend reads
         'result' and renders "No properties" otherwise. WebKit also lacks the
-        accessorPropertiesOnly/nonIndexedPropertiesOnly filters, so apply them here.
+        accessorPropertiesOnly/nonIndexedPropertiesOnly filters, so apply them here. Forwarded
+        without blocking (see _forward_and_translate): a large scope's list takes WebKit longer
+        than the internal wait allowed, which left the Scope panel empty on every pause in a big
+        function and stalled event delivery meanwhile.
         """
         params = message["params"]
-        response = await self.send_message_with_result(
-            "Runtime.getProperties",
+
+        async def translate(reply: dict[str, Any]) -> None:
+            if "result" not in reply:
+                await self.output_queue.put({"id": message["id"], "result": {"result": []}})
+                return
+            properties: list[dict[str, Any]] = reply["result"].get("properties", [])
+            if params.get("accessorPropertiesOnly", False):
+                properties = [p for p in properties if "get" in p or "set" in p]
+            if params.get("nonIndexedPropertiesOnly", False):
+                properties = [p for p in properties if not p.get("name", "").isdigit()]
+            for prop in properties:
+                prop.setdefault("configurable", False)
+                prop.setdefault("enumerable", False)
+            # Expanded objects list function properties whose native descriptions the console
+            # autocomplete inspects; normalize them (see _normalize_native_functions).
+            self._normalize_native_functions(properties)
+            result: dict[str, Any] = {"result": properties}
+            if "internalProperties" in reply["result"]:
+                result["internalProperties"] = reply["result"]["internalProperties"]
+            await self.output_queue.put({"id": message["id"], "result": result})
+
+        await self._forward_and_translate(
+            message,
             {
-                "objectId": params["objectId"],
-                "ownProperties": params.get("ownProperties", False),
-                "generatePreview": params.get("generatePreview", False),
+                "method": "Runtime.getProperties",
+                "params": {
+                    "objectId": params["objectId"],
+                    "ownProperties": params.get("ownProperties", False),
+                    "generatePreview": params.get("generatePreview", False),
+                },
             },
+            translate,
         )
-        if "result" not in response:
-            await self.output_queue.put({"id": message["id"], "result": {"result": []}})
-            return
-        properties: list[dict[str, Any]] = response["result"].get("properties", [])
-        if params.get("accessorPropertiesOnly", False):
-            properties = [p for p in properties if "get" in p or "set" in p]
-        if params.get("nonIndexedPropertiesOnly", False):
-            properties = [p for p in properties if not p.get("name", "").isdigit()]
-        for prop in properties:
-            prop.setdefault("configurable", False)
-            prop.setdefault("enumerable", False)
-        # Expanded objects list function properties whose native descriptions the console
-        # autocomplete inspects; normalize them (see _normalize_native_functions).
-        self._normalize_native_functions(properties)
-        result: dict[str, Any] = {"result": properties}
-        if "internalProperties" in response["result"]:
-            result["internalProperties"] = response["result"]["internalProperties"]
-        await self.output_queue.put({"id": message["id"], "result": result})
 
     async def _runtime_global_lexical_scope_names(self, message: dict[str, Any]):
         """
@@ -2745,6 +2809,33 @@ class CdpTarget:
             })
         return await pending
 
+    async def _wake_late_replies(self) -> None:
+        """Free forwarded client replies that WebKit is withholding.
+
+        iOS 26 WebKit sometimes holds the reply to a client request - and the events that follow
+        it, such as the Debugger.paused after a step - until the next message reaches the page:
+        the work has finished, but the result only arrives right after whatever is sent next.
+        Left alone, a WebStorm/Chrome console evaluate hung until the user's next action, and a
+        step-over in a large script stalled about half the time. Runs while any client reply is
+        outstanding: each interval, if one has waited longer than the interval, send a single
+        throwaway evaluation (one message flushes everything held; its own reply, to an internal
+        id, is dropped on arrival). A prompt reply clears its id before the first interval, so a
+        normal request is never nudged; a request outstanding past REPLY_WAKE_MAX_AGE (a script
+        that never terminates) is dropped from tracking so nudging cannot go on forever.
+        """
+        while self._reply_wake_pending:
+            await asyncio.sleep(REPLY_WAKE_TICK)
+            now = asyncio.get_event_loop().time()
+            for request_id, sent_at in list(self._reply_wake_pending.items()):
+                if now - sent_at > REPLY_WAKE_MAX_AGE:
+                    self._reply_wake_pending.pop(request_id, None)
+            if any(now - sent_at >= REPLY_WAKE_INTERVAL for sent_at in self._reply_wake_pending.values()):
+                await self._send_message_to_target({
+                    "id": self.next_internal_id(),
+                    "method": "Runtime.evaluate",
+                    "params": {"expression": "0"},
+                })
+
     @staticmethod
     def _key_event_init(params: dict[str, Any]) -> str:
         """The JSON the in-page key handlers take: the key and its modifiers, decoded from CDP's
@@ -3039,6 +3130,12 @@ class CdpTarget:
                 message = {"id": message["id"], "result": {}}
         if "id" in message:
             self._pending_requests.pop(message["id"], None)
+            self._reply_wake_pending.pop(message["id"], None)
+            translator = self._reply_translators.pop(message["id"], None)
+            if translator is not None:
+                # A request forwarded without blocking; its translator answers the client itself.
+                await translator(message)
+                return
             if message["id"] < 0:
                 # Response to a bridge-internal request (setup replay or an abandoned wait);
                 # forwarding it would hand the frontend an id it never issued.

--- a/pymobiledevice3/services/web_protocol/inspector_session.py
+++ b/pymobiledevice3/services/web_protocol/inspector_session.py
@@ -7,6 +7,9 @@ from typing import Any, Callable, Optional, cast
 from pymobiledevice3.exceptions import InspectorEvaluateError
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
 
+# Poll interval for waiting on the per-session event queue; see cdp_target.IDLE_POLL_INTERVAL.
+IDLE_POLL_INTERVAL = 0.001
+
 logger = logging.getLogger(__name__)
 console_logger = logging.getLogger("webinspector.console")
 # console history replayed by the page on attach, distinguishable (and silenceable) by logger name
@@ -127,10 +130,10 @@ class InspectorSession:
         if wait_target:
             events = protocol.inspector.session_events(protocol.id_)
             while not events:
-                await asyncio.sleep(0)
-            created = events.pop(0)
+                await asyncio.sleep(IDLE_POLL_INTERVAL)
+            created = events.popleft()
             while "targetInfo" not in created["params"]:
-                created = events.pop(0)
+                created = events.popleft()
             target_id = created["params"]["targetInfo"]["targetId"]
             logger.info(f"Created: {target_id}")
         target = cls(protocol, target_id)
@@ -217,9 +220,9 @@ class InspectorSession:
         while True:
             events = self.protocol.inspector.session_events(self.protocol.id_)
             while not events:
-                await asyncio.sleep(0)
+                await asyncio.sleep(IDLE_POLL_INTERVAL)
 
-            response = events.pop(0)
+            response = events.popleft()
             response_method = response["method"]
             if response_method in self.response_methods:
                 self.response_methods[response_method](response)
@@ -230,7 +233,7 @@ class InspectorSession:
         while True:
             if message_id in self._dispatch_message_responses:
                 return self._dispatch_message_responses.pop(message_id)
-            await asyncio.sleep(0)
+            await asyncio.sleep(IDLE_POLL_INTERVAL)
 
     async def get_properties_raw(self, object_id: str) -> list[dict[str, Any]]:
         """Raw ``Runtime.getProperties`` descriptors, preserving RemoteObject dicts (objectIds)."""

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 import uuid
+from collections import deque
 from collections.abc import Coroutine
 from dataclasses import dataclass, fields
 from enum import Enum
@@ -190,7 +191,7 @@ class WebinspectorService(LockdownService):
         self.connected_application: dict[str, Application] = {}
         self.application_pages: dict[str, Any] = {}
         self.wir_message_results: dict[str, Any] = {}
-        self.wir_events: dict[str, list[Any]] = {}
+        self.wir_events: dict[str, deque[Any]] = {}
         self.receive_handlers = {
             "_rpc_reportCurrentState:": self._handle_report_current_state,
             "_rpc_reportConnectedApplicationList:": self._handle_report_connected_application_list,
@@ -485,7 +486,7 @@ class WebinspectorService(LockdownService):
         await self._forward_did_close(session_id, app_id, page_id)
         self.wir_events.pop(session_id, None)
 
-    def session_events(self, session_id: str) -> list[Any]:
+    def session_events(self, session_id: str) -> deque[Any]:
         """The queue of events `webinspectord` forwarded to one session's socket.
 
         Events carry no id, so a consumer cannot tell its own from another's by content, and
@@ -495,9 +496,10 @@ class WebinspectorService(LockdownService):
         consume each other's events.
 
         :param session_id: The session identifier the socket was set up with.
-        :returns: The session's queue; consumers pop from it in place.
+        :returns: The session's queue (a deque, so consuming from the front is O(1)); consumers pop
+            from it in place.
         """
-        return self.wir_events.setdefault(session_id, [])
+        return self.wir_events.setdefault(session_id, deque())
 
     def find_page_id(self, page_id: str) -> tuple[Application, Page]:
         """Look up the application and page for a known page identifier.

--- a/tests/services/test_inspector_session.py
+++ b/tests/services/test_inspector_session.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+from collections import deque
 from types import SimpleNamespace
 from typing import Any, Optional
 
@@ -11,10 +12,11 @@ from pymobiledevice3.services.web_protocol.inspector_session import InspectorSes
 
 @pytest.fixture()
 async def session():
-    events: dict[str, list[dict[str, Any]]] = {}
+    # The real service hands out a deque (consumed from the front in O(1)); the fake must match.
+    events: dict[str, deque[dict[str, Any]]] = {}
     protocol = SimpleNamespace(
         id_="session-1",
-        inspector=SimpleNamespace(session_events=lambda session_id: events.setdefault(session_id, [])),
+        inspector=SimpleNamespace(session_events=lambda session_id: events.setdefault(session_id, deque())),
     )
     session = InspectorSession(protocol, target_id="page-1")  # pyright: ignore[reportArgumentType]
     yield session

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -4,6 +4,7 @@ import itertools
 import json
 import socket
 import threading
+import time
 import urllib.request
 import uuid
 from collections.abc import AsyncGenerator, Generator
@@ -32,7 +33,11 @@ from pymobiledevice3.services.web_protocol.cdp_server import (
     bridge_version,
     targets_html,
 )
-from pymobiledevice3.services.web_protocol.cdp_target import JS_CONTEXT_EXECUTION_ID, CdpTarget
+from pymobiledevice3.services.web_protocol.cdp_target import (
+    JS_CONTEXT_EXECUTION_ID,
+    REPLY_WAKE_INTERVAL,
+    CdpTarget,
+)
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
 from pymobiledevice3.services.webinspector import SAFARI, Application, AutomationAvailability, Page, WebinspectorService
 
@@ -1076,6 +1081,194 @@ async def testp_cdp_server_carries_a_user_gesture_through(lockdown: LockdownClie
                 f"Runtime.callFunctionOn must carry the gesture too: {with_gesture}"
             )
         finally:
+            await client.close()
+
+
+async def testp_cdp_server_frees_a_withheld_evaluate_reply(lockdown: LockdownClient) -> None:
+    """
+    iOS 26 WebKit occasionally holds a Runtime.evaluate reply until the next message reaches the
+    page, which hung a client's console evaluate - and stalled stepping - until the user's next
+    action. The bridge nudges the page while such a reply is outstanding, so an evaluate returns on
+    its own with nothing sent after it. A large expression source most reliably triggers the hold.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        try:
+            await client.command(1, "Runtime.enable", {})
+            await client.command(2, "Page.navigate", {"url": "https://example.com/"})
+            await asyncio.sleep(3)
+            big = "(() => { let s = 0; " + "s = s + 1; " * 10000 + "return s; })()"
+            # Nothing follows the evaluate; before the fix it hung until the next command. Bound the
+            # wait well under the 30s a genuine hang would take, but above the bridge's nudge cadence.
+            reply = await asyncio.wait_for(
+                client.command(3, "Runtime.evaluate", {"expression": big, "returnByValue": True}),
+                REPLY_WAKE_INTERVAL * 8,
+            )
+            assert reply["result"]["result"]["value"] == 10000, reply
+        finally:
+            await client.close()
+
+
+async def testp_cdp_server_debugs_a_megabyte_script_responsively(lockdown: LockdownClient) -> None:
+    """
+    The whole debugging surface on a ~1 MB script, each step bounded so a regression shows as a
+    failure rather than a slow test: the script defines, a `debugger;` hits, the scope's properties
+    all come back (a large scope's list used to be silently emptied by an internal five-second
+    wait that also stalled event delivery), step-over/into/out land where they should with
+    correct values in scope, a breakpoint set by URL is hit, the script completes with the right
+    result, an armed manual pause stops the next code that runs, and the bridge does not burn CPU
+    while the debugger sits idle at a breakpoint. WebKit withholds a step's reply and paused
+    event until the next message about half the time on a script this size; the watchdog frees
+    them, which is what keeps every bound here tight.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        message_ids = itertools.count(1)
+        pending: dict[int, asyncio.Future[dict[str, Any]]] = {}
+        paused_events: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+        async def reader() -> None:
+            while True:
+                message = await client.receive()
+                if "id" in message and message["id"] in pending and not pending[message["id"]].done():
+                    pending[message["id"]].set_result(message)
+                elif message.get("method") == "Debugger.paused":
+                    paused_events.put_nowait(message["params"])
+
+        reader_task = asyncio.create_task(reader())
+
+        async def call(method: str, params: dict[str, Any], budget: float = TIMEOUT) -> dict[str, Any]:
+            id_ = next(message_ids)
+            future: asyncio.Future[dict[str, Any]] = asyncio.get_event_loop().create_future()
+            pending[id_] = future
+            await client.send({"id": id_, "method": method, "params": params})
+            return await asyncio.wait_for(future, budget)
+
+        async def paused(budget: float = TIMEOUT) -> dict[str, Any]:
+            return await asyncio.wait_for(paused_events.get(), budget)
+
+        def value(reply: dict[str, Any]) -> Any:
+            return reply.get("result", {}).get("result", {}).get("value")
+
+        def top(frame_event: dict[str, Any]) -> dict[str, Any]:
+            return frame_event["callFrames"][0]
+
+        try:
+            for method in ("Runtime.enable", "Page.enable", "Debugger.enable"):
+                await call(method, {})
+            await call("Page.navigate", {"url": "https://example.com/"})
+            await asyncio.sleep(3)
+            while not paused_events.empty():
+                paused_events.get_nowait()
+
+            # ~1 MB: a nested function to step into, a `debugger;` to hit, and 45k hoisted vars.
+            var_count = 45000
+            filler = "\n".join(f"  var v{i} = {i} + 1;" for i in range(var_count))
+            source = (
+                "function inner(x){ let y = x*2; return y+1; }\n"
+                "function bigwork(){\n  let a = 1;\n  let b = 2;\n  debugger;\n  let c = a + b;\n"
+                "  let d = inner(c);\n  let e = d + 1;\n" + filler + "\n  return e;\n}\n//# sourceURL=bigwork.js"
+            )
+            return_line = 8 + var_count
+            assert len(source) > 1_000_000, len(source)
+            defined = await call("Runtime.evaluate", {"expression": source, "returnByValue": True}, 60)
+            assert "error" not in defined, defined
+
+            await call("Runtime.evaluate", {"expression": "setTimeout(() => { window.__r = bigwork(); }, 200); 1"})
+            hit = await paused()
+            assert top(hit).get("functionName") == "bigwork" and top(hit)["location"]["lineNumber"] == 4, top(hit)
+
+            # Idle at the breakpoint: the bridge must not spin a core waiting for nothing.
+            cpu_before, wall_before = time.process_time(), time.perf_counter()
+            await asyncio.sleep(3)
+            cpu_share = (time.process_time() - cpu_before) / (time.perf_counter() - wall_before)
+            assert cpu_share < 0.15, f"bridge burned {cpu_share:.0%} of a core idling at a breakpoint"
+
+            assert (
+                value(
+                    await call(
+                        "Debugger.evaluateOnCallFrame",
+                        {"callFrameId": top(hit)["callFrameId"], "expression": "a+b", "returnByValue": True},
+                    )
+                )
+                == 3
+            )
+
+            # Every non-global scope's properties, as the Sources panel fetches them on each pause.
+            started = time.perf_counter()
+            total = 0
+            for scope in top(hit)["scopeChain"]:
+                object_id = scope["object"].get("objectId")
+                if scope.get("type") == "global" or not object_id:
+                    continue
+                reply = await call("Runtime.getProperties", {"objectId": object_id, "ownProperties": True}, 60)
+                total += len(reply.get("result", {}).get("result", []))
+            assert total >= var_count, f"scope properties truncated: {total} < {var_count}"
+            assert time.perf_counter() - started < 10, "fetching the scope took too long"
+
+            stepped: dict[str, Any] = {}
+            for _ in range(2):  # to the inner() call line
+                started = time.perf_counter()
+                await call("Debugger.stepOver", {})
+                stepped = await paused()
+                assert time.perf_counter() - started < 2, "step-over stalled"
+            assert top(stepped)["location"]["lineNumber"] == 6, top(stepped)
+
+            await call("Debugger.stepInto", {})
+            inside = await paused()
+            assert top(inside).get("functionName") == "inner" and len(inside["callFrames"]) >= 3, top(inside)
+            assert (
+                value(
+                    await call(
+                        "Debugger.evaluateOnCallFrame",
+                        {"callFrameId": top(inside)["callFrameId"], "expression": "x", "returnByValue": True},
+                    )
+                )
+                == 3
+            )
+
+            await call("Debugger.stepOut", {})
+            back = await paused()
+            assert top(back).get("functionName") == "bigwork", top(back)
+
+            for _ in range(3):  # through the big body
+                started = time.perf_counter()
+                await call("Debugger.stepOver", {})
+                await paused()
+                assert time.perf_counter() - started < 2, "step-over in the large body stalled"
+
+            # A breakpoint by URL on the return line must be hit on resume, with the value in scope.
+            set_reply = await call("Debugger.setBreakpointByUrl", {"lineNumber": return_line, "url": "bigwork.js"})
+            assert "error" not in set_reply, set_reply
+            await call("Debugger.resume", {})
+            at_return = await paused()
+            assert top(at_return)["location"]["lineNumber"] == return_line, top(at_return)
+            assert (
+                value(
+                    await call(
+                        "Debugger.evaluateOnCallFrame",
+                        {"callFrameId": top(at_return)["callFrameId"], "expression": "e", "returnByValue": True},
+                    )
+                )
+                == 8
+            )
+            await call("Debugger.resume", {})
+            await asyncio.sleep(1)
+            assert value(await call("Runtime.evaluate", {"expression": "window.__r", "returnByValue": True})) == 8
+
+            # Manual pause: schedule code first, then arm the pause; it stops on that code's first
+            # statement. (Arming before an evaluate pauses inside that evaluate, as in Chrome.)
+            while not paused_events.empty():
+                paused_events.get_nowait()
+            await call("Runtime.evaluate", {"expression": "setTimeout(() => { let q = 1; q++; }, 800); 1"})
+            await call("Debugger.pause", {})
+            manual = await paused(10)
+            assert manual["callFrames"], manual
+            await call("Debugger.resume", {})
+        finally:
+            reader_task.cancel()
             await client.close()
 
 


### PR DESCRIPTION
## Summary

Debugging a large script over CDP from WebStorm or Chrome hung and crawled: a large evaluate appeared to hang until the *next* action, and step-over often did not land. Three separate causes, each measured on a device against a ~1 MB script and fixed here.

### 1. Withheld replies (the hang)
iOS 26 WebKit occasionally holds the reply to a client request — **and the events that follow it, such as the `Debugger.paused` after a step** — until the next message reaches the page. A console evaluate then hung until the user's next action, and **half of all step-overs in the large script stalled the same way** (7 of 14 in a trial; each freed by one throwaway message within ~10 ms). The bridge only nudged the page for its own in-page key handlers (#1915).

A single watchdog now runs while any forwarded client reply is outstanding: every 0.1 s it sends one throwaway evaluation once a reply is 0.25 s late (one message flushes everything held, so traffic is bounded), and drops a request after 20 s. A prompt reply clears its id before the first interval, so a normal request is never nudged. Covers page targets and JSContexts alike.

### 2. The idle spin (the CPU burn)
The receive loop and internal-reply waits polled with `asyncio.sleep(0)`, spinning a core whenever nothing was pending — **23% of a CPU measured while the debugger sat idle at a breakpoint** — and drained the per-session queue with `list.pop(0)`, O(n) per message. Now polls at 1 ms (a queued message is still handled without sleeping, so throughput is unchanged) with a `deque`-backed queue. Idle measures ~4%.

### 3. Empty scopes on a big function (the stall + wrong data)
`Runtime.getProperties` routed a *client's* request through the bridge's own 5-second internal wait, which also pauses event delivery. A large scope's property list — fetched by the Sources panel on **every pause** — took WebKit longer than that, so it was **silently answered with an empty list and nothing reached the client for 5 s per step**. It is now forwarded without blocking under the client's id and translated when the reply arrives. A 45k-variable scope returns in full (~0.9 s).

### Platform limit, documented
The manual pause button (`Debugger.pause`) cannot interrupt JavaScript already busy in a tight loop: WebKit handles inspector messages on the page's JavaScript thread, so the pause lands when the script next yields. Armed while idle it stops the next code that runs, as in Chrome.

## Verification

On iOS 26.6.1, a 1.15 MB / 45k-line script, every step bounded:

| capability | before | after |
|---|---|---|
| define 1 MB script | hung until next message | 0.4 s |
| `debugger;` hit | — | 0.3 s |
| idle CPU at a breakpoint | 23% of a core | ~4% |
| scope properties (45k vars) | empty after a 5 s stall | all 45,005 in 0.9 s |
| step-over in the large body | ~50% stalled indefinitely | ≤ 0.3 s |
| step-into `inner()` / evaluate `x` / step-out | — | correct, 0.01 s |
| breakpoint by URL on line 45008, `e` in scope | — | hit, 8 |
| script completes with correct result | — | 8 |
| armed manual pause stops next code | — | yes |

Two device tests added (`testp_cdp_server_debugs_a_megabyte_script_responsively`, `testp_cdp_server_frees_a_withheld_evaluate_reply`); existing evaluate/navigation/typing/frame/JSContext device tests pass; the non-device suite passes (101). ruff and pyright clean.
