### PR TITLE
cdp: Record a full protocol trace with webinspector cdp --trace

### DIFF
--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -236,6 +236,21 @@ for it; the bridge switches this off again when the client detaches. Candidates
 nobody can take — for example a page that never made it into the listing — are
 declined immediately so no app waits.
 
+### Recording a protocol trace
+
+When something in an editor misbehaves - a step that does not land, an evaluate that never
+answers - a trace of the protocol is the report that lets it be diagnosed rather than
+guessed at:
+
+```shell
+pymobiledevice3 webinspector cdp --trace cdp-trace.jsonl
+```
+
+Attach the editor, reproduce the problem, stop the bridge, and attach the file. It records
+every message in both directions, on both sides of the bridge (editor to bridge, and bridge
+to device), one JSON line each with a timestamp. It contains page content, evaluation results
+and script sources, so treat it as sensitive.
+
 ### Pause new JSContexts on launch
 
 Safari's "Automatically Pause Connecting to JSContexts" has a bridge equivalent that

--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -6,6 +6,7 @@ from asyncio import CancelledError
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from functools import update_wrapper
+from pathlib import Path
 from string import Template
 from typing import Annotated, Any, Optional, cast
 
@@ -35,6 +36,7 @@ from pymobiledevice3.exceptions import (
 from pymobiledevice3.lockdown_service_provider import LockdownServiceProvider
 from pymobiledevice3.osu.os_utils import get_os_utils
 from pymobiledevice3.services.web_protocol.cdp_server import app, find_chrome
+from pymobiledevice3.services.web_protocol.cdp_trace import ProtocolTrace
 from pymobiledevice3.services.web_protocol.driver import By, Cookie, WebDriver
 from pymobiledevice3.services.web_protocol.inspector_session import InspectorSession
 from pymobiledevice3.services.webinspector import SAFARI, ApplicationPage, WebinspectorService
@@ -406,6 +408,13 @@ async def cdp(
             '"Pause new JSContexts on launch" switch.',
         ),
     ] = False,
+    trace: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--trace",
+            help="Record every protocol message, in both directions, to this JSON-lines file - attach it to a bug report.",
+        ),
+    ] = None,
 ) -> None:
     """
     Start a CDP server for debugging WebViews and inspectable JSContexts.
@@ -447,6 +456,11 @@ async def cdp(
     app.state.inspector = WebinspectorService(lockdown=service_provider)
     app.state.chrome_path = find_chrome(chrome)
     app.state.pause_new_targets = pause_new_targets
+    recorder = ProtocolTrace(trace) if trace is not None else None
+    if recorder is not None:
+        app.state.trace = recorder
+        app.state.inspector.trace = recorder.device_hook
+        typer.echo(f"Recording the protocol trace to {trace}")
     print(f"Web Inspector ready. Open in Google Chrome: http://{host}:{port}/")
     server = uvicorn.Server(
         uvicorn.Config(
@@ -457,7 +471,11 @@ async def cdp(
             ws="wsproto",
         )
     )
-    await server.serve()
+    try:
+        await server.serve()
+    finally:
+        if recorder is not None:
+            recorder.close()
 
 
 async def get_js_completions(jsshell: "JsShell", obj: str, prefix: str) -> AsyncIterator[Completion]:

--- a/pymobiledevice3/services/web_protocol/cdp_browser.py
+++ b/pymobiledevice3/services/web_protocol/cdp_browser.py
@@ -8,6 +8,11 @@ from typing import Any, Optional, cast
 from fastapi import WebSocket
 
 from pymobiledevice3.services.web_protocol.cdp_target import CdpTarget
+from pymobiledevice3.services.web_protocol.cdp_trace import (
+    BRIDGE_TO_EDITOR,
+    EDITOR_TO_BRIDGE,
+    ProtocolTrace,
+)
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
 from pymobiledevice3.services.webinspector import (
     Application,
@@ -176,9 +181,18 @@ class CdpBrowser:
         Safari's "Automatically Pause Connecting to JSContexts" (see CdpTarget.pause_on_start).
     """
 
