### PR TITLE
cdp: Log GET access lines at debug to stop landing-page polling flooding output

### DIFF
--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -137,6 +137,25 @@ OSUTILS = get_os_utils()
 logger = logging.getLogger(__name__)
 
 
+class _GetAccessToDebug(logging.Filter):
+    """Treat uvicorn's access log for GET requests as DEBUG.
+
+    The landing page polls GET /api/targets (and fetches icons) every second, which floods the
+    default output; those lines are only useful when debugging. A GET is relabelled DEBUG and
+    dropped unless debug logging is on (the app's stream handler has no level of its own, so
+    relabelling alone would not hide it); POSTs and the rest are left untouched. uvicorn logs
+    access as '%s - "%s %s HTTP/%s" %d' with args (client, method, path, http_version, status).
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        args = record.args
+        if isinstance(args, tuple) and len(args) >= 2 and args[1] == "GET":
+            record.levelno = logging.DEBUG
+            record.levelname = "DEBUG"
+            return logging.getLogger().isEnabledFor(logging.DEBUG)
+        return True
+
+
 cli = InjectingTyper(
     name="webinspector",
     help=(
@@ -462,6 +481,7 @@ async def cdp(
         app.state.inspector.trace = recorder.device_hook
         typer.echo(f"Recording the protocol trace to {trace}")
     print(f"Web Inspector ready. Open in Google Chrome: http://{host}:{port}/")
+    logging.getLogger("uvicorn.access").addFilter(_GetAccessToDebug())
     server = uvicorn.Server(
         uvicorn.Config(
             app,

--- a/tests/cli/test_webinspector_completion.py
+++ b/tests/cli/test_webinspector_completion.py
@@ -52,3 +52,41 @@ async def test_reserved_words_are_not_evaluated() -> None:
     completions = await _collect(completer, "x = await.")
     assert completions == []
     assert "exp" not in captured
+
+
+def test_get_access_logs_are_debug_only() -> None:
+    """The landing page polls GET /api/targets every second; those access lines are relabelled
+    DEBUG and dropped unless debug logging is on, while POSTs and the rest stay at their level."""
+    import logging
+
+    from pymobiledevice3.cli.webinspector import _GetAccessToDebug
+
+    access_filter = _GetAccessToDebug()
+
+    def record(method: str) -> logging.LogRecord:
+        return logging.LogRecord(
+            "uvicorn.access",
+            logging.INFO,
+            __file__,
+            0,
+            '%s - "%s %s HTTP/%s" %d',
+            ("127.0.0.1:1", method, "/api/targets", "1.1", 200),
+            None,
+        )
+
+    root = logging.getLogger()
+    previous = root.level
+    try:
+        root.setLevel(logging.INFO)
+        get_record = record("GET")
+        assert access_filter.filter(get_record) is False, "a GET access log is dropped at INFO"
+        assert get_record.levelno == logging.DEBUG and get_record.levelname == "DEBUG"
+
+        post_record = record("POST")
+        assert access_filter.filter(post_record) is True, "a POST access log is kept"
+        assert post_record.levelno == logging.INFO
+
+        root.setLevel(logging.DEBUG)
+        assert access_filter.filter(record("GET")) is True, "a GET access log is kept when debugging"
+    finally:
+        root.setLevel(previous)


### PR DESCRIPTION
The landing page polls `GET /api/targets` (and fetches icons) roughly once a second, filling the default output with uvicorn access lines. A filter on `uvicorn.access` relabels GET requests DEBUG and drops them unless debug logging is on (the app's stream handler has no level of its own, so relabelling alone would still print them); POST and the rest are untouched. Unit test covers INFO-drops-GET, keeps-POST, and DEBUG-keeps-GET.