### PR TITLE
cdp: Announce all targets when discovery is enabled (fixes VS Code chrome attach hang)

### DIFF
--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -117,6 +117,11 @@ Configuration notes:
 
 - `urlFilter` selects which pages to attach to. `"*"` attaches to every inspectable
   page; narrow it (e.g. `"*myapp.example.com*"`) to pick a specific tab.
+- `"targetSelection": "pick"` prompts you to choose which page to attach to instead of
+  attaching to every match. The prompt appears only when two or more pages match the
+  `urlFilter`; with a single match js-debug attaches to it directly, with no prompt.
+  JSContexts never appear in this prompt — js-debug's picker lists only `page` targets
+  (attach to a JSContext through the `node` configuration below).
 - `webRoot` maps source-mapped URLs to workspace files so breakpoints bind to your
   original sources — point it at the folder your dev server serves from.
 - Source-map warnings for third-party pages you don't control are harmless; silence

--- a/pymobiledevice3/services/web_protocol/cdp_browser.py
+++ b/pymobiledevice3/services/web_protocol/cdp_browser.py
@@ -384,9 +384,12 @@ class CdpBrowser:
         self._discover = bool(message.get("params", {}).get("discover"))
         if self._discover:
             self._events_session = message.get("sessionId")
-            # Announce the current pages before answering so a client awaiting the response
-            # observes the initial Target.targetCreated batch immediately after it.
-            await self._refresh_targets()
+            # Announce every current page before answering so a client awaiting the response
+            # observes the initial Target.targetCreated batch immediately after it. Chrome reports
+            # all existing targets when discovery is enabled; the batch must go out even for pages
+            # already learnt through an earlier Target.getTargets (js-debug's target picker calls
+            # getTargets first, then setDiscoverTargets, and hangs without this initial batch).
+            await self._refresh_targets(announce_all=True)
             self._ensure_poll()
         await self._reply(message, {})
 
@@ -463,13 +466,13 @@ class CdpBrowser:
     def _list_pages(self) -> dict[str, tuple[Application, Page]]:
         return {target_id: (application, page) for target_id, application, page in iter_inspectable(self.inspector)}
 
-    async def _refresh_targets(self) -> None:
+    async def _refresh_targets(self, announce_all: bool = False) -> None:
         """Ask every application for its listing, then bring the client's target list up to date."""
         await self.inspector.get_open_pages()
         await self.inspector.flush_input(PAGE_LISTING_FLUSH)
-        await self._sync_targets()
+        await self._sync_targets(announce_all=announce_all)
 
-    async def _sync_targets(self, attach: bool = True) -> None:
+    async def _sync_targets(self, attach: bool = True, announce_all: bool = False) -> None:
         """Bring the client's target list in line with the listings already received: announce
         new pages, destroy gone ones and, unless `attach` is off, auto-attach the new ones."""
         async with self._refresh_lock:
@@ -487,7 +490,7 @@ class CdpBrowser:
                     "canAccessOpener": False,
                     "browserContextId": DEFAULT_BROWSER_CONTEXT_ID,
                 }
-                if is_new and self._discover:
+                if (is_new or announce_all) and self._discover:
                     await self._send_event("Target.targetCreated", {"targetInfo": self._known_targets[page_id]})
                 if attach and self._auto_attach and page_id not in self._attachments:
                     if self._left_to_its_candidate(page_id, page):

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -227,6 +227,45 @@ class CdpBrowserWebsocketClient(CdpWebsocketClient):
         return await asyncio.wait_for(wait_for_response(), TIMEOUT)
 
 
+async def testp_cdp_browser_endpoint_announces_targets_after_get_targets(lockdown: LockdownClient) -> None:
+    """
+    VS Code's js-debug builds its target picker by calling Target.getTargets first and then
+    Target.setDiscoverTargets, and waits for the initial Target.targetCreated batch before it will
+    attach. The bridge announced only targets that were *new* since it last listed, so a page
+    already learnt through getTargets produced no targetCreated on setDiscoverTargets and js-debug
+    hung with no targets offered. Chrome reports every existing target when discovery is enabled;
+    the batch must arrive whatever was asked before.
+    """
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        version = await http_get_json(port, "/json/version/")
+        browser_id = urlsplit(version["webSocketDebuggerUrl"]).path.rsplit("/", 1)[1]
+        page_id = targets[0]["id"]
+        client = CdpBrowserWebsocketClient(port, browser_id)
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        ids = itertools.count(1)
+        try:
+            await client.command(next(ids), "Target.attachToBrowserTarget", {})
+            listed = await client.command(next(ids), "Target.getTargets", {})
+            target_ids = {t["targetId"] for t in listed["result"]["targetInfos"]}
+            assert page_id in target_ids, f"the Safari page must be listed: {target_ids}"
+
+            # Discovery is enabled only now, after getTargets already learnt the page.
+            await client.send({"id": next(ids), "method": "Target.setDiscoverTargets", "params": {"discover": True}})
+
+            async def announced() -> set[str]:
+                seen: set[str] = set()
+                while page_id not in seen:
+                    message = await client.receive()
+                    if message.get("method") == "Target.targetCreated":
+                        seen.add(message["params"]["targetInfo"]["targetId"])
+                return seen
+
+            seen = await asyncio.wait_for(announced(), TIMEOUT)
+            assert page_id in seen, "setDiscoverTargets must announce the page even after getTargets"
+        finally:
+            await client.close()
+
+
 async def testp_cdp_browser_endpoint_attaches_playwright_style(lockdown: LockdownClient) -> None:
     """
     A Chrome-protocol client attaching over the browser endpoint (Puppeteer/Playwright's


### PR DESCRIPTION
A VS Code (js-debug) `chrome` attach to the bridge did nothing - no targets offered, no attach, no error - `"targetSelection": "pick"` or not.

## Root cause

js-debug's browser attach calls `Target.getTargets` first (to build its target list / picker) and then `Target.setDiscoverTargets`, and waits for the initial `Target.targetCreated` batch before it attaches. The browser endpoint announced a target with `Target.targetCreated` only when it was **new** since the last listing. `getTargets` had already learnt the pages, so `setDiscoverTargets` found nothing new and emitted nothing, and js-debug hung waiting for the batch.

Captured with the bridge's own `--trace`: `attachToBrowserTarget` → `getTargets` (returns the page) → `setDiscoverTargets` → **silence**.

## Fix

`setDiscoverTargets` now announces every current target when discovery is enabled, as Chrome does, regardless of what an earlier `getTargets` already learnt.

## Verified

End to end with js-debug's standalone DAP server against the bridge: a `chrome` attach now discovers the Safari page, spawns its session, attaches, evaluates (`6*7 -> 42`) and stops at a `debugger` statement, where it previously hung. Device test `testp_cdp_browser_endpoint_announces_targets_after_get_targets` covers the regression.

## Note on the picker

The QuickPick chooser (`targetSelection: "pick"`) only appears when two or more page-type targets match, and js-debug's browser attach filters candidates to `type === "page"`, so JSContexts never appear there. With one page it auto-attaches. This fix is what makes either path work at all instead of hanging.