-    def __init__(self, inspector: WebinspectorService, websocket: WebSocket, pause_on_start: bool = False) -> None:
+    def __init__(
+        self,
+        inspector: WebinspectorService,
+        websocket: WebSocket,
+        pause_on_start: bool = False,
+        trace: Optional[ProtocolTrace] = None,
+    ) -> None:
         self.inspector = inspector
         self.websocket = websocket
+        # The --trace recorder, if any: the browser endpoint is what VS Code's js-debug and
+        # Playwright attach to, so its editor side is recorded here.
+        self._trace = trace
         self._pause_on_start = pause_on_start
         # Target.setAutoAttach(waitForDebuggerOnStart): attach before the debuggable runs.
         self._wait_for_debugger = False
@@ -219,6 +233,8 @@ class CdpBrowser:
         """Serve the connection until the client disconnects."""
         async for message in self.websocket.iter_json():
             logger.debug(f"BROWSER CDP INPUT: {message}")
+            if self._trace is not None:
+                self._trace.record(EDITOR_TO_BRIDGE, message, session="browser")
             try:
                 await self._handle(message)
             except Exception:
@@ -307,6 +323,8 @@ class CdpBrowser:
     async def _send(self, message: dict[str, Any]) -> None:
         logger.debug(f"BROWSER CDP OUTPUT: {message}")
         async with self._send_lock:
+            if self._trace is not None:
+                self._trace.record(BRIDGE_TO_EDITOR, message, session="browser")
             await self.websocket.send_json(message)
 
     async def _reply(self, message: dict[str, Any], result: dict[str, Any]) -> None:

--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -35,6 +35,11 @@ from pymobiledevice3.services.web_protocol.cdp_browser import (
     target_url,
 )
 from pymobiledevice3.services.web_protocol.cdp_target import CdpTarget
