### PR TITLE
cdp: Nudge withheld replies without running JavaScript, and cover the debugger's corners

### DIFF
--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -2795,19 +2795,31 @@ class CdpTarget:
         arrives right after whatever is sent next. Observed on iOS 26 with the very same
         expression answering instantly most of the time, so it is a wake-up problem on the
         device, not the script. Left alone, the wait ran out, the target was declared
-        unresponsive and every following key was skipped. Sending a trivial evaluation as
-        soon as the reply is late frees it within milliseconds; nobody waits for the nudge's
+        unresponsive and every following key was skipped. Nudging the page as
+        soon as the reply is late frees it within milliseconds (see _nudge_target); nobody waits for the nudge's
         own reply, and a reply to an internal id nobody waits for is dropped on arrival.
         """
         pending = asyncio.ensure_future(self._evaluate_json_in(context_id, expression))
         done, _ = await asyncio.wait({pending}, timeout=KEY_HANDLER_WAKE_DELAY)
         if not done:
-            await self._send_message_to_target({
-                "id": self.next_internal_id(),
-                "method": "Runtime.evaluate",
-                "params": {"expression": "0"},
-            })
+            await self._nudge_target()
         return await pending
+
+    async def _nudge_target(self) -> None:
+        """Send the page a message that runs no JavaScript, to flush a reply WebKit is withholding.
+
+        Any message reaching the page frees a withheld reply (measured: a step held with its
+        paused event was freed by this in ~10 ms, exactly as by a throwaway evaluation). The
+        message must not run script, because an evaluation is itself a statement: with the Pause
+        button armed, an evaluation used as the nudge paused *inside its own "0"* and the user's
+        code then ran unpaused. Re-send the breakpoints-active setting at its current value - a
+        real Debugger command with nothing to execute and nothing to change.
+        """
+        active = self._setup_messages.get("Debugger.setBreakpointsActive", {}).get("active", True)
+        await self._send_message_to_target(
+            {"id": self.next_internal_id(), "method": "Debugger.setBreakpointsActive", "params": {"active": active}},
+            record=False,
+        )
 
     async def _wake_late_replies(self) -> None:
         """Free forwarded client replies that WebKit is withholding.
@@ -2830,11 +2842,7 @@ class CdpTarget:
                 if now - sent_at > REPLY_WAKE_MAX_AGE:
                     self._reply_wake_pending.pop(request_id, None)
             if any(now - sent_at >= REPLY_WAKE_INTERVAL for sent_at in self._reply_wake_pending.values()):
