### PR TITLE
cdp: Fix JSContext stepping - synthesize Debugger.resumed, clean the paused stack

### DIFF
--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -631,6 +631,7 @@ class CdpTarget:
             "Debugger.scriptParsed": self._debugger_script_parsed,
             "Debugger.scriptFailedToParse": self._debugger_script_failed_to_parse,
             "Debugger.paused": self._debugger_paused,
+            "Debugger.resumed": self._debugger_resumed,
             "Debugger.globalObjectCleared": self._debugger_global_object_cleared,
             "Runtime.executionContextCreated": self._runtime_execution_context_created,
             "Console.messageAdded": self._console_message_added,
@@ -665,6 +666,11 @@ class CdpTarget:
         # Scripts WebKit reports that are its own inspector machinery (the InjectedScript that runs
         # console evaluations), not the debuggee's. Their frames are stripped from a paused stack.
         self._internal_script_ids: set[str] = set()
+        # Whether the client currently believes execution is paused. WebKit emits no
+        # Debugger.resumed when a step resumes-then-repauses (verified: it sends zero of them),
+        # so the client would see paused-after-paused; V8 always alternates paused/resumed, and
+        # WebStorm's step machine waits for the resumed and will not step again without it.
+        self._client_debugger_paused = False
         # For a flat JSContext: the synthetic URL handed to the frontend for a URL-less script ->
         # the script's id. Lets a URL breakpoint (how editors set breakpoints) be turned into a
         # scriptId-location breakpoint, the only kind that binds on a URL-less script.
@@ -3457,10 +3463,23 @@ class CdpTarget:
                 # WebKit names the defining position `location`; Chrome calls it `startLocation`.
                 if "location" in scope:
                     scope["startLocation"] = scope.pop("location")
+        if self._client_debugger_paused:
+            # A step resumed then repaused without WebKit announcing the resume; keep the client's
+            # paused/resumed alternation intact so its stepping does not stall.
+            await self.output_queue.put({"method": "Debugger.resumed"})
+        self._client_debugger_paused = True
         await self.output_queue.put(message)
+
+    async def _debugger_resumed(self, message: dict[str, Any]):
+        # Only meaningful when the client thinks it is paused; a stray resumed otherwise would
+        # break the alternation the synthesized one (see _debugger_paused) maintains.
+        if self._client_debugger_paused:
+            self._client_debugger_paused = False
+            await self.output_queue.put(message)
 
     async def _debugger_global_object_cleared(self, message: dict[str, Any]):
         # Contexts are gone; allow their uniqueIds to be re-announced after the reload.
+        self._client_debugger_paused = False
         for frame_id in list(self._frame_execution_ids):
             await self._destroy_frame_contexts(frame_id)
         self._emitted_context_unique_ids.clear()

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -662,6 +662,9 @@ class CdpTarget:
         # scriptId -> url, from Debugger.scriptParsed; used to fill the `url` WebKit omits from the
         # callFrames of Debugger.paused (Chrome's CallFrame requires it).
         self._script_id_to_url: dict[str, str] = {}
+        # Scripts WebKit reports that are its own inspector machinery (the InjectedScript that runs
+        # console evaluations), not the debuggee's. Their frames are stripped from a paused stack.
+        self._internal_script_ids: set[str] = set()
         # For a flat JSContext: the synthetic URL handed to the frontend for a URL-less script ->
         # the script's id. Lets a URL breakpoint (how editors set breakpoints) be turned into a
         # scriptId-location breakpoint, the only kind that binds on a URL-less script.
@@ -3315,6 +3318,9 @@ class CdpTarget:
         params = message.get("params", {})
         source = params.get("sourceURL", "") or params.get("url", "")
         if any(marker in source for marker in WEBKIT_INTERNAL_SCRIPT_MARKERS):
+            internal_id = params.get("scriptId")
+            if internal_id is not None:
+                self._internal_script_ids.add(str(internal_id))
             return
         script_id = params.get("scriptId")
         if not source and self._flat and script_id is not None:
@@ -3411,6 +3417,24 @@ class CdpTarget:
         line_number: int = location.get("lineNumber", -1)
         return bool(script_id) and script_id != "0" and line_number >= 0
 
+    def _is_inspector_frame(self, frame: dict[str, Any]) -> bool:
+        """Whether a call frame belongs to WebKit's own InjectedScript, not the debuggee.
+
+        WebKit runs a console evaluation *through* its InjectedScript (JavaScript), so a pause
+        inside the evaluation carries that harness at the bottom of the stack - `_wrapCall` and an
+        anonymous frame in a script with no source URL. V8 evaluates natively and shows only the
+        user's frame; WebStorm builds the stack strictly and, given the phantom frames, stopped
+        advancing after the first step (a `debugger;` typed in its console). A real breakpoint in
+        the debuggee's own code has no such frame. Recognized by the id of a script the bridge
+        already hides as internal, or - on a JSContext, whose scripts the bridge has all seen and
+        given synthetic URLs - any frame in a script it never saw parsed.
+        """
+        location: dict[str, Any] = frame.get("location") or {}
+        script_id = location.get("scriptId")
+        if script_id in self._internal_script_ids:
+            return True
+        return bool(self._flat) and script_id is not None and script_id not in self._script_id_to_url
+
     async def _debugger_paused(self, message: dict[str, Any]):
         params = message["params"]
         params["reason"] = DEBUGGER_PAUSED_REASON.get(params["reason"], "other")
@@ -3420,9 +3444,10 @@ class CdpTarget:
         # has (see _is_real_call_frame), omits the required `url`, and uses scope-type enum values
         # Chrome rejects. Untranslated, Chrome's SDK throws while building the paused state and the
         # Sources panel never shows the pause. Drop the native frame and reshape the rest in place.
-        frames = [frame for frame in params.get("callFrames", []) if self._is_real_call_frame(frame)]
-        # Keep the top frame even if it somehow fails the test, so a pause is never frameless.
-        params["callFrames"] = frames or params.get("callFrames", [])[:1]
+        all_frames: list[dict[str, Any]] = params.get("callFrames", [])
+        frames = [f for f in all_frames if self._is_real_call_frame(f) and not self._is_inspector_frame(f)]
+        # Keep the top frame even if it somehow fails the tests, so a pause is never frameless.
+        params["callFrames"] = frames or all_frames[:1]
         for frame in params["callFrames"]:
             if "url" not in frame:
                 script_id = frame.get("location", {}).get("scriptId")

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -3395,15 +3395,35 @@ class CdpTarget:
         }
         await self.output_queue.put(message)
 
+    @staticmethod
+    def _is_real_call_frame(frame: dict[str, Any]) -> bool:
+        """Whether a WebKit call frame denotes real source Chrome can locate.
+
+        WebKit puts a native entry frame at the bottom of a stack - scriptId "0", lineNumber -1 -
+        for the global/native code beneath the script. Chrome's protocol has no such frame (a
+        Location must name a real script at a non-negative line), and js-debug and WebStorm build
+        the stack strictly: the bad frame desynced their step handling, so after one step the
+        session stopped advancing. V8 never emits it; verified against `node --inspect`, whose
+        stacks carry only real script frames.
+        """
+        location: dict[str, Any] = frame.get("location") or {}
+        script_id = location.get("scriptId")
+        line_number: int = location.get("lineNumber", -1)
+        return bool(script_id) and script_id != "0" and line_number >= 0
+
     async def _debugger_paused(self, message: dict[str, Any]):
         params = message["params"]
         params["reason"] = DEBUGGER_PAUSED_REASON.get(params["reason"], "other")
         if "breakpointId" in params.get("data", {}):
             params["hitBreakpoints"] = [params["data"]["breakpointId"]]
