### PR TITLE
cdp: Present the Node.js inspector surface on JSContexts and pages

### DIFF
--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -74,6 +74,15 @@ A `JSContext` only answers the inspector while the thread hosting it services it
 loop. One whose host is blocked elsewhere is still listed (its process registered it) but
 never replies; the bridge gives up on it after a while rather than hanging.
 
+Because the frontend is Node.js's, the bridge presents the Node.js inspector surface on top
+of WebKit's: an uncaught exception, an unhandled rejection or a parse error is reported as
+`Runtime.exceptionThrown` (WebKit reports these as console messages, which VS Code's debugger
+does not render on their own); `Runtime.addBinding` exposes a page function whose calls arrive
+as `Runtime.bindingCalled`; the console's `inspect()` becomes `Runtime.inspectRequested`; and
+the `NodeRuntime`, `NodeWorker` and `NodeTracing` domains an editor enables on attach are
+acknowledged (WebKit has none of them). A URL breakpoint set before its script exists binds and
+reports `Debugger.breakpointResolved` once the script loads, as it would against Node.js.
+
 ## VS Code
 
 VS Code's built-in JavaScript debugger (js-debug) attaches through the browser-level

--- a/misc/protocol/fetch_protocols.py
+++ b/misc/protocol/fetch_protocols.py
@@ -5,8 +5,11 @@ device. Both are open source and this script is the only way their definitions e
 
 - WebKit: Source/JavaScriptCore/inspector/protocol/*.json in the WebKit repository.
 - Chrome:  json/browser_protocol.json and json/js_protocol.json in ChromeDevTools/devtools-protocol.
+- Node:    src/inspector/domain_node_*.pdl in nodejs/node - the domains a Node.js inspector target
+           adds on top of Chrome's (NodeRuntime, NodeWorker, NodeTracing), which editors attaching
+           "as Node" (VS Code's node attach, WebStorm) send to a JSContext.
 
-It writes tests/services/test_web_protocol/protocol/{webkit,cdp}_protocol.json - one entry per
+It writes tests/services/test_web_protocol/protocol/{webkit,cdp,node}_protocol.json - one entry per
 command (parameter names, whether each is optional, return names) and per event (parameter
 names) - pinned to the upstream commits below. The conformance test reads those files. Re-run
 after bumping the pins.
@@ -21,6 +24,8 @@ from typing import Any, Optional
 
 WEBKIT_COMMIT = "587e3a7c563e482a45c3b186d9d5f093aadfb4a8"
 CDP_COMMIT = "90778954a4820558eb0a98194e89000d40087ba4"
+NODE_COMMIT = "ec564135f429b6eb0b82910cace8b29eb1868b2a"
+NODE_DOMAINS = ["domain_node_runtime", "domain_node_worker", "domain_node_tracing"]
 WEBKIT_DOMAINS = [
     "Animation",
     "Audit",
@@ -57,6 +62,47 @@ OUT = Path(__file__).resolve().parents[2] / "tests" / "services" / "test_web_pro
 def fetch(url: str) -> Any:
     with urllib.request.urlopen(url, timeout=60) as response:
         return json.load(response)
+
+
+def fetch_text(url: str) -> str:
+    with urllib.request.urlopen(url, timeout=60) as response:
+        return response.read().decode()
+
+
+def parse_pdl(text: str) -> dict[str, Any]:
+    """Node's protocol is written in PDL, the indented plain-text form Chromium's protocol tooling
+    accepts; indentation is all the structure needed here. Returns {domain: compact domain}."""
+    domains: dict[str, Any] = {}
+    domain: dict[str, Any] = {}
+    member: Optional[dict[str, Any]] = None
+    returns: Optional[list[str]] = None
+    params: Optional[dict[str, Any]] = None
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].rstrip()
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip())
+        words = line.split()
+        if indent == 0 and len(words) >= 2 and words[-2] == "domain":
+            domain = {"commands": {}, "events": {}}
+            domains[words[-1]] = domain
+        elif indent == 2:
+            member = returns = params = None
+            if words[0] in ("command", "event"):
+                member = {"params": {}} if words[0] == "event" else {"params": {}, "returns": []}
+                domain["commands" if words[0] == "command" else "events"][words[-1]] = member
+        elif indent == 4 and member is not None:
+            params = member["params"] if words[0] == "parameters" else None
+            returns = member["returns"] if words[0] == "returns" else None
+        elif indent == 6 and (params is not None or returns is not None):
+            optional = words[0] == "optional"
+            if optional:
+                words = words[1:]
+            if returns is not None:
+                returns.append(words[-1])
+            elif params is not None:
+                params[words[-1]] = {"optional": optional, "type": " ".join(words[:-1])}
+    return domains
 
 
 def compact_domain(domain: dict[str, Any]) -> dict[str, Any]:
@@ -109,6 +155,26 @@ def main() -> None:
         for domain in fetch(url)["domains"]:
             cdp[domain["domain"]] = compact_domain(domain)
     print(f"cdp: {len(cdp)} domains")
+    node: dict[str, Any] = {}
+    for name in NODE_DOMAINS:
+        node.update(
+            parse_pdl(
+                fetch_text(f"https://raw.githubusercontent.com/nodejs/node/{NODE_COMMIT}/src/inspector/{name}.pdl")
+            )
+        )
+    for domain_name, node_domain in node.items():
+        print(f"node {domain_name}: {len(node_domain['commands'])} commands, {len(node_domain['events'])} events")
+    (OUT / "node_protocol.json").write_text(
+        json.dumps(
+            {
+                "source": {"repo": "nodejs/node", "commit": NODE_COMMIT, "path": "src/inspector", "fetched": fetched},
+                "domains": node,
+            },
+            indent=1,
+            sort_keys=True,
+        )
+        + "\n"
+    )
     (OUT / "cdp_protocol.json").write_text(
         json.dumps(
             {

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -117,6 +117,32 @@ _ISOLATED_WORLD_IDS = itertools.count(0x50000000)
 JS_CONTEXT_EXECUTION_ID = 1
 JS_CONTEXT_UNIQUE_ID = "jscontext.1"
 
+# WebKit reports the engine's own errors - uncaught exceptions, unhandled rejections, parse errors
+# - as console messages of this source; Chrome reports them as Runtime.exceptionThrown, which is
+# the only form VS Code's debugger renders (it has no handler for Log.entryAdded at all).
+JAVASCRIPT_ERROR_SOURCE = "javascript"
+UNHANDLED_REJECTION_PREFIX = "Unhandled Promise Rejection: "
+
+# A binding installed by Runtime.addBinding reports its calls through console.debug with this
+# marker as the first argument; the bridge turns those into Runtime.bindingCalled and never
+# forwards them as console output. WebKit has no binding mechanism of its own.
+BINDING_MARKER = "__pymobiledevice3_binding__"
+
+# The domains a Node.js inspector target adds on top of Chrome's. Editors attaching "as Node"
+# (VS Code's node attach, WebStorm) send these to a JSContext; WebKit has none of them, so they
+# are acknowledged here the way an idle Node process would (no workers, nothing traced).
+NODE_ACKNOWLEDGED_METHODS = (
+    "NodeRuntime.enable",
+    "NodeRuntime.disable",
+    "NodeRuntime.notifyWhenWaitingForDisconnect",
+    "NodeWorker.enable",
+    "NodeWorker.disable",
+    "NodeWorker.detach",
+    "NodeWorker.sendMessageToWorker",
+    "NodeTracing.start",
+    "NodeTracing.stop",
+)
+
 # Target.TargetInfo.type of the targets this bridge debugs. WebKit announces "frame", "worker"
 # and "service-worker" ones too - see _target_created.
 PAGE_TARGET_TYPE = "page"
@@ -435,6 +461,7 @@ class CdpTarget:
         # Synthetic isolated world -> the frame it was created for, so its evaluations reach that
         # frame's real context rather than whichever one happened to be announced last.
         self._isolated_world_frames: dict[int, str] = {}
+        self._isolated_world_names: dict[int, str] = {}
         # Frame -> the id of the main-world execution context WebKit announced for it. A page with
         # subframes announces one per frame, and they are not interchangeable.
         self._frame_execution_ids: dict[str, int] = {}
@@ -500,7 +527,8 @@ class CdpTarget:
             "Emulation.setEmulatedVisionDeficiency": partial(self._simple_response, value=None),
             "Emulation.setAutoDarkModeOverride": self._emulation_set_auto_dark_mode_override,
             "Emulation.setEmitTouchEventsForMouse": partial(self._simple_response, value=None),
-            "Debugger.setAsyncCallStackDepth": partial(self._simple_response, value=True),
+            "Debugger.setAsyncCallStackDepth": partial(self._simple_response, value=None),
+            "Debugger.removeBreakpoint": self._debugger_remove_breakpoint,
             "Debugger.enable": self._debugger_enable,
             "Debugger.setSkipAllPauses": self._debugger_set_skip_all_pauses,
             "Debugger.setBreakpointsActive": self._debugger_set_breakpoints_active,
@@ -562,7 +590,10 @@ class CdpTarget:
             "Accessibility.enable": partial(self._simple_response, value=None),
             "Autofill.enable": partial(self._simple_response, value=None),
             "Autofill.setAddresses": partial(self._simple_response, value=None),
-            "Runtime.addBinding": partial(self._simple_response, value=None),
+            "Runtime.addBinding": self._runtime_add_binding,
+            "Runtime.removeBinding": self._runtime_remove_binding,
+            "NodeTracing.getCategories": partial(self._result_response, result={"categories": []}),
+            **{method: partial(self._simple_response, value=None) for method in NODE_ACKNOWLEDGED_METHODS},
             "Runtime.globalLexicalScopeNames": self._runtime_global_lexical_scope_names,
             "Runtime.getProperties": self._runtime_get_properties,
             "Network.setBlockedURLs": partial(self._simple_response, value=None),
@@ -603,6 +634,7 @@ class CdpTarget:
             "Debugger.globalObjectCleared": self._debugger_global_object_cleared,
             "Runtime.executionContextCreated": self._runtime_execution_context_created,
             "Console.messageAdded": self._console_message_added,
+            "Inspector.inspect": self._inspector_inspect,
             "Network.responseReceived": self._network_response_received,
             "Network.loadingFinished": self._network_loading_finished,
             "Network.requestWillBeSent": self._network_request_will_be_sent,
@@ -634,6 +666,14 @@ class CdpTarget:
         # the script's id. Lets a URL breakpoint (how editors set breakpoints) be turned into a
         # scriptId-location breakpoint, the only kind that binds on a URL-less script.
         self._flat_script_url_to_id: dict[str, str] = {}
+        # URL breakpoints a JSContext client set before their script existed: the bridge's own
+        # breakpoint id -> the request, plus the device breakpoint ids it produced once bound.
+        self._flat_pending_url_breakpoints: dict[str, dict[str, Any]] = {}
+        self._flat_bound_url_breakpoints: dict[str, list[str]] = {}
+        # Runtime.addBinding: name -> the executionContextName it is scoped to (None = every main
+        # world). Re-installed into every context created later, as Chrome does.
+        self._bindings: dict[str, Optional[str]] = {}
+        self._exception_ids = itertools.count(1)
         self._eval_side_effect_id = 0
         self._default_execution_id = 0
         self._last_console_api_call: Optional[dict[str, Any]] = None
@@ -1187,7 +1227,10 @@ class CdpTarget:
             )
 
     async def _simple_response(self, message: dict[str, Any], value: Any):
-        await self.output_queue.put({"id": message["id"], "result": {"result": value}})
+        """Acknowledge a request the bridge answers itself: an empty result, as Chrome's protocol
+        defines for commands that return nothing, or {"result": value} for the few that do."""
+        result: dict[str, Any] = {} if value is None else {"result": value}
+        await self.output_queue.put({"id": message["id"], "result": result})
 
     async def _result_response(self, message: dict[str, Any], result: dict[str, Any]):
         """Respond with an exact result body, for methods whose response fields the frontend reads."""
@@ -1411,6 +1454,7 @@ class CdpTarget:
         self._map_frame_ids_outbound(message)
         frame_id = message.get("params", {}).get("frameId")
         if isinstance(frame_id, str):
+            await self._destroy_frame_contexts(frame_id)
             self._announced_frames.discard(frame_id)
             self._frame_execution_ids.pop(frame_id, None)
         await self.output_queue.put(message)
@@ -2042,6 +2086,7 @@ class CdpTarget:
         _page_create_isolated_world for why these are synthesized at all."""
         context_id = next(_ISOLATED_WORLD_IDS)
         self._isolated_world_context_ids.add(context_id)
+        self._isolated_world_names[context_id] = world_name
         if isinstance(frame_id, str):
             self._isolated_world_frames[context_id] = frame_id
             self._announced_worlds.add((frame_id, world_name))
@@ -2057,6 +2102,7 @@ class CdpTarget:
                 }
             },
         })
+        await self._install_bindings_for_context(context_id, world_name)
         return context_id
 
     async def _dom_get_box_model(self, message: dict[str, Any]):
@@ -2447,6 +2493,13 @@ class CdpTarget:
                 locations = [result["actualLocation"]] if "actualLocation" in result else []
                 await self._result_response(message, {"breakpointId": breakpoint_id, "locations": locations})
                 return
+            # No such script yet. Its synthetic URL cannot bind on the device (see
+            # _debugger_script_parsed), so keep the request and bind it when the script appears,
+            # reporting Debugger.breakpointResolved then - what V8 does for a not-yet-loaded file.
+            breakpoint_id = f"{params.get('url') or params.get('urlRegex') or ''}:{params.get('lineNumber', 0)}:{params.get('columnNumber', 0)}"
+            self._flat_pending_url_breakpoints[breakpoint_id] = dict(params)
+            await self._result_response(message, {"breakpointId": breakpoint_id, "locations": []})
+            return
         condition = params.pop("condition", "")
         if condition:
             params["options"]["condition"] = condition
@@ -2508,6 +2561,9 @@ class CdpTarget:
 
     async def _runtime_enable(self, message: dict[str, Any]):
         await self._send_message_to_target(message)
+        # WebKit only reports the console's inspect() through Inspector.inspect once the Inspector
+        # domain is enabled - something no Chrome client sends, as V8 has no such domain.
+        await self._send_message_to_target({"id": self.next_internal_id(), "method": "Inspector.enable", "params": {}})
         if not self._flat:
             return
         # Chrome's frontend expects console output to follow from Runtime.enable alone (V8 emits
@@ -3272,6 +3328,54 @@ class CdpTarget:
         if script_id is not None:
             self._script_id_to_url[script_id] = source
         await self.output_queue.put(message)
+        if self._flat and script_id is not None:
+            await self._bind_pending_url_breakpoints(str(script_id))
+
+    async def _bind_pending_url_breakpoints(self, script_id: str) -> None:
+        """Bind the URL breakpoints waiting for this JSContext script and announce each as resolved.
+
+        Runs in the receive loop (scriptParsed is an event), so the binding request is forwarded
+        with a reply translator rather than awaited here."""
+        for breakpoint_id, request in list(self._flat_pending_url_breakpoints.items()):
+            if self._flat_breakpoint_script(request) != script_id:
+                continue
+            location: dict[str, Any] = {"scriptId": script_id, "lineNumber": request.get("lineNumber", 0)}
+            if "columnNumber" in request:
+                location["columnNumber"] = request["columnNumber"]
+            set_params: dict[str, Any] = {"location": location}
+            if request.get("condition"):
+                set_params["options"] = {"condition": request["condition"]}
+
+            async def resolved(
+                reply: dict[str, Any], breakpoint_id: str = breakpoint_id, location: dict[str, Any] = location
+            ) -> None:
+                result = reply.get("result", {})
+                if "breakpointId" not in result:
+                    logger.warning(f"URL breakpoint {breakpoint_id} did not bind: {reply.get('error')}")
+                    return
+                self._flat_bound_url_breakpoints.setdefault(breakpoint_id, []).append(result["breakpointId"])
+                await self.output_queue.put({
+                    "method": "Debugger.breakpointResolved",
+                    "params": {"breakpointId": breakpoint_id, "location": result.get("actualLocation", location)},
+                })
+
+            await self._forward_and_translate(
+                {"id": self.next_internal_id()}, {"method": "Debugger.setBreakpoint", "params": set_params}, resolved
+            )
+
+    async def _debugger_remove_breakpoint(self, message: dict[str, Any]) -> None:
+        breakpoint_id = message.get("params", {}).get("breakpointId")
+        if breakpoint_id in self._flat_pending_url_breakpoints or breakpoint_id in self._flat_bound_url_breakpoints:
+            self._flat_pending_url_breakpoints.pop(breakpoint_id, None)
+            for device_id in self._flat_bound_url_breakpoints.pop(breakpoint_id, []):
+                await self._send_message_to_target({
+                    "id": self.next_internal_id(),
+                    "method": "Debugger.removeBreakpoint",
+                    "params": {"breakpointId": device_id},
+                })
+            await self._result_response(message, {})
+            return
+        await self._send_message_to_target(message)
 
     async def _debugger_script_failed_to_parse(self, message: dict[str, Any]):
         # The failing source is only known from Runtime.compileScript; parse failures of other
@@ -3312,11 +3416,200 @@ class CdpTarget:
 
     async def _debugger_global_object_cleared(self, message: dict[str, Any]):
         # Contexts are gone; allow their uniqueIds to be re-announced after the reload.
+        for frame_id in list(self._frame_execution_ids):
+            await self._destroy_frame_contexts(frame_id)
         self._emitted_context_unique_ids.clear()
         self._frame_execution_ids.clear()
         self._announced_worlds.clear()
         await self.output_queue.put({"method": "Runtime.executionContextsCleared"})
         await self.output_queue.put({"method": "DOM.documentUpdated"})
+
+    @staticmethod
+    def _is_binding_call(console_message: dict[str, Any]) -> bool:
+        parameters: list[dict[str, Any]] = console_message.get("parameters") or []
+        return (
+            console_message.get("source") == "console-api"
+            and len(parameters) == 4
+            and parameters[0].get("value") == BINDING_MARKER
+        )
+
+    async def _binding_called(self, console_message: dict[str, Any]) -> None:
+        """A call of a function installed by Runtime.addBinding (see _install_binding)."""
+        parameters: list[dict[str, Any]] = console_message["parameters"]
+        context_id = parameters[3].get("value")
+        await self.output_queue.put({
+            "method": "Runtime.bindingCalled",
+            "params": {
+                "name": str(parameters[1].get("value", "")),
+                "payload": str(parameters[2].get("value", "")),
+                "executionContextId": context_id if isinstance(context_id, int) else self._default_execution_id,
+            },
+        })
+
+    def _error_script_url(self, script_id: Any, url: Any) -> str:
+        """The URL of the script an error came from. WebKit stringifies a missing one as
+        "undefined"; the script's announced URL (empty for an evaluation) is what Chrome reports."""
+        if isinstance(script_id, str) and script_id in self._script_id_to_url:
+            return self._script_id_to_url[script_id]
+        return "" if not isinstance(url, str) or url == "undefined" else url
+
+    async def _exception_thrown(self, console_message: dict[str, Any]) -> None:
+        """Runtime.exceptionThrown from WebKit's error console message.
+
+        WebKit numbers lines and columns from 1 in these messages (a throw on the third line of a
+        script reports line 3); Chrome's ExceptionDetails and StackTrace count from 0. Chrome
+        describes the exception through a RemoteObject whose description is the "Name: message"
+        text, with `text` reduced to "Uncaught" (or "Uncaught (in promise)"); editors format the
+        two together.
+        """
+        text = str(console_message.get("text", ""))
+        summary = "Uncaught"
+        if text.startswith(UNHANDLED_REJECTION_PREFIX):
+            text = text[len(UNHANDLED_REJECTION_PREFIX) :]
+            summary = "Uncaught (in promise)"
+        class_name = text.split(":", 1)[0].strip() if ":" in text else "Error"
+        frames: list[dict[str, Any]] = []
+        stack: dict[str, Any] = console_message.get("stackTrace") or {}
+        call_frames: list[dict[str, Any]] = stack.get("callFrames") or []
+        for frame in call_frames:
+            frames.append({
+                "functionName": frame.get("functionName", ""),
+                "scriptId": str(frame.get("scriptId", "")),
+                "url": self._error_script_url(frame.get("scriptId"), frame.get("url")),
+                "lineNumber": max(int(frame.get("lineNumber", 1)) - 1, 0),
+                "columnNumber": max(int(frame.get("columnNumber", 1)) - 1, 0),
+            })
+        top = frames[0] if frames else {}
+        details: dict[str, Any] = {
+            "exceptionId": next(self._exception_ids),
+            "text": summary,
+            "lineNumber": top.get("lineNumber", max(int(console_message.get("line", 1)) - 1, 0)),
+            "columnNumber": top.get("columnNumber", max(int(console_message.get("column", 1)) - 1, 0)),
+            "url": top.get("url", self._error_script_url(None, console_message.get("url"))),
+            "executionContextId": self._default_execution_id,
+            "exception": {"type": "object", "subtype": "error", "className": class_name, "description": text},
+        }
+        if top.get("scriptId"):
+            details["scriptId"] = top["scriptId"]
+        if frames:
+            details["stackTrace"] = {"callFrames": frames}
+        await self.output_queue.put({
+            "method": "Runtime.exceptionThrown",
+            "params": {"timestamp": datetime.now().timestamp() * 1000, "exceptionDetails": details},
+        })
+
+    async def _inspector_inspect(self, message: dict[str, Any]) -> None:
+        """The console's inspect(object): WebKit's Inspector.inspect is Chrome's Runtime.inspectRequested."""
+        params = message.get("params", {})
+        await self.output_queue.put({
+            "method": "Runtime.inspectRequested",
+            "params": {
+                "object": params.get("object", {}),
+                "hints": params.get("hints") or {},
+                "executionContextId": self._default_execution_id,
+            },
+        })
+
+    async def _emit_execution_context_destroyed(self, context_id: int, frame_id: Any) -> None:
+        await self.output_queue.put({
+            "method": "Runtime.executionContextDestroyed",
+            "params": {"executionContextId": context_id, "executionContextUniqueId": f"{frame_id}.{context_id}"},
+        })
+
+    async def _destroy_frame_contexts(self, frame_id: str) -> None:
+        """Announce the end of a frame's contexts - its main world and the isolated worlds
+        synthesized for it - before the frame itself goes; Chrome does the same on navigation."""
+        for context_id, world_frame in list(self._isolated_world_frames.items()):
+            if world_frame == frame_id:
+                await self._emit_execution_context_destroyed(context_id, frame_id)
+                del self._isolated_world_frames[context_id]
+                self._isolated_world_names.pop(context_id, None)
+        main_context = self._frame_execution_ids.get(frame_id)
+        if main_context is not None:
+            await self._emit_execution_context_destroyed(main_context, frame_id)
+
+    def _binding_install_script(self, name: str, context_id: int) -> str:
+        return (
+            f"globalThis[{json.dumps(name)}] = function (payload) {{ "
+            f"console.debug({json.dumps(BINDING_MARKER)}, {json.dumps(name)}, String(payload), {context_id}); }};"
+        )
+
+    async def _install_binding(self, name: str, context_id: int) -> None:
+        """Define the binding function in one execution context, without waiting for the reply."""
+        params: dict[str, Any] = {"expression": self._tag_internal(self._binding_install_script(name, context_id))}
+        real_context = self._real_context_id(context_id)
+        if real_context is not None:
+            params["contextId"] = real_context
+        await self._send_message_to_target({
+            "id": self.next_internal_id(),
+            "method": "Runtime.evaluate",
+            "params": params,
+        })
+
+    def _real_context_id(self, context_id: int) -> Optional[int]:
+        """The device's context for one the client knows: a synthesized isolated world runs in the
+        real main world of its frame; a JSContext has a single, unaddressed context."""
+        if self._flat:
+            return None
+        if context_id in self._isolated_world_context_ids:
+            world_frame = self._isolated_world_frames.get(context_id, self.frame_id)
+            return self._frame_execution_ids.get(world_frame) or self._default_execution_id or None
+        return context_id
+
+    def _binding_contexts(self, world_name: Optional[str]) -> list[int]:
+        """The client-visible contexts a binding scoped to `world_name` belongs in right now."""
+        if world_name is None:
+            if self._flat:
+                return [JS_CONTEXT_EXECUTION_ID]
+            return sorted(set(self._frame_execution_ids.values()))
+        return sorted(cid for cid, name in self._isolated_world_names.items() if name == world_name)
+
+    async def _install_bindings_for_context(self, context_id: int, world_name: Optional[str]) -> None:
+        """A context was just announced: give it every binding registered for its kind."""
+        for name, scope in self._bindings.items():
+            if scope == world_name:
+                await self._install_binding(name, context_id)
+
+    async def _runtime_add_binding(self, message: dict[str, Any]) -> None:
+        """
+        Runtime.addBinding: expose `name` in the page as a function whose calls reach the client as
+        Runtime.bindingCalled. Chrome's semantics: no context given = every main world, now and
+        after reloads; executionContextName = every isolated world of that name, now and later;
+        executionContextId = that one context only. Playwright's exposeFunction/exposeBinding and
+        its init-script plumbing are built on this.
+        """
+        params = message.get("params", {})
+        name = str(params.get("name", ""))
+        if not name:
+            await self._error_response(message, {"code": -32602, "message": "Runtime.addBinding needs a name"})
+            return
+        if isinstance(params.get("executionContextId"), int):
+            await self._install_binding(name, params["executionContextId"])
+        else:
+            world_name = params.get("executionContextName")
+            scope = world_name if isinstance(world_name, str) and world_name else None
+            self._bindings[name] = scope
+            for context_id in self._binding_contexts(scope):
+                await self._install_binding(name, context_id)
+        await self._result_response(message, {})
+
+    async def _runtime_remove_binding(self, message: dict[str, Any]) -> None:
+        name = str(message.get("params", {}).get("name", ""))
+        scope = self._bindings.pop(name, None)
+        contexts = self._binding_contexts(scope) if name else []
+        if scope is None:
+            contexts = sorted(set(contexts) | set(self._isolated_world_names))
+        for context_id in contexts:
+            params: dict[str, Any] = {"expression": self._tag_internal(f"delete globalThis[{json.dumps(name)}];")}
+            real_context = self._real_context_id(context_id)
+            if real_context is not None:
+                params["contextId"] = real_context
+            await self._send_message_to_target({
+                "id": self.next_internal_id(),
+                "method": "Runtime.evaluate",
+                "params": params,
+            })
+        await self._result_response(message, {})
 
     async def _runtime_execution_context_created(self, message: dict[str, Any]):
         context = message["params"]["context"]
@@ -3359,6 +3652,7 @@ class CdpTarget:
             }
         }
         await self.output_queue.put(message)
+        await self._install_bindings_for_context(context["id"], None)
 
     async def _announce_registered_worlds(self, frame_id: str) -> None:
         """Give a freshly loaded document the isolated worlds the client registered by name."""
@@ -3379,6 +3673,12 @@ class CdpTarget:
 
     async def _console_message_added(self, message: dict[str, Any]):
         console_message = message["params"]["message"]
+        if self._is_binding_call(console_message):
+            await self._binding_called(console_message)
+            return
+        if console_message["source"] == JAVASCRIPT_ERROR_SOURCE and console_message.get("level") == "error":
+            await self._exception_thrown(console_message)
+            return
         # Chrome renders console-API output (console.log & friends) from Runtime.consoleAPICalled,
         # complete with the argument objects; Log.entryAdded is only for browser-generated logs.
         if console_message["source"] == "console-api":

--- a/tests/services/test_web_protocol/protocol/node_protocol.json
+++ b/tests/services/test_web_protocol/protocol/node_protocol.json
@@ -1,0 +1,152 @@
+{
+ "domains": {
+  "NodeRuntime": {
+   "commands": {
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {},
+     "returns": []
+    },
+    "notifyWhenWaitingForDisconnect": {
+     "params": {
+      "enabled": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "waitingForDebugger": {
+     "params": {}
+    },
+    "waitingForDisconnect": {
+     "params": {}
+    }
+   }
+  },
+  "NodeTracing": {
+   "commands": {
+    "getCategories": {
+     "params": {},
+     "returns": [
+      "categories"
+     ]
+    },
+    "start": {
+     "params": {
+      "traceConfig": {
+       "optional": false,
+       "type": "TraceConfig"
+      }
+     },
+     "returns": []
+    },
+    "stop": {
+     "params": {},
+     "returns": []
+    }
+   },
+   "events": {
+    "dataCollected": {
+     "params": {
+      "value": {
+       "optional": false,
+       "type": "array of object"
+      }
+     }
+    },
+    "tracingComplete": {
+     "params": {}
+    }
+   }
+  },
+  "NodeWorker": {
+   "commands": {
+    "detach": {
+     "params": {
+      "sessionId": {
+       "optional": false,
+       "type": "SessionID"
+      }
+     },
+     "returns": []
+    },
+    "disable": {
+     "params": {},
+     "returns": []
+    },
+    "enable": {
+     "params": {
+      "waitForDebuggerOnStart": {
+       "optional": false,
+       "type": "boolean"
+      }
+     },
+     "returns": []
+    },
+    "sendMessageToWorker": {
+     "params": {
+      "message": {
+       "optional": false,
+       "type": "string"
+      },
+      "sessionId": {
+       "optional": false,
+       "type": "SessionID"
+      }
+     },
+     "returns": []
+    }
+   },
+   "events": {
+    "attachedToWorker": {
+     "params": {
+      "sessionId": {
+       "optional": false,
+       "type": "SessionID"
+      },
+      "waitingForDebugger": {
+       "optional": false,
+       "type": "boolean"
+      },
+      "workerInfo": {
+       "optional": false,
+       "type": "WorkerInfo"
+      }
+     }
+    },
+    "detachedFromWorker": {
+     "params": {
+      "sessionId": {
+       "optional": false,
+       "type": "SessionID"
+      }
+     }
+    },
+    "receivedMessageFromWorker": {
+     "params": {
+      "message": {
+       "optional": false,
+       "type": "string"
+      },
+      "sessionId": {
+       "optional": false,
+       "type": "SessionID"
+      }
+     }
+    }
+   }
+  }
+ },
+ "source": {
+  "commit": "ec564135f429b6eb0b82910cace8b29eb1868b2a",
+  "fetched": "2026-09-08",
+  "path": "src/inspector",
+  "repo": "nodejs/node"
+ }
+}

--- a/tests/services/test_web_protocol/protocol_inventory.py
+++ b/tests/services/test_web_protocol/protocol_inventory.py
@@ -168,7 +168,11 @@ def collect() -> Inventory:
                 if attr in WEBKIT_EVENT_TABLES:
                     for k in keys:
                         inv.webkit_events_handled[k] = attr
-                elif all(isinstance(v, (ast.Attribute, ast.Call, ast.Name)) for v in table_value.values):
+                elif all(
+                    isinstance(v, (ast.Attribute, ast.Call, ast.Name))
+                    for k, v in zip(table_value.keys, table_value.values)
+                    if k is not None  # a **{...} unpacking carries no literal key
+                ):
                     # any other Domain.name-keyed table of callables is a client handler table
                     for k in keys:
                         inv.client_handled.setdefault(k, attr)

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -2689,6 +2689,210 @@ async def test_user_preference_overrides_are_translated_and_replayed(monkeypatch
         assert target._setup_messages["Page.setEmulatedMedia"] == {"media": ""}
 
 
+async def test_javascript_errors_become_runtime_exception_thrown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WebKit reports uncaught exceptions, unhandled rejections and parse errors as error console
+    messages of source "javascript"; Chrome reports them as Runtime.exceptionThrown, the only form
+    VS Code's debugger renders. Lines and columns are 1-based in WebKit's message, 0-based in Chrome's."""
+    with offline_cdp_target(monkeypatch) as (target, _):
+        target._script_id_to_url["2308"] = ""
+        await target._console_message_added({
+            "method": "Console.messageAdded",
+            "params": {
+                "message": {
+                    "source": "javascript",
+                    "level": "error",
+                    "text": "TypeError: boom",
+                    "type": "log",
+                    "line": 3,
+                    "column": 23,
+                    "url": "undefined",
+                    "stackTrace": {
+                        "callFrames": [
+                            {
+                                "functionName": "later",
+                                "url": "undefined",
+                                "scriptId": "2308",
+                                "lineNumber": 3,
+                                "columnNumber": 23,
+                            },
+                            {"functionName": "", "url": "", "scriptId": "2308", "lineNumber": 1, "columnNumber": 84},
+                        ]
+                    },
+                }
+            },
+        })
+        event = target.output_queue.get_nowait()
+        assert event["method"] == "Runtime.exceptionThrown"
+        details = event["params"]["exceptionDetails"]
+        assert details["text"] == "Uncaught"
+        assert details["exception"] == {
+            "type": "object",
+            "subtype": "error",
+            "className": "TypeError",
+            "description": "TypeError: boom",
+        }
+        assert (details["lineNumber"], details["columnNumber"], details["url"], details["scriptId"]) == (
+            2,
+            22,
+            "",
+            "2308",
+        )
+        assert details["stackTrace"]["callFrames"][0] == {
+            "functionName": "later",
+            "scriptId": "2308",
+            "url": "",
+            "lineNumber": 2,
+            "columnNumber": 22,
+        }
+        assert target.output_queue.empty(), "the error must not also be reported as a Log entry"
+
+        await target._console_message_added({
+            "method": "Console.messageAdded",
+            "params": {
+                "message": {
+                    "source": "javascript",
+                    "level": "error",
+                    "text": "Unhandled Promise Rejection: Error: nope",
+                    "line": 1,
+                    "column": 15,
+                    "url": "",
+                }
+            },
+        })
+        details = target.output_queue.get_nowait()["params"]["exceptionDetails"]
+        assert details["text"] == "Uncaught (in promise)"
+        assert details["exception"]["description"] == "Error: nope"
+        assert details["exceptionId"] == 2
+
+        # Console output stays console output.
+        await target._console_message_added({
+            "method": "Console.messageAdded",
+            "params": {
+                "message": {
+                    "source": "console-api",
+                    "level": "error",
+                    "text": "plain",
+                    "type": "log",
+                    "parameters": [{"type": "string", "value": "plain"}],
+                }
+            },
+        })
+        assert target.output_queue.get_nowait()["method"] == "Runtime.consoleAPICalled"
+
+
+async def test_bindings_are_installed_per_context_and_calls_come_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Runtime.addBinding defines a page function whose calls surface as Runtime.bindingCalled;
+    it is (re)installed in every main-world context, including ones announced later, and the
+    console message that carries a call never reaches the client as console output."""
+    with offline_cdp_target(monkeypatch) as (target, sent):
+
+        def device_messages() -> list[dict[str, Any]]:
+            return [json.loads(m["params"]["message"]) for m in sent]
+
+        target._frame_execution_ids["page-1"] = 7
+        await target._runtime_add_binding({"id": 1, "method": "Runtime.addBinding", "params": {"name": "hook"}})
+        assert target.output_queue.get_nowait() == {"id": 1, "result": {}}
+        install = device_messages()[-1]
+        assert install["method"] == "Runtime.evaluate" and install["params"]["contextId"] == 7
+        assert 'globalThis["hook"]' in install["params"]["expression"]
+        assert "__pymobiledevice3_binding__" in install["params"]["expression"]
+
+        # A context created later gets the binding too, after its announcement.
+        del sent[:]
+        await target._runtime_execution_context_created({
+            "method": "Runtime.executionContextCreated",
+            "params": {"context": {"id": 9, "type": "normal", "frameId": "page-1", "name": ""}},
+        })
+        assert target.output_queue.get_nowait()["method"] == "Runtime.executionContextCreated"
+        assert device_messages()[-1]["params"]["contextId"] == 9
+
+        await target._console_message_added({
+            "method": "Console.messageAdded",
+            "params": {
+                "message": {
+                    "source": "console-api",
+                    "level": "debug",
+                    "type": "log",
+                    "text": "__pymobiledevice3_binding__",
+                    "parameters": [
+                        {"type": "string", "value": "__pymobiledevice3_binding__"},
+                        {"type": "string", "value": "hook"},
+                        {"type": "string", "value": '{"a":1}'},
+                        {"type": "number", "value": 9},
+                    ],
+                }
+            },
+        })
+        assert target.output_queue.get_nowait() == {
+            "method": "Runtime.bindingCalled",
+            "params": {"name": "hook", "payload": '{"a":1}', "executionContextId": 9},
+        }
+        assert target.output_queue.empty()
+
+        del sent[:]
+        await target._runtime_remove_binding({"id": 2, "method": "Runtime.removeBinding", "params": {"name": "hook"}})
+        assert target.output_queue.get_nowait() == {"id": 2, "result": {}}
+        assert all('delete globalThis["hook"]' in m["params"]["expression"] for m in device_messages())
+        assert "hook" not in target._bindings
+
+
+async def test_context_teardown_and_inspect_are_announced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Runtime.executionContextDestroyed precedes executionContextsCleared on a reload and follows
+    a frame's detach; the console's inspect() becomes Runtime.inspectRequested."""
+    with offline_cdp_target(monkeypatch) as (target, _):
+        target._frame_execution_ids["page-1"] = 7
+        world = await target._announce_isolated_world("page-1", "utility")
+        target.output_queue.get_nowait()
+        await target._debugger_global_object_cleared({"method": "Debugger.globalObjectCleared", "params": {}})
+        methods = []
+        while not target.output_queue.empty():
+            methods.append(target.output_queue.get_nowait())
+        assert [m["method"] for m in methods] == [
+            "Runtime.executionContextDestroyed",
+            "Runtime.executionContextDestroyed",
+            "Runtime.executionContextsCleared",
+            "DOM.documentUpdated",
+        ]
+        assert methods[0]["params"] == {"executionContextId": world, "executionContextUniqueId": f"page-1.{world}"}
+        assert methods[1]["params"] == {"executionContextId": 7, "executionContextUniqueId": "page-1.7"}
+
+        await target._inspector_inspect({
+            "method": "Inspector.inspect",
+            "params": {"object": {"type": "object", "subtype": "node", "objectId": "x"}, "hints": {}},
+        })
+        assert target.output_queue.get_nowait() == {
+            "method": "Runtime.inspectRequested",
+            "params": {
+                "object": {"type": "object", "subtype": "node", "objectId": "x"},
+                "hints": {},
+                "executionContextId": 0,
+            },
+        }
+
+
+async def test_node_domains_are_acknowledged_with_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An editor attaching "as Node" enables Node's own domains; WebKit has none, and Chrome's
+    protocol defines empty results for commands that return nothing."""
+    with offline_cdp_target(monkeypatch) as (target, sent):
+        for id_, (method, params) in enumerate(
+            [
+                ("NodeWorker.enable", {"waitForDebuggerOnStart": True}),
+                ("NodeRuntime.notifyWhenWaitingForDisconnect", {"enabled": True}),
+                ("Debugger.setAsyncCallStackDepth", {"maxDepth": 32}),
+            ],
+            start=1,
+        ):
+            await target.from_cdp_special_messages_methods[method]({"id": id_, "method": method, "params": params})
+            assert target.output_queue.get_nowait() == {"id": id_, "result": {}}, method
+        await target.from_cdp_special_messages_methods["NodeTracing.getCategories"]({
+            "id": 9,
+            "method": "NodeTracing.getCategories",
+            "params": {},
+        })
+        assert target.output_queue.get_nowait() == {"id": 9, "result": {"categories": []}}
+        assert sent == [], "nothing Node-specific may reach the device"
+
+
 async def test_a_frame_target_does_not_take_over_the_session(monkeypatch: pytest.MonkeyPatch) -> None:
     """WebKit announces site-isolated subframes as "frame" targets. Their backend implements a
     far smaller domain set than a page's - with site isolation off, no domains at all - so a
@@ -2947,5 +3151,224 @@ async def testp_cdp_server_emulates_user_preferences(lockdown: LockdownClient) -
             assert await preferences() == "false/false/false/true"
             await client.command(next(ids), "Emulation.setEmulatedMedia", {"media": "", "features": []})
             assert await preferences() == "false/false/false/false"
+        finally:
+            await client.close()
+
+
+async def testp_cdp_server_reports_the_node_inspector_events(lockdown: LockdownClient) -> None:
+    """
+    The events a Node.js inspector target emits and Chrome's debugger clients rely on, on a page:
+    an uncaught exception, an unhandled rejection and a parse error arrive as Runtime.exceptionThrown
+    (VS Code renders exceptions from nothing else), a Runtime.addBinding function calls back through
+    Runtime.bindingCalled, the console's inspect() becomes Runtime.inspectRequested, and a navigation
+    destroys the contexts it announced before clearing them.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        ids = itertools.count(1)
+        events: list[dict[str, Any]] = []
+
+        async def command(method: str, params: dict[str, Any]) -> dict[str, Any]:
+            id_ = next(ids)
+            await client.send({"id": id_, "method": method, "params": params})
+
+            async def wait() -> dict[str, Any]:
+                while True:
+                    message = await client.receive()
+                    if message.get("id") == id_:
+                        return message
+                    if "method" in message:
+                        events.append(message)
+
+            return await asyncio.wait_for(wait(), TIMEOUT)
+
+        async def drain(seconds: float) -> None:
+            end = asyncio.get_event_loop().time() + seconds
+            while True:
+                left = end - asyncio.get_event_loop().time()
+                if left <= 0:
+                    return
+                try:
+                    message = await asyncio.wait_for(client.receive(), left)
+                except asyncio.TimeoutError:
+                    return
+                if "method" in message:
+                    events.append(message)
+
+        def named(method: str) -> list[dict[str, Any]]:
+            return [e["params"] for e in events if e["method"] == method]
+
+        try:
+            for method in ("Page.enable", "Runtime.enable", "Debugger.enable", "Log.enable"):
+                await command(method, {})
+            await command("Page.navigate", {"url": "https://example.com/"})
+            await drain(3)
+            events.clear()
+
+            # An uncaught exception thrown on the third line of a timer callback.
+            await command(
+                "Runtime.evaluate",
+                {
+                    "expression": "setTimeout(function later() {\n  const a = 1;\n  throw new RangeError('line3');\n}, 10)"
+                },
+            )
+            await command("Runtime.evaluate", {"expression": "Promise.reject(new Error('nope'))"})
+            await drain(2)
+            thrown = named("Runtime.exceptionThrown")
+            assert len(thrown) == 2, thrown
+            # The rejection is reported before the timer fires; match by text, not order.
+            by_text = {t["exceptionDetails"]["text"]: t for t in thrown}
+            details = by_text["Uncaught"]["exceptionDetails"]
+            assert details["exception"]["description"] == "RangeError: line3"
+            assert details["exception"]["className"] == "RangeError"
+            assert details["lineNumber"] == 2, "Chrome counts lines from 0"
+            assert details["stackTrace"]["callFrames"][0]["functionName"] == "later"
+            assert details["url"] == "", "an evaluation has no URL; WebKit's 'undefined' must not leak"
+            assert by_text["Uncaught (in promise)"]["exceptionDetails"]["exception"]["description"] == "Error: nope"
+            assert not [e for e in named("Log.entryAdded") if e["entry"]["source"] == "javascript"], (
+                "exceptions must not be reported twice"
+            )
+
+            # A binding: install, call from the page, receive the call; survive a reload.
+            events.clear()
+            reply = await command("Runtime.addBinding", {"name": "toEditor"})
+            assert reply == {"id": reply["id"], "result": {}}
+            await drain(0.5)
+            reply = await command(
+                "Runtime.evaluate",
+                {"expression": "toEditor(JSON.stringify({n: 1})); typeof toEditor", "returnByValue": True},
+            )
+            assert reply["result"]["result"]["value"] == "function"
+            await drain(1)
+            calls = named("Runtime.bindingCalled")
+            assert calls and calls[0]["name"] == "toEditor" and calls[0]["payload"] == '{"n":1}', calls
+            assert not named("Runtime.consoleAPICalled"), "the binding's transport must not show as console output"
+
+            events.clear()
+            await command("Page.navigate", {"url": "https://example.com/?again"})
+            await drain(3)
+            methods = [e["method"] for e in events]
+            destroyed = methods.index("Runtime.executionContextDestroyed")
+            assert destroyed < methods.index("Runtime.executionContextsCleared"), methods
+            created = methods.index("Runtime.executionContextCreated", destroyed)
+            assert created > destroyed
+            reply = await command("Runtime.evaluate", {"expression": "typeof toEditor", "returnByValue": True})
+            assert reply["result"]["result"]["value"] == "function", "a binding outlives navigation, as in Chrome"
+
+            # inspect() from the console.
+            events.clear()
+            await command("Runtime.evaluate", {"expression": "inspect(document.body)", "includeCommandLineAPI": True})
+            await drain(1)
+            requested = named("Runtime.inspectRequested")
+            assert requested and requested[0]["object"]["className"] == "HTMLBodyElement", requested
+
+            await command("Runtime.removeBinding", {"name": "toEditor"})
+            await drain(0.5)
+            reply = await command("Runtime.evaluate", {"expression": "typeof toEditor", "returnByValue": True})
+            assert reply["result"]["result"]["value"] == "undefined"
+        finally:
+            await client.close()
+
+
+async def testp_cdp_server_binds_url_breakpoints_set_before_a_jscontext_script(lockdown: LockdownClient) -> None:
+    """
+    An editor sets its breakpoints by URL as soon as it attaches, before the script exists. A
+    JSContext script only gets its (synthetic) URL when it is parsed, so such a breakpoint could
+    not bind; the bridge now keeps it, binds it when the script appears, reports
+    Debugger.breakpointResolved as V8 would - and the breakpoint hits. (A bare JSContext has no
+    timers and reports no unhandled rejection through the console, so the exception path is
+    covered on a page, where WebKit does report them.)
+    """
+    async with cdp_server(lockdown) as (port, _):
+        targets = [target for target in await http_get_json(port, "/json/list") if target["type"] == "node"]
+        if not targets:
+            pytest.skip("no inspectable JSContext on the device")
+        for target in targets:
+            if await evaluate_and_log_in_javascript_context(port, target["id"]):
+                break
+        else:
+            pytest.skip("no listed JSContext answered the inspector")
+        client = CdpWebsocketClient(port, target["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        ids = itertools.count(1)
+        events: list[dict[str, Any]] = []
+
+        async def command(method: str, params: dict[str, Any]) -> dict[str, Any]:
+            id_ = next(ids)
+            await client.send({"id": id_, "method": method, "params": params})
+
+            async def wait() -> dict[str, Any]:
+                while True:
+                    message = await client.receive()
+                    if message.get("id") == id_:
+                        return message
+                    if "method" in message:
+                        events.append(message)
+
+            return await asyncio.wait_for(wait(), TIMEOUT)
+
+        async def until(method: str, seconds: float = 10) -> dict[str, Any]:
+            async def wait() -> dict[str, Any]:
+                while True:
+                    for event in events:
+                        if event["method"] == method:
+                            events.remove(event)
+                            return event["params"]
+                    message = await client.receive()
+                    if "method" in message:
+                        events.append(message)
+
+            return await asyncio.wait_for(wait(), seconds)
+
+        async def drain(seconds: float) -> None:
+            end = asyncio.get_event_loop().time() + seconds
+            while True:
+                left = end - asyncio.get_event_loop().time()
+                if left <= 0:
+                    return
+                try:
+                    message = await asyncio.wait_for(client.receive(), left)
+                except asyncio.TimeoutError:
+                    return
+                if "method" in message:
+                    events.append(message)
+
+        try:
+            await command("Runtime.enable", {})
+            await command("Debugger.enable", {})
+            await command("Debugger.setBreakpointsActive", {"active": True})
+            await drain(1.5)  # the context's existing scripts are announced on enable
+            events.clear()
+            # Learn the next script id from a throwaway evaluation: JSContext scripts are numbered
+            # consecutively, so the editor's breakpoint can target the script that follows.
+            await command("Runtime.evaluate", {"expression": "0"})
+            await drain(1)
+            parsed = [e["params"] for e in events if e["method"] == "Debugger.scriptParsed"]
+            next_id = int(parsed[-1]["scriptId"]) + 1
+            events.clear()
+            url = f"jscontext:///{next_id}.js"
+            reply = await command("Debugger.setBreakpointByUrl", {"url": url, "lineNumber": 1})
+            breakpoint_id = reply["result"]["breakpointId"]
+            assert reply["result"]["locations"] == [], "not bound yet: the script does not exist"
+
+            # The script defines a function; the breakpoint binds as it is parsed and hits when the
+            # function runs later (a one-shot evaluation would have finished before binding).
+            await command("Runtime.evaluate", {"expression": "function bpTarget() {\n  return 41 + 1;\n}\n'defined'"})
+            resolved = await until("Debugger.breakpointResolved")
+            assert resolved["breakpointId"] == breakpoint_id
+            assert resolved["location"]["scriptId"] == str(next_id) and resolved["location"]["lineNumber"] == 1
+            await client.send({"id": next(ids), "method": "Runtime.evaluate", "params": {"expression": "bpTarget()"}})
+            paused = await until("Debugger.paused")
+            location = paused["callFrames"][0]["location"]
+            assert (location["scriptId"], location["lineNumber"]) == (str(next_id), 1), location
+            await command("Debugger.resume", {})
+
+            reply = await command("Debugger.removeBreakpoint", {"breakpointId": breakpoint_id})
+            assert reply == {"id": reply["id"], "result": {}}
+            events.clear()
+            await command("Runtime.evaluate", {"expression": "bpTarget()", "returnByValue": True})
+            await drain(1)
+            assert not [e for e in events if e["method"] == "Debugger.paused"], "removed breakpoints must not hit"
         finally:
             await client.close()

--- a/tests/services/test_web_protocol/test_protocol_conformance.py
+++ b/tests/services/test_web_protocol/test_protocol_conformance.py
@@ -44,7 +44,9 @@ FETCHER = REPO / "misc/protocol/fetch_protocols.py"
 
 inventory: Inventory = collect()
 webkit = load_spec("webkit")
-cdp = load_spec("cdp")
+# What a client may say: Chrome's protocol plus the domains Node.js adds to it, which editors
+# attaching "as Node" send to a JSContext.
+cdp = {**load_spec("cdp"), **load_spec("node")}
 
 
 def test_the_inventory_found_the_bridge() -> None:
@@ -62,7 +64,7 @@ def test_handled_cdp_methods_are_cdp_commands() -> None:
     unknown = sorted(
         m for m in inventory.client_handled if not in_commands(cdp, m) and m not in CDP_METHODS_NO_LONGER_IN_SPEC
     )
-    assert unknown == [], f"handled but not in Chrome's protocol: {unknown}"
+    assert unknown == [], f"handled but neither in Chrome's nor in Node's protocol: {unknown}"
     stale_allowlist = sorted(
         m for m in CDP_METHODS_NO_LONGER_IN_SPEC if in_commands(cdp, m) or m not in inventory.client_handled
     )
@@ -136,7 +138,7 @@ def test_every_protocol_name_in_the_bridge_belongs_to_a_spec() -> None:
 def fetcher_pins() -> dict[str, str]:
     source = FETCHER.read_text()
     pins: dict[str, str] = {}
-    for name in ("webkit", "cdp"):
+    for name in ("webkit", "cdp", "node"):
         match = re.search(rf'^{name.upper()}_COMMIT = "([0-9a-f]{{40}})"', source, re.M)
         assert match is not None, f"{name.upper()}_COMMIT pin missing from {FETCHER}"
         pins[name] = match.group(1)


### PR DESCRIPTION
Third piece of the CDP hardening series (after #1925 and #1926). An editor that attaches to a JSContext does so as a Node.js target, and the bridge only covered part of the Node inspector surface; the gaps showed most in VS Code.

## The problem

VS Code's js-debug renders exceptions from `Runtime.exceptionThrown` and has no handler for `Log.entryAdded`, so an uncaught exception in a JSContext or page produced nothing in the debugger. `NodeWorker.enable`, which js-debug sends on every attach, was forwarded to the device and came back `-32601 'NodeWorker' domain was not found`. `Runtime.addBinding` was acknowledged but never called back, `inspect()` did nothing, and a URL breakpoint set before its JSContext script existed never bound. All of this was found by grounding the bridge against the protocol definitions (the previous PR) and reading js-debug's own source, then confirming on the device.

## What this adds

Each item was checked against WebKit's actual behavior on iOS 26:

- **`Runtime.exceptionThrown`** from WebKit's error console messages: uncaught exceptions, unhandled rejections and parse errors. Lines and columns are rebased from WebKit's 1-based numbering to Chrome's 0-based, and the `"undefined"` URL WebKit puts on an evaluation is normalized to empty. These no longer also appear as `Log.entryAdded`.
- **`Runtime.addBinding` / `removeBinding`** and **`Runtime.bindingCalled`**, over a `console.debug` marker. The binding is installed in every main world and every matching isolated world, including contexts created later, and survives navigation, as in Chrome. Its transport messages never surface as console output. This is what Playwright's `exposeFunction`/`exposeBinding` is built on.
- **`Runtime.inspectRequested`** from WebKit's `Inspector.inspect` (`Runtime.enable` now also enables the Inspector domain, which no Chrome client sends).
- **`Runtime.executionContextDestroyed`** before a reload's `executionContextsCleared` and on frame detach.
- **`Debugger.breakpointResolved`**: a URL breakpoint set on a JSContext script before it exists is kept, bound when the script is parsed, reported resolved, and hits.
- **`Debugger.removeBreakpoint`** routed for those synthetic breakpoints; the **`NodeRuntime`/`NodeWorker`/`NodeTracing`** domains acknowledged; `NodeTracing.getCategories` answered empty.

Acknowledgements now return the empty result Chrome's protocol defines rather than `{"result": null}`.

## Grounding

`fetch_protocols.py` now also vendors nodejs/node's `src/inspector/domain_node_*.pdl` into `protocol/node_protocol.json`, pinned to an upstream commit (parsing PDL with no new dependency). The conformance test accepts a client method that is in Chrome's protocol or Node's, so the acknowledged Node methods are checked rather than flagged.

## Verification

- VS Code's js-debug adapter attached as a Node target to a JSContext through the bridge: zero error replies (previously `NodeWorker.enable` errored). Driven with the standalone DAP server, exercising an uncaught exception, an unhandled rejection and `inspect()`.
- Device tests: `testp_cdp_server_reports_the_node_inspector_events` (page) and `testp_cdp_server_binds_url_breakpoints_set_before_a_jscontext_script` (JSContext), plus offline unit tests for each translation.
- Full offline web-protocol suite, pyright and ruff clean.