-                await self._send_message_to_target({
-                    "id": self.next_internal_id(),
-                    "method": "Runtime.evaluate",
-                    "params": {"expression": "0"},
-                })
+                await self._nudge_target()
 
     @staticmethod
     def _key_event_init(params: dict[str, Any]) -> str:

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -1272,6 +1272,361 @@ async def testp_cdp_server_debugs_a_megabyte_script_responsively(lockdown: Lockd
             await client.close()
 
 
+async def testp_cdp_server_keeps_an_armed_pause_for_user_code(lockdown: LockdownClient) -> None:
+    """
+    With the Pause button armed, a late reply must not cost the user their pause. The bridge nudges
+    the page to free a withheld reply; an evaluation used as that nudge was itself a statement, so
+    the armed pause landed inside the nudge's own "0" and the user's code then ran unpaused. The
+    nudge runs no JavaScript now, so the pause lands on the user's code and holds it.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        message_ids = itertools.count(1)
+        pending: dict[int, asyncio.Future[dict[str, Any]]] = {}
+        paused_events: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+        async def reader() -> None:
+            while True:
+                message = await client.receive()
+                if "id" in message and message["id"] in pending and not pending[message["id"]].done():
+                    pending[message["id"]].set_result(message)
+                elif message.get("method") == "Debugger.paused":
+                    paused_events.put_nowait(message["params"])
+
+        reader_task = asyncio.create_task(reader())
+
+        async def send(method: str, params: dict[str, Any]) -> "asyncio.Future[dict[str, Any]]":
+            """Send without waiting for the reply; the returned future resolves with it."""
+            id_ = next(message_ids)
+            future: asyncio.Future[dict[str, Any]] = asyncio.get_event_loop().create_future()
+            pending[id_] = future
+            await client.send({"id": id_, "method": method, "params": params})
+            return future
+
+        async def call(method: str, params: dict[str, Any], budget: float = TIMEOUT) -> dict[str, Any]:
+            return await asyncio.wait_for(await send(method, params), budget)
+
+        def value(reply: dict[str, Any]) -> Any:
+            return reply.get("result", {}).get("result", {}).get("value")
+
+        try:
+            for method in ("Runtime.enable", "Page.enable", "Debugger.enable"):
+                await call(method, {})
+            # A fresh document: an armed pause takes the very next statement to run, so a timer
+            # left behind by an earlier test on this page would take it instead of the user's code.
+            await call("Page.navigate", {"url": "https://example.com/"})
+            await asyncio.sleep(3)
+            big = await call(
+                "Runtime.evaluate",
+                {
+                    "expression": "window.__big = Object.fromEntries(Array.from({length: 45000}, (_, i) => ['k' + i, i])); window.__big"
+                },
+            )
+            await call(
+                "Runtime.evaluate",
+                {
+                    "expression": (
+                        "window.__ran = undefined;"
+                        " function userCode(){\n  let z = 1;\n  z = z + 1;\n  window.__ran = z;\n  return z;\n}\n"
+                        "//# sourceURL=user.js"
+                    ),
+                    "returnByValue": True,
+                },
+            )
+            while not paused_events.empty():
+                paused_events.get_nowait()
+            # Schedule the user's code first, as the timer's callback itself: an evaluate sent after
+            # arming would be the next statement and take the pause, and so would a wrapper arrow
+            # around the call. Then arm, then cause a reply WebKit needs about a second for, so the
+            # watchdog nudges while the pause is armed.
+            await call("Runtime.evaluate", {"expression": "setTimeout(userCode, 1500); 1", "returnByValue": True})
+            await call("Debugger.pause", {})
+            late = await send(
+                "Runtime.getProperties", {"objectId": big["result"]["result"]["objectId"], "ownProperties": True}
+            )
+            landed = await asyncio.wait_for(paused_events.get(), 10)
+            frame = landed["callFrames"][0]
+            assert frame.get("url") == "user.js", (
+                f"the armed pause must land on the user's code, not the nudge: {frame}"
+            )
+            assert (
+                value(await call("Runtime.evaluate", {"expression": "window.__ran", "returnByValue": True})) is None
+            ), "the user's code must be held at the pause, not have run"
+            await call("Debugger.resume", {})
+            await asyncio.sleep(1)
+            assert value(await call("Runtime.evaluate", {"expression": "window.__ran", "returnByValue": True})) == 2
+            await asyncio.wait_for(late, TIMEOUT)
+        finally:
+            reader_task.cancel()
+            await client.close()
+
+
+async def testp_cdp_server_steps_through_a_large_file_end_to_end(lockdown: LockdownClient) -> None:
+    """
+    Step over every statement of a function in a realistic large file (thousands of helpers, async
+    boundaries), doing what an IDE does at each pause - fetch the scopes and evaluate a watch - and
+    each step must land promptly. This is the workflow that hung on a 22k-line file: WebKit holds
+    a step's reply and paused event until the next message about half the time, and the bridge's
+    watchdog is what keeps every step under the bound.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        message_ids = itertools.count(1)
+        pending: dict[int, asyncio.Future[dict[str, Any]]] = {}
+        paused_events: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+        async def reader() -> None:
+            while True:
+                message = await client.receive()
+                if "id" in message and message["id"] in pending and not pending[message["id"]].done():
+                    pending[message["id"]].set_result(message)
+                elif message.get("method") == "Debugger.paused":
+                    paused_events.put_nowait(message["params"])
+
+        reader_task = asyncio.create_task(reader())
+
+        async def call(method: str, params: dict[str, Any], budget: float = TIMEOUT) -> dict[str, Any]:
+            id_ = next(message_ids)
+            future: asyncio.Future[dict[str, Any]] = asyncio.get_event_loop().create_future()
+            pending[id_] = future
+            await client.send({"id": id_, "method": method, "params": params})
+            return await asyncio.wait_for(future, budget)
+
+        try:
+            for method in ("Runtime.enable", "Page.enable", "Debugger.enable"):
+                await call(method, {})
+            await call("Page.navigate", {"url": "https://example.com/"})
+            await asyncio.sleep(3)
+            while not paused_events.empty():
+                paused_events.get_nowait()
+
+            helpers = 1200
+            calls = 120
+            lines: list[str] = []
+            for i in range(helpers):
+                lines += [
+                    f"function helper{i}(x) {{",
+                    "  const items = [];",
+                    "  for (let k = 0; k < 3; k++) {",
+                    f"    items.push({{ id: k, v: x + k + {i} }});",
+                    "  }",
+                    "  const total = items.reduce((s, it) => s + it.v, 0);",
+                    "  if (total % 2 === 0) { return total; }",
+                    "  return total + 1;",
+                    "}",
+                    "",
+                ]
+            lines += [
+                "function wait(ms) { return new Promise(r => setTimeout(r, ms)); }",
+                "",
+                "async function main() {",
+                "  let acc = 0;",
+                "  debugger;",
+            ]
+            for i in range(calls):
+                if i % 25 == 24:
+                    lines.append("  await wait(10);")
+                lines.append(f"  acc += helper{(i * 7) % helpers}(acc & 0xff);")
+            lines += ["  window.__done = acc;", "  return acc;", "}", "//# sourceURL=large.js"]
+            source = "\n".join(lines)
+            assert source.count("\n") > 12000
+            defined = await call("Runtime.evaluate", {"expression": source, "returnByValue": True}, 60)
+            assert "error" not in defined, defined
+            await call("Runtime.evaluate", {"expression": "setTimeout(() => { main(); }, 200); 1"})
+            frame = (await asyncio.wait_for(paused_events.get(), TIMEOUT))["callFrames"][0]
+            assert frame.get("functionName") == "main", frame
+
+            steps = 0
+            while True:
+                started = time.perf_counter()
+                await call("Debugger.stepOver", {})
+                try:
+                    paused = await asyncio.wait_for(paused_events.get(), 5)
+                except (asyncio.TimeoutError, TimeoutError):
+                    if steps >= calls:  # main returned; nothing left to pause in
+                        break
+                    raise AssertionError(f"step-over #{steps} did not land within 5s") from None
+                frame = paused["callFrames"][0]
+                if frame.get("functionName") != "main":
+                    break
+                assert time.perf_counter() - started < 2, f"step-over #{steps} took too long"
+                for scope in frame["scopeChain"]:
+                    object_id = scope["object"].get("objectId")
+                    if scope.get("type") != "global" and object_id:
+                        await call("Runtime.getProperties", {"objectId": object_id, "ownProperties": True}, 20)
+                await call(
+                    "Debugger.evaluateOnCallFrame",
+                    {"callFrameId": frame["callFrameId"], "expression": "acc", "returnByValue": True},
+                )
+                steps += 1
+            assert steps >= calls, f"expected to step over at least {calls} statements, did {steps}"
+            await asyncio.sleep(2)
+            done = await call("Runtime.evaluate", {"expression": "window.__done", "returnByValue": True})
+            assert isinstance(done.get("result", {}).get("result", {}).get("value"), int), done
+        finally:
+            reader_task.cancel()
+            await client.close()
+
+
+async def testp_cdp_server_survives_debugger_edge_cases(lockdown: LockdownClient) -> None:
+    """
+    The corners a debugging session hits once it is more than a demo, each bounded: rapid
+    step-overs fired without waiting coalesce rather than wedge, step-into descends a recursion
+    and step-out climbs back, a breakpoint set deep in a large file is hit with the right value
+    in scope, pause-on-exceptions lands in the throwing function, and navigating away while paused
+    (a process swap mid-pause) leaves the session alive on the new document.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        message_ids = itertools.count(1)
+        pending: dict[int, asyncio.Future[dict[str, Any]]] = {}
+        paused_events: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+        async def reader() -> None:
+            while True:
+                message = await client.receive()
+                if "id" in message and message["id"] in pending and not pending[message["id"]].done():
+                    pending[message["id"]].set_result(message)
+                elif message.get("method") == "Debugger.paused":
+                    paused_events.put_nowait(message["params"])
+
+        reader_task = asyncio.create_task(reader())
+
+        async def send(method: str, params: dict[str, Any]) -> "asyncio.Future[dict[str, Any]]":
+            id_ = next(message_ids)
+            future: asyncio.Future[dict[str, Any]] = asyncio.get_event_loop().create_future()
+            pending[id_] = future
+            await client.send({"id": id_, "method": method, "params": params})
+            return future
+
+        async def call(method: str, params: dict[str, Any], budget: float = TIMEOUT) -> dict[str, Any]:
+            return await asyncio.wait_for(await send(method, params), budget)
+
+        async def paused(budget: float = 10) -> dict[str, Any]:
+            return await asyncio.wait_for(paused_events.get(), budget)
+
+        def top(event: dict[str, Any]) -> dict[str, Any]:
+            return event["callFrames"][0]
+
+        def value(reply: dict[str, Any]) -> Any:
+            return reply.get("result", {}).get("result", {}).get("value")
+
+        try:
+            for method in ("Runtime.enable", "Page.enable", "Debugger.enable"):
+                await call(method, {})
+            await call("Page.navigate", {"url": "https://example.com/"})
+            await asyncio.sleep(3)
+            while not paused_events.empty():
+                paused_events.get_nowait()
+
+            filler = "\n".join(f"function h{i}(x){{ return x+{i}; }}" for i in range(3000))
+            source = (
+                filler + "\nfunction rec(n){\n  if (n===0) { return 0; }\n  return 1 + rec(n-1);\n}\n"
+                "function deepTarget(v){\n  let w = v * 2;\n  return w;\n}\n"
+                "function boom(){ throw new Error('kaboom'); }\n"
+                "function main(){\n  let a=1;\n  debugger;\n  let b=a+1;\n  let c=b+1;\n  let d=c+1;\n"
+                "  let g=rec(6);\n  let h=deepTarget(g);\n  return h;\n}\n//# sourceURL=edges.js"
+            )
+            lines = source.split("\n")
+            deep_line = next(i for i, line in enumerate(lines) if line.startswith("  let w = v * 2"))
+            await call("Runtime.evaluate", {"expression": source, "returnByValue": True})
+            await call("Runtime.evaluate", {"expression": "setTimeout(() => { window.__m = main(); }, 150); 1"})
+            event = await paused()
+            first_line = top(event)["location"]["lineNumber"]
+
+            # Rapid step-overs without waiting: they may coalesce, but must advance and never wedge.
+            started = time.perf_counter()
+            for _ in range(5):
+                await send("Debugger.stepOver", {})
+            landed: list[int] = []
+            for _ in range(5):
+                try:
+                    landed.append(top(await paused(4))["location"]["lineNumber"])
+                except (asyncio.TimeoutError, TimeoutError):
+                    break
+            assert landed and landed[-1] > first_line and time.perf_counter() - started < 8, landed
+
+            # Step-into descends the recursion; step-out climbs back to main.
+            event = await paused(0.5) if not paused_events.empty() else event
+            for _ in range(40):
+                line = top(event)["location"]["lineNumber"]
+                if "rec(6)" in lines[line] or top(event).get("functionName") != "main":
+                    break
+                await call("Debugger.stepOver", {})
+                event = await paused()
+            assert "rec(6)" in lines[top(event)["location"]["lineNumber"]], top(event)
+            depths: list[int] = []
+            for _ in range(12):
+                await call("Debugger.stepInto", {})
+                event = await paused()
+                depths.append(len(event["callFrames"]))
+                if depths[-1] >= 5:
+                    break
+            assert max(depths) >= 5, f"step-into must descend the recursion: {depths}"
+            for _ in range(12):
+                await call("Debugger.stepOut", {})
+                event = await paused()
+                if top(event).get("functionName") == "main":
+                    break
+            assert top(event).get("functionName") == "main", top(event)
+
+            # A breakpoint deep in the file is hit on resume, with the argument in scope.
+            await call("Debugger.setBreakpointByUrl", {"lineNumber": deep_line, "url": "edges.js"})
+            await call("Debugger.resume", {})
+            event = await paused()
+            assert (
+                top(event).get("functionName") == "deepTarget" and top(event)["location"]["lineNumber"] == deep_line
+            ), top(event)
+            assert (
+                value(
+                    await call(
+                        "Debugger.evaluateOnCallFrame",
+                        {"callFrameId": top(event)["callFrameId"], "expression": "v", "returnByValue": True},
+                    )
+                )
+                == 6
+            )
+            await call("Debugger.resume", {})
+            await asyncio.sleep(1)
+            while not paused_events.empty():
+                paused_events.get_nowait()
+            assert value(await call("Runtime.evaluate", {"expression": "window.__m", "returnByValue": True})) == 12
+
+            # Pause on exceptions lands in the throwing function.
+            await call("Debugger.setPauseOnExceptions", {"state": "all"})
+            await call(
+                "Runtime.evaluate",
+                {
+                    "expression": "setTimeout(() => { try { boom(); } catch (e) { window.__caught = e.message; } }, 150); 1"
+                },
+            )
+            event = await paused()
+            assert event.get("reason") == "exception" and top(event).get("functionName") == "boom", event.get("reason")
+            await call("Debugger.resume", {})
+            await call("Debugger.setPauseOnExceptions", {"state": "none"})
+            await asyncio.sleep(1)
+            while not paused_events.empty():
+                paused_events.get_nowait()
+
+            # Navigating while paused swaps the process mid-pause; the session must come out alive.
+            await call("Runtime.evaluate", {"expression": "setTimeout(() => { main(); }, 150); 1"})
+            await paused()
+            await call("Page.navigate", {"url": "https://example.com/?after"})
+            await asyncio.sleep(4)
+            while not paused_events.empty():
+                paused_events.get_nowait()
+            assert (
+                value(await call("Runtime.evaluate", {"expression": "location.search", "returnByValue": True}, 10))
+                == "?after"
+            )
+        finally:
+            reader_task.cancel()
+            await client.close()
+
+
 async def testp_cdp_server_drives_a_javascript_context(lockdown: LockdownClient) -> None:
     """
     A JSContext debuggable (any process that called -[JSContext setInspectable:YES]) implements


### PR DESCRIPTION
## Summary

Follow-up hardening to #1923, from stress-testing the debugger end to end. Two parts.

### The nudge no longer runs JavaScript
The watchdog that frees a reply WebKit is withholding (and the key handlers' own nudge) sent a throwaway `Runtime.evaluate("0")`. An evaluation is a statement, so with the Pause button armed, pause-on-next-statement could in principle land inside the nudge. **Honest finding:** it did *not* in practice — the test written for this passes against master too, because a bare literal has no statement pause point — so this is defensive, not a fix for a reproduced bug. But nothing guarantees that escape, and the nudge was running script in the page on every late reply. It now re-sends `Debugger.setBreakpointsActive` at its tracked value: a real command with nothing to execute and nothing to change.

Measured on the device: it frees a withheld step (reply and paused event together) in ~10 ms, exactly as the evaluation did; it works in a session that never enabled the Debugger; and the JSContext (flat) path behaves the same.

### Three new device tests
- **Armed pause + late reply** — the pause must land on the user's code and hold it. Note for anyone editing it: anything that runs after arming (an evaluate, even an arrow wrapper around the call) takes the pause itself, so the user code is scheduled as the timer's direct callback, and the test navigates to a fresh document first so no timer left on the shared page by an earlier test can take it.
- **Large file end to end** — step over every statement of `main()` in a ~12k-line file with `await` boundaries, fetching scopes and a watch at each pause as an IDE does.
- **Debugger edge cases** — rapid step-overs fired without waiting coalesce rather than wedge (as in Chrome); step-into descends a recursion to depth 5 and step-out climbs back; a breakpoint deep in the file is hit with the argument in scope; pause-on-exceptions lands in the throwing function; navigating while paused (a process swap mid-pause) leaves the session alive on the new document.

## Stress results (iOS 26.6.1, shipped v11.9.1 code plus this change)

| scenario | result |
|---|---|
| 164 step-overs through `main()` on a 14k-line file, scopes + watch per step | every step ≤ 0.01s, none slow |
| withheld evals (page, JSContext, and a no-Debugger session) | freed in ~0.3s |
| 1 MB full-surface test, withheld-eval test | pass |
| 5 rapid step-overs | coalesce to 2 pauses, no hang |

All device tests above pass together; the non-device suite passes (78); ruff and pyright clean.

## Note on the original report
The WebStorm step-over stall that prompted this was on a separate, offline workstation. It could not be reproduced here on v11.9.1 under heavier load than described, and every symptom matches the pre-#1923 withheld-reply bug — so the most likely cause is that machine running an older version. The landing page header and `pymobiledevice3 version` show what's installed.
