### PR TITLE
cdp: Check the bridge against the WebKit and Chrome protocol definitions

### DIFF
--- a/misc/protocol/fetch_protocols.py
+++ b/misc/protocol/fetch_protocols.py
@@ -1,0 +1,131 @@
+"""Vendor compact summaries of the two protocols the CDP bridge translates between.
+
+The bridge speaks Chrome's DevTools Protocol to editors and WebKit's inspector protocol to the
+device. Both are open source and this script is the only way their definitions enter the repo:
+
+- WebKit: Source/JavaScriptCore/inspector/protocol/*.json in the WebKit repository.
+- Chrome:  json/browser_protocol.json and json/js_protocol.json in ChromeDevTools/devtools-protocol.
+
+It writes tests/services/test_web_protocol/protocol/{webkit,cdp}_protocol.json - one entry per
+command (parameter names, whether each is optional, return names) and per event (parameter
+names) - pinned to the upstream commits below. The conformance test reads those files. Re-run
+after bumping the pins.
+"""
+
+import datetime
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any, Optional
+
+WEBKIT_COMMIT = "587e3a7c563e482a45c3b186d9d5f093aadfb4a8"
+CDP_COMMIT = "90778954a4820558eb0a98194e89000d40087ba4"
+WEBKIT_DOMAINS = [
+    "Animation",
+    "Audit",
+    "Browser",
+    "CPUProfiler",
+    "CSS",
+    "Canvas",
+    "Console",
+    "DOM",
+    "DOMDebugger",
+    "DOMStorage",
+    "Debugger",
+    "GenericTypes",
+    "Heap",
+    "IndexedDB",
+    "Inspector",
+    "LayerTree",
+    "Memory",
+    "Network",
+    "Page",
+    "Recording",
+    "Runtime",
+    "ScriptProfiler",
+    "Security",
+    "ServiceWorker",
+    "Storage",
+    "Target",
+    "Timeline",
+    "Worker",
+]
+OUT = Path(__file__).resolve().parents[2] / "tests" / "services" / "test_web_protocol" / "protocol"
+
+
+def fetch(url: str) -> Any:
+    with urllib.request.urlopen(url, timeout=60) as response:
+        return json.load(response)
+
+
+def compact_domain(domain: dict[str, Any]) -> dict[str, Any]:
+    def params(items: Optional[list[dict[str, Any]]]) -> dict[str, Any]:
+        return {
+            p["name"]: {"optional": bool(p.get("optional", False)), "type": p.get("type") or p.get("$ref", "")}
+            for p in (items or [])
+        }
+
+    def names(items: Optional[list[dict[str, Any]]]) -> list[str]:
+        return [item["name"] for item in (items or [])]
+
+    commands: list[dict[str, Any]] = domain.get("commands", [])
+    events: list[dict[str, Any]] = domain.get("events", [])
+    return {
+        "commands": {
+            c["name"]: {"params": params(c.get("parameters")), "returns": names(c.get("returns"))} for c in commands
+        },
+        "events": {e["name"]: {"params": params(e.get("parameters"))} for e in events},
+    }
+
+
+def main() -> None:
+    fetched = datetime.date.today().isoformat()
+    webkit: dict[str, Any] = {}
+    for name in WEBKIT_DOMAINS:
+        url = f"https://raw.githubusercontent.com/WebKit/WebKit/{WEBKIT_COMMIT}/Source/JavaScriptCore/inspector/protocol/{name}.json"
+        domain = fetch(url)
+        webkit[domain["domain"]] = compact_domain(domain)
+        print(f"webkit {domain['domain']}: {len(webkit[domain['domain']]['commands'])} commands")
+    (OUT / "webkit_protocol.json").write_text(
+        json.dumps(
+            {
+                "source": {
+                    "repo": "WebKit/WebKit",
+                    "commit": WEBKIT_COMMIT,
+                    "path": "Source/JavaScriptCore/inspector/protocol",
+                    "fetched": fetched,
+                },
+                "domains": webkit,
+            },
+            indent=1,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    cdp: dict[str, Any] = {}
+    for file in ("browser_protocol.json", "js_protocol.json"):
+        url = f"https://raw.githubusercontent.com/ChromeDevTools/devtools-protocol/{CDP_COMMIT}/json/{file}"
+        for domain in fetch(url)["domains"]:
+            cdp[domain["domain"]] = compact_domain(domain)
+    print(f"cdp: {len(cdp)} domains")
+    (OUT / "cdp_protocol.json").write_text(
+        json.dumps(
+            {
+                "source": {
+                    "repo": "ChromeDevTools/devtools-protocol",
+                    "commit": CDP_COMMIT,
+                    "path": "json",
+                    "fetched": fetched,
+                },
+                "domains": cdp,
+            },
+            indent=1,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -130,7 +130,6 @@ TARGET_CLOSED_ERROR: dict[str, Any] = {"code": -32000, "message": "Inspected tar
 REPLAYED_SETUP_METHODS = frozenset({
     "Network.setResourceCachingDisabled",
     "Page.setEmulatedMedia",
-    "Page.setForcedAppearance",
     "Debugger.setBreakpointsActive",
     "Debugger.setPauseOnExceptions",
     "Debugger.setAsyncStackTraceDepth",
@@ -143,6 +142,20 @@ REPLAYED_MULTI_SETUP_METHODS = frozenset({
     "Debugger.setBreakpointByUrl",
     "Debugger.setShouldBlackboxURL",
 })
+
+# Replayed setup methods whose latest params are kept per value of one parameter: the user
+# preference overrides are independent per preference name, and a later clear must replace (not
+# join) the override it clears.
+REPLAYED_KEYED_SETUP_METHODS: dict[str, str] = {"Page.overrideUserPreference": "name"}
+
+# Chrome's Emulation.setEmulatedMedia features -> WebKit's Page.overrideUserPreference
+# (Page.UserPreferenceName, Page.UserPreferenceValue). A feature value with no WebKit counterpart
+# ("" is Chrome's reset; "less"/"custom" contrast has no WebKit value) clears that override.
+USER_PREFERENCE_FEATURES: dict[str, tuple[str, dict[str, str]]] = {
+    "prefers-color-scheme": ("PrefersColorScheme", {"dark": "Dark", "light": "Light"}),
+    "prefers-reduced-motion": ("PrefersReducedMotion", {"reduce": "Reduce", "no-preference": "NoPreference"}),
+    "prefers-contrast": ("PrefersContrast", {"more": "More", "no-preference": "NoPreference"}),
+}
 
 NETWORK_RESOURCE_TYPES = [
     "Document",
@@ -588,7 +601,6 @@ class CdpTarget:
             "Debugger.scriptFailedToParse": self._debugger_script_failed_to_parse,
             "Debugger.paused": self._debugger_paused,
             "Debugger.globalObjectCleared": self._debugger_global_object_cleared,
-            "Page.defaultAppearanceDidChange": self._page_default_appearance_did_change,
             "Runtime.executionContextCreated": self._runtime_execution_context_created,
             "Console.messageAdded": self._console_message_added,
             "Network.responseReceived": self._network_response_received,
@@ -666,6 +678,8 @@ class CdpTarget:
         self._unresponsive_last_probe: dict[str, float] = {}
         # setup (domain enables & co.) the frontend established, replayed onto new targets
         self._setup_messages: dict[Any, dict[str, Any]] = {}
+        # WebKit user preferences currently overridden through Emulation.setEmulatedMedia features.
+        self._emulated_preferences: set[str] = set()
         self._setup_sent_targets: set[str] = {target_id}
         # Targets announced as pages - the only kind this session talks to (see _target_created).
         self._page_targets: set[str] = {target_id}
@@ -1156,6 +1170,8 @@ class CdpTarget:
             self._setup_messages[method] = params
         elif method in REPLAYED_MULTI_SETUP_METHODS:
             self._setup_messages[(method, json.dumps(params, sort_keys=True))] = params
+        elif method in REPLAYED_KEYED_SETUP_METHODS:
+            self._setup_messages[(method, str(params.get(REPLAYED_KEYED_SETUP_METHODS[method])))] = params
 
     async def _send_setup_to_target(self, target_id: str):
         """Replay the frontend's recorded setup onto a new target (once per target)."""
@@ -2298,17 +2314,47 @@ class CdpTarget:
         for child in cast(list[Any], tree.get("childFrames") or []):
             self._remember_frame_tree(child)
 
+    async def _override_user_preference(self, name: str, value: Optional[str]) -> None:
+        """Page.overrideUserPreference: `value` absent clears the override (WebKit main and iOS 26)."""
+        params: dict[str, Any] = {"name": name}
+        if value is not None:
+            params["value"] = value
+        await self._send_message_to_target({
+            "id": self.next_internal_id(),
+            "method": "Page.overrideUserPreference",
+            "params": params,
+        })
+
     async def _emulation_set_emulated_media(self, message: dict[str, Any]):
+        # Chrome carries the media type and the media features in one command; WebKit takes the
+        # type (Page.setEmulatedMedia, `media` required) and each feature as a separate user
+        # preference override. Features absent from the list are reset, as in Chrome.
+        params: dict[str, Any] = message.get("params") or {}
+        features: list[dict[str, Any]] = params.get("features") or []
+        wanted: dict[str, Optional[str]] = {}
+        for feature in features:
+            mapping = USER_PREFERENCE_FEATURES.get(str(feature.get("name", "")))
+            if mapping is None:
+                continue
+            name, values = mapping
+            wanted[name] = values.get(str(feature.get("value", "")))
+        for name in sorted(self._emulated_preferences - set(wanted)):
+            wanted[name] = None
+        for name, value in wanted.items():
+            await self._override_user_preference(name, value)
+        self._emulated_preferences = {name for name, value in wanted.items() if value is not None}
         message["method"] = "Page.setEmulatedMedia"
+        message["params"] = {"media": params.get("media") or ""}
         await self._send_message_to_target(message)
 
     async def _emulation_set_auto_dark_mode_override(self, message: dict[str, Any]):
-        message["method"] = "Page.setForcedAppearance"
-        params = message["params"]
-        if not params:
-            await self._simple_response(message, None)
-            return
-        message["params"] = {"appearance": "Dark" if params["enabled"] else "Light"}
+        # `enabled` absent restores the page's own color scheme; so does a valueless override.
+        params: dict[str, Any] = message.get("params") or {}
+        enabled: Optional[bool] = params.get("enabled")
+        message["method"] = "Page.overrideUserPreference"
+        message["params"] = {"name": "PrefersColorScheme"}
+        if enabled is not None:
+            message["params"]["value"] = "Dark" if enabled else "Light"
         await self._send_message_to_target(message)
 
     async def _debugger_enable(self, message: dict[str, Any]):
@@ -3271,9 +3317,6 @@ class CdpTarget:
         self._announced_worlds.clear()
         await self.output_queue.put({"method": "Runtime.executionContextsCleared"})
         await self.output_queue.put({"method": "DOM.documentUpdated"})
-
-    async def _page_default_appearance_did_change(self, message: dict[str, Any]):
-        pass
 
     async def _runtime_execution_context_created(self, message: dict[str, Any]):
         context = message["params"]["context"]

--- a/tests/services/test_web_protocol/protocol/cdp_protocol.json
+++ b/tests/services/test_web_protocol/protocol/cdp_protocol.json
@@ -1,0 +1,12115 @@
+{
+ "domains": {
+  "Accessibility": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getAXNodeAndAncestors": {
+     "params": {
+      "backendNodeId": {
+       "optional": true,
+       "type": "DOM.BackendNodeId"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "DOM.NodeId"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": [
+      "nodes"
+     ]
+    },
+    "getChildAXNodes": {
+     "params": {
+      "frameId": {
+       "optional": true,
+       "type": "Page.FrameId"
+      },
+      "id": {
+       "optional": false,
+       "type": "AXNodeId"
+      }
+     },
+     "returns": [
+      "nodes"
+     ]
+    },
+    "getFullAXTree": {
+     "params": {
+      "depth": {
+       "optional": true,
+       "type": "integer"
+      },
+      "frameId": {
+       "optional": true,
+       "type": "Page.FrameId"
+      }
+     },
+     "returns": [
+      "nodes"
+     ]
+    },
+    "getPartialAXTree": {
+     "params": {
+      "backendNodeId": {
+       "optional": true,
+       "type": "DOM.BackendNodeId"
+      },
+      "fetchRelatives": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "DOM.NodeId"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": [
+      "nodes"
+     ]
+    },
+    "getRootAXNode": {
+     "params": {
+      "frameId": {
+       "optional": true,
+       "type": "Page.FrameId"
+      }
+     },
+     "returns": [
+      "node"
+     ]
+    },
+    "queryAXTree": {
+     "params": {
+      "accessibleName": {
+       "optional": true,
+       "type": "string"
+      },
+      "backendNodeId": {
+       "optional": true,
+       "type": "DOM.BackendNodeId"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "DOM.NodeId"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "Runtime.RemoteObjectId"
+      },
+      "role": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "nodes"
+     ]
+    }
+   },
+   "events": {
+    "loadComplete": {
+     "params": {
+      "root": {
+       "optional": false,
+       "type": "AXNode"
+      }
+     }
+    },
+    "nodesUpdated": {
+     "params": {
+      "nodes": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    }
+   }
+  },
+  "Ads": {
+   "commands": {
+    "getAdMetrics": {
+     "params": {},
+     "returns": [
+      "metrics"
+     ]
+    },
+    "getAdScripts": {
+     "params": {},
+     "returns": [
+      "newScripts"
+     ]
+    }
+   },
+   "events": {}
+  },
+  "Animation": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getCurrentTime": {
+     "params": {
+      "id": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "currentTime"
+     ]
+    },
+    "getPlaybackRate": {
+     "params": {},
+     "returns": [
+      "playbackRate"
+     ]
+    },
+    "releaseAnimations": {
+     "params": {
+      "animations": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "resolveAnimation": {
+     "params": {
+      "animationId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "remoteObject"
+     ]
+    },
+    "seekAnimations": {
+     "params": {
+      "animations": {
+       "optional": false,
+       "type": "array"
+      },
+      "currentTime": {
+       "optional": false,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "setPaused": {
+     "params": {
+      "animations": {
+       "optional": false,
+       "type": "array"
+      },
+      "paused": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setPlaybackRate": {
+     "params": {
+      "playbackRate": {
+       "optional": false,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "setTiming": {
+     "params": {
+      "animationId": {
+       "optional": false,
+       "type": "string"
+      },
+      "delay": {
+       "optional": false,
+       "type": "number"
+      },
+      "duration": {
+       "optional": false,
+       "type": "number"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "animationCanceled": {
+     "params": {
+      "id": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "animationCreated": {
+     "params": {
+      "id": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "animationStarted": {
+     "params": {
+      "animation": {
+       "optional": false,
+       "type": "Animation"
+      }
+     }
+    },
+    "animationUpdated": {
+     "params": {
+      "animation": {
+       "optional": false,
+       "type": "Animation"
+      }
+     }
+    }
+   }
+  },
+  "Audits": {
+   "commands": {
+    "checkFormsIssues": {
+     "params": {},
+     "returns": [
+      "formIssues"
+     ]
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getEncodedResponse": {
+     "params": {
+      "encoding": {
+       "optional": false,
+       "type": "string"
+      },
+      "quality": {
+       "optional": true,
+       "type": "number"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "Network.RequestId"
+      },
+      "sizeOnly": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "body",
+      "originalSize",
+      "encodedSize"
+     ]
+    }
+   },
+   "events": {
+    "issueAdded": {
+     "params": {
+      "issue": {
+       "optional": false,
+       "type": "InspectorIssue"
+      }
+     }
+    }
+   }
+  },
+  "Autofill": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "setAddresses": {
+     "params": {
+      "addresses": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "trigger": {
+     "params": {
+      "address": {
+       "optional": true,
+       "type": "Address"
+      },
+      "card": {
+       "optional": true,
+       "type": "CreditCard"
+      },
+      "fieldId": {
+       "optional": false,
+       "type": "DOM.BackendNodeId"
+      },
+      "frameId": {
+       "optional": true,
+       "type": "Page.FrameId"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "addressFormFilled": {
+     "params": {
+      "addressUi": {
+       "optional": false,
+       "type": "AddressUI"
+      },
+      "filledFields": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    }
+   }
+  },
+  "BackgroundService": {
+   "commands": {
+    "clearEvents": {
+     "params": {
+      "service": {
+       "optional": false,
+       "type": "ServiceName"
+      }
+     },
+     "returns": []
+    },
+    "setRecording": {
+     "params": {
+      "service": {
+       "optional": false,
+       "type": "ServiceName"
+      },
+      "shouldRecord": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "startObserving": {
+     "params": {
+      "service": {
+       "optional": false,
+       "type": "ServiceName"
+      }
+     },
+     "returns": []
+    },
+    "stopObserving": {
+     "params": {
+      "service": {
+       "optional": false,
+       "type": "ServiceName"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "backgroundServiceEventReceived": {
+     "params": {
+      "backgroundServiceEvent": {
+       "optional": false,
+       "type": "BackgroundServiceEvent"
+      }
+     }
+    },
+    "recordingStateChanged": {
+     "params": {
+      "isRecording": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "service": {
+       "optional": false,
+       "type": "ServiceName"
+      }
+     }
+    }
+   }
+  },
+  "BluetoothEmulation": {
+   "commands": {
+    "addCharacteristic": {
+     "params": {
+      "characteristicUuid": {
+       "optional": false,
+       "type": "string"
+      },
+      "properties": {
+       "optional": false,
+       "type": "CharacteristicProperties"
+      },
+      "serviceId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "characteristicId"
+     ]
+    },
+    "addDescriptor": {
+     "params": {
+      "characteristicId": {
+       "optional": false,
+       "type": "string"
+      },
+      "descriptorUuid": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "descriptorId"
+     ]
+    },
+    "addService": {
+     "params": {
+      "address": {
+       "optional": false,
+       "type": "string"
+      },
+      "serviceUuid": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "serviceId"
+     ]
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {
+      "leSupported": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "state": {
+       "optional": false,
+       "type": "CentralState"
+      }
+     },
+     "returns": []
+    },
+    "removeCharacteristic": {
+     "params": {
+      "characteristicId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "removeDescriptor": {
+     "params": {
+      "descriptorId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "removeService": {
+     "params": {
+      "serviceId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setSimulatedCentralState": {
+     "params": {
+      "state": {
+       "optional": false,
+       "type": "CentralState"
+      }
+     },
+     "returns": []
+    },
+    "simulateAdvertisement": {
+     "params": {
+      "entry": {
+       "optional": false,
+       "type": "ScanEntry"
+      }
+     },
+     "returns": []
+    },
+    "simulateCharacteristicOperationResponse": {
+     "params": {
+      "characteristicId": {
+       "optional": false,
+       "type": "string"
+      },
+      "code": {
+       "optional": false,
+       "type": "integer"
+      },
+      "data": {
+       "optional": true,
+       "type": "string"
+      },
+      "type": {
+       "optional": false,
+       "type": "CharacteristicOperationType"
+      }
+     },
+     "returns": []
+    },
+    "simulateDescriptorOperationResponse": {
+     "params": {
+      "code": {
+       "optional": false,
+       "type": "integer"
+      },
+      "data": {
+       "optional": true,
+       "type": "string"
+      },
+      "descriptorId": {
+       "optional": false,
+       "type": "string"
+      },
+      "type": {
+       "optional": false,
+       "type": "DescriptorOperationType"
+      }
+     },
+     "returns": []
+    },
+    "simulateGATTDisconnection": {
+     "params": {
+      "address": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "simulateGATTOperationResponse": {
+     "params": {
+      "address": {
+       "optional": false,
+       "type": "string"
+      },
+      "code": {
+       "optional": false,
+       "type": "integer"
+      },
+      "type": {
+       "optional": false,
+       "type": "GATTOperationType"
+      }
+     },
+     "returns": []
+    },
+    "simulatePreconnectedPeripheral": {
+     "params": {
+      "address": {
+       "optional": false,
+       "type": "string"
+      },
+      "knownServiceUuids": {
+       "optional": false,
+       "type": "array"
+      },
+      "manufacturerData": {
+       "optional": false,
+       "type": "array"
+      },
+      "name": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "characteristicOperationReceived": {
+     "params": {
+      "characteristicId": {
+       "optional": false,
+       "type": "string"
+      },
+      "data": {
+       "optional": true,
+       "type": "string"
+      },
+      "type": {
+       "optional": false,
+       "type": "CharacteristicOperationType"
+      },
+      "writeType": {
+       "optional": true,
+       "type": "CharacteristicWriteType"
+      }
+     }
+    },
+    "descriptorOperationReceived": {
+     "params": {
+      "data": {
+       "optional": true,
+       "type": "string"
+      },
+      "descriptorId": {
+       "optional": false,
+       "type": "string"
+      },
+      "type": {
+       "optional": false,
+       "type": "DescriptorOperationType"
+      }
+     }
+    },
+    "gattOperationReceived": {
+     "params": {
+      "address": {
+       "optional": false,
+       "type": "string"
+      },
+      "type": {
+       "optional": false,
+       "type": "GATTOperationType"
+      }
+     }
+    }
+   }
+  },
+  "Browser": {
+   "commands": {
+    "addMockCamera": {
+     "params": {
+      "deviceId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "addPrivacySandboxEnrollmentOverride": {
+     "params": {
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "cancelDownload": {
+     "params": {
+      "browserContextId": {
+       "optional": true,
+       "type": "BrowserContextID"
+      },
+      "guid": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "close": {
+     "params": {},
+     "returns": []
+    },
+    "crash": {
+     "params": {},
+     "returns": []
+    },
+    "crashGpuProcess": {
+     "params": {},
+     "returns": []
+    },
+    "executeBrowserCommand": {
+     "params": {
+      "commandId": {
+       "optional": false,
+       "type": "BrowserCommandId"
+      }
+     },
+     "returns": []
+    },
+    "getBrowserCommandLine": {
+     "params": {},
+     "returns": [
+      "arguments"
+     ]
+    },
+    "getGlobalPrivacyControl": {
+     "params": {},
+     "returns": [
+      "gpc"
+     ]
+    },
+    "getHistogram": {
+     "params": {
+      "delta": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "name": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "histogram"
+     ]
+    },
+    "getHistograms": {
+     "params": {
+      "delta": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "query": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "histograms"
+     ]
+    },
+    "getVersion": {
+     "params": {},
+     "returns": [
+      "protocolVersion",
+      "product",
+      "revision",
+      "userAgent",
+      "jsVersion"
+     ]
+    },
+    "getWindowBounds": {
+     "params": {
+      "windowId": {
+       "optional": false,
+       "type": "WindowID"
+      }
+     },
+     "returns": [
+      "bounds"
+     ]
+    },
+    "getWindowForTarget": {
+     "params": {
+      "targetId": {
+       "optional": true,
+       "type": "Target.TargetID"
+      }
+     },
+     "returns": [
+      "windowId",
+      "bounds"
+     ]
+    },
+    "grantPermissions": {
+     "params": {
+      "browserContextId": {
+       "optional": true,
+       "type": "BrowserContextID"
+      },
+      "origin": {
+       "optional": true,
+       "type": "string"
+      },
+      "permissions": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "resetPermissions": {
+     "params": {
+      "browserContextId": {
+       "optional": true,
+       "type": "BrowserContextID"
+      }
+     },
+     "returns": []
+    },
+    "setContentsSize": {
+     "params": {
+      "height": {
+       "optional": true,
+       "type": "integer"
+      },
+      "width": {
+       "optional": true,
+       "type": "integer"
+      },
+      "windowId": {
+       "optional": false,
+       "type": "WindowID"
+      }
+     },
+     "returns": []
+    },
+    "setDockTile": {
+     "params": {
+      "badgeLabel": {
+       "optional": true,
+       "type": "string"
+      },
+      "image": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setDownloadBehavior": {
+     "params": {
+      "behavior": {
+       "optional": false,
+       "type": "string"
+      },
+      "browserContextId": {
+       "optional": true,
+       "type": "BrowserContextID"
+      },
+      "downloadPath": {
+       "optional": true,
+       "type": "string"
+      },
+      "eventsEnabled": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setGlobalPrivacyControl": {
+     "params": {
+      "gpc": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "gpc"
+     ]
+    },
+    "setPermission": {
+     "params": {
+      "browserContextId": {
+       "optional": true,
+       "type": "BrowserContextID"
+      },
+      "embeddedOrigin": {
+       "optional": true,
+       "type": "string"
+      },
+      "origin": {
+       "optional": true,
+       "type": "string"
+      },
+      "permission": {
+       "optional": false,
+       "type": "PermissionDescriptor"
+      },
+      "setting": {
+       "optional": false,
+       "type": "PermissionSetting"
+      }
+     },
+     "returns": []
+    },
+    "setWindowBounds": {
+     "params": {
+      "bounds": {
+       "optional": false,
+       "type": "Bounds"
+      },
+      "windowId": {
+       "optional": false,
+       "type": "WindowID"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "downloadProgress": {
+     "params": {
+      "filePath": {
+       "optional": true,
+       "type": "string"
+      },
+      "guid": {
+       "optional": false,
+       "type": "string"
+      },
+      "receivedBytes": {
+       "optional": false,
+       "type": "number"
+      },
+      "state": {
+       "optional": false,
+       "type": "string"
+      },
+      "totalBytes": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "downloadWillBegin": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "Page.FrameId"
+      },
+      "guid": {
+       "optional": false,
+       "type": "string"
+      },
+      "suggestedFilename": {
+       "optional": false,
+       "type": "string"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    }
+   }
+  },
+  "CSS": {
+   "commands": {
+    "addRule": {
+     "params": {
+      "location": {
+       "optional": false,
+       "type": "SourceRange"
+      },
+      "nodeForPropertySyntaxValidation": {
+       "optional": true,
+       "type": "DOM.NodeId"
+      },
+      "ruleText": {
+       "optional": false,
+       "type": "string"
+      },
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      }
+     },
+     "returns": [
+      "rule"
+     ]
+    },
+    "collectClassNames": {
+     "params": {
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      }
+     },
+     "returns": [
+      "classNames"
+     ]
+    },
+    "createStyleSheet": {
+     "params": {
+      "force": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "frameId": {
+       "optional": false,
+       "type": "Page.FrameId"
+      }
+     },
+     "returns": [
+      "styleSheetId"
+     ]
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "forcePseudoState": {
+     "params": {
+      "forcedPseudoClasses": {
+       "optional": false,
+       "type": "array"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": []
+    },
+    "forceStartingStyle": {
+     "params": {
+      "forced": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": []
+    },
+    "getAnimatedStylesForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "animationStyles",
+      "transitionsStyle",
+      "inherited"
+     ]
+    },
+    "getBackgroundColors": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "backgroundColors",
+      "computedFontSize",
+      "computedFontWeight"
+     ]
+    },
+    "getComputedStyleForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "computedStyle",
+      "extraFields"
+     ]
+    },
+    "getEnvironmentVariables": {
+     "params": {},
+     "returns": [
+      "environmentVariables"
+     ]
+    },
+    "getInlineStylesForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "inlineStyle",
+      "attributesStyle"
+     ]
+    },
+    "getLayersForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "rootLayer"
+     ]
+    },
+    "getLocationForSelector": {
+     "params": {
+      "selectorText": {
+       "optional": false,
+       "type": "string"
+      },
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      }
+     },
+     "returns": [
+      "ranges"
+     ]
+    },
+    "getLonghandProperties": {
+     "params": {
+      "shorthandName": {
+       "optional": false,
+       "type": "string"
+      },
+      "value": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "longhandProperties"
+     ]
+    },
+    "getMatchedStylesForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "inlineStyle",
+      "attributesStyle",
+      "matchedCSSRules",
+      "pseudoElements",
+      "inherited",
+      "inheritedPseudoElements",
+      "cssKeyframesRules",
+      "cssPositionTryRules",
+      "activePositionFallbackIndex",
+      "cssPropertyRules",
+      "cssPropertyRegistrations",
+      "cssAtRules",
+      "parentLayoutNodeId",
+      "cssFunctionRules"
+     ]
+    },
+    "getMediaQueries": {
+     "params": {},
+     "returns": [
+      "medias"
+     ]
+    },
+    "getPlatformFontsForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "fonts"
+     ]
+    },
+    "getStyleSheetText": {
+     "params": {
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      }
+     },
+     "returns": [
+      "text"
+     ]
+    },
+    "resolveValues": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      },
+      "propertyName": {
+       "optional": true,
+       "type": "string"
+      },
+      "pseudoIdentifier": {
+       "optional": true,
+       "type": "string"
+      },
+      "pseudoType": {
+       "optional": true,
+       "type": "DOM.PseudoType"
+      },
+      "values": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": [
+      "results"
+     ]
+    },
+    "setContainerQueryConditionText": {
+     "params": {
+      "range": {
+       "optional": false,
+       "type": "SourceRange"
+      },
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      },
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "containerQuery"
+     ]
+    },
+    "setContainerQueryText": {
+     "params": {
+      "range": {
+       "optional": false,
+       "type": "SourceRange"
+      },
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      },
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "containerQuery"
+     ]
+    },
+    "setEffectivePropertyValueForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      },
+      "propertyName": {
+       "optional": false,
+       "type": "string"
+      },
+      "value": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setKeyframeKey": {
+     "params": {
+      "keyText": {
+       "optional": false,
+       "type": "string"
+      },
+      "range": {
+       "optional": false,
+       "type": "SourceRange"
+      },
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      }
+     },
+     "returns": [
+      "keyText"
+     ]
+    },
+    "setLocalFontsEnabled": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setMediaText": {
+     "params": {
+      "range": {
+       "optional": false,
+       "type": "SourceRange"
+      },
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      },
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "media"
+     ]
+    },
+    "setNavigationText": {
+     "params": {
+      "range": {
+       "optional": false,
+       "type": "SourceRange"
+      },
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      },
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "navigation"
+     ]
+    },
+    "setPropertyRulePropertyName": {
+     "params": {
+      "propertyName": {
+       "optional": false,
+       "type": "string"
+      },
+      "range": {
+       "optional": false,
+       "type": "SourceRange"
+      },
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      }
+     },
+     "returns": [
+      "propertyName"
+     ]
+    },
+    "setRuleSelector": {
+     "params": {
+      "range": {
+       "optional": false,
+       "type": "SourceRange"
+      },
+      "selector": {
+       "optional": false,
+       "type": "string"
+      },
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      }
+     },
+     "returns": [
+      "selectorList"
+     ]
+    },
+    "setScopeText": {
+     "params": {
+      "range": {
+       "optional": false,
+       "type": "SourceRange"
+      },
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      },
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "scope"
+     ]
+    },
+    "setStyleSheetText": {
+     "params": {
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      },
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "sourceMapURL"
+     ]
+    },
+    "setStyleTexts": {
+     "params": {
+      "edits": {
+       "optional": false,
+       "type": "array"
+      },
+      "nodeForPropertySyntaxValidation": {
+       "optional": true,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "styles"
+     ]
+    },
+    "setSupportsText": {
+     "params": {
+      "range": {
+       "optional": false,
+       "type": "SourceRange"
+      },
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      },
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "supports"
+     ]
+    },
+    "startRuleUsageTracking": {
+     "params": {},
+     "returns": []
+    },
+    "stopRuleUsageTracking": {
+     "params": {},
+     "returns": [
+      "ruleUsage"
+     ]
+    },
+    "takeComputedStyleUpdates": {
+     "params": {},
+     "returns": [
+      "nodeIds"
+     ]
+    },
+    "takeCoverageDelta": {
+     "params": {},
+     "returns": [
+      "coverage",
+      "timestamp"
+     ]
+    },
+    "trackComputedStyleUpdates": {
+     "params": {
+      "propertiesToTrack": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "trackComputedStyleUpdatesForNode": {
+     "params": {
+      "nodeId": {
+       "optional": true,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "computedStyleUpdated": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     }
+    },
+    "fontsUpdated": {
+     "params": {
+      "font": {
+       "optional": true,
+       "type": "FontFace"
+      }
+     }
+    },
+    "mediaQueryResultChanged": {
+     "params": {}
+    },
+    "styleSheetAdded": {
+     "params": {
+      "header": {
+       "optional": false,
+       "type": "CSSStyleSheetHeader"
+      }
+     }
+    },
+    "styleSheetChanged": {
+     "params": {
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      }
+     }
+    },
+    "styleSheetRemoved": {
+     "params": {
+      "styleSheetId": {
+       "optional": false,
+       "type": "DOM.StyleSheetId"
+      }
+     }
+    }
+   }
+  },
+  "CacheStorage": {
+   "commands": {
+    "deleteCache": {
+     "params": {
+      "cacheId": {
+       "optional": false,
+       "type": "CacheId"
+      }
+     },
+     "returns": []
+    },
+    "deleteEntry": {
+     "params": {
+      "cacheId": {
+       "optional": false,
+       "type": "CacheId"
+      },
+      "request": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "requestCacheNames": {
+     "params": {
+      "securityOrigin": {
+       "optional": true,
+       "type": "string"
+      },
+      "storageBucket": {
+       "optional": true,
+       "type": "Storage.StorageBucket"
+      },
+      "storageKey": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "caches"
+     ]
+    },
+    "requestCachedResponse": {
+     "params": {
+      "cacheId": {
+       "optional": false,
+       "type": "CacheId"
+      },
+      "requestHeaders": {
+       "optional": false,
+       "type": "array"
+      },
+      "requestURL": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "response"
+     ]
+    },
+    "requestEntries": {
+     "params": {
+      "cacheId": {
+       "optional": false,
+       "type": "CacheId"
+      },
+      "pageSize": {
+       "optional": true,
+       "type": "integer"
+      },
+      "pathFilter": {
+       "optional": true,
+       "type": "string"
+      },
+      "skipCount": {
+       "optional": true,
+       "type": "integer"
+      }
+     },
+     "returns": [
+      "cacheDataEntries",
+      "returnCount"
+     ]
+    }
+   },
+   "events": {}
+  },
+  "Cast": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {
+      "presentationUrl": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setSinkToUse": {
+     "params": {
+      "sinkName": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "startDesktopMirroring": {
+     "params": {
+      "sinkName": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "startTabMirroring": {
+     "params": {
+      "sinkName": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "stopCasting": {
+     "params": {
+      "sinkName": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "issueUpdated": {
+     "params": {
+      "issueMessage": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "sinksUpdated": {
+     "params": {
+      "sinks": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    }
+   }
+  },
+  "Console": {
+   "commands": {
+    "clearMessages": {
+     "params": {},
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "messageAdded": {
+     "params": {
+      "message": {
+       "optional": false,
+       "type": "ConsoleMessage"
+      }
+     }
+    }
+   }
+  },
+  "CrashReportContext": {
+   "commands": {
+    "getEntries": {
+     "params": {},
+     "returns": [
+      "entries"
+     ]
+    }
+   },
+   "events": {}
+  },
+  "DOM": {
+   "commands": {
+    "collectClassNamesFromSubtree": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "classNames"
+     ]
+    },
+    "copyTo": {
+     "params": {
+      "insertBeforeNodeId": {
+       "optional": true,
+       "type": "NodeId"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "targetNodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "describeNode": {
+     "params": {
+      "backendNodeId": {
+       "optional": true,
+       "type": "BackendNodeId"
+      },
+      "depth": {
+       "optional": true,
+       "type": "integer"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "NodeId"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "Runtime.RemoteObjectId"
+      },
+      "pierce": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "node"
+     ]
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "discardSearchResults": {
+     "params": {
+      "searchId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "enable": {
+     "params": {
+      "includeWhitespace": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "focus": {
+     "params": {
+      "backendNodeId": {
+       "optional": true,
+       "type": "BackendNodeId"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "NodeId"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": []
+    },
+    "forceShowInterest": {
+     "params": {
+      "enable": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": []
+    },
+    "forceShowPopover": {
+     "params": {
+      "enable": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "invokerNodeId": {
+       "optional": true,
+       "type": "BackendNodeId"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "nodeIds"
+     ]
+    },
+    "getAnchorElement": {
+     "params": {
+      "anchorSpecifier": {
+       "optional": true,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "getAttributes": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "attributes"
+     ]
+    },
+    "getBoxModel": {
+     "params": {
+      "backendNodeId": {
+       "optional": true,
+       "type": "BackendNodeId"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "NodeId"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": [
+      "model"
+     ]
+    },
+    "getContainerForNode": {
+     "params": {
+      "containerName": {
+       "optional": true,
+       "type": "string"
+      },
+      "logicalAxes": {
+       "optional": true,
+       "type": "LogicalAxes"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "physicalAxes": {
+       "optional": true,
+       "type": "PhysicalAxes"
+      },
+      "queriesAnchored": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "queriesScrollState": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "getContentQuads": {
+     "params": {
+      "backendNodeId": {
+       "optional": true,
+       "type": "BackendNodeId"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "NodeId"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": [
+      "quads"
+     ]
+    },
+    "getDetachedDomNodes": {
+     "params": {},
+     "returns": [
+      "detachedNodes"
+     ]
+    },
+    "getDocument": {
+     "params": {
+      "depth": {
+       "optional": true,
+       "type": "integer"
+      },
+      "pierce": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "root"
+     ]
+    },
+    "getElementByRelation": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "relation": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "getFileInfo": {
+     "params": {
+      "objectId": {
+       "optional": false,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": [
+      "path"
+     ]
+    },
+    "getFlattenedDocument": {
+     "params": {
+      "depth": {
+       "optional": true,
+       "type": "integer"
+      },
+      "pierce": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "nodes"
+     ]
+    },
+    "getFrameOwner": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "Page.FrameId"
+      }
+     },
+     "returns": [
+      "backendNodeId",
+      "nodeId"
+     ]
+    },
+    "getNodeForLocation": {
+     "params": {
+      "ignorePointerEventsNone": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includeUserAgentShadowDOM": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "x": {
+       "optional": false,
+       "type": "integer"
+      },
+      "y": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": [
+      "backendNodeId",
+      "frameId",
+      "nodeId"
+     ]
+    },
+    "getNodeStackTraces": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "creation"
+     ]
+    },
+    "getNodesForSubtreeByStyle": {
+     "params": {
+      "computedStyles": {
+       "optional": false,
+       "type": "array"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "pierce": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "nodeIds"
+     ]
+    },
+    "getOuterHTML": {
+     "params": {
+      "backendNodeId": {
+       "optional": true,
+       "type": "BackendNodeId"
+      },
+      "includeShadowDOM": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "NodeId"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": [
+      "outerHTML"
+     ]
+    },
+    "getQueryingDescendantsForContainer": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "nodeIds"
+     ]
+    },
+    "getRelayoutBoundary": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "getSearchResults": {
+     "params": {
+      "fromIndex": {
+       "optional": false,
+       "type": "integer"
+      },
+      "searchId": {
+       "optional": false,
+       "type": "string"
+      },
+      "toIndex": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": [
+      "nodeIds"
+     ]
+    },
+    "getTopLayerElements": {
+     "params": {},
+     "returns": [
+      "nodeIds"
+     ]
+    },
+    "hideHighlight": {
+     "params": {},
+     "returns": []
+    },
+    "highlightNode": {
+     "params": {},
+     "returns": []
+    },
+    "highlightRect": {
+     "params": {},
+     "returns": []
+    },
+    "markUndoableState": {
+     "params": {},
+     "returns": []
+    },
+    "moveTo": {
+     "params": {
+      "insertBeforeNodeId": {
+       "optional": true,
+       "type": "NodeId"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "targetNodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "performSearch": {
+     "params": {
+      "includeUserAgentShadowDOM": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "query": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "searchId",
+      "resultCount"
+     ]
+    },
+    "pushNodeByPathToFrontend": {
+     "params": {
+      "path": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "pushNodesByBackendIdsToFrontend": {
+     "params": {
+      "backendNodeIds": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": [
+      "nodeIds"
+     ]
+    },
+    "querySelector": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "selector": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "querySelectorAll": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "selector": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "nodeIds"
+     ]
+    },
+    "redo": {
+     "params": {},
+     "returns": []
+    },
+    "removeAttribute": {
+     "params": {
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": []
+    },
+    "removeNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": []
+    },
+    "requestChildNodes": {
+     "params": {
+      "depth": {
+       "optional": true,
+       "type": "integer"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "pierce": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "requestNode": {
+     "params": {
+      "objectId": {
+       "optional": false,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "resolveNode": {
+     "params": {
+      "backendNodeId": {
+       "optional": true,
+       "type": "DOM.BackendNodeId"
+      },
+      "executionContextId": {
+       "optional": true,
+       "type": "Runtime.ExecutionContextId"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "NodeId"
+      },
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "object"
+     ]
+    },
+    "scrollIntoViewIfNeeded": {
+     "params": {
+      "backendNodeId": {
+       "optional": true,
+       "type": "BackendNodeId"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "NodeId"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "Runtime.RemoteObjectId"
+      },
+      "rect": {
+       "optional": true,
+       "type": "Rect"
+      }
+     },
+     "returns": []
+    },
+    "setAttributeValue": {
+     "params": {
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "value": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setAttributesAsText": {
+     "params": {
+      "name": {
+       "optional": true,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setFileInputFiles": {
+     "params": {
+      "backendNodeId": {
+       "optional": true,
+       "type": "BackendNodeId"
+      },
+      "files": {
+       "optional": false,
+       "type": "array"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "NodeId"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": []
+    },
+    "setInspectedNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": []
+    },
+    "setNodeName": {
+     "params": {
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "setNodeStackTracesEnabled": {
+     "params": {
+      "enable": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setNodeValue": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "value": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setOuterHTML": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "outerHTML": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "undo": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "adRelatedStateUpdated": {
+     "params": {
+      "adProvenance": {
+       "optional": true,
+       "type": "Network.AdProvenance"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     }
+    },
+    "adoptedStyleSheetsModified": {
+     "params": {
+      "adoptedStyleSheets": {
+       "optional": false,
+       "type": "array"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "affectedByStartingStylesFlagUpdated": {
+     "params": {
+      "affectedByStartingStyles": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     }
+    },
+    "attributeModified": {
+     "params": {
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "value": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "attributeRemoved": {
+     "params": {
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "characterDataModified": {
+     "params": {
+      "characterData": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "childNodeCountUpdated": {
+     "params": {
+      "childNodeCount": {
+       "optional": false,
+       "type": "integer"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "childNodeInserted": {
+     "params": {
+      "node": {
+       "optional": false,
+       "type": "Node"
+      },
+      "parentNodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "previousNodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "childNodeRemoved": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "parentNodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "distributedNodesUpdated": {
+     "params": {
+      "distributedNodes": {
+       "optional": false,
+       "type": "array"
+      },
+      "insertionPointId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "documentUpdated": {
+     "params": {}
+    },
+    "inlineStyleInvalidated": {
+     "params": {
+      "nodeIds": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    },
+    "pseudoElementAdded": {
+     "params": {
+      "parentId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "pseudoElement": {
+       "optional": false,
+       "type": "Node"
+      }
+     }
+    },
+    "pseudoElementRemoved": {
+     "params": {
+      "parentId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "pseudoElementId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "scrollableFlagUpdated": {
+     "params": {
+      "isScrollable": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     }
+    },
+    "setChildNodes": {
+     "params": {
+      "nodes": {
+       "optional": false,
+       "type": "array"
+      },
+      "parentId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "shadowRootPopped": {
+     "params": {
+      "hostId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "rootId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "shadowRootPushed": {
+     "params": {
+      "hostId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "root": {
+       "optional": false,
+       "type": "Node"
+      }
+     }
+    },
+    "topLayerElementsUpdated": {
+     "params": {}
+    }
+   }
+  },
+  "DOMDebugger": {
+   "commands": {
+    "getEventListeners": {
+     "params": {
+      "depth": {
+       "optional": true,
+       "type": "integer"
+      },
+      "objectId": {
+       "optional": false,
+       "type": "Runtime.RemoteObjectId"
+      },
+      "pierce": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "listeners"
+     ]
+    },
+    "removeDOMBreakpoint": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      },
+      "type": {
+       "optional": false,
+       "type": "DOMBreakpointType"
+      }
+     },
+     "returns": []
+    },
+    "removeEventListenerBreakpoint": {
+     "params": {
+      "eventName": {
+       "optional": false,
+       "type": "string"
+      },
+      "targetName": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "removeInstrumentationBreakpoint": {
+     "params": {
+      "eventName": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "removeXHRBreakpoint": {
+     "params": {
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setBreakOnCSPViolation": {
+     "params": {
+      "violationTypes": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "setDOMBreakpoint": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      },
+      "type": {
+       "optional": false,
+       "type": "DOMBreakpointType"
+      }
+     },
+     "returns": []
+    },
+    "setEventListenerBreakpoint": {
+     "params": {
+      "eventName": {
+       "optional": false,
+       "type": "string"
+      },
+      "targetName": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setInstrumentationBreakpoint": {
+     "params": {
+      "eventName": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setXHRBreakpoint": {
+     "params": {
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {}
+  },
+  "DOMSnapshot": {
+   "commands": {
+    "captureSnapshot": {
+     "params": {
+      "computedStyles": {
+       "optional": false,
+       "type": "array"
+      },
+      "includeBlendedBackgroundColors": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includeDOMRects": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includePaintOrder": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includeTextColorOpacities": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "documents",
+      "strings"
+     ]
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getSnapshot": {
+     "params": {
+      "computedStyleWhitelist": {
+       "optional": false,
+       "type": "array"
+      },
+      "includeEventListeners": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includePaintOrder": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includeUserAgentShadowTree": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "domNodes",
+      "layoutTreeNodes",
+      "computedStyles"
+     ]
+    }
+   },
+   "events": {}
+  },
+  "DOMStorage": {
+   "commands": {
+    "clear": {
+     "params": {
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getDOMStorageItems": {
+     "params": {
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     },
+     "returns": [
+      "entries"
+     ]
+    },
+    "removeDOMStorageItem": {
+     "params": {
+      "key": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     },
+     "returns": []
+    },
+    "setDOMStorageItem": {
+     "params": {
+      "key": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      },
+      "value": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "domStorageItemAdded": {
+     "params": {
+      "key": {
+       "optional": false,
+       "type": "string"
+      },
+      "newValue": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     }
+    },
+    "domStorageItemRemoved": {
+     "params": {
+      "key": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     }
+    },
+    "domStorageItemUpdated": {
+     "params": {
+      "key": {
+       "optional": false,
+       "type": "string"
+      },
+      "newValue": {
+       "optional": false,
+       "type": "string"
+      },
+      "oldValue": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     }
+    },
+    "domStorageItemsCleared": {
+     "params": {
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     }
+    }
+   }
+  },
+  "Debugger": {
+   "commands": {
+    "continueToLocation": {
+     "params": {
+      "location": {
+       "optional": false,
+       "type": "Location"
+      },
+      "targetCallFrames": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "disassembleWasmModule": {
+     "params": {
+      "scriptId": {
+       "optional": false,
+       "type": "Runtime.ScriptId"
+      }
+     },
+     "returns": [
+      "streamId",
+      "totalNumberOfLines",
+      "functionBodyOffsets",
+      "chunk"
+     ]
+    },
+    "enable": {
+     "params": {
+      "maxScriptsCacheSize": {
+       "optional": true,
+       "type": "number"
+      }
+     },
+     "returns": [
+      "debuggerId"
+     ]
+    },
+    "evaluateOnCallFrame": {
+     "params": {
+      "callFrameId": {
+       "optional": false,
+       "type": "CallFrameId"
+      },
+      "expression": {
+       "optional": false,
+       "type": "string"
+      },
+      "generatePreview": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includeCommandLineAPI": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      },
+      "returnByValue": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "scopeNumber": {
+       "optional": true,
+       "type": "integer"
+      },
+      "silent": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "throwOnSideEffect": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "timeout": {
+       "optional": true,
+       "type": "Runtime.TimeDelta"
+      }
+     },
+     "returns": [
+      "result",
+      "exceptionDetails"
+     ]
+    },
+    "getPossibleBreakpoints": {
+     "params": {
+      "end": {
+       "optional": true,
+       "type": "Location"
+      },
+      "restrictToFunction": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "start": {
+       "optional": false,
+       "type": "Location"
+      }
+     },
+     "returns": [
+      "locations"
+     ]
+    },
+    "getScriptSource": {
+     "params": {
+      "scriptId": {
+       "optional": false,
+       "type": "Runtime.ScriptId"
+      }
+     },
+     "returns": [
+      "scriptSource",
+      "bytecode"
+     ]
+    },
+    "getStackTrace": {
+     "params": {
+      "stackTraceId": {
+       "optional": false,
+       "type": "Runtime.StackTraceId"
+      }
+     },
+     "returns": [
+      "stackTrace"
+     ]
+    },
+    "getWasmBytecode": {
+     "params": {
+      "scriptId": {
+       "optional": false,
+       "type": "Runtime.ScriptId"
+      }
+     },
+     "returns": [
+      "bytecode"
+     ]
+    },
+    "nextWasmDisassemblyChunk": {
+     "params": {
+      "streamId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "chunk"
+     ]
+    },
+    "pause": {
+     "params": {},
+     "returns": []
+    },
+    "pauseOnAsyncCall": {
+     "params": {
+      "parentStackTraceId": {
+       "optional": false,
+       "type": "Runtime.StackTraceId"
+      }
+     },
+     "returns": []
+    },
+    "removeBreakpoint": {
+     "params": {
+      "breakpointId": {
+       "optional": false,
+       "type": "BreakpointId"
+      }
+     },
+     "returns": []
+    },
+    "restartFrame": {
+     "params": {
+      "callFrameId": {
+       "optional": false,
+       "type": "CallFrameId"
+      },
+      "mode": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "callFrames",
+      "asyncStackTrace",
+      "asyncStackTraceId"
+     ]
+    },
+    "resume": {
+     "params": {
+      "terminateOnResume": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "searchInContent": {
+     "params": {
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "query": {
+       "optional": false,
+       "type": "string"
+      },
+      "scriptId": {
+       "optional": false,
+       "type": "Runtime.ScriptId"
+      }
+     },
+     "returns": [
+      "result"
+     ]
+    },
+    "setAsyncCallStackDepth": {
+     "params": {
+      "maxDepth": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "setBlackboxExecutionContexts": {
+     "params": {
+      "uniqueIds": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "setBlackboxPatterns": {
+     "params": {
+      "patterns": {
+       "optional": false,
+       "type": "array"
+      },
+      "skipAnonymous": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setBlackboxedRanges": {
+     "params": {
+      "positions": {
+       "optional": false,
+       "type": "array"
+      },
+      "scriptId": {
+       "optional": false,
+       "type": "Runtime.ScriptId"
+      }
+     },
+     "returns": []
+    },
+    "setBreakpoint": {
+     "params": {
+      "condition": {
+       "optional": true,
+       "type": "string"
+      },
+      "location": {
+       "optional": false,
+       "type": "Location"
+      }
+     },
+     "returns": [
+      "breakpointId",
+      "actualLocation"
+     ]
+    },
+    "setBreakpointByUrl": {
+     "params": {
+      "columnNumber": {
+       "optional": true,
+       "type": "integer"
+      },
+      "condition": {
+       "optional": true,
+       "type": "string"
+      },
+      "lineNumber": {
+       "optional": false,
+       "type": "integer"
+      },
+      "scriptHash": {
+       "optional": true,
+       "type": "string"
+      },
+      "url": {
+       "optional": true,
+       "type": "string"
+      },
+      "urlRegex": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "breakpointId",
+      "locations"
+     ]
+    },
+    "setBreakpointOnFunctionCall": {
+     "params": {
+      "condition": {
+       "optional": true,
+       "type": "string"
+      },
+      "objectId": {
+       "optional": false,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": [
+      "breakpointId"
+     ]
+    },
+    "setBreakpointsActive": {
+     "params": {
+      "active": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setInstrumentationBreakpoint": {
+     "params": {
+      "instrumentation": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "breakpointId"
+     ]
+    },
+    "setPauseOnExceptions": {
+     "params": {
+      "state": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setReturnValue": {
+     "params": {
+      "newValue": {
+       "optional": false,
+       "type": "Runtime.CallArgument"
+      }
+     },
+     "returns": []
+    },
+    "setScriptSource": {
+     "params": {
+      "allowTopFrameEditing": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "dryRun": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "scriptId": {
+       "optional": false,
+       "type": "Runtime.ScriptId"
+      },
+      "scriptSource": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "callFrames",
+      "stackChanged",
+      "asyncStackTrace",
+      "asyncStackTraceId",
+      "status",
+      "exceptionDetails"
+     ]
+    },
+    "setSkipAllPauses": {
+     "params": {
+      "skip": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setVariableValue": {
+     "params": {
+      "callFrameId": {
+       "optional": false,
+       "type": "CallFrameId"
+      },
+      "newValue": {
+       "optional": false,
+       "type": "Runtime.CallArgument"
+      },
+      "scopeNumber": {
+       "optional": false,
+       "type": "integer"
+      },
+      "variableName": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "stepInto": {
+     "params": {
+      "breakOnAsyncCall": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "skipList": {
+       "optional": true,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "stepOut": {
+     "params": {},
+     "returns": []
+    },
+    "stepOver": {
+     "params": {
+      "skipList": {
+       "optional": true,
+       "type": "array"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "breakpointResolved": {
+     "params": {
+      "breakpointId": {
+       "optional": false,
+       "type": "BreakpointId"
+      },
+      "location": {
+       "optional": false,
+       "type": "Location"
+      }
+     }
+    },
+    "paused": {
+     "params": {
+      "asyncCallStackTraceId": {
+       "optional": true,
+       "type": "Runtime.StackTraceId"
+      },
+      "asyncStackTrace": {
+       "optional": true,
+       "type": "Runtime.StackTrace"
+      },
+      "asyncStackTraceId": {
+       "optional": true,
+       "type": "Runtime.StackTraceId"
+      },
+      "callFrames": {
+       "optional": false,
+       "type": "array"
+      },
+      "data": {
+       "optional": true,
+       "type": "object"
+      },
+      "hitBreakpoints": {
+       "optional": true,
+       "type": "array"
+      },
+      "reason": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "resumed": {
+     "params": {}
+    },
+    "scriptFailedToParse": {
+     "params": {
+      "buildId": {
+       "optional": false,
+       "type": "string"
+      },
+      "codeOffset": {
+       "optional": true,
+       "type": "integer"
+      },
+      "embedderName": {
+       "optional": true,
+       "type": "string"
+      },
+      "endColumn": {
+       "optional": false,
+       "type": "integer"
+      },
+      "endLine": {
+       "optional": false,
+       "type": "integer"
+      },
+      "executionContextAuxData": {
+       "optional": true,
+       "type": "object"
+      },
+      "executionContextId": {
+       "optional": false,
+       "type": "Runtime.ExecutionContextId"
+      },
+      "hasSourceURL": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "hash": {
+       "optional": false,
+       "type": "string"
+      },
+      "isModule": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "length": {
+       "optional": true,
+       "type": "integer"
+      },
+      "scriptId": {
+       "optional": false,
+       "type": "Runtime.ScriptId"
+      },
+      "scriptLanguage": {
+       "optional": true,
+       "type": "Debugger.ScriptLanguage"
+      },
+      "sourceMapURL": {
+       "optional": true,
+       "type": "string"
+      },
+      "stackTrace": {
+       "optional": true,
+       "type": "Runtime.StackTrace"
+      },
+      "startColumn": {
+       "optional": false,
+       "type": "integer"
+      },
+      "startLine": {
+       "optional": false,
+       "type": "integer"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "scriptParsed": {
+     "params": {
+      "buildId": {
+       "optional": false,
+       "type": "string"
+      },
+      "codeOffset": {
+       "optional": true,
+       "type": "integer"
+      },
+      "debugSymbols": {
+       "optional": true,
+       "type": "array"
+      },
+      "embedderName": {
+       "optional": true,
+       "type": "string"
+      },
+      "endColumn": {
+       "optional": false,
+       "type": "integer"
+      },
+      "endLine": {
+       "optional": false,
+       "type": "integer"
+      },
+      "executionContextAuxData": {
+       "optional": true,
+       "type": "object"
+      },
+      "executionContextId": {
+       "optional": false,
+       "type": "Runtime.ExecutionContextId"
+      },
+      "hasSourceURL": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "hash": {
+       "optional": false,
+       "type": "string"
+      },
+      "isLiveEdit": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "isModule": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "length": {
+       "optional": true,
+       "type": "integer"
+      },
+      "resolvedBreakpoints": {
+       "optional": true,
+       "type": "array"
+      },
+      "scriptId": {
+       "optional": false,
+       "type": "Runtime.ScriptId"
+      },
+      "scriptLanguage": {
+       "optional": true,
+       "type": "Debugger.ScriptLanguage"
+      },
+      "sourceMapURL": {
+       "optional": true,
+       "type": "string"
+      },
+      "stackTrace": {
+       "optional": true,
+       "type": "Runtime.StackTrace"
+      },
+      "startColumn": {
+       "optional": false,
+       "type": "integer"
+      },
+      "startLine": {
+       "optional": false,
+       "type": "integer"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    }
+   }
+  },
+  "DeviceAccess": {
+   "commands": {
+    "cancelPrompt": {
+     "params": {
+      "id": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "selectPrompt": {
+     "params": {
+      "deviceId": {
+       "optional": false,
+       "type": "DeviceId"
+      },
+      "id": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "deviceRequestPrompted": {
+     "params": {
+      "devices": {
+       "optional": false,
+       "type": "array"
+      },
+      "id": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     }
+    }
+   }
+  },
+  "DeviceOrientation": {
+   "commands": {
+    "clearDeviceOrientationOverride": {
+     "params": {},
+     "returns": []
+    },
+    "setDeviceOrientationOverride": {
+     "params": {
+      "alpha": {
+       "optional": false,
+       "type": "number"
+      },
+      "beta": {
+       "optional": false,
+       "type": "number"
+      },
+      "gamma": {
+       "optional": false,
+       "type": "number"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {}
+  },
+  "DigitalCredentials": {
+   "commands": {
+    "setVirtualWalletBehavior": {
+     "params": {
+      "action": {
+       "optional": false,
+       "type": "VirtualWalletAction"
+      },
+      "frameId": {
+       "optional": true,
+       "type": "Page.FrameId"
+      },
+      "protocol": {
+       "optional": true,
+       "type": "string"
+      },
+      "response": {
+       "optional": true,
+       "type": "object"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {}
+  },
+  "Emulation": {
+   "commands": {
+    "addScreen": {
+     "params": {
+      "colorDepth": {
+       "optional": true,
+       "type": "integer"
+      },
+      "devicePixelRatio": {
+       "optional": true,
+       "type": "number"
+      },
+      "height": {
+       "optional": false,
+       "type": "integer"
+      },
+      "isInternal": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "label": {
+       "optional": true,
+       "type": "string"
+      },
+      "left": {
+       "optional": false,
+       "type": "integer"
+      },
+      "rotation": {
+       "optional": true,
+       "type": "integer"
+      },
+      "top": {
+       "optional": false,
+       "type": "integer"
+      },
+      "width": {
+       "optional": false,
+       "type": "integer"
+      },
+      "workAreaInsets": {
+       "optional": true,
+       "type": "WorkAreaInsets"
+      }
+     },
+     "returns": [
+      "screenInfo"
+     ]
+    },
+    "canEmulate": {
+     "params": {},
+     "returns": [
+      "result"
+     ]
+    },
+    "clearDeviceMetricsOverride": {
+     "params": {},
+     "returns": []
+    },
+    "clearDevicePostureOverride": {
+     "params": {},
+     "returns": []
+    },
+    "clearDisplayFeaturesOverride": {
+     "params": {},
+     "returns": []
+    },
+    "clearGeolocationOverride": {
+     "params": {},
+     "returns": []
+    },
+    "clearIdleOverride": {
+     "params": {},
+     "returns": []
+    },
+    "getOverriddenSensorInformation": {
+     "params": {
+      "type": {
+       "optional": false,
+       "type": "SensorType"
+      }
+     },
+     "returns": [
+      "requestedSamplingFrequency"
+     ]
+    },
+    "getScreenInfos": {
+     "params": {},
+     "returns": [
+      "screenInfos"
+     ]
+    },
+    "removeScreen": {
+     "params": {
+      "screenId": {
+       "optional": false,
+       "type": "ScreenId"
+      }
+     },
+     "returns": []
+    },
+    "resetPageScaleFactor": {
+     "params": {},
+     "returns": []
+    },
+    "setAutoDarkModeOverride": {
+     "params": {
+      "enabled": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setAutomationOverride": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setCPUPerformanceOverride": {
+     "params": {
+      "performanceTier": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setCPUThrottlingRate": {
+     "params": {
+      "rate": {
+       "optional": false,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "setDataSaverOverride": {
+     "params": {
+      "dataSaverEnabled": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setDefaultBackgroundColorOverride": {
+     "params": {
+      "color": {
+       "optional": true,
+       "type": "DOM.RGBA"
+      }
+     },
+     "returns": []
+    },
+    "setDeviceMetricsOverride": {
+     "params": {
+      "devicePosture": {
+       "optional": true,
+       "type": "DevicePosture"
+      },
+      "deviceScaleFactor": {
+       "optional": false,
+       "type": "number"
+      },
+      "displayFeature": {
+       "optional": true,
+       "type": "DisplayFeature"
+      },
+      "dontSetVisibleSize": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "height": {
+       "optional": false,
+       "type": "integer"
+      },
+      "mobile": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "positionX": {
+       "optional": true,
+       "type": "integer"
+      },
+      "positionY": {
+       "optional": true,
+       "type": "integer"
+      },
+      "scale": {
+       "optional": true,
+       "type": "number"
+      },
+      "screenHeight": {
+       "optional": true,
+       "type": "integer"
+      },
+      "screenOrientation": {
+       "optional": true,
+       "type": "ScreenOrientation"
+      },
+      "screenOrientationLockEmulation": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "screenWidth": {
+       "optional": true,
+       "type": "integer"
+      },
+      "scrollbarType": {
+       "optional": true,
+       "type": "string"
+      },
+      "viewport": {
+       "optional": true,
+       "type": "Page.Viewport"
+      },
+      "viewportMeta": {
+       "optional": true,
+       "type": "string"
+      },
+      "width": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "setDevicePostureOverride": {
+     "params": {
+      "posture": {
+       "optional": false,
+       "type": "DevicePosture"
+      }
+     },
+     "returns": []
+    },
+    "setDisabledImageTypes": {
+     "params": {
+      "imageTypes": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "setDisplayFeaturesOverride": {
+     "params": {
+      "features": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "setDocumentCookieDisabled": {
+     "params": {
+      "disabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setEmitTouchEventsForMouse": {
+     "params": {
+      "configuration": {
+       "optional": true,
+       "type": "string"
+      },
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setEmulatedMedia": {
+     "params": {
+      "features": {
+       "optional": true,
+       "type": "array"
+      },
+      "media": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setEmulatedOSTextScale": {
+     "params": {
+      "scale": {
+       "optional": true,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "setEmulatedVisionDeficiency": {
+     "params": {
+      "type": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setFocusEmulationEnabled": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setGeolocationOverride": {
+     "params": {
+      "accuracy": {
+       "optional": true,
+       "type": "number"
+      },
+      "altitude": {
+       "optional": true,
+       "type": "number"
+      },
+      "altitudeAccuracy": {
+       "optional": true,
+       "type": "number"
+      },
+      "heading": {
+       "optional": true,
+       "type": "number"
+      },
+      "latitude": {
+       "optional": true,
+       "type": "number"
+      },
+      "longitude": {
+       "optional": true,
+       "type": "number"
+      },
+      "speed": {
+       "optional": true,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "setHardwareConcurrencyOverride": {
+     "params": {
+      "hardwareConcurrency": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "setIdleOverride": {
+     "params": {
+      "isScreenUnlocked": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "isUserActive": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setLocaleOverride": {
+     "params": {
+      "locale": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setNavigatorOverrides": {
+     "params": {
+      "platform": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setPageScaleFactor": {
+     "params": {
+      "pageScaleFactor": {
+       "optional": false,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "setPressureSourceOverrideEnabled": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "metadata": {
+       "optional": true,
+       "type": "PressureMetadata"
+      },
+      "source": {
+       "optional": false,
+       "type": "PressureSource"
+      }
+     },
+     "returns": []
+    },
+    "setPressureStateOverride": {
+     "params": {
+      "source": {
+       "optional": false,
+       "type": "PressureSource"
+      },
+      "state": {
+       "optional": false,
+       "type": "PressureState"
+      }
+     },
+     "returns": []
+    },
+    "setPrimaryScreen": {
+     "params": {
+      "screenId": {
+       "optional": false,
+       "type": "ScreenId"
+      }
+     },
+     "returns": []
+    },
+    "setSafeAreaInsetsOverride": {
+     "params": {
+      "insets": {
+       "optional": false,
+       "type": "SafeAreaInsets"
+      }
+     },
+     "returns": []
+    },
+    "setScriptExecutionDisabled": {
+     "params": {
+      "value": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setScrollbarsHidden": {
+     "params": {
+      "hidden": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setSensorOverrideEnabled": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "metadata": {
+       "optional": true,
+       "type": "SensorMetadata"
+      },
+      "type": {
+       "optional": false,
+       "type": "SensorType"
+      }
+     },
+     "returns": []
+    },
+    "setSensorOverrideReadings": {
+     "params": {
+      "reading": {
+       "optional": false,
+       "type": "SensorReading"
+      },
+      "type": {
+       "optional": false,
+       "type": "SensorType"
+      }
+     },
+     "returns": []
+    },
+    "setSmallViewportHeightDifferenceOverride": {
+     "params": {
+      "difference": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "setTimezoneOverride": {
+     "params": {
+      "timezoneId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setTouchEmulationEnabled": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "maxTouchPoints": {
+       "optional": true,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "setUserAgentOverride": {
+     "params": {
+      "acceptLanguage": {
+       "optional": true,
+       "type": "string"
+      },
+      "platform": {
+       "optional": true,
+       "type": "string"
+      },
+      "userAgent": {
+       "optional": false,
+       "type": "string"
+      },
+      "userAgentMetadata": {
+       "optional": true,
+       "type": "UserAgentMetadata"
+      }
+     },
+     "returns": []
+    },
+    "setVirtualKeyboardGeometryOverride": {
+     "params": {
+      "keyboardRect": {
+       "optional": true,
+       "type": "DOM.Rect"
+      }
+     },
+     "returns": []
+    },
+    "setVirtualTimePolicy": {
+     "params": {
+      "budget": {
+       "optional": true,
+       "type": "number"
+      },
+      "initialVirtualTime": {
+       "optional": true,
+       "type": "Network.TimeSinceEpoch"
+      },
+      "maxVirtualTimeTaskStarvationCount": {
+       "optional": true,
+       "type": "integer"
+      },
+      "policy": {
+       "optional": false,
+       "type": "VirtualTimePolicy"
+      }
+     },
+     "returns": [
+      "virtualTimeTicksBase"
+     ]
+    },
+    "setVisibleSize": {
+     "params": {
+      "height": {
+       "optional": false,
+       "type": "integer"
+      },
+      "width": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "updateScreen": {
+     "params": {
+      "colorDepth": {
+       "optional": true,
+       "type": "integer"
+      },
+      "devicePixelRatio": {
+       "optional": true,
+       "type": "number"
+      },
+      "height": {
+       "optional": true,
+       "type": "integer"
+      },
+      "isInternal": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "label": {
+       "optional": true,
+       "type": "string"
+      },
+      "left": {
+       "optional": true,
+       "type": "integer"
+      },
+      "rotation": {
+       "optional": true,
+       "type": "integer"
+      },
+      "screenId": {
+       "optional": false,
+       "type": "ScreenId"
+      },
+      "top": {
+       "optional": true,
+       "type": "integer"
+      },
+      "width": {
+       "optional": true,
+       "type": "integer"
+      },
+      "workAreaInsets": {
+       "optional": true,
+       "type": "WorkAreaInsets"
+      }
+     },
+     "returns": [
+      "screenInfo"
+     ]
+    }
+   },
+   "events": {
+    "screenOrientationLockChanged": {
+     "params": {
+      "locked": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "orientation": {
+       "optional": true,
+       "type": "ScreenOrientation"
+      }
+     }
+    },
+    "virtualTimeBudgetExpired": {
+     "params": {}
+    }
+   }
+  },
+  "EventBreakpoints": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "removeInstrumentationBreakpoint": {
+     "params": {
+      "eventName": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setInstrumentationBreakpoint": {
+     "params": {
+      "eventName": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {}
+  },
+  "Extensions": {
+   "commands": {
+    "clearStorageItems": {
+     "params": {
+      "id": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageArea": {
+       "optional": false,
+       "type": "StorageArea"
+      }
+     },
+     "returns": []
+    },
+    "getExtensions": {
+     "params": {},
+     "returns": [
+      "extensions"
+     ]
+    },
+    "getStorageItems": {
+     "params": {
+      "id": {
+       "optional": false,
+       "type": "string"
+      },
+      "keys": {
+       "optional": true,
+       "type": "array"
+      },
+      "storageArea": {
+       "optional": false,
+       "type": "StorageArea"
+      }
+     },
+     "returns": [
+      "data"
+     ]
+    },
+    "loadUnpacked": {
+     "params": {
+      "enableInIncognito": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "path": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "id"
+     ]
+    },
+    "removeStorageItems": {
+     "params": {
+      "id": {
+       "optional": false,
+       "type": "string"
+      },
+      "keys": {
+       "optional": false,
+       "type": "array"
+      },
+      "storageArea": {
+       "optional": false,
+       "type": "StorageArea"
+      }
+     },
+     "returns": []
+    },
+    "setStorageItems": {
+     "params": {
+      "id": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageArea": {
+       "optional": false,
+       "type": "StorageArea"
+      },
+      "values": {
+       "optional": false,
+       "type": "object"
+      }
+     },
+     "returns": []
+    },
+    "triggerAction": {
+     "params": {
+      "id": {
+       "optional": false,
+       "type": "string"
+      },
+      "targetId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "uninstall": {
+     "params": {
+      "id": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {}
+  },
+  "FedCm": {
+   "commands": {
+    "clickDialogButton": {
+     "params": {
+      "dialogButton": {
+       "optional": false,
+       "type": "DialogButton"
+      },
+      "dialogId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "dismissDialog": {
+     "params": {
+      "dialogId": {
+       "optional": false,
+       "type": "string"
+      },
+      "triggerCooldown": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "enable": {
+     "params": {
+      "disableRejectionDelay": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "openUrl": {
+     "params": {
+      "accountIndex": {
+       "optional": false,
+       "type": "integer"
+      },
+      "accountUrlType": {
+       "optional": false,
+       "type": "AccountUrlType"
+      },
+      "dialogId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "resetCooldown": {
+     "params": {},
+     "returns": []
+    },
+    "selectAccount": {
+     "params": {
+      "accountIndex": {
+       "optional": false,
+       "type": "integer"
+      },
+      "dialogId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "dialogClosed": {
+     "params": {
+      "dialogId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "dialogShown": {
+     "params": {
+      "accounts": {
+       "optional": false,
+       "type": "array"
+      },
+      "dialogId": {
+       "optional": false,
+       "type": "string"
+      },
+      "dialogType": {
+       "optional": false,
+       "type": "DialogType"
+      },
+      "subtitle": {
+       "optional": true,
+       "type": "string"
+      },
+      "title": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    }
+   }
+  },
+  "Fetch": {
+   "commands": {
+    "continueRequest": {
+     "params": {
+      "headers": {
+       "optional": true,
+       "type": "array"
+      },
+      "interceptResponse": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "method": {
+       "optional": true,
+       "type": "string"
+      },
+      "postData": {
+       "optional": true,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "url": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "continueResponse": {
+     "params": {
+      "binaryResponseHeaders": {
+       "optional": true,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "responseCode": {
+       "optional": true,
+       "type": "integer"
+      },
+      "responseHeaders": {
+       "optional": true,
+       "type": "array"
+      },
+      "responsePhrase": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "continueWithAuth": {
+     "params": {
+      "authChallengeResponse": {
+       "optional": false,
+       "type": "AuthChallengeResponse"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {
+      "handleAuthRequests": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "patterns": {
+       "optional": true,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "failRequest": {
+     "params": {
+      "errorReason": {
+       "optional": false,
+       "type": "Network.ErrorReason"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": []
+    },
+    "fulfillRequest": {
+     "params": {
+      "binaryResponseHeaders": {
+       "optional": true,
+       "type": "string"
+      },
+      "body": {
+       "optional": true,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "responseCode": {
+       "optional": false,
+       "type": "integer"
+      },
+      "responseHeaders": {
+       "optional": true,
+       "type": "array"
+      },
+      "responsePhrase": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "getResponseBody": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": [
+      "body",
+      "base64Encoded"
+     ]
+    },
+    "takeResponseBodyAsStream": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": [
+      "stream"
+     ]
+    }
+   },
+   "events": {
+    "authRequired": {
+     "params": {
+      "authChallenge": {
+       "optional": false,
+       "type": "AuthChallenge"
+      },
+      "frameId": {
+       "optional": false,
+       "type": "Page.FrameId"
+      },
+      "request": {
+       "optional": false,
+       "type": "Network.Request"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "resourceType": {
+       "optional": false,
+       "type": "Network.ResourceType"
+      }
+     }
+    },
+    "requestPaused": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "Page.FrameId"
+      },
+      "networkId": {
+       "optional": true,
+       "type": "Network.RequestId"
+      },
+      "redirectedRequestId": {
+       "optional": true,
+       "type": "RequestId"
+      },
+      "request": {
+       "optional": false,
+       "type": "Network.Request"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "resourceType": {
+       "optional": false,
+       "type": "Network.ResourceType"
+      },
+      "responseErrorReason": {
+       "optional": true,
+       "type": "Network.ErrorReason"
+      },
+      "responseHeaders": {
+       "optional": true,
+       "type": "array"
+      },
+      "responseStatusCode": {
+       "optional": true,
+       "type": "integer"
+      },
+      "responseStatusText": {
+       "optional": true,
+       "type": "string"
+      }
+     }
+    }
+   }
+  },
+  "FileSystem": {
+   "commands": {
+    "getDirectory": {
+     "params": {
+      "bucketFileSystemLocator": {
+       "optional": false,
+       "type": "BucketFileSystemLocator"
+      }
+     },
+     "returns": [
+      "directory"
+     ]
+    }
+   },
+   "events": {}
+  },
+  "HeadlessExperimental": {
+   "commands": {
+    "beginFrame": {
+     "params": {
+      "frameTimeTicks": {
+       "optional": true,
+       "type": "number"
+      },
+      "interval": {
+       "optional": true,
+       "type": "number"
+      },
+      "noDisplayUpdates": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "screenshot": {
+       "optional": true,
+       "type": "ScreenshotParams"
+      }
+     },
+     "returns": [
+      "hasDamage",
+      "screenshotData"
+     ]
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {}
+  },
+  "HeapProfiler": {
+   "commands": {
+    "addInspectedHeapObject": {
+     "params": {
+      "heapObjectId": {
+       "optional": false,
+       "type": "HeapSnapshotObjectId"
+      }
+     },
+     "returns": []
+    },
+    "collectGarbage": {
+     "params": {},
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getHeapObjectId": {
+     "params": {
+      "objectId": {
+       "optional": false,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": [
+      "heapSnapshotObjectId"
+     ]
+    },
+    "getObjectByHeapObjectId": {
+     "params": {
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      },
+      "objectId": {
+       "optional": false,
+       "type": "HeapSnapshotObjectId"
+      }
+     },
+     "returns": [
+      "result"
+     ]
+    },
+    "getSamplingProfile": {
+     "params": {},
+     "returns": [
+      "profile"
+     ]
+    },
+    "startSampling": {
+     "params": {
+      "includeObjectsCollectedByMajorGC": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includeObjectsCollectedByMinorGC": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "samplingInterval": {
+       "optional": true,
+       "type": "number"
+      },
+      "stackDepth": {
+       "optional": true,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "startTrackingHeapObjects": {
+     "params": {
+      "trackAllocations": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "stopSampling": {
+     "params": {},
+     "returns": [
+      "profile"
+     ]
+    },
+    "stopTrackingHeapObjects": {
+     "params": {
+      "captureNumericValue": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "exposeInternals": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "reportProgress": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "treatGlobalObjectsAsRoots": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "takeHeapSnapshot": {
+     "params": {
+      "captureNumericValue": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "exposeInternals": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "reportProgress": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "treatGlobalObjectsAsRoots": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "addHeapSnapshotChunk": {
+     "params": {
+      "chunk": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "heapStatsUpdate": {
+     "params": {
+      "statsUpdate": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    },
+    "lastSeenObjectId": {
+     "params": {
+      "lastSeenObjectId": {
+       "optional": false,
+       "type": "integer"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "reportHeapSnapshotProgress": {
+     "params": {
+      "done": {
+       "optional": false,
+       "type": "integer"
+      },
+      "finished": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "total": {
+       "optional": false,
+       "type": "integer"
+      }
+     }
+    },
+    "resetProfiles": {
+     "params": {}
+    }
+   }
+  },
+  "IO": {
+   "commands": {
+    "close": {
+     "params": {
+      "handle": {
+       "optional": false,
+       "type": "StreamHandle"
+      }
+     },
+     "returns": []
+    },
+    "read": {
+     "params": {
+      "handle": {
+       "optional": false,
+       "type": "StreamHandle"
+      },
+      "offset": {
+       "optional": true,
+       "type": "integer"
+      },
+      "size": {
+       "optional": true,
+       "type": "integer"
+      }
+     },
+     "returns": [
+      "base64Encoded",
+      "data",
+      "eof"
+     ]
+    },
+    "resolveBlob": {
+     "params": {
+      "objectId": {
+       "optional": false,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": [
+      "uuid"
+     ]
+    }
+   },
+   "events": {}
+  },
+  "IndexedDB": {
+   "commands": {
+    "clearObjectStore": {
+     "params": {
+      "databaseName": {
+       "optional": false,
+       "type": "string"
+      },
+      "objectStoreName": {
+       "optional": false,
+       "type": "string"
+      },
+      "securityOrigin": {
+       "optional": true,
+       "type": "string"
+      },
+      "storageBucket": {
+       "optional": true,
+       "type": "Storage.StorageBucket"
+      },
+      "storageKey": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "deleteDatabase": {
+     "params": {
+      "databaseName": {
+       "optional": false,
+       "type": "string"
+      },
+      "securityOrigin": {
+       "optional": true,
+       "type": "string"
+      },
+      "storageBucket": {
+       "optional": true,
+       "type": "Storage.StorageBucket"
+      },
+      "storageKey": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "deleteObjectStoreEntries": {
+     "params": {
+      "databaseName": {
+       "optional": false,
+       "type": "string"
+      },
+      "keyRange": {
+       "optional": false,
+       "type": "KeyRange"
+      },
+      "objectStoreName": {
+       "optional": false,
+       "type": "string"
+      },
+      "securityOrigin": {
+       "optional": true,
+       "type": "string"
+      },
+      "storageBucket": {
+       "optional": true,
+       "type": "Storage.StorageBucket"
+      },
+      "storageKey": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getMetadata": {
+     "params": {
+      "databaseName": {
+       "optional": false,
+       "type": "string"
+      },
+      "objectStoreName": {
+       "optional": false,
+       "type": "string"
+      },
+      "securityOrigin": {
+       "optional": true,
+       "type": "string"
+      },
+      "storageBucket": {
+       "optional": true,
+       "type": "Storage.StorageBucket"
+      },
+      "storageKey": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "entriesCount",
+      "keyGeneratorValue"
+     ]
+    },
+    "requestData": {
+     "params": {
+      "databaseName": {
+       "optional": false,
+       "type": "string"
+      },
+      "indexName": {
+       "optional": true,
+       "type": "string"
+      },
+      "keyRange": {
+       "optional": true,
+       "type": "KeyRange"
+      },
+      "objectStoreName": {
+       "optional": false,
+       "type": "string"
+      },
+      "pageSize": {
+       "optional": false,
+       "type": "integer"
+      },
+      "securityOrigin": {
+       "optional": true,
+       "type": "string"
+      },
+      "skipCount": {
+       "optional": false,
+       "type": "integer"
+      },
+      "storageBucket": {
+       "optional": true,
+       "type": "Storage.StorageBucket"
+      },
+      "storageKey": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "objectStoreDataEntries",
+      "hasMore"
+     ]
+    },
+    "requestDatabase": {
+     "params": {
+      "databaseName": {
+       "optional": false,
+       "type": "string"
+      },
+      "securityOrigin": {
+       "optional": true,
+       "type": "string"
+      },
+      "storageBucket": {
+       "optional": true,
+       "type": "Storage.StorageBucket"
+      },
+      "storageKey": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "databaseWithObjectStores"
+     ]
+    },
+    "requestDatabaseNames": {
+     "params": {
+      "securityOrigin": {
+       "optional": true,
+       "type": "string"
+      },
+      "storageBucket": {
+       "optional": true,
+       "type": "Storage.StorageBucket"
+      },
+      "storageKey": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "databaseNames"
+     ]
+    }
+   },
+   "events": {}
+  },
+  "Input": {
+   "commands": {
+    "cancelDragging": {
+     "params": {},
+     "returns": []
+    },
+    "dispatchDragEvent": {
+     "params": {
+      "data": {
+       "optional": false,
+       "type": "DragData"
+      },
+      "modifiers": {
+       "optional": true,
+       "type": "integer"
+      },
+      "type": {
+       "optional": false,
+       "type": "string"
+      },
+      "x": {
+       "optional": false,
+       "type": "number"
+      },
+      "y": {
+       "optional": false,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "dispatchKeyEvent": {
+     "params": {
+      "autoRepeat": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "code": {
+       "optional": true,
+       "type": "string"
+      },
+      "commands": {
+       "optional": true,
+       "type": "array"
+      },
+      "isKeypad": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "isSystemKey": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "key": {
+       "optional": true,
+       "type": "string"
+      },
+      "keyIdentifier": {
+       "optional": true,
+       "type": "string"
+      },
+      "location": {
+       "optional": true,
+       "type": "integer"
+      },
+      "modifiers": {
+       "optional": true,
+       "type": "integer"
+      },
+      "nativeVirtualKeyCode": {
+       "optional": true,
+       "type": "integer"
+      },
+      "text": {
+       "optional": true,
+       "type": "string"
+      },
+      "timestamp": {
+       "optional": true,
+       "type": "TimeSinceEpoch"
+      },
+      "type": {
+       "optional": false,
+       "type": "string"
+      },
+      "unmodifiedText": {
+       "optional": true,
+       "type": "string"
+      },
+      "windowsVirtualKeyCode": {
+       "optional": true,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "dispatchMouseEvent": {
+     "params": {
+      "button": {
+       "optional": true,
+       "type": "MouseButton"
+      },
+      "buttons": {
+       "optional": true,
+       "type": "integer"
+      },
+      "clickCount": {
+       "optional": true,
+       "type": "integer"
+      },
+      "deltaX": {
+       "optional": true,
+       "type": "number"
+      },
+      "deltaY": {
+       "optional": true,
+       "type": "number"
+      },
+      "force": {
+       "optional": true,
+       "type": "number"
+      },
+      "modifiers": {
+       "optional": true,
+       "type": "integer"
+      },
+      "pointerType": {
+       "optional": true,
+       "type": "string"
+      },
+      "tangentialPressure": {
+       "optional": true,
+       "type": "number"
+      },
+      "tiltX": {
+       "optional": true,
+       "type": "number"
+      },
+      "tiltY": {
+       "optional": true,
+       "type": "number"
+      },
+      "timestamp": {
+       "optional": true,
+       "type": "TimeSinceEpoch"
+      },
+      "twist": {
+       "optional": true,
+       "type": "integer"
+      },
+      "type": {
+       "optional": false,
+       "type": "string"
+      },
+      "x": {
+       "optional": false,
+       "type": "number"
+      },
+      "y": {
+       "optional": false,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "dispatchTouchEvent": {
+     "params": {
+      "modifiers": {
+       "optional": true,
+       "type": "integer"
+      },
+      "timestamp": {
+       "optional": true,
+       "type": "TimeSinceEpoch"
+      },
+      "touchPoints": {
+       "optional": false,
+       "type": "array"
+      },
+      "type": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "emulateTouchFromMouseEvent": {
+     "params": {
+      "button": {
+       "optional": false,
+       "type": "MouseButton"
+      },
+      "clickCount": {
+       "optional": true,
+       "type": "integer"
+      },
+      "deltaX": {
+       "optional": true,
+       "type": "number"
+      },
+      "deltaY": {
+       "optional": true,
+       "type": "number"
+      },
+      "modifiers": {
+       "optional": true,
+       "type": "integer"
+      },
+      "timestamp": {
+       "optional": true,
+       "type": "TimeSinceEpoch"
+      },
+      "type": {
+       "optional": false,
+       "type": "string"
+      },
+      "x": {
+       "optional": false,
+       "type": "integer"
+      },
+      "y": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "imeSetComposition": {
+     "params": {
+      "replacementEnd": {
+       "optional": true,
+       "type": "integer"
+      },
+      "replacementStart": {
+       "optional": true,
+       "type": "integer"
+      },
+      "selectionEnd": {
+       "optional": false,
+       "type": "integer"
+      },
+      "selectionStart": {
+       "optional": false,
+       "type": "integer"
+      },
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "insertText": {
+     "params": {
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setIgnoreInputEvents": {
+     "params": {
+      "ignore": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setInterceptDrags": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "synthesizePinchGesture": {
+     "params": {
+      "gestureSourceType": {
+       "optional": true,
+       "type": "GestureSourceType"
+      },
+      "relativeSpeed": {
+       "optional": true,
+       "type": "integer"
+      },
+      "scaleFactor": {
+       "optional": false,
+       "type": "number"
+      },
+      "x": {
+       "optional": false,
+       "type": "number"
+      },
+      "y": {
+       "optional": false,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "synthesizeScrollGesture": {
+     "params": {
+      "gestureSourceType": {
+       "optional": true,
+       "type": "GestureSourceType"
+      },
+      "interactionMarkerName": {
+       "optional": true,
+       "type": "string"
+      },
+      "preventFling": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "repeatCount": {
+       "optional": true,
+       "type": "integer"
+      },
+      "repeatDelayMs": {
+       "optional": true,
+       "type": "integer"
+      },
+      "speed": {
+       "optional": true,
+       "type": "integer"
+      },
+      "x": {
+       "optional": false,
+       "type": "number"
+      },
+      "xDistance": {
+       "optional": true,
+       "type": "number"
+      },
+      "xOverscroll": {
+       "optional": true,
+       "type": "number"
+      },
+      "y": {
+       "optional": false,
+       "type": "number"
+      },
+      "yDistance": {
+       "optional": true,
+       "type": "number"
+      },
+      "yOverscroll": {
+       "optional": true,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "synthesizeTapGesture": {
+     "params": {
+      "duration": {
+       "optional": true,
+       "type": "integer"
+      },
+      "gestureSourceType": {
+       "optional": true,
+       "type": "GestureSourceType"
+      },
+      "tapCount": {
+       "optional": true,
+       "type": "integer"
+      },
+      "x": {
+       "optional": false,
+       "type": "number"
+      },
+      "y": {
+       "optional": false,
+       "type": "number"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "dragIntercepted": {
+     "params": {
+      "data": {
+       "optional": false,
+       "type": "DragData"
+      }
+     }
+    }
+   }
+  },
+  "Inspector": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "detached": {
+     "params": {
+      "reason": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "targetCrashed": {
+     "params": {}
+    },
+    "targetReloadedAfterCrash": {
+     "params": {}
+    },
+    "workerScriptLoaded": {
+     "params": {}
+    }
+   }
+  },
+  "LayerTree": {
+   "commands": {
+    "compositingReasons": {
+     "params": {
+      "layerId": {
+       "optional": false,
+       "type": "LayerId"
+      }
+     },
+     "returns": [
+      "compositingReasons",
+      "compositingReasonIds"
+     ]
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "loadSnapshot": {
+     "params": {
+      "tiles": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": [
+      "snapshotId"
+     ]
+    },
+    "makeSnapshot": {
+     "params": {
+      "layerId": {
+       "optional": false,
+       "type": "LayerId"
+      }
+     },
+     "returns": [
+      "snapshotId"
+     ]
+    },
+    "profileSnapshot": {
+     "params": {
+      "clipRect": {
+       "optional": true,
+       "type": "DOM.Rect"
+      },
+      "minDuration": {
+       "optional": true,
+       "type": "number"
+      },
+      "minRepeatCount": {
+       "optional": true,
+       "type": "integer"
+      },
+      "snapshotId": {
+       "optional": false,
+       "type": "SnapshotId"
+      }
+     },
+     "returns": [
+      "timings"
+     ]
+    },
+    "releaseSnapshot": {
+     "params": {
+      "snapshotId": {
+       "optional": false,
+       "type": "SnapshotId"
+      }
+     },
+     "returns": []
+    },
+    "replaySnapshot": {
+     "params": {
+      "fromStep": {
+       "optional": true,
+       "type": "integer"
+      },
+      "scale": {
+       "optional": true,
+       "type": "number"
+      },
+      "snapshotId": {
+       "optional": false,
+       "type": "SnapshotId"
+      },
+      "toStep": {
+       "optional": true,
+       "type": "integer"
+      }
+     },
+     "returns": [
+      "dataURL"
+     ]
+    },
+    "snapshotCommandLog": {
+     "params": {
+      "snapshotId": {
+       "optional": false,
+       "type": "SnapshotId"
+      }
+     },
+     "returns": [
+      "commandLog"
+     ]
+    }
+   },
+   "events": {
+    "layerPainted": {
+     "params": {
+      "clip": {
+       "optional": false,
+       "type": "DOM.Rect"
+      },
+      "layerId": {
+       "optional": false,
+       "type": "LayerId"
+      }
+     }
+    },
+    "layerTreeDidChange": {
+     "params": {
+      "layers": {
+       "optional": true,
+       "type": "array"
+      }
+     }
+    }
+   }
+  },
+  "Log": {
+   "commands": {
+    "clear": {
+     "params": {},
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "startViolationsReport": {
+     "params": {
+      "config": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "stopViolationsReport": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "entryAdded": {
+     "params": {
+      "entry": {
+       "optional": false,
+       "type": "LogEntry"
+      }
+     }
+    }
+   }
+  },
+  "Media": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "playerCreated": {
+     "params": {
+      "player": {
+       "optional": false,
+       "type": "Player"
+      }
+     }
+    },
+    "playerErrorsRaised": {
+     "params": {
+      "errors": {
+       "optional": false,
+       "type": "array"
+      },
+      "playerId": {
+       "optional": false,
+       "type": "PlayerId"
+      }
+     }
+    },
+    "playerEventsAdded": {
+     "params": {
+      "events": {
+       "optional": false,
+       "type": "array"
+      },
+      "playerId": {
+       "optional": false,
+       "type": "PlayerId"
+      }
+     }
+    },
+    "playerMessagesLogged": {
+     "params": {
+      "messages": {
+       "optional": false,
+       "type": "array"
+      },
+      "playerId": {
+       "optional": false,
+       "type": "PlayerId"
+      }
+     }
+    },
+    "playerPropertiesChanged": {
+     "params": {
+      "playerId": {
+       "optional": false,
+       "type": "PlayerId"
+      },
+      "properties": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    }
+   }
+  },
+  "Memory": {
+   "commands": {
+    "forciblyPurgeJavaScriptMemory": {
+     "params": {},
+     "returns": []
+    },
+    "getAllTimeSamplingProfile": {
+     "params": {},
+     "returns": [
+      "profile"
+     ]
+    },
+    "getBrowserSamplingProfile": {
+     "params": {},
+     "returns": [
+      "profile"
+     ]
+    },
+    "getDOMCounters": {
+     "params": {},
+     "returns": [
+      "documents",
+      "nodes",
+      "jsEventListeners"
+     ]
+    },
+    "getDOMCountersForLeakDetection": {
+     "params": {},
+     "returns": [
+      "counters"
+     ]
+    },
+    "getSamplingProfile": {
+     "params": {},
+     "returns": [
+      "profile"
+     ]
+    },
+    "prepareForLeakDetection": {
+     "params": {},
+     "returns": []
+    },
+    "setPressureNotificationsSuppressed": {
+     "params": {
+      "suppressed": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "simulatePressureNotification": {
+     "params": {
+      "level": {
+       "optional": false,
+       "type": "PressureLevel"
+      }
+     },
+     "returns": []
+    },
+    "startSampling": {
+     "params": {
+      "samplingInterval": {
+       "optional": true,
+       "type": "integer"
+      },
+      "suppressRandomness": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "stopSampling": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {}
+  },
+  "Network": {
+   "commands": {
+    "canClearBrowserCache": {
+     "params": {},
+     "returns": [
+      "result"
+     ]
+    },
+    "canClearBrowserCookies": {
+     "params": {},
+     "returns": [
+      "result"
+     ]
+    },
+    "canEmulateNetworkConditions": {
+     "params": {},
+     "returns": [
+      "result"
+     ]
+    },
+    "clearBrowserCache": {
+     "params": {},
+     "returns": []
+    },
+    "clearBrowserCookies": {
+     "params": {},
+     "returns": []
+    },
+    "configureDurableMessages": {
+     "params": {
+      "maxResourceBufferSize": {
+       "optional": true,
+       "type": "integer"
+      },
+      "maxTotalBufferSize": {
+       "optional": true,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "deleteCookies": {
+     "params": {
+      "domain": {
+       "optional": true,
+       "type": "string"
+      },
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "partitionKey": {
+       "optional": true,
+       "type": "CookiePartitionKey"
+      },
+      "path": {
+       "optional": true,
+       "type": "string"
+      },
+      "url": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "deleteDeviceBoundSession": {
+     "params": {
+      "key": {
+       "optional": false,
+       "type": "DeviceBoundSessionKey"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "emulateNetworkConditions": {
+     "params": {
+      "connectionType": {
+       "optional": true,
+       "type": "ConnectionType"
+      },
+      "downloadThroughput": {
+       "optional": false,
+       "type": "number"
+      },
+      "latency": {
+       "optional": false,
+       "type": "number"
+      },
+      "offline": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "packetLoss": {
+       "optional": true,
+       "type": "number"
+      },
+      "packetQueueLength": {
+       "optional": true,
+       "type": "integer"
+      },
+      "packetReordering": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "uploadThroughput": {
+       "optional": false,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "emulateNetworkConditionsByRule": {
+     "params": {
+      "emulateOfflineServiceWorker": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "matchedNetworkConditions": {
+       "optional": false,
+       "type": "array"
+      },
+      "offline": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "ruleIds"
+     ]
+    },
+    "enable": {
+     "params": {
+      "enableDurableMessages": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "maxPostDataSize": {
+       "optional": true,
+       "type": "integer"
+      },
+      "maxResourceBufferSize": {
+       "optional": true,
+       "type": "integer"
+      },
+      "maxTotalBufferSize": {
+       "optional": true,
+       "type": "integer"
+      },
+      "reportDirectSocketTraffic": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "enableDeviceBoundSessions": {
+     "params": {
+      "enable": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "enableReportingApi": {
+     "params": {
+      "enable": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "fetchSchemefulSite": {
+     "params": {
+      "origin": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "schemefulSite"
+     ]
+    },
+    "getAllCookies": {
+     "params": {},
+     "returns": [
+      "cookies"
+     ]
+    },
+    "getCertificate": {
+     "params": {
+      "origin": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "tableNames"
+     ]
+    },
+    "getCookies": {
+     "params": {
+      "urls": {
+       "optional": true,
+       "type": "array"
+      }
+     },
+     "returns": [
+      "cookies"
+     ]
+    },
+    "getRequestPostData": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": [
+      "postData",
+      "base64Encoded"
+     ]
+    },
+    "getResponseBody": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": [
+      "body",
+      "base64Encoded"
+     ]
+    },
+    "getSecurityIsolationStatus": {
+     "params": {
+      "frameId": {
+       "optional": true,
+       "type": "Page.FrameId"
+      }
+     },
+     "returns": [
+      "status"
+     ]
+    },
+    "loadNetworkResource": {
+     "params": {
+      "frameId": {
+       "optional": true,
+       "type": "Page.FrameId"
+      },
+      "options": {
+       "optional": false,
+       "type": "LoadNetworkResourceOptions"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "resource"
+     ]
+    },
+    "overrideNetworkState": {
+     "params": {
+      "connectionType": {
+       "optional": true,
+       "type": "ConnectionType"
+      },
+      "downloadThroughput": {
+       "optional": false,
+       "type": "number"
+      },
+      "latency": {
+       "optional": false,
+       "type": "number"
+      },
+      "offline": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "uploadThroughput": {
+       "optional": false,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "replayXHR": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": []
+    },
+    "searchInResponseBody": {
+     "params": {
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "query": {
+       "optional": false,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": [
+      "result"
+     ]
+    },
+    "setAttachDebugStack": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setBlockedURLs": {
+     "params": {
+      "urlPatterns": {
+       "optional": true,
+       "type": "array"
+      },
+      "urls": {
+       "optional": true,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "setBypassServiceWorker": {
+     "params": {
+      "bypass": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setCacheDisabled": {
+     "params": {
+      "cacheDisabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setCookie": {
+     "params": {
+      "domain": {
+       "optional": true,
+       "type": "string"
+      },
+      "expires": {
+       "optional": true,
+       "type": "TimeSinceEpoch"
+      },
+      "httpOnly": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "partitionKey": {
+       "optional": true,
+       "type": "CookiePartitionKey"
+      },
+      "path": {
+       "optional": true,
+       "type": "string"
+      },
+      "priority": {
+       "optional": true,
+       "type": "CookiePriority"
+      },
+      "sameSite": {
+       "optional": true,
+       "type": "CookieSameSite"
+      },
+      "secure": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "sourcePort": {
+       "optional": true,
+       "type": "integer"
+      },
+      "sourceScheme": {
+       "optional": true,
+       "type": "CookieSourceScheme"
+      },
+      "url": {
+       "optional": true,
+       "type": "string"
+      },
+      "value": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "success"
+     ]
+    },
+    "setCookieControls": {
+     "params": {
+      "enableThirdPartyCookieRestriction": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setCookies": {
+     "params": {
+      "cookies": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "setExtraHTTPHeaders": {
+     "params": {
+      "headers": {
+       "optional": false,
+       "type": "Headers"
+      }
+     },
+     "returns": []
+    },
+    "setUserAgentOverride": {
+     "params": {
+      "acceptLanguage": {
+       "optional": true,
+       "type": "string"
+      },
+      "platform": {
+       "optional": true,
+       "type": "string"
+      },
+      "userAgent": {
+       "optional": false,
+       "type": "string"
+      },
+      "userAgentMetadata": {
+       "optional": true,
+       "type": "Emulation.UserAgentMetadata"
+      }
+     },
+     "returns": []
+    },
+    "streamResourceContent": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": [
+      "bufferedData"
+     ]
+    }
+   },
+   "events": {
+    "dataReceived": {
+     "params": {
+      "data": {
+       "optional": true,
+       "type": "string"
+      },
+      "dataLength": {
+       "optional": false,
+       "type": "integer"
+      },
+      "encodedDataLength": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "deviceBoundSessionEventOccurred": {
+     "params": {
+      "challengeEventDetails": {
+       "optional": true,
+       "type": "ChallengeEventDetails"
+      },
+      "creationEventDetails": {
+       "optional": true,
+       "type": "CreationEventDetails"
+      },
+      "eventId": {
+       "optional": false,
+       "type": "DeviceBoundSessionEventId"
+      },
+      "refreshEventDetails": {
+       "optional": true,
+       "type": "RefreshEventDetails"
+      },
+      "sessionId": {
+       "optional": true,
+       "type": "string"
+      },
+      "site": {
+       "optional": false,
+       "type": "string"
+      },
+      "succeeded": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "terminationEventDetails": {
+       "optional": true,
+       "type": "TerminationEventDetails"
+      }
+     }
+    },
+    "deviceBoundSessionsAdded": {
+     "params": {
+      "sessions": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    },
+    "directTCPSocketAborted": {
+     "params": {
+      "errorMessage": {
+       "optional": false,
+       "type": "ErrorReason"
+      },
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "directTCPSocketChunkReceived": {
+     "params": {
+      "data": {
+       "optional": false,
+       "type": "string"
+      },
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "directTCPSocketChunkSent": {
+     "params": {
+      "data": {
+       "optional": false,
+       "type": "string"
+      },
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "directTCPSocketClosed": {
+     "params": {
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "directTCPSocketCreated": {
+     "params": {
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "initiator": {
+       "optional": true,
+       "type": "Initiator"
+      },
+      "options": {
+       "optional": false,
+       "type": "DirectTCPSocketOptions"
+      },
+      "remoteAddr": {
+       "optional": false,
+       "type": "string"
+      },
+      "remotePort": {
+       "optional": false,
+       "type": "integer"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "directTCPSocketOpened": {
+     "params": {
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "localAddr": {
+       "optional": true,
+       "type": "string"
+      },
+      "localPort": {
+       "optional": true,
+       "type": "integer"
+      },
+      "remoteAddr": {
+       "optional": false,
+       "type": "string"
+      },
+      "remotePort": {
+       "optional": false,
+       "type": "integer"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "directUDPSocketAborted": {
+     "params": {
+      "errorMessage": {
+       "optional": false,
+       "type": "ErrorReason"
+      },
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "directUDPSocketChunkReceived": {
+     "params": {
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "message": {
+       "optional": false,
+       "type": "DirectUDPMessage"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "directUDPSocketChunkSent": {
+     "params": {
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "message": {
+       "optional": false,
+       "type": "DirectUDPMessage"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "directUDPSocketClosed": {
+     "params": {
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "directUDPSocketCreated": {
+     "params": {
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "initiator": {
+       "optional": true,
+       "type": "Initiator"
+      },
+      "options": {
+       "optional": false,
+       "type": "DirectUDPSocketOptions"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "directUDPSocketJoinedMulticastGroup": {
+     "params": {
+      "IPAddress": {
+       "optional": false,
+       "type": "string"
+      },
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     }
+    },
+    "directUDPSocketLeftMulticastGroup": {
+     "params": {
+      "IPAddress": {
+       "optional": false,
+       "type": "string"
+      },
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     }
+    },
+    "directUDPSocketOpened": {
+     "params": {
+      "identifier": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "localAddr": {
+       "optional": false,
+       "type": "string"
+      },
+      "localPort": {
+       "optional": false,
+       "type": "integer"
+      },
+      "remoteAddr": {
+       "optional": true,
+       "type": "string"
+      },
+      "remotePort": {
+       "optional": true,
+       "type": "integer"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "eventSourceMessageReceived": {
+     "params": {
+      "data": {
+       "optional": false,
+       "type": "string"
+      },
+      "eventId": {
+       "optional": false,
+       "type": "string"
+      },
+      "eventName": {
+       "optional": false,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "loadingFailed": {
+     "params": {
+      "blockedReason": {
+       "optional": true,
+       "type": "BlockedReason"
+      },
+      "canceled": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "corsErrorStatus": {
+       "optional": true,
+       "type": "CorsErrorStatus"
+      },
+      "errorText": {
+       "optional": false,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      },
+      "type": {
+       "optional": false,
+       "type": "ResourceType"
+      }
+     }
+    },
+    "loadingFinished": {
+     "params": {
+      "encodedDataLength": {
+       "optional": false,
+       "type": "number"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "policyUpdated": {
+     "params": {}
+    },
+    "reportingApiEndpointsChangedForOrigin": {
+     "params": {
+      "endpoints": {
+       "optional": false,
+       "type": "array"
+      },
+      "origin": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "reportingApiReportAdded": {
+     "params": {
+      "report": {
+       "optional": false,
+       "type": "ReportingApiReport"
+      }
+     }
+    },
+    "reportingApiReportUpdated": {
+     "params": {
+      "report": {
+       "optional": false,
+       "type": "ReportingApiReport"
+      }
+     }
+    },
+    "requestServedFromCache": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     }
+    },
+    "requestWillBeSent": {
+     "params": {
+      "documentURL": {
+       "optional": false,
+       "type": "string"
+      },
+      "frameId": {
+       "optional": true,
+       "type": "Page.FrameId"
+      },
+      "hasUserGesture": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "initiator": {
+       "optional": false,
+       "type": "Initiator"
+      },
+      "loaderId": {
+       "optional": false,
+       "type": "LoaderId"
+      },
+      "redirectHasExtraInfo": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "redirectResponse": {
+       "optional": true,
+       "type": "Response"
+      },
+      "renderBlockingBehavior": {
+       "optional": true,
+       "type": "RenderBlockingBehavior"
+      },
+      "request": {
+       "optional": false,
+       "type": "Request"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      },
+      "type": {
+       "optional": true,
+       "type": "ResourceType"
+      },
+      "wallTime": {
+       "optional": false,
+       "type": "TimeSinceEpoch"
+      }
+     }
+    },
+    "requestWillBeSentExtraInfo": {
+     "params": {
+      "appliedNetworkConditionsId": {
+       "optional": true,
+       "type": "string"
+      },
+      "associatedCookies": {
+       "optional": false,
+       "type": "array"
+      },
+      "clientSecurityState": {
+       "optional": true,
+       "type": "ClientSecurityState"
+      },
+      "connectTiming": {
+       "optional": false,
+       "type": "ConnectTiming"
+      },
+      "deviceBoundSessionUsages": {
+       "optional": true,
+       "type": "array"
+      },
+      "headers": {
+       "optional": false,
+       "type": "Headers"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "siteHasCookieInOtherPartition": {
+       "optional": true,
+       "type": "boolean"
+      }
+     }
+    },
+    "resourceChangedPriority": {
+     "params": {
+      "newPriority": {
+       "optional": false,
+       "type": "ResourcePriority"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "responseReceived": {
+     "params": {
+      "frameId": {
+       "optional": true,
+       "type": "Page.FrameId"
+      },
+      "hasExtraInfo": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "loaderId": {
+       "optional": false,
+       "type": "LoaderId"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "response": {
+       "optional": false,
+       "type": "Response"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      },
+      "type": {
+       "optional": false,
+       "type": "ResourceType"
+      }
+     }
+    },
+    "responseReceivedEarlyHints": {
+     "params": {
+      "headers": {
+       "optional": false,
+       "type": "Headers"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     }
+    },
+    "responseReceivedExtraInfo": {
+     "params": {
+      "blockedCookies": {
+       "optional": false,
+       "type": "array"
+      },
+      "cookiePartitionKey": {
+       "optional": true,
+       "type": "CookiePartitionKey"
+      },
+      "cookiePartitionKeyOpaque": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "exemptedCookies": {
+       "optional": true,
+       "type": "array"
+      },
+      "headers": {
+       "optional": false,
+       "type": "Headers"
+      },
+      "headersText": {
+       "optional": true,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "resourceIPAddressSpace": {
+       "optional": false,
+       "type": "IPAddressSpace"
+      },
+      "statusCode": {
+       "optional": false,
+       "type": "integer"
+      }
+     }
+    },
+    "signedExchangeReceived": {
+     "params": {
+      "info": {
+       "optional": false,
+       "type": "SignedExchangeInfo"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     }
+    },
+    "trustTokenOperationDone": {
+     "params": {
+      "issuedTokenCount": {
+       "optional": true,
+       "type": "integer"
+      },
+      "issuerOrigin": {
+       "optional": true,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "status": {
+       "optional": false,
+       "type": "string"
+      },
+      "topLevelOrigin": {
+       "optional": true,
+       "type": "string"
+      },
+      "type": {
+       "optional": false,
+       "type": "TrustTokenOperationType"
+      }
+     }
+    },
+    "webSocketClosed": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "webSocketCreated": {
+     "params": {
+      "initiator": {
+       "optional": true,
+       "type": "Initiator"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "webSocketFrameError": {
+     "params": {
+      "errorMessage": {
+       "optional": false,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "webSocketFrameReceived": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "response": {
+       "optional": false,
+       "type": "WebSocketFrame"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "webSocketFrameSent": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "response": {
+       "optional": false,
+       "type": "WebSocketFrame"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "webSocketHandshakeResponseReceived": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "response": {
+       "optional": false,
+       "type": "WebSocketResponse"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      }
+     }
+    },
+    "webSocketWillSendHandshakeRequest": {
+     "params": {
+      "request": {
+       "optional": false,
+       "type": "WebSocketRequest"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      },
+      "wallTime": {
+       "optional": false,
+       "type": "TimeSinceEpoch"
+      }
+     }
+    },
+    "webTransportClosed": {
+     "params": {
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      },
+      "transportId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     }
+    },
+    "webTransportConnectionEstablished": {
+     "params": {
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      },
+      "transportId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     }
+    },
+    "webTransportCreated": {
+     "params": {
+      "initiator": {
+       "optional": true,
+       "type": "Initiator"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "MonotonicTime"
+      },
+      "transportId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    }
+   }
+  },
+  "Overlay": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getGridHighlightObjectsForTest": {
+     "params": {
+      "nodeIds": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": [
+      "highlights"
+     ]
+    },
+    "getHighlightObjectForTest": {
+     "params": {
+      "colorFormat": {
+       "optional": true,
+       "type": "ColorFormat"
+      },
+      "includeDistance": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includeStyle": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      },
+      "showAccessibilityInfo": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "highlight"
+     ]
+    },
+    "getSourceOrderHighlightObjectForTest": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "highlight"
+     ]
+    },
+    "hideHighlight": {
+     "params": {},
+     "returns": []
+    },
+    "highlightFrame": {
+     "params": {
+      "contentColor": {
+       "optional": true,
+       "type": "DOM.RGBA"
+      },
+      "contentOutlineColor": {
+       "optional": true,
+       "type": "DOM.RGBA"
+      },
+      "frameId": {
+       "optional": false,
+       "type": "Page.FrameId"
+      }
+     },
+     "returns": []
+    },
+    "highlightNode": {
+     "params": {
+      "backendNodeId": {
+       "optional": true,
+       "type": "DOM.BackendNodeId"
+      },
+      "highlightConfig": {
+       "optional": false,
+       "type": "HighlightConfig"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "DOM.NodeId"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "Runtime.RemoteObjectId"
+      },
+      "selector": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "highlightQuad": {
+     "params": {
+      "color": {
+       "optional": true,
+       "type": "DOM.RGBA"
+      },
+      "outlineColor": {
+       "optional": true,
+       "type": "DOM.RGBA"
+      },
+      "quad": {
+       "optional": false,
+       "type": "DOM.Quad"
+      }
+     },
+     "returns": []
+    },
+    "highlightRect": {
+     "params": {
+      "color": {
+       "optional": true,
+       "type": "DOM.RGBA"
+      },
+      "height": {
+       "optional": false,
+       "type": "integer"
+      },
+      "outlineColor": {
+       "optional": true,
+       "type": "DOM.RGBA"
+      },
+      "width": {
+       "optional": false,
+       "type": "integer"
+      },
+      "x": {
+       "optional": false,
+       "type": "integer"
+      },
+      "y": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "highlightSourceOrder": {
+     "params": {
+      "backendNodeId": {
+       "optional": true,
+       "type": "DOM.BackendNodeId"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "DOM.NodeId"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "Runtime.RemoteObjectId"
+      },
+      "sourceOrderConfig": {
+       "optional": false,
+       "type": "SourceOrderConfig"
+      }
+     },
+     "returns": []
+    },
+    "setInspectMode": {
+     "params": {
+      "highlightConfig": {
+       "optional": true,
+       "type": "HighlightConfig"
+      },
+      "mode": {
+       "optional": false,
+       "type": "InspectMode"
+      }
+     },
+     "returns": []
+    },
+    "setPausedInDebuggerMessage": {
+     "params": {
+      "message": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setShowAdHighlights": {
+     "params": {
+      "show": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setShowContainerQueryOverlays": {
+     "params": {
+      "containerQueryHighlightConfigs": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "setShowDebugBorders": {
+     "params": {
+      "show": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setShowDisplayCutout": {
+     "params": {
+      "displayCutoutConfig": {
+       "optional": true,
+       "type": "DisplayCutoutConfig"
+      }
+     },
+     "returns": []
+    },
+    "setShowFPSCounter": {
+     "params": {
+      "show": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setShowFlexOverlays": {
+     "params": {
+      "flexNodeHighlightConfigs": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "setShowGridOverlays": {
+     "params": {
+      "gridNodeHighlightConfigs": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "setShowHinge": {
+     "params": {
+      "hingeConfig": {
+       "optional": true,
+       "type": "HingeConfig"
+      }
+     },
+     "returns": []
+    },
+    "setShowHitTestBorders": {
+     "params": {
+      "show": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setShowInspectedElementAnchor": {
+     "params": {
+      "inspectedElementAnchorConfig": {
+       "optional": false,
+       "type": "InspectedElementAnchorConfig"
+      }
+     },
+     "returns": []
+    },
+    "setShowIsolatedElements": {
+     "params": {
+      "isolatedElementHighlightConfigs": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "setShowLayoutShiftRegions": {
+     "params": {
+      "result": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setShowPaintRects": {
+     "params": {
+      "result": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setShowScrollBottleneckRects": {
+     "params": {
+      "show": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setShowScrollSnapOverlays": {
+     "params": {
+      "scrollSnapHighlightConfigs": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "setShowViewportSizeOnResize": {
+     "params": {
+      "show": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setShowWebVitals": {
+     "params": {
+      "show": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setShowWindowControlsOverlay": {
+     "params": {
+      "windowControlsOverlayConfig": {
+       "optional": true,
+       "type": "WindowControlsOverlayConfig"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "inspectModeCanceled": {
+     "params": {}
+    },
+    "inspectNodeRequested": {
+     "params": {
+      "backendNodeId": {
+       "optional": false,
+       "type": "DOM.BackendNodeId"
+      }
+     }
+    },
+    "inspectPanelShowRequested": {
+     "params": {
+      "backendNodeId": {
+       "optional": false,
+       "type": "DOM.BackendNodeId"
+      }
+     }
+    },
+    "inspectedElementWindowRestored": {
+     "params": {
+      "backendNodeId": {
+       "optional": false,
+       "type": "DOM.BackendNodeId"
+      }
+     }
+    },
+    "nodeHighlightRequested": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     }
+    },
+    "screenshotRequested": {
+     "params": {
+      "viewport": {
+       "optional": false,
+       "type": "Page.Viewport"
+      }
+     }
+    }
+   }
+  },
+  "PWA": {
+   "commands": {
+    "changeAppUserSettings": {
+     "params": {
+      "displayMode": {
+       "optional": true,
+       "type": "DisplayMode"
+      },
+      "linkCapturing": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "manifestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "getOsAppState": {
+     "params": {
+      "manifestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "badgeCount",
+      "fileHandlers"
+     ]
+    },
+    "install": {
+     "params": {
+      "installUrlOrBundleUrl": {
+       "optional": true,
+       "type": "string"
+      },
+      "manifestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "launch": {
+     "params": {
+      "manifestId": {
+       "optional": false,
+       "type": "string"
+      },
+      "url": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "targetId"
+     ]
+    },
+    "launchFilesInApp": {
+     "params": {
+      "files": {
+       "optional": false,
+       "type": "array"
+      },
+      "manifestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "targetIds"
+     ]
+    },
+    "openCurrentPageInApp": {
+     "params": {
+      "manifestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "uninstall": {
+     "params": {
+      "manifestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {}
+  },
+  "Page": {
+   "commands": {
+    "addCompilationCache": {
+     "params": {
+      "data": {
+       "optional": false,
+       "type": "string"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "addScriptToEvaluateOnLoad": {
+     "params": {
+      "scriptSource": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "identifier"
+     ]
+    },
+    "addScriptToEvaluateOnNewDocument": {
+     "params": {
+      "includeCommandLineAPI": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "runImmediately": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "source": {
+       "optional": false,
+       "type": "string"
+      },
+      "worldName": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "identifier"
+     ]
+    },
+    "bringToFront": {
+     "params": {},
+     "returns": []
+    },
+    "captureScreenshot": {
+     "params": {
+      "captureBeyondViewport": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "clip": {
+       "optional": true,
+       "type": "Viewport"
+      },
+      "format": {
+       "optional": true,
+       "type": "string"
+      },
+      "fromSurface": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "optimizeForSpeed": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "quality": {
+       "optional": true,
+       "type": "integer"
+      }
+     },
+     "returns": [
+      "data"
+     ]
+    },
+    "captureSnapshot": {
+     "params": {
+      "format": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "data"
+     ]
+    },
+    "clearCompilationCache": {
+     "params": {},
+     "returns": []
+    },
+    "clearDeviceMetricsOverride": {
+     "params": {},
+     "returns": []
+    },
+    "clearDeviceOrientationOverride": {
+     "params": {},
+     "returns": []
+    },
+    "clearGeolocationOverride": {
+     "params": {},
+     "returns": []
+    },
+    "close": {
+     "params": {},
+     "returns": []
+    },
+    "crash": {
+     "params": {},
+     "returns": []
+    },
+    "createIsolatedWorld": {
+     "params": {
+      "contentSecurityPolicy": {
+       "optional": true,
+       "type": "string"
+      },
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "grantUniveralAccess": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "worldName": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "executionContextId"
+     ]
+    },
+    "deleteCookie": {
+     "params": {
+      "cookieName": {
+       "optional": false,
+       "type": "string"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {
+      "enableFileChooserOpenedEvent": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "generateTestReport": {
+     "params": {
+      "group": {
+       "optional": true,
+       "type": "string"
+      },
+      "message": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "getAdScriptAncestry": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      }
+     },
+     "returns": [
+      "adScriptAncestry"
+     ]
+    },
+    "getAnnotatedPageContent": {
+     "params": {
+      "includeActionableInformation": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "content"
+     ]
+    },
+    "getAppId": {
+     "params": {},
+     "returns": [
+      "appId",
+      "recommendedId"
+     ]
+    },
+    "getAppManifest": {
+     "params": {
+      "manifestId": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "url",
+      "errors",
+      "data",
+      "parsed",
+      "manifest"
+     ]
+    },
+    "getFrameTree": {
+     "params": {},
+     "returns": [
+      "frameTree"
+     ]
+    },
+    "getInstallabilityErrors": {
+     "params": {},
+     "returns": [
+      "installabilityErrors"
+     ]
+    },
+    "getLayoutMetrics": {
+     "params": {},
+     "returns": [
+      "layoutViewport",
+      "visualViewport",
+      "contentSize",
+      "cssLayoutViewport",
+      "cssVisualViewport",
+      "cssContentSize"
+     ]
+    },
+    "getManifestIcons": {
+     "params": {},
+     "returns": [
+      "primaryIcon"
+     ]
+    },
+    "getNavigationHistory": {
+     "params": {},
+     "returns": [
+      "currentIndex",
+      "entries"
+     ]
+    },
+    "getOriginTrials": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      }
+     },
+     "returns": [
+      "originTrials"
+     ]
+    },
+    "getPermissionsPolicyState": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      }
+     },
+     "returns": [
+      "states"
+     ]
+    },
+    "getResourceContent": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "content",
+      "base64Encoded"
+     ]
+    },
+    "getResourceTree": {
+     "params": {},
+     "returns": [
+      "frameTree"
+     ]
+    },
+    "handleJavaScriptDialog": {
+     "params": {
+      "accept": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "promptText": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "navigate": {
+     "params": {
+      "frameId": {
+       "optional": true,
+       "type": "FrameId"
+      },
+      "referrer": {
+       "optional": true,
+       "type": "string"
+      },
+      "referrerPolicy": {
+       "optional": true,
+       "type": "ReferrerPolicy"
+      },
+      "transitionType": {
+       "optional": true,
+       "type": "TransitionType"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "frameId",
+      "loaderId",
+      "errorText",
+      "isDownload"
+     ]
+    },
+    "navigateToHistoryEntry": {
+     "params": {
+      "entryId": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "printToPDF": {
+     "params": {
+      "displayHeaderFooter": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "footerTemplate": {
+       "optional": true,
+       "type": "string"
+      },
+      "generateDocumentOutline": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "generateTaggedPDF": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "headerTemplate": {
+       "optional": true,
+       "type": "string"
+      },
+      "landscape": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "marginBottom": {
+       "optional": true,
+       "type": "number"
+      },
+      "marginLeft": {
+       "optional": true,
+       "type": "number"
+      },
+      "marginRight": {
+       "optional": true,
+       "type": "number"
+      },
+      "marginTop": {
+       "optional": true,
+       "type": "number"
+      },
+      "pageRanges": {
+       "optional": true,
+       "type": "string"
+      },
+      "paperHeight": {
+       "optional": true,
+       "type": "number"
+      },
+      "paperWidth": {
+       "optional": true,
+       "type": "number"
+      },
+      "preferCSSPageSize": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "printBackground": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "scale": {
+       "optional": true,
+       "type": "number"
+      },
+      "transferMode": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "data",
+      "stream"
+     ]
+    },
+    "produceCompilationCache": {
+     "params": {
+      "scripts": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "reload": {
+     "params": {
+      "ignoreCache": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "loaderId": {
+       "optional": true,
+       "type": "Network.LoaderId"
+      },
+      "scriptToEvaluateOnLoad": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "removeScriptToEvaluateOnLoad": {
+     "params": {
+      "identifier": {
+       "optional": false,
+       "type": "ScriptIdentifier"
+      }
+     },
+     "returns": []
+    },
+    "removeScriptToEvaluateOnNewDocument": {
+     "params": {
+      "identifier": {
+       "optional": false,
+       "type": "ScriptIdentifier"
+      }
+     },
+     "returns": []
+    },
+    "resetNavigationHistory": {
+     "params": {},
+     "returns": []
+    },
+    "screencastFrameAck": {
+     "params": {
+      "sessionId": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "searchInResource": {
+     "params": {
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "query": {
+       "optional": false,
+       "type": "string"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "result"
+     ]
+    },
+    "setAdBlockingEnabled": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setBypassCSP": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setDeviceMetricsOverride": {
+     "params": {
+      "deviceScaleFactor": {
+       "optional": false,
+       "type": "number"
+      },
+      "dontSetVisibleSize": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "height": {
+       "optional": false,
+       "type": "integer"
+      },
+      "mobile": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "positionX": {
+       "optional": true,
+       "type": "integer"
+      },
+      "positionY": {
+       "optional": true,
+       "type": "integer"
+      },
+      "scale": {
+       "optional": true,
+       "type": "number"
+      },
+      "screenHeight": {
+       "optional": true,
+       "type": "integer"
+      },
+      "screenOrientation": {
+       "optional": true,
+       "type": "Emulation.ScreenOrientation"
+      },
+      "screenWidth": {
+       "optional": true,
+       "type": "integer"
+      },
+      "viewport": {
+       "optional": true,
+       "type": "Viewport"
+      },
+      "width": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "setDeviceOrientationOverride": {
+     "params": {
+      "alpha": {
+       "optional": false,
+       "type": "number"
+      },
+      "beta": {
+       "optional": false,
+       "type": "number"
+      },
+      "gamma": {
+       "optional": false,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "setDocumentContent": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "html": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setDownloadBehavior": {
+     "params": {
+      "behavior": {
+       "optional": false,
+       "type": "string"
+      },
+      "downloadPath": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setFontFamilies": {
+     "params": {
+      "fontFamilies": {
+       "optional": false,
+       "type": "FontFamilies"
+      },
+      "forScripts": {
+       "optional": true,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "setFontSizes": {
+     "params": {
+      "fontSizes": {
+       "optional": false,
+       "type": "FontSizes"
+      }
+     },
+     "returns": []
+    },
+    "setGeolocationOverride": {
+     "params": {
+      "accuracy": {
+       "optional": true,
+       "type": "number"
+      },
+      "latitude": {
+       "optional": true,
+       "type": "number"
+      },
+      "longitude": {
+       "optional": true,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "setInterceptFileChooserDialog": {
+     "params": {
+      "cancel": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setLifecycleEventsEnabled": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setPrerenderingAllowed": {
+     "params": {
+      "isAllowed": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setRPHRegistrationMode": {
+     "params": {
+      "mode": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setSPCTransactionMode": {
+     "params": {
+      "mode": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setTouchEmulationEnabled": {
+     "params": {
+      "configuration": {
+       "optional": true,
+       "type": "string"
+      },
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setWebLifecycleState": {
+     "params": {
+      "state": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "startScreenRecording": {
+     "params": {
+      "audio": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "frameRate": {
+       "optional": true,
+       "type": "integer"
+      },
+      "maxHeight": {
+       "optional": true,
+       "type": "integer"
+      },
+      "maxWidth": {
+       "optional": true,
+       "type": "integer"
+      }
+     },
+     "returns": [
+      "stream"
+     ]
+    },
+    "startScreencast": {
+     "params": {
+      "everyNthFrame": {
+       "optional": true,
+       "type": "integer"
+      },
+      "format": {
+       "optional": true,
+       "type": "string"
+      },
+      "maxFramesInFlight": {
+       "optional": true,
+       "type": "integer"
+      },
+      "maxHeight": {
+       "optional": true,
+       "type": "integer"
+      },
+      "maxWidth": {
+       "optional": true,
+       "type": "integer"
+      },
+      "quality": {
+       "optional": true,
+       "type": "integer"
+      },
+      "sendLastFrame": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "stopLoading": {
+     "params": {},
+     "returns": []
+    },
+    "stopScreenRecording": {
+     "params": {},
+     "returns": [
+      "stream"
+     ]
+    },
+    "stopScreencast": {
+     "params": {},
+     "returns": []
+    },
+    "waitForDebugger": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "backForwardCacheNotUsed": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "loaderId": {
+       "optional": false,
+       "type": "Network.LoaderId"
+      },
+      "notRestoredExplanations": {
+       "optional": false,
+       "type": "array"
+      },
+      "notRestoredExplanationsTree": {
+       "optional": true,
+       "type": "BackForwardCacheNotRestoredExplanationTree"
+      }
+     }
+    },
+    "compilationCacheProduced": {
+     "params": {
+      "data": {
+       "optional": false,
+       "type": "string"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "documentOpened": {
+     "params": {
+      "frame": {
+       "optional": false,
+       "type": "Frame"
+      }
+     }
+    },
+    "domContentEventFired": {
+     "params": {
+      "timestamp": {
+       "optional": false,
+       "type": "Network.MonotonicTime"
+      }
+     }
+    },
+    "downloadProgress": {
+     "params": {
+      "guid": {
+       "optional": false,
+       "type": "string"
+      },
+      "receivedBytes": {
+       "optional": false,
+       "type": "number"
+      },
+      "state": {
+       "optional": false,
+       "type": "string"
+      },
+      "totalBytes": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "downloadWillBegin": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "guid": {
+       "optional": false,
+       "type": "string"
+      },
+      "suggestedFilename": {
+       "optional": false,
+       "type": "string"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "fileChooserOpened": {
+     "params": {
+      "backendNodeId": {
+       "optional": true,
+       "type": "DOM.BackendNodeId"
+      },
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "mode": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "frameAttached": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "parentFrameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "stack": {
+       "optional": true,
+       "type": "Runtime.StackTrace"
+      }
+     }
+    },
+    "frameClearedScheduledNavigation": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      }
+     }
+    },
+    "frameDetached": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "reason": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "frameNavigated": {
+     "params": {
+      "frame": {
+       "optional": false,
+       "type": "Frame"
+      },
+      "type": {
+       "optional": false,
+       "type": "NavigationType"
+      }
+     }
+    },
+    "frameRequestedNavigation": {
+     "params": {
+      "disposition": {
+       "optional": false,
+       "type": "ClientNavigationDisposition"
+      },
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "reason": {
+       "optional": false,
+       "type": "ClientNavigationReason"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "frameResized": {
+     "params": {}
+    },
+    "frameScheduledNavigation": {
+     "params": {
+      "delay": {
+       "optional": false,
+       "type": "number"
+      },
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "reason": {
+       "optional": false,
+       "type": "ClientNavigationReason"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "frameStartedLoading": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      }
+     }
+    },
+    "frameStartedNavigating": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "loaderId": {
+       "optional": false,
+       "type": "Network.LoaderId"
+      },
+      "navigationType": {
+       "optional": false,
+       "type": "string"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "frameStoppedLoading": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      }
+     }
+    },
+    "frameSubtreeWillBeDetached": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      }
+     }
+    },
+    "interstitialHidden": {
+     "params": {}
+    },
+    "interstitialShown": {
+     "params": {}
+    },
+    "javascriptDialogClosed": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "result": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "userInput": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "javascriptDialogOpening": {
+     "params": {
+      "defaultPrompt": {
+       "optional": true,
+       "type": "string"
+      },
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "hasBrowserHandler": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "message": {
+       "optional": false,
+       "type": "string"
+      },
+      "type": {
+       "optional": false,
+       "type": "DialogType"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "lifecycleEvent": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "loaderId": {
+       "optional": false,
+       "type": "Network.LoaderId"
+      },
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Network.MonotonicTime"
+      }
+     }
+    },
+    "loadEventFired": {
+     "params": {
+      "timestamp": {
+       "optional": false,
+       "type": "Network.MonotonicTime"
+      }
+     }
+    },
+    "navigatedWithinDocument": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "navigationType": {
+       "optional": false,
+       "type": "string"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "screencastFrame": {
+     "params": {
+      "data": {
+       "optional": false,
+       "type": "string"
+      },
+      "metadata": {
+       "optional": false,
+       "type": "ScreencastFrameMetadata"
+      },
+      "sessionId": {
+       "optional": false,
+       "type": "integer"
+      }
+     }
+    },
+    "screencastVisibilityChanged": {
+     "params": {
+      "visible": {
+       "optional": false,
+       "type": "boolean"
+      }
+     }
+    },
+    "windowOpen": {
+     "params": {
+      "url": {
+       "optional": false,
+       "type": "string"
+      },
+      "userGesture": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "windowFeatures": {
+       "optional": false,
+       "type": "array"
+      },
+      "windowName": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    }
+   }
+  },
+  "Performance": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {
+      "timeDomain": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "getMetrics": {
+     "params": {},
+     "returns": [
+      "metrics"
+     ]
+    },
+    "setTimeDomain": {
+     "params": {
+      "timeDomain": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "metrics": {
+     "params": {
+      "metrics": {
+       "optional": false,
+       "type": "array"
+      },
+      "title": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    }
+   }
+  },
+  "PerformanceTimeline": {
+   "commands": {
+    "enable": {
+     "params": {
+      "eventTypes": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "timelineEventAdded": {
+     "params": {
+      "event": {
+       "optional": false,
+       "type": "TimelineEvent"
+      }
+     }
+    }
+   }
+  },
+  "Preload": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "prefetchStatusUpdated": {
+     "params": {
+      "initiatingFrameId": {
+       "optional": false,
+       "type": "Page.FrameId"
+      },
+      "key": {
+       "optional": false,
+       "type": "PreloadingAttemptKey"
+      },
+      "pipelineId": {
+       "optional": false,
+       "type": "PreloadPipelineId"
+      },
+      "prefetchStatus": {
+       "optional": false,
+       "type": "PrefetchStatus"
+      },
+      "prefetchUrl": {
+       "optional": false,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "Network.RequestId"
+      },
+      "status": {
+       "optional": false,
+       "type": "PreloadingStatus"
+      }
+     }
+    },
+    "preloadEnabledStateUpdated": {
+     "params": {
+      "disabledByBatterySaver": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "disabledByDataSaver": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "disabledByHoldbackPrefetchSpeculationRules": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "disabledByHoldbackPrerenderSpeculationRules": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "disabledByPreference": {
+       "optional": false,
+       "type": "boolean"
+      }
+     }
+    },
+    "preloadingAttemptSourcesUpdated": {
+     "params": {
+      "loaderId": {
+       "optional": false,
+       "type": "Network.LoaderId"
+      },
+      "preloadingAttemptSources": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    },
+    "prerenderStatusUpdated": {
+     "params": {
+      "disallowedMojoInterface": {
+       "optional": true,
+       "type": "string"
+      },
+      "key": {
+       "optional": false,
+       "type": "PreloadingAttemptKey"
+      },
+      "mismatchedHeaders": {
+       "optional": true,
+       "type": "array"
+      },
+      "pipelineId": {
+       "optional": false,
+       "type": "PreloadPipelineId"
+      },
+      "prerenderStatus": {
+       "optional": true,
+       "type": "PrerenderFinalStatus"
+      },
+      "status": {
+       "optional": false,
+       "type": "PreloadingStatus"
+      }
+     }
+    },
+    "ruleSetRemoved": {
+     "params": {
+      "id": {
+       "optional": false,
+       "type": "RuleSetId"
+      }
+     }
+    },
+    "ruleSetUpdated": {
+     "params": {
+      "ruleSet": {
+       "optional": false,
+       "type": "RuleSet"
+      }
+     }
+    }
+   }
+  },
+  "Profiler": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getBestEffortCoverage": {
+     "params": {},
+     "returns": [
+      "result"
+     ]
+    },
+    "setSamplingInterval": {
+     "params": {
+      "interval": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "start": {
+     "params": {},
+     "returns": []
+    },
+    "startPreciseCoverage": {
+     "params": {
+      "allowTriggeredUpdates": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "callCount": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "detailed": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "timestamp"
+     ]
+    },
+    "stop": {
+     "params": {},
+     "returns": [
+      "profile"
+     ]
+    },
+    "stopPreciseCoverage": {
+     "params": {},
+     "returns": []
+    },
+    "takePreciseCoverage": {
+     "params": {},
+     "returns": [
+      "result",
+      "timestamp"
+     ]
+    }
+   },
+   "events": {
+    "consoleProfileFinished": {
+     "params": {
+      "id": {
+       "optional": false,
+       "type": "string"
+      },
+      "location": {
+       "optional": false,
+       "type": "Debugger.Location"
+      },
+      "profile": {
+       "optional": false,
+       "type": "Profile"
+      },
+      "title": {
+       "optional": true,
+       "type": "string"
+      }
+     }
+    },
+    "consoleProfileStarted": {
+     "params": {
+      "id": {
+       "optional": false,
+       "type": "string"
+      },
+      "location": {
+       "optional": false,
+       "type": "Debugger.Location"
+      },
+      "title": {
+       "optional": true,
+       "type": "string"
+      }
+     }
+    },
+    "preciseCoverageDeltaUpdate": {
+     "params": {
+      "occasion": {
+       "optional": false,
+       "type": "string"
+      },
+      "result": {
+       "optional": false,
+       "type": "array"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    }
+   }
+  },
+  "Runtime": {
+   "commands": {
+    "addBinding": {
+     "params": {
+      "executionContextId": {
+       "optional": true,
+       "type": "ExecutionContextId"
+      },
+      "executionContextName": {
+       "optional": true,
+       "type": "string"
+      },
+      "name": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "awaitPromise": {
+     "params": {
+      "generatePreview": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "promiseObjectId": {
+       "optional": false,
+       "type": "RemoteObjectId"
+      },
+      "returnByValue": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "result",
+      "exceptionDetails"
+     ]
+    },
+    "callFunctionOn": {
+     "params": {
+      "arguments": {
+       "optional": true,
+       "type": "array"
+      },
+      "awaitPromise": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "executionContextId": {
+       "optional": true,
+       "type": "ExecutionContextId"
+      },
+      "functionDeclaration": {
+       "optional": false,
+       "type": "string"
+      },
+      "generatePreview": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "RemoteObjectId"
+      },
+      "returnByValue": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "serializationOptions": {
+       "optional": true,
+       "type": "SerializationOptions"
+      },
+      "silent": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "throwOnSideEffect": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "uniqueContextId": {
+       "optional": true,
+       "type": "string"
+      },
+      "userGesture": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "result",
+      "exceptionDetails"
+     ]
+    },
+    "compileScript": {
+     "params": {
+      "executionContextId": {
+       "optional": true,
+       "type": "ExecutionContextId"
+      },
+      "expression": {
+       "optional": false,
+       "type": "string"
+      },
+      "persistScript": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "sourceURL": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "scriptId",
+      "exceptionDetails"
+     ]
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "discardConsoleEntries": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "evaluate": {
+     "params": {
+      "allowUnsafeEvalBlockedByCSP": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "awaitPromise": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "contextId": {
+       "optional": true,
+       "type": "ExecutionContextId"
+      },
+      "disableBreaks": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "expression": {
+       "optional": false,
+       "type": "string"
+      },
+      "generatePreview": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includeCommandLineAPI": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      },
+      "replMode": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "returnByValue": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "serializationOptions": {
+       "optional": true,
+       "type": "SerializationOptions"
+      },
+      "silent": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "throwOnSideEffect": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "timeout": {
+       "optional": true,
+       "type": "TimeDelta"
+      },
+      "uniqueContextId": {
+       "optional": true,
+       "type": "string"
+      },
+      "userGesture": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "result",
+      "exceptionDetails"
+     ]
+    },
+    "getExceptionDetails": {
+     "params": {
+      "errorObjectId": {
+       "optional": false,
+       "type": "RemoteObjectId"
+      }
+     },
+     "returns": [
+      "exceptionDetails"
+     ]
+    },
+    "getHeapUsage": {
+     "params": {},
+     "returns": [
+      "usedSize",
+      "totalSize",
+      "embedderHeapUsedSize",
+      "backingStorageSize"
+     ]
+    },
+    "getIsolateId": {
+     "params": {},
+     "returns": [
+      "id"
+     ]
+    },
+    "getProperties": {
+     "params": {
+      "accessorPropertiesOnly": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "generatePreview": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "nonIndexedPropertiesOnly": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "objectId": {
+       "optional": false,
+       "type": "RemoteObjectId"
+      },
+      "ownProperties": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "result",
+      "internalProperties",
+      "privateProperties",
+      "exceptionDetails"
+     ]
+    },
+    "globalLexicalScopeNames": {
+     "params": {
+      "executionContextId": {
+       "optional": true,
+       "type": "ExecutionContextId"
+      }
+     },
+     "returns": [
+      "names"
+     ]
+    },
+    "queryObjects": {
+     "params": {
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      },
+      "prototypeObjectId": {
+       "optional": false,
+       "type": "RemoteObjectId"
+      }
+     },
+     "returns": [
+      "objects"
+     ]
+    },
+    "releaseObject": {
+     "params": {
+      "objectId": {
+       "optional": false,
+       "type": "RemoteObjectId"
+      }
+     },
+     "returns": []
+    },
+    "releaseObjectGroup": {
+     "params": {
+      "objectGroup": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "removeBinding": {
+     "params": {
+      "name": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "runIfWaitingForDebugger": {
+     "params": {},
+     "returns": []
+    },
+    "runScript": {
+     "params": {
+      "awaitPromise": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "executionContextId": {
+       "optional": true,
+       "type": "ExecutionContextId"
+      },
+      "generatePreview": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includeCommandLineAPI": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      },
+      "returnByValue": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "scriptId": {
+       "optional": false,
+       "type": "ScriptId"
+      },
+      "silent": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "result",
+      "exceptionDetails"
+     ]
+    },
+    "setAsyncCallStackDepth": {
+     "params": {
+      "maxDepth": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "setCustomObjectFormatterEnabled": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setMaxCallStackSizeToCapture": {
+     "params": {
+      "size": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "terminateExecution": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "bindingCalled": {
+     "params": {
+      "executionContextId": {
+       "optional": false,
+       "type": "ExecutionContextId"
+      },
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "payload": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "consoleAPICalled": {
+     "params": {
+      "args": {
+       "optional": false,
+       "type": "array"
+      },
+      "context": {
+       "optional": true,
+       "type": "string"
+      },
+      "executionContextId": {
+       "optional": false,
+       "type": "ExecutionContextId"
+      },
+      "stackTrace": {
+       "optional": true,
+       "type": "StackTrace"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      },
+      "type": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "exceptionRevoked": {
+     "params": {
+      "exceptionId": {
+       "optional": false,
+       "type": "integer"
+      },
+      "reason": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "exceptionThrown": {
+     "params": {
+      "exceptionDetails": {
+       "optional": false,
+       "type": "ExceptionDetails"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      }
+     }
+    },
+    "executionContextCreated": {
+     "params": {
+      "context": {
+       "optional": false,
+       "type": "ExecutionContextDescription"
+      }
+     }
+    },
+    "executionContextDestroyed": {
+     "params": {
+      "executionContextId": {
+       "optional": false,
+       "type": "ExecutionContextId"
+      },
+      "executionContextUniqueId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "executionContextsCleared": {
+     "params": {}
+    },
+    "inspectRequested": {
+     "params": {
+      "executionContextId": {
+       "optional": true,
+       "type": "ExecutionContextId"
+      },
+      "hints": {
+       "optional": false,
+       "type": "object"
+      },
+      "object": {
+       "optional": false,
+       "type": "RemoteObject"
+      }
+     }
+    }
+   }
+  },
+  "Schema": {
+   "commands": {
+    "getDomains": {
+     "params": {},
+     "returns": [
+      "domains"
+     ]
+    }
+   },
+   "events": {}
+  },
+  "Security": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "handleCertificateError": {
+     "params": {
+      "action": {
+       "optional": false,
+       "type": "CertificateErrorAction"
+      },
+      "eventId": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "setIgnoreCertificateErrors": {
+     "params": {
+      "ignore": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setOverrideCertificateErrors": {
+     "params": {
+      "override": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "certificateError": {
+     "params": {
+      "errorType": {
+       "optional": false,
+       "type": "string"
+      },
+      "eventId": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestURL": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "securityStateChanged": {
+     "params": {
+      "explanations": {
+       "optional": false,
+       "type": "array"
+      },
+      "insecureContentStatus": {
+       "optional": false,
+       "type": "InsecureContentStatus"
+      },
+      "schemeIsCryptographic": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "securityState": {
+       "optional": false,
+       "type": "SecurityState"
+      },
+      "summary": {
+       "optional": true,
+       "type": "string"
+      }
+     }
+    },
+    "visibleSecurityStateChanged": {
+     "params": {
+      "visibleSecurityState": {
+       "optional": false,
+       "type": "VisibleSecurityState"
+      }
+     }
+    }
+   }
+  },
+  "ServiceWorker": {
+   "commands": {
+    "deliverPushMessage": {
+     "params": {
+      "data": {
+       "optional": false,
+       "type": "string"
+      },
+      "origin": {
+       "optional": false,
+       "type": "string"
+      },
+      "registrationId": {
+       "optional": false,
+       "type": "RegistrationID"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "dispatchPeriodicSyncEvent": {
+     "params": {
+      "origin": {
+       "optional": false,
+       "type": "string"
+      },
+      "registrationId": {
+       "optional": false,
+       "type": "RegistrationID"
+      },
+      "tag": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "dispatchSyncEvent": {
+     "params": {
+      "lastChance": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "origin": {
+       "optional": false,
+       "type": "string"
+      },
+      "registrationId": {
+       "optional": false,
+       "type": "RegistrationID"
+      },
+      "tag": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "setForceUpdateOnPageLoad": {
+     "params": {
+      "forceUpdateOnPageLoad": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "skipWaiting": {
+     "params": {
+      "scopeURL": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "startWorker": {
+     "params": {
+      "scopeURL": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "stopAllWorkers": {
+     "params": {},
+     "returns": []
+    },
+    "stopWorker": {
+     "params": {
+      "versionId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "unregister": {
+     "params": {
+      "scopeURL": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "updateRegistration": {
+     "params": {
+      "scopeURL": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "workerErrorReported": {
+     "params": {
+      "errorMessage": {
+       "optional": false,
+       "type": "ServiceWorkerErrorMessage"
+      }
+     }
+    },
+    "workerRegistrationUpdated": {
+     "params": {
+      "registrations": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    },
+    "workerVersionUpdated": {
+     "params": {
+      "versions": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    }
+   }
+  },
+  "SmartCardEmulation": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "reportBeginTransactionResult": {
+     "params": {
+      "handle": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "reportConnectResult": {
+     "params": {
+      "activeProtocol": {
+       "optional": true,
+       "type": "Protocol"
+      },
+      "handle": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "reportDataResult": {
+     "params": {
+      "data": {
+       "optional": false,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "reportError": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      },
+      "resultCode": {
+       "optional": false,
+       "type": "ResultCode"
+      }
+     },
+     "returns": []
+    },
+    "reportEstablishContextResult": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "reportGetStatusChangeResult": {
+     "params": {
+      "readerStates": {
+       "optional": false,
+       "type": "array"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "reportListReadersResult": {
+     "params": {
+      "readers": {
+       "optional": false,
+       "type": "array"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "reportPlainResult": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "reportReleaseContextResult": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "reportStatusResult": {
+     "params": {
+      "atr": {
+       "optional": false,
+       "type": "string"
+      },
+      "protocol": {
+       "optional": true,
+       "type": "Protocol"
+      },
+      "readerName": {
+       "optional": false,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      },
+      "state": {
+       "optional": false,
+       "type": "ConnectionState"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "beginTransactionRequested": {
+     "params": {
+      "handle": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "cancelRequested": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "connectRequested": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "integer"
+      },
+      "preferredProtocols": {
+       "optional": false,
+       "type": "ProtocolSet"
+      },
+      "reader": {
+       "optional": false,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      },
+      "shareMode": {
+       "optional": false,
+       "type": "ShareMode"
+      }
+     }
+    },
+    "controlRequested": {
+     "params": {
+      "controlCode": {
+       "optional": false,
+       "type": "integer"
+      },
+      "data": {
+       "optional": false,
+       "type": "string"
+      },
+      "handle": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "disconnectRequested": {
+     "params": {
+      "disposition": {
+       "optional": false,
+       "type": "Disposition"
+      },
+      "handle": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "endTransactionRequested": {
+     "params": {
+      "disposition": {
+       "optional": false,
+       "type": "Disposition"
+      },
+      "handle": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "establishContextRequested": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "getAttribRequested": {
+     "params": {
+      "attribId": {
+       "optional": false,
+       "type": "integer"
+      },
+      "handle": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "getStatusChangeRequested": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "integer"
+      },
+      "readerStates": {
+       "optional": false,
+       "type": "array"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      },
+      "timeout": {
+       "optional": true,
+       "type": "integer"
+      }
+     }
+    },
+    "listReadersRequested": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "releaseContextRequested": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "setAttribRequested": {
+     "params": {
+      "attribId": {
+       "optional": false,
+       "type": "integer"
+      },
+      "data": {
+       "optional": false,
+       "type": "string"
+      },
+      "handle": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "statusRequested": {
+     "params": {
+      "handle": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "transmitRequested": {
+     "params": {
+      "data": {
+       "optional": false,
+       "type": "string"
+      },
+      "handle": {
+       "optional": false,
+       "type": "integer"
+      },
+      "protocol": {
+       "optional": true,
+       "type": "Protocol"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    }
+   }
+  },
+  "Storage": {
+   "commands": {
+    "clearCookies": {
+     "params": {
+      "browserContextId": {
+       "optional": true,
+       "type": "Browser.BrowserContextID"
+      }
+     },
+     "returns": []
+    },
+    "clearDataForOrigin": {
+     "params": {
+      "origin": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageTypes": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "clearDataForStorageKey": {
+     "params": {
+      "storageKey": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageTypes": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "clearTrustTokens": {
+     "params": {
+      "issuerOrigin": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "didDeleteTokens"
+     ]
+    },
+    "deleteStorageBucket": {
+     "params": {
+      "bucket": {
+       "optional": false,
+       "type": "StorageBucket"
+      }
+     },
+     "returns": []
+    },
+    "getCookies": {
+     "params": {
+      "browserContextId": {
+       "optional": true,
+       "type": "Browser.BrowserContextID"
+      }
+     },
+     "returns": [
+      "cookies"
+     ]
+    },
+    "getRelatedWebsiteSets": {
+     "params": {},
+     "returns": [
+      "sets"
+     ]
+    },
+    "getStorageKey": {
+     "params": {
+      "frameId": {
+       "optional": true,
+       "type": "Page.FrameId"
+      }
+     },
+     "returns": [
+      "storageKey"
+     ]
+    },
+    "getStorageKeyForFrame": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "Page.FrameId"
+      }
+     },
+     "returns": [
+      "storageKey"
+     ]
+    },
+    "getTrustTokens": {
+     "params": {},
+     "returns": [
+      "tokens"
+     ]
+    },
+    "getUsageAndQuota": {
+     "params": {
+      "origin": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "usage",
+      "quota",
+      "overrideActive",
+      "usageBreakdown"
+     ]
+    },
+    "overrideQuotaForOrigin": {
+     "params": {
+      "origin": {
+       "optional": false,
+       "type": "string"
+      },
+      "quotaSize": {
+       "optional": true,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "runBounceTrackingMitigations": {
+     "params": {},
+     "returns": [
+      "deletedSites"
+     ]
+    },
+    "setCookies": {
+     "params": {
+      "browserContextId": {
+       "optional": true,
+       "type": "Browser.BrowserContextID"
+      },
+      "cookies": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "setStorageBucketTracking": {
+     "params": {
+      "enable": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "storageKey": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "trackCacheStorageForOrigin": {
+     "params": {
+      "origin": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "trackCacheStorageForStorageKey": {
+     "params": {
+      "storageKey": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "trackIndexedDBForOrigin": {
+     "params": {
+      "origin": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "trackIndexedDBForStorageKey": {
+     "params": {
+      "storageKey": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "untrackCacheStorageForOrigin": {
+     "params": {
+      "origin": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "untrackCacheStorageForStorageKey": {
+     "params": {
+      "storageKey": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "untrackIndexedDBForOrigin": {
+     "params": {
+      "origin": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "untrackIndexedDBForStorageKey": {
+     "params": {
+      "storageKey": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "cacheStorageContentUpdated": {
+     "params": {
+      "bucketId": {
+       "optional": false,
+       "type": "string"
+      },
+      "cacheName": {
+       "optional": false,
+       "type": "string"
+      },
+      "origin": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageKey": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "cacheStorageListUpdated": {
+     "params": {
+      "bucketId": {
+       "optional": false,
+       "type": "string"
+      },
+      "origin": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageKey": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "indexedDBContentUpdated": {
+     "params": {
+      "bucketId": {
+       "optional": false,
+       "type": "string"
+      },
+      "databaseName": {
+       "optional": false,
+       "type": "string"
+      },
+      "objectStoreName": {
+       "optional": false,
+       "type": "string"
+      },
+      "origin": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageKey": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "indexedDBListUpdated": {
+     "params": {
+      "bucketId": {
+       "optional": false,
+       "type": "string"
+      },
+      "origin": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageKey": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "storageBucketCreatedOrUpdated": {
+     "params": {
+      "bucketInfo": {
+       "optional": false,
+       "type": "StorageBucketInfo"
+      }
+     }
+    },
+    "storageBucketDeleted": {
+     "params": {
+      "bucketId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    }
+   }
+  },
+  "SystemInfo": {
+   "commands": {
+    "getFeatureState": {
+     "params": {
+      "featureState": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "featureEnabled"
+     ]
+    },
+    "getInfo": {
+     "params": {},
+     "returns": [
+      "gpu",
+      "modelName",
+      "modelVersion",
+      "commandLine"
+     ]
+    },
+    "getProcessInfo": {
+     "params": {},
+     "returns": [
+      "processInfo"
+     ]
+    }
+   },
+   "events": {}
+  },
+  "Target": {
+   "commands": {
+    "activateTarget": {
+     "params": {
+      "targetId": {
+       "optional": false,
+       "type": "TargetID"
+      }
+     },
+     "returns": []
+    },
+    "attachToBrowserTarget": {
+     "params": {},
+     "returns": [
+      "sessionId"
+     ]
+    },
+    "attachToTarget": {
+     "params": {
+      "flatten": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "targetId": {
+       "optional": false,
+       "type": "TargetID"
+      }
+     },
+     "returns": [
+      "sessionId"
+     ]
+    },
+    "autoAttachRelated": {
+     "params": {
+      "filter": {
+       "optional": true,
+       "type": "TargetFilter"
+      },
+      "targetId": {
+       "optional": false,
+       "type": "TargetID"
+      },
+      "waitForDebuggerOnStart": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "closeTarget": {
+     "params": {
+      "targetId": {
+       "optional": false,
+       "type": "TargetID"
+      }
+     },
+     "returns": [
+      "success"
+     ]
+    },
+    "createBrowserContext": {
+     "params": {
+      "disposeOnDetach": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "originsWithUniversalNetworkAccess": {
+       "optional": true,
+       "type": "array"
+      },
+      "proxyBypassList": {
+       "optional": true,
+       "type": "string"
+      },
+      "proxyServer": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "browserContextId"
+     ]
+    },
+    "createTarget": {
+     "params": {
+      "background": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "browserContextId": {
+       "optional": true,
+       "type": "Browser.BrowserContextID"
+      },
+      "enableBeginFrameControl": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "focus": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "forTab": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "height": {
+       "optional": true,
+       "type": "integer"
+      },
+      "hidden": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "left": {
+       "optional": true,
+       "type": "integer"
+      },
+      "newWindow": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "top": {
+       "optional": true,
+       "type": "integer"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      },
+      "width": {
+       "optional": true,
+       "type": "integer"
+      },
+      "windowState": {
+       "optional": true,
+       "type": "WindowState"
+      }
+     },
+     "returns": [
+      "targetId"
+     ]
+    },
+    "detachFromTarget": {
+     "params": {
+      "sessionId": {
+       "optional": true,
+       "type": "SessionID"
+      },
+      "targetId": {
+       "optional": true,
+       "type": "TargetID"
+      }
+     },
+     "returns": []
+    },
+    "disposeBrowserContext": {
+     "params": {
+      "browserContextId": {
+       "optional": false,
+       "type": "Browser.BrowserContextID"
+      }
+     },
+     "returns": []
+    },
+    "exposeDevToolsProtocol": {
+     "params": {
+      "bindingName": {
+       "optional": true,
+       "type": "string"
+      },
+      "inheritPermissions": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "targetId": {
+       "optional": false,
+       "type": "TargetID"
+      }
+     },
+     "returns": []
+    },
+    "getBrowserContexts": {
+     "params": {},
+     "returns": [
+      "browserContextIds",
+      "defaultBrowserContextId"
+     ]
+    },
+    "getDevToolsTarget": {
+     "params": {
+      "targetId": {
+       "optional": false,
+       "type": "TargetID"
+      }
+     },
+     "returns": [
+      "targetId"
+     ]
+    },
+    "getTargetInfo": {
+     "params": {
+      "targetId": {
+       "optional": true,
+       "type": "TargetID"
+      }
+     },
+     "returns": [
+      "targetInfo"
+     ]
+    },
+    "getTargets": {
+     "params": {
+      "filter": {
+       "optional": true,
+       "type": "TargetFilter"
+      }
+     },
+     "returns": [
+      "targetInfos"
+     ]
+    },
+    "openDevTools": {
+     "params": {
+      "panelId": {
+       "optional": true,
+       "type": "string"
+      },
+      "targetId": {
+       "optional": false,
+       "type": "TargetID"
+      }
+     },
+     "returns": [
+      "targetId"
+     ]
+    },
+    "sendMessageToTarget": {
+     "params": {
+      "message": {
+       "optional": false,
+       "type": "string"
+      },
+      "sessionId": {
+       "optional": true,
+       "type": "SessionID"
+      },
+      "targetId": {
+       "optional": true,
+       "type": "TargetID"
+      }
+     },
+     "returns": []
+    },
+    "setAutoAttach": {
+     "params": {
+      "autoAttach": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "filter": {
+       "optional": true,
+       "type": "TargetFilter"
+      },
+      "flatten": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "waitForDebuggerOnStart": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setDiscoverTargets": {
+     "params": {
+      "discover": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "filter": {
+       "optional": true,
+       "type": "TargetFilter"
+      }
+     },
+     "returns": []
+    },
+    "setRemoteLocations": {
+     "params": {
+      "locations": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "attachedToTarget": {
+     "params": {
+      "sessionId": {
+       "optional": false,
+       "type": "SessionID"
+      },
+      "targetInfo": {
+       "optional": false,
+       "type": "TargetInfo"
+      },
+      "waitingForDebugger": {
+       "optional": false,
+       "type": "boolean"
+      }
+     }
+    },
+    "detachedFromTarget": {
+     "params": {
+      "sessionId": {
+       "optional": false,
+       "type": "SessionID"
+      },
+      "targetId": {
+       "optional": true,
+       "type": "TargetID"
+      }
+     }
+    },
+    "receivedMessageFromTarget": {
+     "params": {
+      "message": {
+       "optional": false,
+       "type": "string"
+      },
+      "sessionId": {
+       "optional": false,
+       "type": "SessionID"
+      },
+      "targetId": {
+       "optional": true,
+       "type": "TargetID"
+      }
+     }
+    },
+    "targetCrashed": {
+     "params": {
+      "errorCode": {
+       "optional": false,
+       "type": "integer"
+      },
+      "status": {
+       "optional": false,
+       "type": "string"
+      },
+      "targetId": {
+       "optional": false,
+       "type": "TargetID"
+      }
+     }
+    },
+    "targetCreated": {
+     "params": {
+      "targetInfo": {
+       "optional": false,
+       "type": "TargetInfo"
+      }
+     }
+    },
+    "targetDestroyed": {
+     "params": {
+      "targetId": {
+       "optional": false,
+       "type": "TargetID"
+      }
+     }
+    },
+    "targetInfoChanged": {
+     "params": {
+      "targetInfo": {
+       "optional": false,
+       "type": "TargetInfo"
+      }
+     }
+    }
+   }
+  },
+  "Tethering": {
+   "commands": {
+    "bind": {
+     "params": {
+      "port": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "unbind": {
+     "params": {
+      "port": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "accepted": {
+     "params": {
+      "connectionId": {
+       "optional": false,
+       "type": "string"
+      },
+      "port": {
+       "optional": false,
+       "type": "integer"
+      }
+     }
+    }
+   }
+  },
+  "Tracing": {
+   "commands": {
+    "end": {
+     "params": {},
+     "returns": []
+    },
+    "getCategories": {
+     "params": {},
+     "returns": [
+      "categories"
+     ]
+    },
+    "getTrackEventDescriptor": {
+     "params": {},
+     "returns": [
+      "descriptor"
+     ]
+    },
+    "recordClockSyncMarker": {
+     "params": {
+      "syncId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "requestMemoryDump": {
+     "params": {
+      "deterministic": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "levelOfDetail": {
+       "optional": true,
+       "type": "MemoryDumpLevelOfDetail"
+      }
+     },
+     "returns": [
+      "dumpGuid",
+      "success"
+     ]
+    },
+    "start": {
+     "params": {
+      "bufferUsageReportingInterval": {
+       "optional": true,
+       "type": "number"
+      },
+      "categories": {
+       "optional": true,
+       "type": "string"
+      },
+      "options": {
+       "optional": true,
+       "type": "string"
+      },
+      "perfettoConfig": {
+       "optional": true,
+       "type": "string"
+      },
+      "screenshotMaxCount": {
+       "optional": true,
+       "type": "integer"
+      },
+      "screenshotMaxSize": {
+       "optional": true,
+       "type": "integer"
+      },
+      "streamCompression": {
+       "optional": true,
+       "type": "StreamCompression"
+      },
+      "streamFormat": {
+       "optional": true,
+       "type": "StreamFormat"
+      },
+      "traceConfig": {
+       "optional": true,
+       "type": "TraceConfig"
+      },
+      "tracingBackend": {
+       "optional": true,
+       "type": "TracingBackend"
+      },
+      "transferMode": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "bufferUsage": {
+     "params": {
+      "eventCount": {
+       "optional": true,
+       "type": "number"
+      },
+      "percentFull": {
+       "optional": true,
+       "type": "number"
+      },
+      "value": {
+       "optional": true,
+       "type": "number"
+      }
+     }
+    },
+    "dataCollected": {
+     "params": {
+      "value": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    },
+    "tracingComplete": {
+     "params": {
+      "dataLossOccurred": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "stream": {
+       "optional": true,
+       "type": "IO.StreamHandle"
+      },
+      "streamCompression": {
+       "optional": true,
+       "type": "StreamCompression"
+      },
+      "traceFormat": {
+       "optional": true,
+       "type": "StreamFormat"
+      }
+     }
+    }
+   }
+  },
+  "WebAudio": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getRealtimeData": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      }
+     },
+     "returns": [
+      "realtimeData"
+     ]
+    }
+   },
+   "events": {
+    "audioListenerCreated": {
+     "params": {
+      "listener": {
+       "optional": false,
+       "type": "AudioListener"
+      }
+     }
+    },
+    "audioListenerWillBeDestroyed": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "listenerId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      }
+     }
+    },
+    "audioNodeCreated": {
+     "params": {
+      "node": {
+       "optional": false,
+       "type": "AudioNode"
+      }
+     }
+    },
+    "audioNodeWillBeDestroyed": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      }
+     }
+    },
+    "audioParamCreated": {
+     "params": {
+      "param": {
+       "optional": false,
+       "type": "AudioParam"
+      }
+     }
+    },
+    "audioParamWillBeDestroyed": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "paramId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      }
+     }
+    },
+    "contextChanged": {
+     "params": {
+      "context": {
+       "optional": false,
+       "type": "BaseAudioContext"
+      }
+     }
+    },
+    "contextCreated": {
+     "params": {
+      "context": {
+       "optional": false,
+       "type": "BaseAudioContext"
+      }
+     }
+    },
+    "contextWillBeDestroyed": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      }
+     }
+    },
+    "nodeParamConnected": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "destinationId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "sourceId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "sourceOutputIndex": {
+       "optional": true,
+       "type": "number"
+      }
+     }
+    },
+    "nodeParamDisconnected": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "destinationId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "sourceId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "sourceOutputIndex": {
+       "optional": true,
+       "type": "number"
+      }
+     }
+    },
+    "nodesConnected": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "destinationId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "destinationInputIndex": {
+       "optional": true,
+       "type": "number"
+      },
+      "sourceId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "sourceOutputIndex": {
+       "optional": true,
+       "type": "number"
+      }
+     }
+    },
+    "nodesDisconnected": {
+     "params": {
+      "contextId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "destinationId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "destinationInputIndex": {
+       "optional": true,
+       "type": "number"
+      },
+      "sourceId": {
+       "optional": false,
+       "type": "GraphObjectId"
+      },
+      "sourceOutputIndex": {
+       "optional": true,
+       "type": "number"
+      }
+     }
+    }
+   }
+  },
+  "WebAuthn": {
+   "commands": {
+    "addCredential": {
+     "params": {
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      },
+      "credential": {
+       "optional": false,
+       "type": "Credential"
+      }
+     },
+     "returns": []
+    },
+    "addVirtualAuthenticator": {
+     "params": {
+      "options": {
+       "optional": false,
+       "type": "VirtualAuthenticatorOptions"
+      }
+     },
+     "returns": [
+      "authenticatorId"
+     ]
+    },
+    "clearCredentials": {
+     "params": {
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {
+      "enableUI": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "getCredential": {
+     "params": {
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      },
+      "credentialId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "credential"
+     ]
+    },
+    "getCredentials": {
+     "params": {
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      }
+     },
+     "returns": [
+      "credentials"
+     ]
+    },
+    "removeCredential": {
+     "params": {
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      },
+      "credentialId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "removeVirtualAuthenticator": {
+     "params": {
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      }
+     },
+     "returns": []
+    },
+    "setAutomaticPresenceSimulation": {
+     "params": {
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      },
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setCredentialProperties": {
+     "params": {
+      "activeCmtgKeyIndex": {
+       "optional": true,
+       "type": "integer"
+      },
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      },
+      "backupEligibility": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "backupState": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "credentialId": {
+       "optional": false,
+       "type": "string"
+      },
+      "generateCmtgKeyOnNextOperation": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "signCount": {
+       "optional": true,
+       "type": "number"
+      }
+     },
+     "returns": []
+    },
+    "setResponseOverrideBits": {
+     "params": {
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      },
+      "isBadUP": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "isBadUV": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "isBogusSignature": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setUserVerified": {
+     "params": {
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      },
+      "isUserVerified": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "credentialAdded": {
+     "params": {
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      },
+      "credential": {
+       "optional": false,
+       "type": "Credential"
+      }
+     }
+    },
+    "credentialAsserted": {
+     "params": {
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      },
+      "credential": {
+       "optional": false,
+       "type": "Credential"
+      }
+     }
+    },
+    "credentialDeleted": {
+     "params": {
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      },
+      "credentialId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "credentialUpdated": {
+     "params": {
+      "authenticatorId": {
+       "optional": false,
+       "type": "AuthenticatorId"
+      },
+      "credential": {
+       "optional": false,
+       "type": "Credential"
+      }
+     }
+    }
+   }
+  },
+  "WebMCP": {
+   "commands": {
+    "cancelInvocation": {
+     "params": {
+      "invocationId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "invokeTool": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "Page.FrameId"
+      },
+      "input": {
+       "optional": false,
+       "type": "object"
+      },
+      "toolName": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "invocationId"
+     ]
+    }
+   },
+   "events": {
+    "toolInvoked": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "Page.FrameId"
+      },
+      "input": {
+       "optional": false,
+       "type": "string"
+      },
+      "invocationId": {
+       "optional": false,
+       "type": "string"
+      },
+      "toolName": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "toolResponded": {
+     "params": {
+      "errorText": {
+       "optional": true,
+       "type": "string"
+      },
+      "exception": {
+       "optional": true,
+       "type": "Runtime.RemoteObject"
+      },
+      "invocationId": {
+       "optional": false,
+       "type": "string"
+      },
+      "output": {
+       "optional": true,
+       "type": "any"
+      },
+      "status": {
+       "optional": false,
+       "type": "InvocationStatus"
+      }
+     }
+    },
+    "toolsAdded": {
+     "params": {
+      "tools": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    },
+    "toolsRemoved": {
+     "params": {
+      "tools": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    }
+   }
+  }
+ },
+ "source": {
+  "commit": "90778954a4820558eb0a98194e89000d40087ba4",
+  "fetched": "2026-09-08",
+  "path": "json",
+  "repo": "ChromeDevTools/devtools-protocol"
+ }
+}

--- a/tests/services/test_web_protocol/protocol/webkit_protocol.json
+++ b/tests/services/test_web_protocol/protocol/webkit_protocol.json
@@ -1,0 +1,4381 @@
+{
+ "domains": {
+  "Animation": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "requestEffect": {
+     "params": {
+      "animationId": {
+       "optional": false,
+       "type": "AnimationId"
+      }
+     },
+     "returns": [
+      "effect"
+     ]
+    },
+    "requestEffectTarget": {
+     "params": {
+      "animationId": {
+       "optional": false,
+       "type": "AnimationId"
+      }
+     },
+     "returns": [
+      "effectTarget"
+     ]
+    },
+    "resolveAnimation": {
+     "params": {
+      "animationId": {
+       "optional": false,
+       "type": "AnimationId"
+      },
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "object"
+     ]
+    },
+    "startTracking": {
+     "params": {},
+     "returns": []
+    },
+    "stopTracking": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "animationCreated": {
+     "params": {
+      "animation": {
+       "optional": false,
+       "type": "Animation"
+      }
+     }
+    },
+    "animationDestroyed": {
+     "params": {
+      "animationId": {
+       "optional": false,
+       "type": "AnimationId"
+      }
+     }
+    },
+    "effectChanged": {
+     "params": {
+      "animationId": {
+       "optional": false,
+       "type": "AnimationId"
+      }
+     }
+    },
+    "nameChanged": {
+     "params": {
+      "animationId": {
+       "optional": false,
+       "type": "AnimationId"
+      },
+      "name": {
+       "optional": true,
+       "type": "string"
+      }
+     }
+    },
+    "targetChanged": {
+     "params": {
+      "animationId": {
+       "optional": false,
+       "type": "AnimationId"
+      }
+     }
+    },
+    "trackingComplete": {
+     "params": {
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "trackingStart": {
+     "params": {
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "trackingUpdate": {
+     "params": {
+      "event": {
+       "optional": false,
+       "type": "TrackingUpdate"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    }
+   }
+  },
+  "Audit": {
+   "commands": {
+    "run": {
+     "params": {
+      "contextId": {
+       "optional": true,
+       "type": "Runtime.ExecutionContextId"
+      },
+      "test": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "result",
+      "wasThrown"
+     ]
+    },
+    "setup": {
+     "params": {
+      "contextId": {
+       "optional": true,
+       "type": "Runtime.ExecutionContextId"
+      }
+     },
+     "returns": []
+    },
+    "teardown": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {}
+  },
+  "Browser": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "extensionsDisabled": {
+     "params": {
+      "extensionIds": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    },
+    "extensionsEnabled": {
+     "params": {
+      "extensions": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    }
+   }
+  },
+  "CPUProfiler": {
+   "commands": {
+    "startTracking": {
+     "params": {},
+     "returns": []
+    },
+    "stopTracking": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "trackingComplete": {
+     "params": {
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "trackingStart": {
+     "params": {
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "trackingUpdate": {
+     "params": {
+      "event": {
+       "optional": false,
+       "type": "Event"
+      }
+     }
+    }
+   }
+  },
+  "CSS": {
+   "commands": {
+    "addRule": {
+     "params": {
+      "selector": {
+       "optional": false,
+       "type": "string"
+      },
+      "styleSheetId": {
+       "optional": false,
+       "type": "StyleSheetId"
+      }
+     },
+     "returns": [
+      "rule"
+     ]
+    },
+    "createStyleSheet": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "Network.FrameId"
+      }
+     },
+     "returns": [
+      "styleSheetId"
+     ]
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "forcePseudoState": {
+     "params": {
+      "forcedPseudoClasses": {
+       "optional": false,
+       "type": "array"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": []
+    },
+    "getAllStyleSheets": {
+     "params": {},
+     "returns": [
+      "headers"
+     ]
+    },
+    "getComputedStyleForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "computedStyle"
+     ]
+    },
+    "getFontDataForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "primaryFont"
+     ]
+    },
+    "getInlineStylesForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "inlineStyle",
+      "attributesStyle"
+     ]
+    },
+    "getMatchedStylesForNode": {
+     "params": {
+      "includeInherited": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includePseudo": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "matchedCSSRules",
+      "pseudoElements",
+      "inherited"
+     ]
+    },
+    "getStyleSheet": {
+     "params": {
+      "styleSheetId": {
+       "optional": false,
+       "type": "StyleSheetId"
+      }
+     },
+     "returns": [
+      "styleSheet"
+     ]
+    },
+    "getStyleSheetText": {
+     "params": {
+      "styleSheetId": {
+       "optional": false,
+       "type": "StyleSheetId"
+      }
+     },
+     "returns": [
+      "text"
+     ]
+    },
+    "getSupportedCSSProperties": {
+     "params": {},
+     "returns": [
+      "cssProperties"
+     ]
+    },
+    "getSupportedSystemFontFamilyNames": {
+     "params": {},
+     "returns": [
+      "fontFamilyNames"
+     ]
+    },
+    "setGroupingHeaderText": {
+     "params": {
+      "headerText": {
+       "optional": false,
+       "type": "string"
+      },
+      "ruleId": {
+       "optional": false,
+       "type": "CSSRuleId"
+      }
+     },
+     "returns": [
+      "grouping"
+     ]
+    },
+    "setLayoutContextTypeChangedMode": {
+     "params": {
+      "mode": {
+       "optional": false,
+       "type": "LayoutContextTypeChangedMode"
+      }
+     },
+     "returns": []
+    },
+    "setRuleSelector": {
+     "params": {
+      "ruleId": {
+       "optional": false,
+       "type": "CSSRuleId"
+      },
+      "selector": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "rule"
+     ]
+    },
+    "setStyleSheetText": {
+     "params": {
+      "styleSheetId": {
+       "optional": false,
+       "type": "StyleSheetId"
+      },
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setStyleText": {
+     "params": {
+      "styleId": {
+       "optional": false,
+       "type": "CSSStyleId"
+      },
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "style"
+     ]
+    }
+   },
+   "events": {
+    "mediaQueryResultChanged": {
+     "params": {}
+    },
+    "nodeLayoutFlagsChanged": {
+     "params": {
+      "layoutFlags": {
+       "optional": true,
+       "type": "array"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     }
+    },
+    "styleSheetAdded": {
+     "params": {
+      "header": {
+       "optional": false,
+       "type": "CSSStyleSheetHeader"
+      }
+     }
+    },
+    "styleSheetChanged": {
+     "params": {
+      "styleSheetId": {
+       "optional": false,
+       "type": "StyleSheetId"
+      }
+     }
+    },
+    "styleSheetRemoved": {
+     "params": {
+      "styleSheetId": {
+       "optional": false,
+       "type": "StyleSheetId"
+      }
+     }
+    }
+   }
+  },
+  "Canvas": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "requestCSSCanvasClientNodes": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      }
+     },
+     "returns": [
+      "clientNodeIds"
+     ]
+    },
+    "requestContent": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      }
+     },
+     "returns": [
+      "content"
+     ]
+    },
+    "requestNodes": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      }
+     },
+     "returns": [
+      "nodeIds"
+     ]
+    },
+    "requestShaderSource": {
+     "params": {
+      "programId": {
+       "optional": false,
+       "type": "ProgramId"
+      },
+      "shaderType": {
+       "optional": false,
+       "type": "ShaderType"
+      }
+     },
+     "returns": [
+      "source"
+     ]
+    },
+    "resolveContext": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      },
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "object"
+     ]
+    },
+    "setRecordingAutoCaptureFrameCount": {
+     "params": {
+      "count": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "setShaderProgramDisabled": {
+     "params": {
+      "disabled": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "programId": {
+       "optional": false,
+       "type": "ProgramId"
+      }
+     },
+     "returns": []
+    },
+    "setShaderProgramHighlighted": {
+     "params": {
+      "highlighted": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "programId": {
+       "optional": false,
+       "type": "ProgramId"
+      }
+     },
+     "returns": []
+    },
+    "startRecording": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      },
+      "frameCount": {
+       "optional": true,
+       "type": "integer"
+      },
+      "memoryLimit": {
+       "optional": true,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "stopRecording": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      }
+     },
+     "returns": []
+    },
+    "updateShader": {
+     "params": {
+      "programId": {
+       "optional": false,
+       "type": "ProgramId"
+      },
+      "shaderType": {
+       "optional": false,
+       "type": "ShaderType"
+      },
+      "source": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "canvasAdded": {
+     "params": {
+      "canvas": {
+       "optional": false,
+       "type": "Canvas"
+      }
+     }
+    },
+    "canvasMemoryChanged": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      },
+      "memoryCost": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "canvasRemoved": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      }
+     }
+    },
+    "canvasSizeChanged": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      },
+      "sizes": {
+       "optional": true,
+       "type": "array"
+      }
+     }
+    },
+    "cssCanvasClientNodesChanged": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      }
+     }
+    },
+    "cssCanvasNamesChanged": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      },
+      "cssCanvasNames": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    },
+    "extensionEnabled": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      },
+      "extension": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "nodesChanged": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      }
+     }
+    },
+    "programCreated": {
+     "params": {
+      "shaderProgram": {
+       "optional": false,
+       "type": "ShaderProgram"
+      }
+     }
+    },
+    "programDeleted": {
+     "params": {
+      "programId": {
+       "optional": false,
+       "type": "ProgramId"
+      }
+     }
+    },
+    "recordingFinished": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      },
+      "recording": {
+       "optional": true,
+       "type": "Recording.Recording"
+      }
+     }
+    },
+    "recordingProgress": {
+     "params": {
+      "bufferUsed": {
+       "optional": false,
+       "type": "integer"
+      },
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      },
+      "frames": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    },
+    "recordingStarted": {
+     "params": {
+      "canvasId": {
+       "optional": false,
+       "type": "CanvasId"
+      },
+      "initiator": {
+       "optional": false,
+       "type": "Recording.Initiator"
+      }
+     }
+    }
+   }
+  },
+  "Console": {
+   "commands": {
+    "clearMessages": {
+     "params": {},
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getLoggingChannels": {
+     "params": {},
+     "returns": [
+      "channels"
+     ]
+    },
+    "setConsoleClearAPIEnabled": {
+     "params": {
+      "enable": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setLoggingChannelLevel": {
+     "params": {
+      "level": {
+       "optional": false,
+       "type": "ChannelLevel"
+      },
+      "source": {
+       "optional": false,
+       "type": "ChannelSource"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "heapSnapshot": {
+     "params": {
+      "snapshotData": {
+       "optional": false,
+       "type": "Heap.HeapSnapshotData"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      },
+      "title": {
+       "optional": true,
+       "type": "string"
+      }
+     }
+    },
+    "messageAdded": {
+     "params": {
+      "message": {
+       "optional": false,
+       "type": "ConsoleMessage"
+      }
+     }
+    },
+    "messageRepeatCountUpdated": {
+     "params": {
+      "count": {
+       "optional": false,
+       "type": "integer"
+      },
+      "timestamp": {
+       "optional": true,
+       "type": "number"
+      }
+     }
+    },
+    "messagesCleared": {
+     "params": {
+      "reason": {
+       "optional": false,
+       "type": "ClearReason"
+      }
+     }
+    }
+   }
+  },
+  "DOM": {
+   "commands": {
+    "discardSearchResults": {
+     "params": {
+      "searchId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "focus": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": []
+    },
+    "getAccessibilityPropertiesForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "properties"
+     ]
+    },
+    "getAssociatedDataForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "associatedData"
+     ]
+    },
+    "getAttributes": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "attributes"
+     ]
+    },
+    "getDataBindingsForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "dataBindings"
+     ]
+    },
+    "getDocument": {
+     "params": {},
+     "returns": [
+      "root"
+     ]
+    },
+    "getEventListenersForNode": {
+     "params": {
+      "includeAncestors": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "listeners"
+     ]
+    },
+    "getMediaStats": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "mediaStats"
+     ]
+    },
+    "getOuterHTML": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "outerHTML"
+     ]
+    },
+    "getSearchResults": {
+     "params": {
+      "fromIndex": {
+       "optional": false,
+       "type": "integer"
+      },
+      "searchId": {
+       "optional": false,
+       "type": "string"
+      },
+      "toIndex": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": [
+      "nodeIds"
+     ]
+    },
+    "getSupportedEventNames": {
+     "params": {},
+     "returns": [
+      "eventNames"
+     ]
+    },
+    "hideFlexOverlay": {
+     "params": {
+      "nodeId": {
+       "optional": true,
+       "type": "NodeId"
+      }
+     },
+     "returns": []
+    },
+    "hideGridOverlay": {
+     "params": {
+      "nodeId": {
+       "optional": true,
+       "type": "NodeId"
+      }
+     },
+     "returns": []
+    },
+    "hideHighlight": {
+     "params": {},
+     "returns": []
+    },
+    "highlightFrame": {
+     "params": {
+      "contentColor": {
+       "optional": true,
+       "type": "RGBAColor"
+      },
+      "contentOutlineColor": {
+       "optional": true,
+       "type": "RGBAColor"
+      },
+      "frameId": {
+       "optional": false,
+       "type": "Network.FrameId"
+      }
+     },
+     "returns": []
+    },
+    "highlightNode": {
+     "params": {
+      "flexOverlayConfig": {
+       "optional": true,
+       "type": "FlexOverlayConfig"
+      },
+      "gridOverlayConfig": {
+       "optional": true,
+       "type": "GridOverlayConfig"
+      },
+      "highlightConfig": {
+       "optional": false,
+       "type": "HighlightConfig"
+      },
+      "nodeId": {
+       "optional": true,
+       "type": "NodeId"
+      },
+      "objectId": {
+       "optional": true,
+       "type": "Runtime.RemoteObjectId"
+      },
+      "showRulers": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "highlightNodeList": {
+     "params": {
+      "flexOverlayConfig": {
+       "optional": true,
+       "type": "FlexOverlayConfig"
+      },
+      "gridOverlayConfig": {
+       "optional": true,
+       "type": "GridOverlayConfig"
+      },
+      "highlightConfig": {
+       "optional": false,
+       "type": "HighlightConfig"
+      },
+      "nodeIds": {
+       "optional": false,
+       "type": "array"
+      },
+      "showRulers": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "highlightQuad": {
+     "params": {
+      "color": {
+       "optional": true,
+       "type": "RGBAColor"
+      },
+      "outlineColor": {
+       "optional": true,
+       "type": "RGBAColor"
+      },
+      "quad": {
+       "optional": false,
+       "type": "Quad"
+      },
+      "usePageCoordinates": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "highlightRect": {
+     "params": {
+      "color": {
+       "optional": true,
+       "type": "RGBAColor"
+      },
+      "height": {
+       "optional": false,
+       "type": "integer"
+      },
+      "outlineColor": {
+       "optional": true,
+       "type": "RGBAColor"
+      },
+      "usePageCoordinates": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "width": {
+       "optional": false,
+       "type": "integer"
+      },
+      "x": {
+       "optional": false,
+       "type": "integer"
+      },
+      "y": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "highlightSelector": {
+     "params": {
+      "flexOverlayConfig": {
+       "optional": true,
+       "type": "FlexOverlayConfig"
+      },
+      "frameId": {
+       "optional": true,
+       "type": "string"
+      },
+      "gridOverlayConfig": {
+       "optional": true,
+       "type": "GridOverlayConfig"
+      },
+      "highlightConfig": {
+       "optional": false,
+       "type": "HighlightConfig"
+      },
+      "selectorString": {
+       "optional": false,
+       "type": "string"
+      },
+      "showRulers": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "insertAdjacentHTML": {
+     "params": {
+      "html": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "position": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "markUndoableState": {
+     "params": {},
+     "returns": []
+    },
+    "moveTo": {
+     "params": {
+      "insertBeforeNodeId": {
+       "optional": true,
+       "type": "NodeId"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "targetNodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "performSearch": {
+     "params": {
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "nodeIds": {
+       "optional": true,
+       "type": "array"
+      },
+      "query": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "searchId",
+      "resultCount"
+     ]
+    },
+    "pushNodeByPathToFrontend": {
+     "params": {
+      "path": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "querySelector": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "selector": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "querySelectorAll": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "selector": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "nodeIds"
+     ]
+    },
+    "redo": {
+     "params": {},
+     "returns": []
+    },
+    "removeAttribute": {
+     "params": {
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": []
+    },
+    "removeBreakpointForEventListener": {
+     "params": {
+      "eventListenerId": {
+       "optional": false,
+       "type": "EventListenerId"
+      }
+     },
+     "returns": []
+    },
+    "removeNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": []
+    },
+    "requestAssignedNodes": {
+     "params": {
+      "slotElementId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "assignedNodeIds"
+     ]
+    },
+    "requestAssignedSlot": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "slotElementId"
+     ]
+    },
+    "requestChildNodes": {
+     "params": {
+      "depth": {
+       "optional": true,
+       "type": "integer"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": []
+    },
+    "requestNode": {
+     "params": {
+      "objectId": {
+       "optional": false,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "resolveNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "object"
+     ]
+    },
+    "setAllowEditingUserAgentShadowTrees": {
+     "params": {
+      "allow": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setAttributeValue": {
+     "params": {
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "value": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setAttributesAsText": {
+     "params": {
+      "name": {
+       "optional": true,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setBreakpointForEventListener": {
+     "params": {
+      "eventListenerId": {
+       "optional": false,
+       "type": "EventListenerId"
+      },
+      "options": {
+       "optional": true,
+       "type": "Debugger.BreakpointOptions"
+      }
+     },
+     "returns": []
+    },
+    "setEventListenerDisabled": {
+     "params": {
+      "disabled": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "eventListenerId": {
+       "optional": false,
+       "type": "EventListenerId"
+      }
+     },
+     "returns": []
+    },
+    "setInspectModeEnabled": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "flexOverlayConfig": {
+       "optional": true,
+       "type": "FlexOverlayConfig"
+      },
+      "gridOverlayConfig": {
+       "optional": true,
+       "type": "GridOverlayConfig"
+      },
+      "highlightConfig": {
+       "optional": true,
+       "type": "HighlightConfig"
+      },
+      "showRulers": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setInspectedNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": []
+    },
+    "setNodeName": {
+     "params": {
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": [
+      "nodeId"
+     ]
+    },
+    "setNodeValue": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "value": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setOuterHTML": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "outerHTML": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "showFlexOverlay": {
+     "params": {
+      "flexOverlayConfig": {
+       "optional": false,
+       "type": "FlexOverlayConfig"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": []
+    },
+    "showGridOverlay": {
+     "params": {
+      "gridOverlayConfig": {
+       "optional": false,
+       "type": "GridOverlayConfig"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     },
+     "returns": []
+    },
+    "undo": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "attributeModified": {
+     "params": {
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "value": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "attributeRemoved": {
+     "params": {
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "characterDataModified": {
+     "params": {
+      "characterData": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "childNodeCountUpdated": {
+     "params": {
+      "childNodeCount": {
+       "optional": false,
+       "type": "integer"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "childNodeInserted": {
+     "params": {
+      "node": {
+       "optional": false,
+       "type": "Node"
+      },
+      "parentNodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "previousNodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "childNodeRemoved": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "parentNodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "customElementStateChanged": {
+     "params": {
+      "customElementState": {
+       "optional": false,
+       "type": "CustomElementState"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "didAddEventListener": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "didFireEvent": {
+     "params": {
+      "data": {
+       "optional": true,
+       "type": "object"
+      },
+      "eventName": {
+       "optional": false,
+       "type": "string"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Network.Timestamp"
+      }
+     }
+    },
+    "documentUpdated": {
+     "params": {}
+    },
+    "inlineStyleInvalidated": {
+     "params": {
+      "nodeIds": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    },
+    "inspect": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "powerEfficientPlaybackStateChanged": {
+     "params": {
+      "isPowerEfficient": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Network.Timestamp"
+      }
+     }
+    },
+    "pseudoElementAdded": {
+     "params": {
+      "parentId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "pseudoElement": {
+       "optional": false,
+       "type": "Node"
+      }
+     }
+    },
+    "pseudoElementRemoved": {
+     "params": {
+      "parentId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "pseudoElementId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "setChildNodes": {
+     "params": {
+      "nodes": {
+       "optional": false,
+       "type": "array"
+      },
+      "parentId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "shadowRootPopped": {
+     "params": {
+      "hostId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "rootId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "shadowRootPushed": {
+     "params": {
+      "hostId": {
+       "optional": false,
+       "type": "NodeId"
+      },
+      "root": {
+       "optional": false,
+       "type": "Node"
+      }
+     }
+    },
+    "willDestroyDOMNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    },
+    "willRemoveEventListener": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "NodeId"
+      }
+     }
+    }
+   }
+  },
+  "DOMDebugger": {
+   "commands": {
+    "removeDOMBreakpoint": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      },
+      "type": {
+       "optional": false,
+       "type": "DOMBreakpointType"
+      }
+     },
+     "returns": []
+    },
+    "removeEventBreakpoint": {
+     "params": {
+      "breakpointType": {
+       "optional": false,
+       "type": "EventBreakpointType"
+      },
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "eventName": {
+       "optional": true,
+       "type": "string"
+      },
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "removeURLBreakpoint": {
+     "params": {
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setDOMBreakpoint": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      },
+      "options": {
+       "optional": true,
+       "type": "Debugger.BreakpointOptions"
+      },
+      "type": {
+       "optional": false,
+       "type": "DOMBreakpointType"
+      }
+     },
+     "returns": []
+    },
+    "setEventBreakpoint": {
+     "params": {
+      "breakpointType": {
+       "optional": false,
+       "type": "EventBreakpointType"
+      },
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "eventName": {
+       "optional": true,
+       "type": "string"
+      },
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "options": {
+       "optional": true,
+       "type": "Debugger.BreakpointOptions"
+      }
+     },
+     "returns": []
+    },
+    "setURLBreakpoint": {
+     "params": {
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "options": {
+       "optional": true,
+       "type": "Debugger.BreakpointOptions"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {}
+  },
+  "DOMStorage": {
+   "commands": {
+    "clearDOMStorageItems": {
+     "params": {
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getDOMStorageItems": {
+     "params": {
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     },
+     "returns": [
+      "entries"
+     ]
+    },
+    "removeDOMStorageItem": {
+     "params": {
+      "key": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     },
+     "returns": []
+    },
+    "setDOMStorageItem": {
+     "params": {
+      "key": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      },
+      "value": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "domStorageItemAdded": {
+     "params": {
+      "key": {
+       "optional": false,
+       "type": "string"
+      },
+      "newValue": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     }
+    },
+    "domStorageItemRemoved": {
+     "params": {
+      "key": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     }
+    },
+    "domStorageItemUpdated": {
+     "params": {
+      "key": {
+       "optional": false,
+       "type": "string"
+      },
+      "newValue": {
+       "optional": false,
+       "type": "string"
+      },
+      "oldValue": {
+       "optional": false,
+       "type": "string"
+      },
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     }
+    },
+    "domStorageItemsCleared": {
+     "params": {
+      "storageId": {
+       "optional": false,
+       "type": "StorageId"
+      }
+     }
+    }
+   }
+  },
+  "Debugger": {
+   "commands": {
+    "addSymbolicBreakpoint": {
+     "params": {
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "options": {
+       "optional": true,
+       "type": "BreakpointOptions"
+      },
+      "symbol": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "continueToLocation": {
+     "params": {
+      "location": {
+       "optional": false,
+       "type": "Location"
+      }
+     },
+     "returns": []
+    },
+    "continueUntilNextRunLoop": {
+     "params": {},
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "evaluateOnCallFrame": {
+     "params": {
+      "callFrameId": {
+       "optional": false,
+       "type": "CallFrameId"
+      },
+      "doNotPauseOnExceptionsAndMuteConsole": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "emulateUserGesture": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "expression": {
+       "optional": false,
+       "type": "string"
+      },
+      "generatePreview": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includeCommandLineAPI": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      },
+      "returnByValue": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "saveResult": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "result",
+      "wasThrown",
+      "savedResultIndex"
+     ]
+    },
+    "getBreakpointLocations": {
+     "params": {
+      "end": {
+       "optional": false,
+       "type": "Location"
+      },
+      "start": {
+       "optional": false,
+       "type": "Location"
+      }
+     },
+     "returns": [
+      "locations"
+     ]
+    },
+    "getFunctionDetails": {
+     "params": {
+      "functionId": {
+       "optional": false,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": [
+      "details"
+     ]
+    },
+    "getScriptSource": {
+     "params": {
+      "scriptId": {
+       "optional": false,
+       "type": "ScriptId"
+      }
+     },
+     "returns": [
+      "scriptSource"
+     ]
+    },
+    "pause": {
+     "params": {},
+     "returns": []
+    },
+    "removeBreakpoint": {
+     "params": {
+      "breakpointId": {
+       "optional": false,
+       "type": "BreakpointId"
+      }
+     },
+     "returns": []
+    },
+    "removeSymbolicBreakpoint": {
+     "params": {
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "symbol": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "resume": {
+     "params": {},
+     "returns": []
+    },
+    "searchInContent": {
+     "params": {
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "query": {
+       "optional": false,
+       "type": "string"
+      },
+      "scriptId": {
+       "optional": false,
+       "type": "ScriptId"
+      }
+     },
+     "returns": [
+      "result"
+     ]
+    },
+    "setAsyncStackTraceDepth": {
+     "params": {
+      "depth": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "setBlackboxBreakpointEvaluations": {
+     "params": {
+      "blackboxBreakpointEvaluations": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setBreakpoint": {
+     "params": {
+      "location": {
+       "optional": false,
+       "type": "Location"
+      },
+      "options": {
+       "optional": true,
+       "type": "BreakpointOptions"
+      }
+     },
+     "returns": [
+      "breakpointId",
+      "actualLocation"
+     ]
+    },
+    "setBreakpointByUrl": {
+     "params": {
+      "columnNumber": {
+       "optional": true,
+       "type": "integer"
+      },
+      "lineNumber": {
+       "optional": false,
+       "type": "integer"
+      },
+      "options": {
+       "optional": true,
+       "type": "BreakpointOptions"
+      },
+      "url": {
+       "optional": true,
+       "type": "string"
+      },
+      "urlRegex": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "breakpointId",
+      "locations"
+     ]
+    },
+    "setBreakpointsActive": {
+     "params": {
+      "active": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setPauseForInternalScripts": {
+     "params": {
+      "shouldPause": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setPauseOnAssertions": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "options": {
+       "optional": true,
+       "type": "BreakpointOptions"
+      }
+     },
+     "returns": []
+    },
+    "setPauseOnDebuggerStatements": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "options": {
+       "optional": true,
+       "type": "BreakpointOptions"
+      }
+     },
+     "returns": []
+    },
+    "setPauseOnExceptions": {
+     "params": {
+      "options": {
+       "optional": true,
+       "type": "BreakpointOptions"
+      },
+      "state": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setPauseOnMicrotasks": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "options": {
+       "optional": true,
+       "type": "BreakpointOptions"
+      }
+     },
+     "returns": []
+    },
+    "setShouldBlackboxURL": {
+     "params": {
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "shouldBlackbox": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "sourceRanges": {
+       "optional": true,
+       "type": "array"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "stepInto": {
+     "params": {},
+     "returns": []
+    },
+    "stepNext": {
+     "params": {},
+     "returns": []
+    },
+    "stepOut": {
+     "params": {},
+     "returns": []
+    },
+    "stepOver": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "breakpointResolved": {
+     "params": {
+      "breakpointId": {
+       "optional": false,
+       "type": "BreakpointId"
+      },
+      "location": {
+       "optional": false,
+       "type": "Location"
+      }
+     }
+    },
+    "didSampleProbe": {
+     "params": {
+      "sample": {
+       "optional": false,
+       "type": "ProbeSample"
+      }
+     }
+    },
+    "globalObjectCleared": {
+     "params": {}
+    },
+    "paused": {
+     "params": {
+      "asyncStackTrace": {
+       "optional": true,
+       "type": "Console.StackTrace"
+      },
+      "callFrames": {
+       "optional": false,
+       "type": "array"
+      },
+      "data": {
+       "optional": true,
+       "type": "object"
+      },
+      "reason": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "playBreakpointActionSound": {
+     "params": {
+      "breakpointActionId": {
+       "optional": false,
+       "type": "BreakpointActionIdentifier"
+      }
+     }
+    },
+    "resumed": {
+     "params": {}
+    },
+    "scriptFailedToParse": {
+     "params": {
+      "errorLine": {
+       "optional": false,
+       "type": "integer"
+      },
+      "errorMessage": {
+       "optional": false,
+       "type": "string"
+      },
+      "scriptSource": {
+       "optional": false,
+       "type": "string"
+      },
+      "startLine": {
+       "optional": false,
+       "type": "integer"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "scriptParsed": {
+     "params": {
+      "displayName": {
+       "optional": true,
+       "type": "string"
+      },
+      "endColumn": {
+       "optional": false,
+       "type": "integer"
+      },
+      "endLine": {
+       "optional": false,
+       "type": "integer"
+      },
+      "executionContextId": {
+       "optional": false,
+       "type": "Runtime.ExecutionContextId"
+      },
+      "isContentScript": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "requestId": {
+       "optional": true,
+       "type": "Network.RequestId"
+      },
+      "scriptId": {
+       "optional": false,
+       "type": "ScriptId"
+      },
+      "scriptType": {
+       "optional": false,
+       "type": "ScriptType"
+      },
+      "sourceMapURL": {
+       "optional": true,
+       "type": "string"
+      },
+      "sourceURL": {
+       "optional": true,
+       "type": "string"
+      },
+      "startColumn": {
+       "optional": false,
+       "type": "integer"
+      },
+      "startLine": {
+       "optional": false,
+       "type": "integer"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    }
+   }
+  },
+  "GenericTypes": {
+   "commands": {},
+   "events": {}
+  },
+  "Heap": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "gc": {
+     "params": {},
+     "returns": []
+    },
+    "getPreview": {
+     "params": {
+      "heapObjectId": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": [
+      "string",
+      "functionDetails",
+      "preview"
+     ]
+    },
+    "getRemoteObject": {
+     "params": {
+      "heapObjectId": {
+       "optional": false,
+       "type": "integer"
+      },
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "result"
+     ]
+    },
+    "snapshot": {
+     "params": {},
+     "returns": [
+      "timestamp",
+      "snapshotData"
+     ]
+    },
+    "startTracking": {
+     "params": {},
+     "returns": []
+    },
+    "stopTracking": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "garbageCollected": {
+     "params": {
+      "collection": {
+       "optional": false,
+       "type": "GarbageCollection"
+      }
+     }
+    },
+    "trackingComplete": {
+     "params": {
+      "snapshotData": {
+       "optional": false,
+       "type": "HeapSnapshotData"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "trackingStart": {
+     "params": {
+      "snapshotData": {
+       "optional": false,
+       "type": "HeapSnapshotData"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    }
+   }
+  },
+  "IndexedDB": {
+   "commands": {
+    "clearObjectStore": {
+     "params": {
+      "databaseName": {
+       "optional": false,
+       "type": "string"
+      },
+      "objectStoreName": {
+       "optional": false,
+       "type": "string"
+      },
+      "securityOrigin": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "requestData": {
+     "params": {
+      "databaseName": {
+       "optional": false,
+       "type": "string"
+      },
+      "indexName": {
+       "optional": false,
+       "type": "string"
+      },
+      "keyRange": {
+       "optional": true,
+       "type": "KeyRange"
+      },
+      "objectStoreName": {
+       "optional": false,
+       "type": "string"
+      },
+      "pageSize": {
+       "optional": false,
+       "type": "integer"
+      },
+      "securityOrigin": {
+       "optional": false,
+       "type": "string"
+      },
+      "skipCount": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": [
+      "objectStoreDataEntries",
+      "hasMore"
+     ]
+    },
+    "requestDatabase": {
+     "params": {
+      "databaseName": {
+       "optional": false,
+       "type": "string"
+      },
+      "securityOrigin": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "databaseWithObjectStores"
+     ]
+    },
+    "requestDatabaseNames": {
+     "params": {
+      "securityOrigin": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "databaseNames"
+     ]
+    }
+   },
+   "events": {}
+  },
+  "Inspector": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "initialized": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "evaluateForTestInFrontend": {
+     "params": {
+      "script": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "inspect": {
+     "params": {
+      "hints": {
+       "optional": false,
+       "type": "object"
+      },
+      "object": {
+       "optional": false,
+       "type": "Runtime.RemoteObject"
+      }
+     }
+    }
+   }
+  },
+  "LayerTree": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "layersForNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "layers"
+     ]
+    },
+    "reasonsForCompositingLayer": {
+     "params": {
+      "layerId": {
+       "optional": false,
+       "type": "LayerId"
+      }
+     },
+     "returns": [
+      "compositingReasons"
+     ]
+    },
+    "requestContent": {
+     "params": {
+      "layerId": {
+       "optional": false,
+       "type": "LayerId"
+      }
+     },
+     "returns": [
+      "content"
+     ]
+    }
+   },
+   "events": {
+    "layerTreeDidChange": {
+     "params": {}
+    }
+   }
+  },
+  "Memory": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "startTracking": {
+     "params": {},
+     "returns": []
+    },
+    "stopTracking": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "memoryPressure": {
+     "params": {
+      "severity": {
+       "optional": false,
+       "type": "string"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "trackingComplete": {
+     "params": {
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "trackingStart": {
+     "params": {
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "trackingUpdate": {
+     "params": {
+      "event": {
+       "optional": false,
+       "type": "Event"
+      }
+     }
+    }
+   }
+  },
+  "Network": {
+   "commands": {
+    "addInterception": {
+     "params": {
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "stage": {
+       "optional": false,
+       "type": "NetworkStage"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getResponseBody": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": [
+      "body",
+      "base64Encoded"
+     ]
+    },
+    "getSerializedCertificate": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": [
+      "serializedCertificate"
+     ]
+    },
+    "interceptContinue": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "stage": {
+       "optional": false,
+       "type": "NetworkStage"
+      }
+     },
+     "returns": []
+    },
+    "interceptRequestWithError": {
+     "params": {
+      "errorType": {
+       "optional": false,
+       "type": "ResourceErrorType"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": []
+    },
+    "interceptRequestWithResponse": {
+     "params": {
+      "base64Encoded": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "content": {
+       "optional": false,
+       "type": "string"
+      },
+      "headers": {
+       "optional": false,
+       "type": "Headers"
+      },
+      "mimeType": {
+       "optional": false,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "status": {
+       "optional": false,
+       "type": "integer"
+      },
+      "statusText": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "interceptWithRequest": {
+     "params": {
+      "headers": {
+       "optional": true,
+       "type": "Headers"
+      },
+      "method": {
+       "optional": true,
+       "type": "string"
+      },
+      "postData": {
+       "optional": true,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "url": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "interceptWithResponse": {
+     "params": {
+      "base64Encoded": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "content": {
+       "optional": false,
+       "type": "string"
+      },
+      "headers": {
+       "optional": true,
+       "type": "Headers"
+      },
+      "mimeType": {
+       "optional": true,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "status": {
+       "optional": true,
+       "type": "integer"
+      },
+      "statusText": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "loadResource": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "content",
+      "mimeType",
+      "status"
+     ]
+    },
+    "removeInterception": {
+     "params": {
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "stage": {
+       "optional": false,
+       "type": "NetworkStage"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "resolveWebSocket": {
+     "params": {
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     },
+     "returns": [
+      "object"
+     ]
+    },
+    "setClearResourceDataOnNavigate": {
+     "params": {
+      "clearResourceDataOnNavigate": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setEmulatedConditions": {
+     "params": {
+      "bytesPerSecondLimit": {
+       "optional": true,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "setExtraHTTPHeaders": {
+     "params": {
+      "headers": {
+       "optional": false,
+       "type": "Headers"
+      }
+     },
+     "returns": []
+    },
+    "setInterceptionEnabled": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setResourceCachingDisabled": {
+     "params": {
+      "disabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "dataReceived": {
+     "params": {
+      "dataLength": {
+       "optional": false,
+       "type": "integer"
+      },
+      "encodedDataLength": {
+       "optional": false,
+       "type": "integer"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      }
+     }
+    },
+    "loadingFailed": {
+     "params": {
+      "canceled": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "errorText": {
+       "optional": false,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      }
+     }
+    },
+    "loadingFinished": {
+     "params": {
+      "metrics": {
+       "optional": true,
+       "type": "Metrics"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "sourceMapURL": {
+       "optional": true,
+       "type": "string"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      }
+     }
+    },
+    "requestIntercepted": {
+     "params": {
+      "request": {
+       "optional": false,
+       "type": "Request"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      }
+     }
+    },
+    "requestServedFromMemoryCache": {
+     "params": {
+      "documentURL": {
+       "optional": false,
+       "type": "string"
+      },
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "initiator": {
+       "optional": false,
+       "type": "Initiator"
+      },
+      "loaderId": {
+       "optional": false,
+       "type": "LoaderId"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "resource": {
+       "optional": false,
+       "type": "CachedResource"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      }
+     }
+    },
+    "requestWillBeSent": {
+     "params": {
+      "documentURL": {
+       "optional": false,
+       "type": "string"
+      },
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "initiator": {
+       "optional": false,
+       "type": "Initiator"
+      },
+      "loaderId": {
+       "optional": false,
+       "type": "LoaderId"
+      },
+      "redirectResponse": {
+       "optional": true,
+       "type": "Response"
+      },
+      "request": {
+       "optional": false,
+       "type": "Request"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "targetId": {
+       "optional": true,
+       "type": "string"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      },
+      "type": {
+       "optional": true,
+       "type": "Page.ResourceType"
+      },
+      "walltime": {
+       "optional": false,
+       "type": "Walltime"
+      }
+     }
+    },
+    "responseIntercepted": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "response": {
+       "optional": false,
+       "type": "Response"
+      }
+     }
+    },
+    "responseReceived": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "FrameId"
+      },
+      "loaderId": {
+       "optional": false,
+       "type": "LoaderId"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "response": {
+       "optional": false,
+       "type": "Response"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      },
+      "type": {
+       "optional": false,
+       "type": "Page.ResourceType"
+      }
+     }
+    },
+    "webSocketClosed": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      }
+     }
+    },
+    "webSocketCreated": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "webSocketFrameError": {
+     "params": {
+      "errorMessage": {
+       "optional": false,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      }
+     }
+    },
+    "webSocketFrameReceived": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "response": {
+       "optional": false,
+       "type": "WebSocketFrame"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      }
+     }
+    },
+    "webSocketFrameSent": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "response": {
+       "optional": false,
+       "type": "WebSocketFrame"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      }
+     }
+    },
+    "webSocketHandshakeResponseReceived": {
+     "params": {
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "response": {
+       "optional": false,
+       "type": "WebSocketResponse"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      }
+     }
+    },
+    "webSocketWillSendHandshakeRequest": {
+     "params": {
+      "request": {
+       "optional": false,
+       "type": "WebSocketRequest"
+      },
+      "requestId": {
+       "optional": false,
+       "type": "RequestId"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "Timestamp"
+      },
+      "walltime": {
+       "optional": false,
+       "type": "Walltime"
+      }
+     }
+    }
+   }
+  },
+  "Page": {
+   "commands": {
+    "archive": {
+     "params": {},
+     "returns": [
+      "data"
+     ]
+    },
+    "deleteCookie": {
+     "params": {
+      "cookieName": {
+       "optional": false,
+       "type": "string"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getCookies": {
+     "params": {},
+     "returns": [
+      "cookies"
+     ]
+    },
+    "getResourceContent": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "Network.FrameId"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "content",
+      "base64Encoded"
+     ]
+    },
+    "getResourceTree": {
+     "params": {},
+     "returns": [
+      "frameTree"
+     ]
+    },
+    "overrideSetting": {
+     "params": {
+      "setting": {
+       "optional": false,
+       "type": "Setting"
+      },
+      "value": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "overrideUserAgent": {
+     "params": {
+      "value": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "overrideUserPreference": {
+     "params": {
+      "name": {
+       "optional": false,
+       "type": "UserPreferenceName"
+      },
+      "value": {
+       "optional": true,
+       "type": "UserPreferenceValue"
+      }
+     },
+     "returns": []
+    },
+    "reload": {
+     "params": {
+      "ignoreCache": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "revalidateAllResources": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "searchInResource": {
+     "params": {
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "frameId": {
+       "optional": false,
+       "type": "Network.FrameId"
+      },
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "query": {
+       "optional": false,
+       "type": "string"
+      },
+      "requestId": {
+       "optional": true,
+       "type": "Network.RequestId"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "result"
+     ]
+    },
+    "searchInResources": {
+     "params": {
+      "caseSensitive": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "isRegex": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "text": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "result"
+     ]
+    },
+    "setBootstrapScript": {
+     "params": {
+      "source": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setCookie": {
+     "params": {
+      "cookie": {
+       "optional": false,
+       "type": "Cookie"
+      },
+      "shouldPartition": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setEmulatedMedia": {
+     "params": {
+      "media": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setScreenSizeOverride": {
+     "params": {
+      "height": {
+       "optional": true,
+       "type": "integer"
+      },
+      "width": {
+       "optional": true,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "setShowPaintRects": {
+     "params": {
+      "result": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setShowRulers": {
+     "params": {
+      "result": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "snapshotNode": {
+     "params": {
+      "nodeId": {
+       "optional": false,
+       "type": "DOM.NodeId"
+      }
+     },
+     "returns": [
+      "dataURL"
+     ]
+    },
+    "snapshotRect": {
+     "params": {
+      "coordinateSystem": {
+       "optional": false,
+       "type": "CoordinateSystem"
+      },
+      "height": {
+       "optional": false,
+       "type": "integer"
+      },
+      "width": {
+       "optional": false,
+       "type": "integer"
+      },
+      "x": {
+       "optional": false,
+       "type": "integer"
+      },
+      "y": {
+       "optional": false,
+       "type": "integer"
+      }
+     },
+     "returns": [
+      "dataURL"
+     ]
+    }
+   },
+   "events": {
+    "defaultUserPreferencesDidChange": {
+     "params": {
+      "preferences": {
+       "optional": false,
+       "type": "array"
+      }
+     }
+    },
+    "domContentEventFired": {
+     "params": {
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "frameDetached": {
+     "params": {
+      "frameId": {
+       "optional": false,
+       "type": "Network.FrameId"
+      }
+     }
+    },
+    "frameNavigated": {
+     "params": {
+      "frame": {
+       "optional": false,
+       "type": "Frame"
+      }
+     }
+    },
+    "loadEventFired": {
+     "params": {
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    }
+   }
+  },
+  "Recording": {
+   "commands": {},
+   "events": {}
+  },
+  "Runtime": {
+   "commands": {
+    "awaitPromise": {
+     "params": {
+      "generatePreview": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "promiseObjectId": {
+       "optional": false,
+       "type": "RemoteObjectId"
+      },
+      "returnByValue": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "saveResult": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "result",
+      "wasThrown",
+      "savedResultIndex"
+     ]
+    },
+    "callFunctionOn": {
+     "params": {
+      "arguments": {
+       "optional": true,
+       "type": "array"
+      },
+      "awaitPromise": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "doNotPauseOnExceptionsAndMuteConsole": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "emulateUserGesture": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "functionDeclaration": {
+       "optional": false,
+       "type": "string"
+      },
+      "generatePreview": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "objectId": {
+       "optional": false,
+       "type": "RemoteObjectId"
+      },
+      "returnByValue": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "result",
+      "wasThrown"
+     ]
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "disableControlFlowProfiler": {
+     "params": {},
+     "returns": []
+    },
+    "disableTypeProfiler": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "enableControlFlowProfiler": {
+     "params": {},
+     "returns": []
+    },
+    "enableTypeProfiler": {
+     "params": {},
+     "returns": []
+    },
+    "evaluate": {
+     "params": {
+      "contextId": {
+       "optional": true,
+       "type": "Runtime.ExecutionContextId"
+      },
+      "doNotPauseOnExceptionsAndMuteConsole": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "emulateUserGesture": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "expression": {
+       "optional": false,
+       "type": "string"
+      },
+      "generatePreview": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "includeCommandLineAPI": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      },
+      "returnByValue": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "saveResult": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "result",
+      "wasThrown",
+      "savedResultIndex"
+     ]
+    },
+    "getBasicBlocks": {
+     "params": {
+      "sourceID": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "basicBlocks"
+     ]
+    },
+    "getCollectionEntries": {
+     "params": {
+      "fetchCount": {
+       "optional": true,
+       "type": "integer"
+      },
+      "fetchStart": {
+       "optional": true,
+       "type": "integer"
+      },
+      "objectGroup": {
+       "optional": true,
+       "type": "string"
+      },
+      "objectId": {
+       "optional": false,
+       "type": "Runtime.RemoteObjectId"
+      }
+     },
+     "returns": [
+      "entries"
+     ]
+    },
+    "getDisplayableProperties": {
+     "params": {
+      "fetchCount": {
+       "optional": true,
+       "type": "integer"
+      },
+      "fetchStart": {
+       "optional": true,
+       "type": "integer"
+      },
+      "generatePreview": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "objectId": {
+       "optional": false,
+       "type": "RemoteObjectId"
+      }
+     },
+     "returns": [
+      "properties",
+      "internalProperties"
+     ]
+    },
+    "getPreview": {
+     "params": {
+      "objectId": {
+       "optional": false,
+       "type": "RemoteObjectId"
+      }
+     },
+     "returns": [
+      "preview"
+     ]
+    },
+    "getProperties": {
+     "params": {
+      "fetchCount": {
+       "optional": true,
+       "type": "integer"
+      },
+      "fetchStart": {
+       "optional": true,
+       "type": "integer"
+      },
+      "generatePreview": {
+       "optional": true,
+       "type": "boolean"
+      },
+      "objectId": {
+       "optional": false,
+       "type": "RemoteObjectId"
+      },
+      "ownProperties": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": [
+      "properties",
+      "internalProperties"
+     ]
+    },
+    "getRuntimeTypesForVariablesAtOffsets": {
+     "params": {
+      "locations": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": [
+      "types"
+     ]
+    },
+    "parse": {
+     "params": {
+      "source": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": [
+      "result",
+      "message",
+      "range"
+     ]
+    },
+    "releaseObject": {
+     "params": {
+      "objectId": {
+       "optional": false,
+       "type": "RemoteObjectId"
+      }
+     },
+     "returns": []
+    },
+    "releaseObjectGroup": {
+     "params": {
+      "objectGroup": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "saveResult": {
+     "params": {
+      "contextId": {
+       "optional": true,
+       "type": "ExecutionContextId"
+      },
+      "value": {
+       "optional": false,
+       "type": "CallArgument"
+      }
+     },
+     "returns": [
+      "savedResultIndex"
+     ]
+    },
+    "setSavedResultAlias": {
+     "params": {
+      "alias": {
+       "optional": true,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "executionContextCreated": {
+     "params": {
+      "context": {
+       "optional": false,
+       "type": "ExecutionContextDescription"
+      }
+     }
+    }
+   }
+  },
+  "ScriptProfiler": {
+   "commands": {
+    "startTracking": {
+     "params": {
+      "includeSamples": {
+       "optional": true,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "stopTracking": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "trackingComplete": {
+     "params": {
+      "samples": {
+       "optional": true,
+       "type": "Samples"
+      },
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "trackingStart": {
+     "params": {
+      "timestamp": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "trackingUpdate": {
+     "params": {
+      "event": {
+       "optional": false,
+       "type": "Event"
+      }
+     }
+    }
+   }
+  },
+  "Security": {
+   "commands": {},
+   "events": {}
+  },
+  "ServiceWorker": {
+   "commands": {
+    "getInitializationInfo": {
+     "params": {},
+     "returns": [
+      "info"
+     ]
+    }
+   },
+   "events": {}
+  },
+  "Storage": {
+   "commands": {
+    "deleteCookies": {
+     "params": {
+      "filter": {
+       "optional": true,
+       "type": "CookieFilter"
+      },
+      "partition": {
+       "optional": true,
+       "type": "PartitionDescriptor"
+      }
+     },
+     "returns": [
+      "partitionKey"
+     ]
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "getCookies": {
+     "params": {
+      "filter": {
+       "optional": true,
+       "type": "CookieFilter"
+      },
+      "partition": {
+       "optional": true,
+       "type": "PartitionDescriptor"
+      }
+     },
+     "returns": [
+      "cookies",
+      "partitionKey"
+     ]
+    },
+    "setCookie": {
+     "params": {
+      "cookie": {
+       "optional": false,
+       "type": "Cookie"
+      },
+      "partition": {
+       "optional": true,
+       "type": "PartitionDescriptor"
+      }
+     },
+     "returns": [
+      "partitionKey"
+     ]
+    }
+   },
+   "events": {}
+  },
+  "Target": {
+   "commands": {
+    "resume": {
+     "params": {
+      "targetId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "sendMessageToTarget": {
+     "params": {
+      "message": {
+       "optional": false,
+       "type": "string"
+      },
+      "targetId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "setPauseOnStart": {
+     "params": {
+      "pauseOnStart": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "didCommitProvisionalTarget": {
+     "params": {
+      "newTargetId": {
+       "optional": false,
+       "type": "string"
+      },
+      "oldTargetId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "dispatchMessageFromTarget": {
+     "params": {
+      "message": {
+       "optional": false,
+       "type": "string"
+      },
+      "targetId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "targetCreated": {
+     "params": {
+      "targetInfo": {
+       "optional": false,
+       "type": "TargetInfo"
+      }
+     }
+    },
+    "targetDestroyed": {
+     "params": {
+      "targetId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    }
+   }
+  },
+  "Timeline": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "setAutoCaptureEnabled": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "setInstruments": {
+     "params": {
+      "instruments": {
+       "optional": false,
+       "type": "array"
+      }
+     },
+     "returns": []
+    },
+    "start": {
+     "params": {
+      "maxCallStackDepth": {
+       "optional": true,
+       "type": "integer"
+      }
+     },
+     "returns": []
+    },
+    "stop": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "autoCaptureStarted": {
+     "params": {}
+    },
+    "eventRecorded": {
+     "params": {
+      "record": {
+       "optional": false,
+       "type": "TimelineEvent"
+      }
+     }
+    },
+    "recordingStarted": {
+     "params": {
+      "startTime": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    },
+    "recordingStopped": {
+     "params": {
+      "endTime": {
+       "optional": false,
+       "type": "number"
+      }
+     }
+    }
+   }
+  },
+  "Worker": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "initialized": {
+     "params": {
+      "workerId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    },
+    "sendMessageToWorker": {
+     "params": {
+      "message": {
+       "optional": false,
+       "type": "string"
+      },
+      "workerId": {
+       "optional": false,
+       "type": "string"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "dispatchMessageFromWorker": {
+     "params": {
+      "message": {
+       "optional": false,
+       "type": "string"
+      },
+      "workerId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "workerCreated": {
+     "params": {
+      "name": {
+       "optional": false,
+       "type": "string"
+      },
+      "url": {
+       "optional": false,
+       "type": "string"
+      },
+      "workerId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    },
+    "workerTerminated": {
+     "params": {
+      "workerId": {
+       "optional": false,
+       "type": "string"
+      }
+     }
+    }
+   }
+  }
+ },
+ "source": {
+  "commit": "587e3a7c563e482a45c3b186d9d5f093aadfb4a8",
+  "fetched": "2026-09-08",
+  "path": "Source/JavaScriptCore/inspector/protocol",
+  "repo": "WebKit/WebKit"
+ }
+}

--- a/tests/services/test_web_protocol/protocol_inventory.py
+++ b/tests/services/test_web_protocol/protocol_inventory.py
@@ -1,0 +1,232 @@
+"""What the CDP bridge says on each side of the wire, read from its source with `ast`.
+
+The bridge translates between two protocols. Everything it does with a protocol name falls into
+one of four roles, each checked against the spec that governs it:
+
+- a CDP method it handles itself (the handler tables)      -> must be a real CDP method
+- a WebKit event it translates (the dispatch table)        -> must be a real WebKit event
+- a message it sends the device (`_send_message_to_target`, `send_message_with_result`, ...)
+                                                           -> a real WebKit command, with real parameters
+- an event it emits to the editor (`output_queue.put`, `_send_event`, ...)
+                                                           -> a real CDP event
+
+Classification is by the enclosing call in the AST, not by text, so it cannot mistake a method
+rename sent to the device for an event emitted to the editor. Names in neither spec are typos or
+undocumented inventions, and are reported as such.
+"""
+
+import ast
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional, cast
+
+REPO = Path(__file__).resolve().parents[3]
+SOURCES = [
+    REPO / "pymobiledevice3/services/web_protocol/cdp_target.py",
+    REPO / "pymobiledevice3/services/web_protocol/cdp_browser.py",
+    REPO / "pymobiledevice3/services/web_protocol/cdp_server.py",
+]
+SPECS = Path(__file__).resolve().parent / "protocol"
+NAME = re.compile(r"^[A-Z][A-Za-z]+\.[a-z][A-Za-z]+$")
+
+WEBKIT_BOUND_CALLS = {
+    "_send_message_to_target",
+    "send_message_with_result",
+    "send_message_with_result_across_swaps",
+    "_forward_and_translate",
+    "send_command",
+    "_send_message_flat",
+}
+CLIENT_BOUND_CALLS = {"put", "_send_event", "_send", "append", "send_json"}
+WEBKIT_EVENT_TABLES = {"to_cdp_special_dispatched_messages_methods", "to_cdp_special_messages_methods"}
+
+
+@dataclass
+class Send:
+    method: str
+    params: Optional[frozenset[str]]  # literal parameter keys, or None when not a literal dict
+    where: str
+
+
+@dataclass
+class Inventory:
+    client_handled: dict[str, str] = field(default_factory=dict)  # CDP method -> table
+    webkit_events_handled: dict[str, str] = field(default_factory=dict)
+    webkit_bound: list[Send] = field(default_factory=list)
+    client_bound_events: list[Send] = field(default_factory=list)
+    all_names: dict[str, set[str]] = field(default_factory=dict)  # name -> files
+    constants: dict[str, set[str]] = field(default_factory=dict)  # module-level NAME = frozenset({...}) / {...: ...}
+
+
+def _const_str(node: ast.AST) -> Optional[str]:
+    return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None
+
+
+def _dict_get(d: ast.Dict, key: str) -> Optional[ast.AST]:
+    for k, v in zip(d.keys, d.values):
+        if k is not None and _const_str(k) == key:
+            return v
+    return None
+
+
+def _literal_keys(node: Optional[ast.AST]) -> Optional[frozenset[str]]:
+    if not isinstance(node, ast.Dict):
+        return None
+    keys: set[str] = set()
+    for k in node.keys:
+        if k is None:  # **spread - not fully literal
+            return None
+        s = _const_str(k)
+        if s is None:
+            return None
+        keys.add(s)
+    return frozenset(keys)
+
+
+def _func_name(call: ast.Call) -> str:
+    f = call.func
+    if isinstance(f, ast.Attribute):
+        return f.attr
+    if isinstance(f, ast.Name):
+        return f.id
+    return ""
+
+
+def _enclosing(node: ast.AST, parents: dict[int, ast.AST]) -> str:
+    cur: Optional[ast.AST] = node
+    while cur is not None:
+        if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return cur.name
+        cur = parents.get(id(cur))
+    return "<module>"
+
+
+def _message_dicts(node: ast.AST) -> list[ast.Dict]:
+    """Dict literals carrying a "method" key, anywhere under `node`."""
+    return [d for d in ast.walk(node) if isinstance(d, ast.Dict) and _dict_get(d, "method") is not None]
+
+
+def collect() -> Inventory:
+    inv = Inventory()
+    for path in SOURCES:
+        text = path.read_text()
+        tree = ast.parse(text)
+        parents: dict[int, ast.AST] = {}
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                parents[id(child)] = parent
+        for statement in tree.body:
+            # module-level string sets and string-keyed dicts: NAME = frozenset({...}) / NAME = {...}
+            if isinstance(statement, (ast.Assign, ast.AnnAssign)):
+                target = statement.targets[0] if isinstance(statement, ast.Assign) else statement.target
+                value = statement.value
+                if isinstance(value, ast.Call) and _func_name(value) == "frozenset" and value.args:
+                    value = value.args[0]
+                if isinstance(target, ast.Name) and isinstance(value, (ast.Set, ast.Dict)):
+                    elements = value.keys if isinstance(value, ast.Dict) else value.elts
+                    strings = [_const_str(e) for e in elements if e is not None]
+                    if strings and all(strings):
+                        inv.constants[target.id] = {cast(str, x) for x in strings}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str) and NAME.match(node.value):
+                inv.all_names.setdefault(node.value, set()).add(path.name)
+            # a method rename before a forward: message["method"] = "Domain.name"  -> sent to WebKit
+            if isinstance(node, (ast.Assign, ast.AnnAssign)):
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                value = node.value
+                for target in targets:
+                    if (
+                        isinstance(target, ast.Subscript)
+                        and _const_str(target.slice) == "method"
+                        and value is not None
+                        and _const_str(value)
+                        and NAME.match(_const_str(value) or "")
+                    ):
+                        inv.webkit_bound.append(Send(cast(str, _const_str(value)), None, _enclosing(node, parents)))
+            # handler / dispatch tables: self.<table> = { "Domain.name": ..., }  (plain or annotated)
+            table_value = node.value if isinstance(node, (ast.Assign, ast.AnnAssign)) else None
+            if isinstance(table_value, ast.Dict):
+                target = (
+                    node.targets[0]
+                    if isinstance(node, ast.Assign) and len(node.targets) == 1
+                    else (node.target if isinstance(node, ast.AnnAssign) else None)
+                )
+                node = cast(Any, node)
+                node.value = table_value
+                if target is None:
+                    continue
+                attr = (
+                    target.attr
+                    if isinstance(target, ast.Attribute)
+                    else (target.id if isinstance(target, ast.Name) else "")
+                )
+                keys = [s for s in (_const_str(k) for k in table_value.keys if k is not None) if s and NAME.match(s)]
+                if not keys:
+                    continue
+                if attr in WEBKIT_EVENT_TABLES:
+                    for k in keys:
+                        inv.webkit_events_handled[k] = attr
+                elif all(isinstance(v, (ast.Attribute, ast.Call, ast.Name)) for v in table_value.values):
+                    # any other Domain.name-keyed table of callables is a client handler table
+                    for k in keys:
+                        inv.client_handled.setdefault(k, attr)
+            if isinstance(node, ast.Call):
+                name = _func_name(node)
+                where = _enclosing(node, parents)
+                if name in WEBKIT_BOUND_CALLS:
+                    if (
+                        name in ("send_message_with_result", "send_message_with_result_across_swaps", "send_command")
+                        and node.args
+                    ):
+                        method = _const_str(node.args[0])
+                        if method:
+                            params = (
+                                _literal_keys(node.args[1])
+                                if len(node.args) > 1
+                                else frozenset(kw.arg for kw in node.keywords if kw.arg)
+                            )
+                            inv.webkit_bound.append(Send(method, params, where))
+                            continue
+                    for d in [
+                        a for a in list(node.args) + [kw.value for kw in node.keywords] for a in _message_dicts(a)
+                    ]:
+                        method = _const_str(_dict_get(d, "method") or ast.Constant(value=None))
+                        if method:
+                            inv.webkit_bound.append(Send(method, _literal_keys(_dict_get(d, "params")), where))
+                elif name in CLIENT_BOUND_CALLS:
+                    if name == "_send_event" and node.args:
+                        method = _const_str(node.args[0])
+                        if method:
+                            inv.client_bound_events.append(Send(method, None, where))
+                            continue
+                    for d in [a for a in node.args for a in _message_dicts(a)]:
+                        method = _const_str(_dict_get(d, "method") or ast.Constant(value=None))
+                        if method and NAME.match(method):
+                            inv.client_bound_events.append(Send(method, None, where))
+    return inv
+
+
+def load_spec(name: str) -> dict[str, Any]:
+    return json.loads((SPECS / f"{name}_protocol.json").read_text())["domains"]
+
+
+def split(name: str) -> tuple[str, str]:
+    domain, _, member = name.partition(".")
+    return domain, member
+
+
+def in_commands(spec: dict[str, Any], name: str) -> bool:
+    d, m = split(name)
+    return m in spec.get(d, {}).get("commands", {})
+
+
+def in_events(spec: dict[str, Any], name: str) -> bool:
+    d, m = split(name)
+    return m in spec.get(d, {}).get("events", {})
+
+
+def command_params(spec: dict[str, Any], name: str) -> dict[str, Any]:
+    d, m = split(name)
+    return spec.get(d, {}).get("commands", {}).get(m, {}).get("params", {})

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -2624,6 +2624,71 @@ async def test_a_page_target_takes_over_the_session(monkeypatch: pytest.MonkeyPa
         assert target.output_queue.get_nowait()["method"] == "Target.targetInfoChanged"
 
 
+async def test_user_preference_overrides_are_translated_and_replayed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Chrome's dark-mode emulation - Emulation.setAutoDarkModeOverride and the media features of
+    Emulation.setEmulatedMedia - maps onto WebKit's Page.overrideUserPreference (the command that
+    replaced Page.setForcedAppearance, which iOS 26 no longer knows). A feature dropped from the
+    list is reset, as in Chrome, and the latest override per preference survives a process swap."""
+    with offline_cdp_target(monkeypatch) as (target, sent):
+
+        def device_messages() -> list[dict[str, Any]]:
+            return [json.loads(m["params"]["message"]) for m in sent]
+
+        await target._emulation_set_auto_dark_mode_override({
+            "id": 1,
+            "method": "Emulation.setAutoDarkModeOverride",
+            "params": {"enabled": True},
+        })
+        assert device_messages()[-1] == {
+            "id": 1,
+            "method": "Page.overrideUserPreference",
+            "params": {"name": "PrefersColorScheme", "value": "Dark"},
+        }
+
+        await target._emulation_set_emulated_media({
+            "id": 2,
+            "method": "Emulation.setEmulatedMedia",
+            "params": {
+                "media": "print",
+                "features": [
+                    {"name": "prefers-reduced-motion", "value": "reduce"},
+                    {"name": "prefers-contrast", "value": "less"},
+                    {"name": "color-gamut", "value": "p3"},
+                ],
+            },
+        })
+        methods = [(m["method"], m["params"]) for m in device_messages()[1:]]
+        assert methods == [
+            ("Page.overrideUserPreference", {"name": "PrefersReducedMotion", "value": "Reduce"}),
+            # No WebKit value for "less": the override is cleared rather than guessed.
+            ("Page.overrideUserPreference", {"name": "PrefersContrast"}),
+            ("Page.setEmulatedMedia", {"media": "print"}),
+        ]
+        assert device_messages()[-1]["id"] == 2, "the client's reply must come from setEmulatedMedia"
+
+        # Reduced motion is gone from the list, so it is reset; media is required by WebKit.
+        del sent[:]
+        await target._emulation_set_emulated_media({"id": 3, "method": "Emulation.setEmulatedMedia", "params": {}})
+        assert [(m["method"], m["params"]) for m in device_messages()] == [
+            ("Page.overrideUserPreference", {"name": "PrefersReducedMotion"}),
+            ("Page.setEmulatedMedia", {"media": ""}),
+        ]
+
+        # `enabled` absent means "stop overriding", and replaces the earlier Dark for replay.
+        await target._emulation_set_auto_dark_mode_override({
+            "id": 4,
+            "method": "Emulation.setAutoDarkModeOverride",
+            "params": {},
+        })
+        replayed = {k: v for k, v in target._setup_messages.items() if isinstance(k, tuple)}
+        assert replayed == {
+            ("Page.overrideUserPreference", "PrefersColorScheme"): {"name": "PrefersColorScheme"},
+            ("Page.overrideUserPreference", "PrefersReducedMotion"): {"name": "PrefersReducedMotion"},
+            ("Page.overrideUserPreference", "PrefersContrast"): {"name": "PrefersContrast"},
+        }
+        assert target._setup_messages["Page.setEmulatedMedia"] == {"media": ""}
+
+
 async def test_a_frame_target_does_not_take_over_the_session(monkeypatch: pytest.MonkeyPatch) -> None:
     """WebKit announces site-isolated subframes as "frame" targets. Their backend implements a
     far smaller domain set than a page's - with site isolation off, no domains at all - so a
@@ -2824,5 +2889,63 @@ async def testp_cdp_server_handles_editing_keys(lockdown: LockdownClient) -> Non
                 "the page's keydown listener must see every key with its modifiers"
             )
             assert await field_value() == "helloz", "a page that prevents Cmd-A's default must keep its value"
+        finally:
+            await client.close()
+
+
+async def testp_cdp_server_emulates_user_preferences(lockdown: LockdownClient) -> None:
+    """
+    Chrome's rendering emulation (prefers-color-scheme, prefers-reduced-motion, prefers-contrast,
+    print media) must reach the page. The WebKit command the bridge used to send for dark mode no
+    longer exists on iOS 26 ("'Page.setForcedAppearance' was not found"), so the page kept its own
+    scheme while the editor showed the emulation as active.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        ids = itertools.count(1)
+        try:
+            await client.command(next(ids), "Page.enable", {})
+            await client.command(next(ids), "Runtime.enable", {})
+            await client.command(next(ids), "Page.navigate", {"url": "https://example.com/"})
+            await asyncio.sleep(3)
+
+            async def preferences() -> str:
+                reply = await client.command(
+                    next(ids),
+                    "Runtime.evaluate",
+                    {
+                        "expression": "['(prefers-color-scheme: dark)', '(prefers-reduced-motion: reduce)', "
+                        "'(prefers-contrast: more)', 'print'].map((m) => matchMedia(m).matches).join('/')",
+                        "returnByValue": True,
+                    },
+                )
+                return reply["result"]["result"]["value"]
+
+            assert await preferences() == "false/false/false/false"
+
+            reply = await client.command(next(ids), "Emulation.setAutoDarkModeOverride", {"enabled": True})
+            assert "error" not in reply, reply
+            assert await preferences() == "true/false/false/false"
+            await client.command(next(ids), "Emulation.setAutoDarkModeOverride", {})
+            assert await preferences() == "false/false/false/false"
+
+            features = [
+                {"name": "prefers-color-scheme", "value": "dark"},
+                {"name": "prefers-reduced-motion", "value": "reduce"},
+                {"name": "prefers-contrast", "value": "more"},
+            ]
+            reply = await client.command(next(ids), "Emulation.setEmulatedMedia", {"media": "", "features": features})
+            assert "error" not in reply, reply
+            assert await preferences() == "true/true/true/false"
+            # Chrome semantics: features left out of the next list are reset.
+            await client.command(next(ids), "Emulation.setEmulatedMedia", {"media": "", "features": features[:1]})
+            assert await preferences() == "true/false/false/false"
+            # WebKit renders an emulated print media type with the light scheme, whatever the
+            # override says (verified on iOS 26 in either order), so print is checked on its own.
+            await client.command(next(ids), "Emulation.setEmulatedMedia", {"media": "print", "features": []})
+            assert await preferences() == "false/false/false/true"
+            await client.command(next(ids), "Emulation.setEmulatedMedia", {"media": "", "features": []})
+            assert await preferences() == "false/false/false/false"
         finally:
             await client.close()

--- a/tests/services/test_web_protocol/test_protocol_conformance.py
+++ b/tests/services/test_web_protocol/test_protocol_conformance.py
@@ -1,0 +1,152 @@
+"""The CDP bridge against the two protocol definitions it translates between.
+
+Every protocol name the bridge uses is checked against the spec that governs its role (see
+protocol_inventory): CDP methods it handles and events it emits against Chrome's protocol; WebKit
+commands it sends (with their literal parameters) and WebKit events it translates against
+WebKit's. The specs are vendored by misc/protocol/fetch_protocols.py, pinned to upstream commits.
+
+These tests need no device; they read the bridge's source. A name that fails here is either a typo,
+a command one side has since removed or renamed (Page.setForcedAppearance was one: gone from
+WebKit, iOS 26 answered it with "not found"), or a bridge-internal invention that must be
+justified below.
+"""
+
+import json
+import re
+
+from pymobiledevice3.services.web_protocol.cdp_target import (
+    NOOP_ABSENT_DOMAINS,
+    REPLAYED_KEYED_SETUP_METHODS,
+    REPLAYED_MULTI_SETUP_METHODS,
+    REPLAYED_SETUP_METHODS,
+    WEBKIT_ONLY_EVENTS,
+)
+from tests.services.test_web_protocol.protocol_inventory import (
+    REPO,
+    SPECS,
+    Inventory,
+    collect,
+    command_params,
+    in_commands,
+    in_events,
+    load_spec,
+)
+
+# CDP methods the bridge answers that the pinned Chrome protocol no longer defines, with the
+# reason each is kept. Anything else outside the spec fails.
+CDP_METHODS_NO_LONGER_IN_SPEC = {
+    # Defined in CDP through mid-2025 (devtools-protocol f9ae1d44 still carries it) and gone since;
+    # Chrome builds from before the removal still send it, so it keeps its local acknowledgement.
+    "Network.clearAcceptedEncodingsOverride": "removed from CDP after 2025-06",
+}
+
+FETCHER = REPO / "misc/protocol/fetch_protocols.py"
+
+inventory: Inventory = collect()
+webkit = load_spec("webkit")
+cdp = load_spec("cdp")
+
+
+def test_the_inventory_found_the_bridge() -> None:
+    """Guards the AST extraction itself: an empty inventory would pass every check below."""
+    assert inventory.constants["NOOP_ABSENT_DOMAINS"] == set(NOOP_ABSENT_DOMAINS)
+    assert inventory.constants["WEBKIT_ONLY_EVENTS"] == set(WEBKIT_ONLY_EVENTS)
+    assert inventory.constants["REPLAYED_SETUP_METHODS"] == set(REPLAYED_SETUP_METHODS)
+    assert len(inventory.client_handled) > 60
+    assert len(inventory.webkit_events_handled) > 10
+    assert len({s.method for s in inventory.webkit_bound}) > 20
+    assert len({s.method for s in inventory.client_bound_events}) > 8
+
+
+def test_handled_cdp_methods_are_cdp_commands() -> None:
+    unknown = sorted(
+        m for m in inventory.client_handled if not in_commands(cdp, m) and m not in CDP_METHODS_NO_LONGER_IN_SPEC
+    )
+    assert unknown == [], f"handled but not in Chrome's protocol: {unknown}"
+    stale_allowlist = sorted(
+        m for m in CDP_METHODS_NO_LONGER_IN_SPEC if in_commands(cdp, m) or m not in inventory.client_handled
+    )
+    assert stale_allowlist == [], f"allowlist entries no longer needed: {stale_allowlist}"
+
+
+def test_no_op_domains_are_absent_from_webkit() -> None:
+    """Input/Overlay requests are acknowledged instead of forwarded because WebKit has no such
+    domains; should WebKit grow one, forwarding must be reconsidered."""
+    present = sorted(d for d in NOOP_ABSENT_DOMAINS if d in webkit)
+    assert present == []
+
+
+def test_translated_webkit_events_are_webkit_events() -> None:
+    unknown = sorted(m for m in inventory.webkit_events_handled if not in_events(webkit, m))
+    assert unknown == [], f"translated but not a WebKit event: {unknown}"
+    dropped_unknown = sorted(m for m in WEBKIT_ONLY_EVENTS if not in_events(webkit, m))
+    assert dropped_unknown == [], f"dropped as WebKit-only but not a WebKit event: {dropped_unknown}"
+    in_chrome_too = sorted(m for m in WEBKIT_ONLY_EVENTS if in_events(cdp, m))
+    assert in_chrome_too == [], f"dropped as WebKit-only yet Chrome defines it: {in_chrome_too}"
+
+
+def test_messages_sent_to_the_device_are_webkit_commands() -> None:
+    unknown = sorted({f"{s.method} ({s.where})" for s in inventory.webkit_bound if not in_commands(webkit, s.method)})
+    assert unknown == [], f"sent to the device but not a WebKit command: {unknown}"
+
+
+def test_literal_parameters_match_the_webkit_command() -> None:
+    """Where the bridge builds a device message from literals, its keys must be the command's
+    parameters and every required one must be present."""
+    problems: list[str] = []
+    for send in inventory.webkit_bound:
+        if send.params is None or not in_commands(webkit, send.method):
+            continue
+        spec = command_params(webkit, send.method)
+        unknown = sorted(send.params - set(spec))
+        missing = sorted(k for k, v in spec.items() if not v["optional"] and k not in send.params)
+        if unknown or missing:
+            problems.append(f"{send.method} in {send.where}: unknown={unknown} missing={missing}")
+    assert problems == []
+
+
+def test_replayed_setup_methods_are_webkit_commands() -> None:
+    """Setup replayed onto the target after a process swap must be something the target answers."""
+    replayed = set(REPLAYED_SETUP_METHODS) | set(REPLAYED_MULTI_SETUP_METHODS) | set(REPLAYED_KEYED_SETUP_METHODS)
+    unknown = sorted(m for m in replayed if not in_commands(webkit, m))
+    assert unknown == [], f"replayed but not a WebKit command: {unknown}"
+    for method, key in REPLAYED_KEYED_SETUP_METHODS.items():
+        assert key in command_params(webkit, method), f"{method} has no parameter {key!r}"
+
+
+def test_events_emitted_to_the_client_are_cdp_events() -> None:
+    unknown = sorted({f"{s.method} ({s.where})" for s in inventory.client_bound_events if not in_events(cdp, s.method)})
+    assert unknown == [], f"emitted to the client but not a Chrome event: {unknown}"
+
+
+def test_every_protocol_name_in_the_bridge_belongs_to_a_spec() -> None:
+    """Catches what the role-based checks cannot see: names in comparisons, sets and comments-as-code."""
+
+    def known(name: str) -> bool:
+        return in_commands(cdp, name) or in_events(cdp, name) or in_commands(webkit, name) or in_events(webkit, name)
+
+    unknown = sorted(
+        f"{n} ({', '.join(sorted(files))})"
+        for n, files in inventory.all_names.items()
+        if not known(n) and n not in CDP_METHODS_NO_LONGER_IN_SPEC
+    )
+    assert unknown == [], f"in neither protocol: {unknown}"
+
+
+def fetcher_pins() -> dict[str, str]:
+    source = FETCHER.read_text()
+    pins: dict[str, str] = {}
+    for name in ("webkit", "cdp"):
+        match = re.search(rf'^{name.upper()}_COMMIT = "([0-9a-f]{{40}})"', source, re.M)
+        assert match is not None, f"{name.upper()}_COMMIT pin missing from {FETCHER}"
+        pins[name] = match.group(1)
+    return pins
+
+
+def test_vendored_specs_match_the_fetcher_pins() -> None:
+    """The JSON under protocol/ must be what fetch_protocols.py would produce for its pins."""
+    for spec, commit in fetcher_pins().items():
+        header = json.loads((SPECS / f"{spec}_protocol.json").read_text())["source"]
+        assert header["commit"] == commit, (
+            f"{spec}_protocol.json was fetched at another commit; re-run {FETCHER.relative_to(REPO)}"
+        )


### PR DESCRIPTION
Second piece of the CDP hardening series (after #1925): the bridge is checked against the two open protocol definitions it translates between, instead of relying on names lifted from traffic captures.

## What's in it

**Vendored protocol definitions.** `misc/protocol/fetch_protocols.py` writes compact summaries of WebKit's inspector protocol (`Source/JavaScriptCore/inspector/protocol/*.json`) and Chrome's (`browser_protocol.json` + `js_protocol.json`) into `tests/services/test_web_protocol/protocol/`, pinned to upstream commits. A test fails if the JSON was fetched at a commit other than the pinned one.

**Conformance tests** (`test_protocol_conformance.py`, no device needed). `protocol_inventory.py` reads the bridge's source with `ast` and classifies every protocol name by role; each role is checked against the spec that governs it:

- CDP methods the bridge handles must be CDP commands
- WebKit events it translates (and the ones it deliberately drops) must be WebKit events
- everything it sends to the device must be a WebKit command, and literal parameters must match (no unknown keys, no missing required ones)
- everything it emits to the editor must be a CDP event
- setup replayed after a process swap must be WebKit commands
- any other `Domain.name` literal must exist in one of the two protocols

One justified allowlist entry: `Network.clearAcceptedEncodingsOverride`, removed from CDP after mid-2025 but still sent by older Chrome builds.

These checks are name- and parameter-level only. They say nothing about whether a reply's shape or a behaviour matches what an editor expects; that is the measured, on-the-wire compliance report planned as the next PR on top of the `--trace` recorder.

## What the checks found and this PR fixes

- `Page.setForcedAppearance` no longer exists: neither WebKit main nor Safari 26's protocol define it, and iOS 26 answers `'Page.setForcedAppearance' was not found`. Chrome's dark-mode emulation (`Emulation.setAutoDarkModeOverride`) therefore did nothing while the editor showed it active. It now maps onto `Page.overrideUserPreference`, and so do the media features of `Emulation.setEmulatedMedia` (`prefers-color-scheme`, `prefers-reduced-motion`, `prefers-contrast`), which were previously dropped. Features left out of a later call are reset, as in Chrome; the latest override per preference is replayed after a process swap.
- The handler for `Page.defaultAppearanceDidChange`, an event that no longer exists, is removed.

Verified on iOS 26: all three preferences flip and clear through both Chrome paths. An emulated `print` media type renders the light scheme regardless of the override (WebKit behaviour, either order), so the device test checks print separately.

## Tests

- `test_protocol_conformance.py`: 10 tests, no device. Pass against master with #1921 and #1922 merged.
- `test_user_preference_overrides_are_translated_and_replayed` (offline) and `testp_cdp_server_emulates_user_preferences` (device).
- Full `testp_` CDP suite run against an iOS 26 device.