-        # WebKit's CallFrame differs from Chrome's: it omits the required `url` and uses scope-type
-        # enum values Chrome rejects. Untranslated, Chrome's SDK throws while building the paused
-        # state and the Sources panel never shows the pause. Reshape each frame in place.
-        for frame in params.get("callFrames", []):
+        # WebKit's CallFrame differs from Chrome's: it carries a bottom native frame Chrome never
+        # has (see _is_real_call_frame), omits the required `url`, and uses scope-type enum values
+        # Chrome rejects. Untranslated, Chrome's SDK throws while building the paused state and the
+        # Sources panel never shows the pause. Drop the native frame and reshape the rest in place.
+        frames = [frame for frame in params.get("callFrames", []) if self._is_real_call_frame(frame)]
+        # Keep the top frame even if it somehow fails the test, so a pause is never frameless.
+        params["callFrames"] = frames or params.get("callFrames", [])[:1]
+        for frame in params["callFrames"]:
             if "url" not in frame:
                 script_id = frame.get("location", {}).get("scriptId")
                 frame["url"] = self._script_id_to_url.get(script_id, "")

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -2689,6 +2689,48 @@ async def test_user_preference_overrides_are_translated_and_replayed(monkeypatch
         assert target._setup_messages["Page.setEmulatedMedia"] == {"media": ""}
 
 
+async def test_stepping_gets_a_synthesized_resumed_between_pauses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WebKit emits no Debugger.resumed when a step resumes then repauses (it sends none at all),
+    so a client would see paused-after-paused; V8 always alternates, and WebStorm's step machine
+    waits for the resumed and will not step again without it. The bridge injects one before a pause
+    the client is not expecting, keeping the paused/resumed alternation."""
+
+    async def a_pause(line: int) -> dict[str, Any]:
+        return {
+            "method": "Debugger.paused",
+            "params": {
+                "reason": "other",
+                "callFrames": [
+                    {
+                        "callFrameId": "cf",
+                        "functionName": "f",
+                        "location": {"scriptId": "9", "lineNumber": line, "columnNumber": 0},
+                    }
+                ],
+            },
+        }
+
+    with offline_cdp_target(monkeypatch) as (target, _):
+        target._script_id_to_url["9"] = "x.js"
+
+        await target._debugger_paused(await a_pause(1))
+        assert target.output_queue.get_nowait()["method"] == "Debugger.paused", "the first pause stands alone"
+        assert target.output_queue.empty()
+
+        # A step: WebKit sends only the next pause. The bridge precedes it with a resumed.
+        await target._debugger_paused(await a_pause(2))
+        assert target.output_queue.get_nowait() == {"method": "Debugger.resumed"}
+        assert target.output_queue.get_nowait()["params"]["callFrames"][0]["location"]["lineNumber"] == 2
+        assert target.output_queue.empty()
+
+        # A real resumed from the device (an explicit resume-to-run) is forwarded once and clears.
+        await target._debugger_resumed({"method": "Debugger.resumed"})
+        assert target.output_queue.get_nowait() == {"method": "Debugger.resumed"}
+        # A stray resumed while the client is already running is dropped (would break alternation).
+        await target._debugger_resumed({"method": "Debugger.resumed"})
+        assert target.output_queue.empty()
+
+
 async def test_a_paused_stack_drops_webkit_native_frames(monkeypatch: pytest.MonkeyPatch) -> None:
     """WebKit puts a native entry frame - scriptId "0", lineNumber -1 - at the bottom of a paused
     call stack. Chrome's protocol has no such frame and js-debug/WebStorm build the stack strictly;

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -2731,6 +2731,64 @@ async def test_a_paused_stack_drops_webkit_native_frames(monkeypatch: pytest.Mon
         assert event["params"]["reason"] == "other", "DebuggerStatement maps to Chrome's 'other'"
 
 
+async def test_a_paused_stack_drops_the_injected_script_harness(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WebKit runs a console evaluation through its InjectedScript, so a pause inside it carries
+    that harness beneath the user's frame - `_wrapCall` and an anon frame in a script with no
+    source. V8 shows only the user frame; WebStorm built the stack strictly and stopped stepping
+    after one step. On a JSContext (flat) session the bridge strips those frames, leaving the
+    single user frame node reports. Recognized by the id of a script hidden as internal, or - the
+    JSContext case, where every real script is known - a frame in a script never seen parsed."""
+    with offline_cdp_target(monkeypatch) as (target, _):
+        target._flat = True
+        # The console eval's own script, given a synthetic URL when it was parsed.
+        await target._debugger_script_parsed({
+            "method": "Debugger.scriptParsed",
+            "params": {"scriptId": "675", "url": "", "startLine": 0, "endLine": 0, "endColumn": 3},
+        })
+        # WebKit's InjectedScript, hidden from the client (its source carries the marker).
+        await target._debugger_script_parsed({
+            "method": "Debugger.scriptParsed",
+            "params": {"scriptId": "27", "sourceURL": "__InjectedScript_WebKit.js"},
+        })
+        assert "27" in target._internal_script_ids
+        assert target.output_queue.get_nowait()["method"] == "Debugger.scriptParsed", (
+            "only the user script is forwarded"
+        )
+        assert target.output_queue.empty()
+
+        await target._debugger_paused({
+            "method": "Debugger.paused",
+            "params": {
+                "reason": "DebuggerStatement",
+                "callFrames": [
+                    {
+                        "callFrameId": "cf0",
+                        "functionName": "global code",
+                        "location": {"scriptId": "675", "lineNumber": 1, "columnNumber": 0},
+                    },
+                    {
+                        "callFrameId": "cf1",
+                        "functionName": "",
+                        "location": {"scriptId": "0", "lineNumber": -1, "columnNumber": -1},
+                    },
+                    {
+                        "callFrameId": "cf2",
+                        "functionName": "",
+                        "location": {"scriptId": "27", "lineNumber": 444, "columnNumber": 79},
+                    },
+                    {
+                        "callFrameId": "cf3",
+                        "functionName": "_wrapCall",
+                        "location": {"scriptId": "27", "lineNumber": 451, "columnNumber": 9},
+                    },
+                ],
+            },
+        })
+        frames = target.output_queue.get_nowait()["params"]["callFrames"]
+        assert [f["callFrameId"] for f in frames] == ["cf0"], "only the user's own frame survives"
+        assert frames[0]["url"] == "jscontext:///675.js"
+
+
 async def test_a_paused_stack_keeps_the_top_frame_even_if_it_looks_native(monkeypatch: pytest.MonkeyPatch) -> None:
     """A pause must never be frameless: if every frame failed the real-source test, keep the top one."""
     with offline_cdp_target(monkeypatch) as (target, _):

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -2689,6 +2689,64 @@ async def test_user_preference_overrides_are_translated_and_replayed(monkeypatch
         assert target._setup_messages["Page.setEmulatedMedia"] == {"media": ""}
 
 
+async def test_a_paused_stack_drops_webkit_native_frames(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WebKit puts a native entry frame - scriptId "0", lineNumber -1 - at the bottom of a paused
+    call stack. Chrome's protocol has no such frame and js-debug/WebStorm build the stack strictly;
+    the bad frame desynced their step handling, so stepping stopped advancing after one step. The
+    bridge drops it and reshapes the real frames (url filled in, scope types mapped)."""
+    with offline_cdp_target(monkeypatch) as (target, _):
+        target._script_id_to_url["294"] = "jscontext:///294.js"
+        await target._debugger_paused({
+            "method": "Debugger.paused",
+            "params": {
+                "reason": "DebuggerStatement",
+                "callFrames": [
+                    {
+                        "callFrameId": "cf0",
+                        "functionName": "global code",
+                        "location": {"scriptId": "294", "lineNumber": 2, "columnNumber": 0},
+                        "scopeChain": [
+                            {
+                                "type": "global",
+                                "object": {"objectId": "s0"},
+                                "location": {"scriptId": "294", "lineNumber": 0},
+                            }
+                        ],
+                    },
+                    {
+                        "callFrameId": "cf1",
+                        "functionName": "",
+                        "location": {"scriptId": "0", "lineNumber": -1, "columnNumber": -1},
+                        "scopeChain": [],
+                    },
+                ],
+            },
+        })
+        event = target.output_queue.get_nowait()
+        frames = event["params"]["callFrames"]
+        assert [f["callFrameId"] for f in frames] == ["cf0"], "the native scriptId-0 frame must be gone"
+        assert frames[0]["url"] == "jscontext:///294.js", "the real frame gets its url filled in"
+        scope = frames[0]["scopeChain"][0]
+        assert scope["type"] == "global" and "startLocation" in scope and "location" not in scope
+        assert event["params"]["reason"] == "other", "DebuggerStatement maps to Chrome's 'other'"
+
+
+async def test_a_paused_stack_keeps_the_top_frame_even_if_it_looks_native(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pause must never be frameless: if every frame failed the real-source test, keep the top one."""
+    with offline_cdp_target(monkeypatch) as (target, _):
+        await target._debugger_paused({
+            "method": "Debugger.paused",
+            "params": {
+                "reason": "other",
+                "callFrames": [
+                    {"callFrameId": "cf0", "functionName": "x", "location": {"scriptId": "0", "lineNumber": -1}}
+                ],
+            },
+        })
+        frames = target.output_queue.get_nowait()["params"]["callFrames"]
+        assert [f["callFrameId"] for f in frames] == ["cf0"]
+
+
 async def test_javascript_errors_become_runtime_exception_thrown(monkeypatch: pytest.MonkeyPatch) -> None:
     """WebKit reports uncaught exceptions, unhandled rejections and parse errors as error console
     messages of source "javascript"; Chrome reports them as Runtime.exceptionThrown, the only form


### PR DESCRIPTION
A step-over in WebStorm attached to a JSContext stopped advancing after the first step: paused at a `debugger;`, stepped once, then nothing, though the console still evaluated.

## Root cause (found by diffing WebStorm-vs-node against WebStorm-vs-JSContext)

The same console input works against real `node --inspect`. Capturing both sessions and diffing them, the difference that stalls WebStorm is the event alternation:

- **node** emits `Debugger.paused` → `Debugger.resumed` → `Debugger.paused` across a step.
- **WebKit** emits **no `Debugger.resumed` at all** (verified on the device: zero `resumed` for two `paused`, where node sends one between them).

Chrome's protocol alternates paused/resumed, and WebStorm's step machine waits for the `resumed` before it will issue another step. Seeing `paused` straight after `paused`, it stalled. js-debug tolerates it, which is why it could not reproduce the wedge.

## Fix

The bridge tracks whether the client believes it is paused and **synthesizes a `Debugger.resumed`** before a pause the client is not expecting, so a step reads as `paused → resumed → paused` as it does on node. A real `resumed` from the device is forwarded once and clears the state; a stray one while already running is dropped; a navigation resets it.

Verified on an iOS 26 JSContext: the client now sees `paused@1 → resumed → paused@2 → resumed → …` across a run of step-overs.

## Two supporting stack-cleaning fixes (same branch)

While diffing the sessions, the paused call stack also differed from node's and is cleaned up so the stacks match:

- **Native entry frame** dropped: WebKit puts a `scriptId "0"`, `lineNumber -1` frame at the bottom of every stack; Chrome has no equivalent.
- **InjectedScript harness** dropped: WebKit runs a console evaluation through its InjectedScript (JavaScript), leaving `_wrapCall` and an anonymous frame beneath the user's; node (native eval) shows only the user frame.

The top frame is always kept, so a pause is never frameless. These make the JSContext pause report the single user frame node reports; the `resumed` synthesis is what unblocks stepping.

## Tests

- Offline: `test_stepping_gets_a_synthesized_resumed_between_pauses`, `test_a_paused_stack_drops_the_injected_script_harness`, `test_a_paused_stack_drops_webkit_native_frames`, `test_a_paused_stack_keeps_the_top_frame_even_if_it_looks_native`.
- Device stepping and JSContext tests pass unchanged.

Ruled out along the way against real node: a silent console eval pauses on `debugger;` in node too, and a step-completion carries reason `"other"` in node too.