+from pymobiledevice3.services.web_protocol.cdp_trace import (
+    BRIDGE_TO_EDITOR,
+    EDITOR_TO_BRIDGE,
+    ProtocolTrace,
+)
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
 from pymobiledevice3.services.webinspector import (
     Application,
@@ -955,16 +960,27 @@ async def devtools_frontend(path: str) -> Response:
     return Response(content=data, media_type=content_type)
 
 
+def _trace() -> Optional[ProtocolTrace]:
+    """The protocol trace this run records to, if `--trace` was given."""
+    return getattr(app.state, "trace", None)
+
+
 async def from_cdp(target: CdpTarget, websocket: WebSocket) -> None:
+    trace = _trace()
     async for message in websocket.iter_json():
         logger.debug(f"CDP INPUT:  {message}")
+        if trace is not None:
+            trace.record(EDITOR_TO_BRIDGE, message, session=target.session_id, page=str(target.page_id))
         await target.send(message)
 
 
 async def to_cdp(target: CdpTarget, websocket: WebSocket) -> None:
+    trace = _trace()
     while True:
         message = await target.receive()
         logger.debug(f"CDP OUTPUT:  {message}")
+        if trace is not None:
+            trace.record(BRIDGE_TO_EDITOR, message, session=target.session_id, page=str(target.page_id))
         await websocket.send_json(message)
 
 
@@ -973,7 +989,12 @@ async def browser_debugger(websocket: WebSocket, connection_id: str):
     """Browser-level endpoint (the one /json/version advertises): flat-session Target-domain
     debugging for Chrome-compatible clients such as VS Code's js-debug and Puppeteer."""
     await websocket.accept()
-    browser = CdpBrowser(app.state.inspector, websocket, pause_on_start=getattr(app.state, "pause_new_targets", False))
+    browser = CdpBrowser(
+        app.state.inspector,
+        websocket,
+        pause_on_start=getattr(app.state, "pause_new_targets", False),
+        trace=_trace(),
+    )
     try:
         await browser.run()
     finally:

--- a/pymobiledevice3/services/web_protocol/cdp_trace.py
+++ b/pymobiledevice3/services/web_protocol/cdp_trace.py
@@ -1,0 +1,92 @@
+"""Record every message the CDP bridge exchanges, in both directions, as JSON lines.
+
+Four directions are recorded: what the editor sends the bridge and what the bridge answers it
+(the CDP side), and what the bridge sends the device and what the device sends back (the
+WebKit inspector side). A trace is what turns "step-over did not land in WebStorm" into a
+reproducible report: it shows exactly which request got no reply, or which reply the editor
+never acted on, without guessing at either end.
+
+Each line is one message:
+
+    {"t": <seconds since the trace started>, "dir": "<direction>", "session": "<inspector
+     session>", "page": "<page id>", "msg": {...}}
+
+A trace contains page content, evaluation results and script sources; treat it as sensitive.
+"""
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Optional, TextIO, cast
+
+logger = logging.getLogger(__name__)
+
+EDITOR_TO_BRIDGE = "editor->bridge"
+BRIDGE_TO_EDITOR = "bridge->editor"
+BRIDGE_TO_DEVICE = "bridge->device"
+DEVICE_TO_BRIDGE = "device->bridge"
+
+
+class ProtocolTrace:
+    """A JSON-lines protocol trace, flushed per message so a crash loses nothing."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._file: Optional[TextIO] = path.open("w", encoding="utf-8")
+        self._started = time.monotonic()
+        self._failed = False
+
+    def record(self, direction: str, message: Any, *, session: str = "", page: str = "") -> None:
+        """Append one message. Never raises into the bridge: a trace that cannot be written is
+        logged once and abandoned, the debugging session it was watching goes on."""
+        if self._file is None or self._failed:
+            return
+        try:
+            line = json.dumps(
+                {
+                    "t": round(time.monotonic() - self._started, 6),
+                    "dir": direction,
+                    "session": session,
+                    "page": page,
+                    "msg": message,
+                },
+                default=str,
+            )
+            self._file.write(line + "\n")
+            self._file.flush()
+        except Exception:
+            self._failed = True
+            logger.exception(f"protocol trace {self.path} cannot be written; tracing stopped")
+
+    def device_hook(self, direction: str, session: str, message: Any) -> None:
+        """The inspector service's hook shape: (direction, session id, message).
+
+        A page target speaks through WebKit's Target domain: every message is wrapped in
+        Target.sendMessageToTarget or Target.dispatchMessageFromTarget with the real one
+        JSON-encoded inside. Record the inner message, and note the wrapper and target id, so a
+        trace reads as the protocol exchange it is rather than as a stream of envelopes.
+        """
+        page = ""
+        if isinstance(message, dict):
+            wrapped = cast(dict[str, Any], message)
+            wrapper = wrapped.get("method")
+            params = wrapped.get("params")
+            if wrapper in ("Target.sendMessageToTarget", "Target.dispatchMessageFromTarget") and isinstance(
+                params, dict
+            ):
+                inner = cast(dict[str, Any], params).get("message")
+                if isinstance(inner, str):
+                    try:
+                        unwrapped = json.loads(inner)
+                    except ValueError:
+                        unwrapped = None
+                    if isinstance(unwrapped, dict):
+                        page = str(cast(dict[str, Any], params).get("targetId", ""))
+                        message = {**cast(dict[str, Any], unwrapped), "_wrapper": wrapper}
+        self.record(direction, message, session=session, page=page)
+
+    def close(self) -> None:
+        if self._file is not None:
+            self._file.close()
+            self._file = None

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -6,7 +6,7 @@ from collections import deque
 from collections.abc import Coroutine
 from dataclasses import dataclass, fields
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 from pymobiledevice3.exceptions import (
     ConnectionTerminatedError,
@@ -191,6 +191,9 @@ class WebinspectorService(LockdownService):
         self.connected_application: dict[str, Application] = {}
         self.application_pages: dict[str, Any] = {}
         self.wir_message_results: dict[str, Any] = {}
+        # Optional observer of every inspector-protocol message crossing the page sockets, as
+        # (direction, session id, message); the CDP bridge's --trace recorder plugs in here.
+        self.trace: Optional[Callable[[str, str, Any], None]] = None
         self.wir_events: dict[str, deque[Any]] = {}
         self.receive_handlers = {
             "_rpc_reportCurrentState:": self._handle_report_current_state,
@@ -585,6 +588,9 @@ class WebinspectorService(LockdownService):
 
     async def _handle_application_sent_data(self, arg: dict[str, Any]):
         response = json.loads(arg["WIRMessageDataKey"])
+        trace = getattr(self, "trace", None)
+        if trace is not None:
+            trace("device->bridge", arg.get("WIRDestinationKey", ""), response)
 
         if "id" in response:
             self.wir_message_results[response["id"]] = response
@@ -637,6 +643,9 @@ class WebinspectorService(LockdownService):
         )
 
     async def _forward_socket_data(self, session_id: str, app_id: str, page_id: int, data: dict[str, Any]):
+        trace = getattr(self, "trace", None)
+        if trace is not None:
+            trace("bridge->device", session_id, data)
         await self._send_message(
             "_rpc_forwardSocketData:",
             {

--- a/tests/services/test_web_protocol/test_cdp_trace.py
+++ b/tests/services/test_web_protocol/test_cdp_trace.py
@@ -1,0 +1,172 @@
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from pymobiledevice3.services.web_protocol import cdp_server
+from pymobiledevice3.services.web_protocol.cdp_trace import (
+    BRIDGE_TO_DEVICE,
+    BRIDGE_TO_EDITOR,
+    DEVICE_TO_BRIDGE,
+    EDITOR_TO_BRIDGE,
+    ProtocolTrace,
+)
+from pymobiledevice3.services.webinspector import WebinspectorService
+
+
+def _lines(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+def test_trace_writes_one_json_line_per_message_and_flushes(tmp_path: Path) -> None:
+    """Each message is one line with its direction, session, page and a timestamp, written
+    through immediately - a bridge that crashes right after must not lose the last exchange."""
+    trace = ProtocolTrace(tmp_path / "t.jsonl")
+    trace.record(EDITOR_TO_BRIDGE, {"id": 1, "method": "Runtime.evaluate"}, session="S", page="P:1")
+    # Read before close: flushed per message.
+    first = _lines(tmp_path / "t.jsonl")
+    assert len(first) == 1
+    assert first[0]["dir"] == EDITOR_TO_BRIDGE
+    assert first[0]["session"] == "S" and first[0]["page"] == "P:1"
+    assert first[0]["msg"] == {"id": 1, "method": "Runtime.evaluate"}
+    assert first[0]["t"] >= 0
+    trace.record(BRIDGE_TO_EDITOR, {"id": 1, "result": {}}, session="S", page="P:1")
+    trace.close()
+    assert [entry["dir"] for entry in _lines(tmp_path / "t.jsonl")] == [EDITOR_TO_BRIDGE, BRIDGE_TO_EDITOR]
+
+
+def test_trace_survives_an_unserializable_message(tmp_path: Path) -> None:
+    """Whatever a message carries, the trace never raises into the bridge."""
+    trace = ProtocolTrace(tmp_path / "t.jsonl")
+    trace.record(DEVICE_TO_BRIDGE, {"blob": b"\x00\xff"}, session="S")
+    trace.close()
+    (entry,) = _lines(tmp_path / "t.jsonl")
+    assert entry["dir"] == DEVICE_TO_BRIDGE and "blob" in entry["msg"]
+
+
+def test_trace_stops_quietly_when_the_file_cannot_be_written(tmp_path: Path) -> None:
+    trace = ProtocolTrace(tmp_path / "t.jsonl")
+    trace.close()
+    trace.record(EDITOR_TO_BRIDGE, {"id": 1})  # closed: must be a no-op, not an error
+    assert (tmp_path / "t.jsonl").read_text() == ""
+
+
+async def test_inspector_hooks_record_both_device_directions(tmp_path: Path) -> None:
+    """The inspector service reports what crosses a page socket: what the bridge sends the
+    device, and what the device sends back, keyed by the session it belongs to."""
+    inspector = WebinspectorService.__new__(WebinspectorService)
+    inspector.wir_message_results = {}
+    inspector.wir_events = {}
+    inspector.trace = None
+    trace = ProtocolTrace(tmp_path / "t.jsonl")
+    inspector.trace = trace.device_hook
+    sent: list[dict[str, Any]] = []
+
+    async def fake_send_message(selector: str, args: dict[str, Any]) -> None:
+        sent.append(args)
+
+    inspector._send_message = fake_send_message  # pyright: ignore[reportAttributeAccessIssue]
+    await inspector._forward_socket_data("SESSION", "PID:1", 1, {"id": 7, "method": "Runtime.enable"})
+    await inspector._handle_application_sent_data({
+        "WIRDestinationKey": "SESSION",
+        "WIRMessageDataKey": json.dumps({"id": 7, "result": {}}),
+    })
+    await inspector._handle_application_sent_data({
+        "WIRDestinationKey": "SESSION",
+        "WIRMessageDataKey": json.dumps({"method": "Debugger.paused", "params": {}}),
+    })
+    trace.close()
+    entries = _lines(tmp_path / "t.jsonl")
+    assert [(e["dir"], e["session"]) for e in entries] == [
+        (BRIDGE_TO_DEVICE, "SESSION"),
+        (DEVICE_TO_BRIDGE, "SESSION"),
+        (DEVICE_TO_BRIDGE, "SESSION"),
+    ]
+    assert entries[0]["msg"]["method"] == "Runtime.enable"
+    assert entries[2]["msg"]["method"] == "Debugger.paused"
+    assert sent, "the message must still reach the device"
+
+
+def test_device_hook_unwraps_target_envelopes(tmp_path: Path) -> None:
+    """A page target's messages travel inside Target.* envelopes; the trace records the real
+    message, naming the envelope and the target it was for."""
+    trace = ProtocolTrace(tmp_path / "t.jsonl")
+    trace.device_hook(
+        BRIDGE_TO_DEVICE,
+        "S",
+        {
+            "method": "Target.sendMessageToTarget",
+            "params": {"targetId": "page-7", "message": json.dumps({"id": 3, "method": "Runtime.evaluate"})},
+        },
+    )
+    trace.device_hook(
+        DEVICE_TO_BRIDGE,
+        "S",
+        {
+            "method": "Target.dispatchMessageFromTarget",
+            "params": {"targetId": "page-7", "message": json.dumps({"id": 3, "result": {}})},
+        },
+    )
+    trace.device_hook(DEVICE_TO_BRIDGE, "S", {"method": "Target.targetCreated", "params": {}})  # not an envelope
+    trace.close()
+    entries = _lines(tmp_path / "t.jsonl")
+    assert entries[0]["msg"] == {"id": 3, "method": "Runtime.evaluate", "_wrapper": "Target.sendMessageToTarget"}
+    assert entries[0]["page"] == "page-7"
+    assert entries[1]["msg"] == {"id": 3, "result": {}, "_wrapper": "Target.dispatchMessageFromTarget"}
+    assert entries[2]["msg"]["method"] == "Target.targetCreated" and entries[2]["page"] == ""
+
+
+async def test_page_endpoint_records_both_editor_directions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The page websocket pump records what the editor sent and what the bridge answered."""
+    trace = ProtocolTrace(tmp_path / "t.jsonl")
+    monkeypatch.setattr(cdp_server.app.state, "trace", trace, raising=False)
+    inbound = [{"id": 1, "method": "Runtime.enable"}]
+    outbound = [{"id": 1, "result": {}}]
+    received: list[dict[str, Any]] = []
+    delivered: list[dict[str, Any]] = []
+
+    class FakeTarget:
+        session_id = "S"
+        page_id = "P:1"
+
+        async def send(self, message: dict[str, Any]) -> None:
+            received.append(message)
+
+        async def receive(self) -> dict[str, Any]:
+            if outbound:
+                return outbound.pop(0)
+            await asyncio.sleep(3600)
+            raise AssertionError
+
+    class FakeWebsocket:
+        async def iter_json(self) -> AsyncIterator[dict[str, Any]]:
+            for message in inbound:
+                yield message
+
+        async def send_json(self, message: dict[str, Any]) -> None:
+            delivered.append(message)
+            raise asyncio.CancelledError  # one message is enough
+
+    target = cast(Any, FakeTarget())
+    websocket = cast(Any, FakeWebsocket())
+    await cdp_server.from_cdp(target, websocket)
+    with pytest.raises(asyncio.CancelledError):
+        await cdp_server.to_cdp(target, websocket)
+    trace.close()
+    monkeypatch.delattr(cdp_server.app.state, "trace", raising=False)
+    entries = _lines(tmp_path / "t.jsonl")
+    assert [(e["dir"], e["session"], e["page"]) for e in entries] == [
+        (EDITOR_TO_BRIDGE, "S", "P:1"),
+        (BRIDGE_TO_EDITOR, "S", "P:1"),
+    ]
+    assert received == [{"id": 1, "method": "Runtime.enable"}] and delivered == [{"id": 1, "result": {}}]
+
+
+def test_no_trace_means_no_recording(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr(cdp_server.app.state, "trace", raising=False)
+    assert cdp_server._trace() is None
+    _ = SimpleNamespace  # keep the import honest for future fakes


### PR DESCRIPTION
## Summary

First of the reliability changes we discussed. The recurring CDP bugs surfaced as editor reports that could not be reproduced here, because nothing recorded what the editor and the device actually exchanged. This adds `pymobiledevice3 webinspector cdp --trace <file>`.

It writes every protocol message, in **both directions on both sides of the bridge** — `editor->bridge`, `bridge->editor`, `bridge->device`, `device->bridge` — as one timestamped JSON line each. A page target's messages ride inside WebKit's `Target.sendMessageToTarget` / `Target.dispatchMessageFromTarget` envelopes; the device side records the real inner message and notes the envelope and target id, so a trace reads as the protocol exchange it is rather than a stream of envelopes.

```shell
pymobiledevice3 webinspector cdp --trace cdp-trace.jsonl
# attach the editor, reproduce, stop the bridge, attach the file to the report
```

This turns "step-over did not land in WebStorm" into a diagnosable report: the trace shows exactly which request got no reply, or which reply the editor never acted on. The recorder never raises into the bridge (a trace that cannot be written is logged once and abandoned) and flushes per message so a crash loses nothing. It carries page content, evaluation results and script sources, and is documented as sensitive.

## Verification

- Live against a real Chrome DevTools frontend (the same frontend WebStorm and Chrome use), on both a **JSContext** (flat path) and a **Safari page** (Target-multiplexed): full `editor-request -> bridge -> device -> reply -> editor` chains recorded, and the `Target.*` envelopes unwrapped to the inner messages with the target id preserved.
- Unit tests (`test_cdp_trace.py`): the writer and its per-message flush, the Target-envelope unwrapping, the inspector's device-side hooks (both directions, keyed by session), and the page websocket pump.
- Non-device suite over every touched module (150) and a device regression (page, JSContext, eval) pass; ruff and pyright clean.

## On editor coverage

You asked to always test with VS Code and WebStorm. I verified the recorder against the DevTools frontend end to end, but could **not** drive the editor GUIs headlessly on this machine: VS Code's js-debug rejected the attach config its build expects, and WebStorm screen capture is blocked here (no screen-recording permission). This recorder is exactly the tool that makes an editor session capturable — the natural next step (its own PR) is to record golden `--trace` flows from VS Code and WebStorm on a machine where they can be driven, and replay them as regression fixtures.
