### PR TITLE
cdp: Validate emitted-event schema and add a page-path golden flow

### DIFF
--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -1432,6 +1432,9 @@ class CdpTarget:
             self._top_frame_commits += 1
         # This handler bypasses the pass-through path, so map the frame ids here.
         self._map_frame_ids_outbound(message)
+        # Chrome requires Page.frameNavigated.type; WebKit omits it. Every navigation the bridge
+        # sees is an ordinary one (WebKit reports no back/forward-cache restore).
+        message.get("params", {}).setdefault("type", "Navigation")
         mapped = message.get("params", {}).get("frame", {})
         client_frame_id = mapped.get("id")
         client_parent_id = mapped.get("parentId")
@@ -3339,6 +3342,14 @@ class CdpTarget:
             self._flat_script_url_to_id[source] = script_id
         if script_id is not None:
             self._script_id_to_url[script_id] = source
+        # Chrome requires `hash` and `executionContextId` on Debugger.scriptParsed (verified: node
+        # sends both); WebKit omits them. Fill a stable per-script hash and the context the script
+        # belongs to - the one context on a JSContext, the page's default otherwise - so a client
+        # keying scripts on either does not choke. `buildId` is newer and node omits it too.
+        if "hash" not in params:
+            params["hash"] = hashlib.sha1(f"{script_id}:{source}".encode()).hexdigest()
+        if "executionContextId" not in params:
+            params["executionContextId"] = self._default_execution_id or JS_CONTEXT_EXECUTION_ID
         await self.output_queue.put(message)
         if self._flat and script_id is not None:
             await self._bind_pending_url_breakpoints(str(script_id))

--- a/tests/services/test_web_protocol/golden/README.md
+++ b/tests/services/test_web_protocol/golden/README.md
@@ -25,4 +25,10 @@ output, not the recording.
 3. Use only public/synthetic page content - a trace carries page content and is otherwise sensitive.
 4. Add a test that calls `replay_flat_session` and asserts the behavior the flow exercises.
 
-`golden_flow` currently models the un-multiplexed JSContext path only.
+`golden_flow` models both paths: `replay_flat_session` for the un-multiplexed JSContext path and
+`replay_page_session` for the Target-multiplexed page path (the fixture is the same unwrapped form
+either way; the page replay re-wraps device messages in the Target envelope). Fixtures:
+`webstorm_jscontext_stepping.jsonl` and `safari_page_stepping.jsonl`.
+
+Each golden test also runs `protocol_inventory.validate_editor_event` over every emitted event, so
+a missing required parameter of Chrome's protocol fails the test.

--- a/tests/services/test_web_protocol/golden/safari_page_stepping.jsonl
+++ b/tests/services/test_web_protocol/golden/safari_page_stepping.jsonl
@@ -1,0 +1,75 @@
+{"dir": "device->bridge", "msg": {"method": "Target.targetCreated", "params": {"targetInfo": {"targetId": "page-780", "type": "page"}}}, "page": ""}
+{"dir": "editor->bridge", "msg": {"id": 1, "method": "Page.enable", "params": {}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 1, "method": "Page.enable", "params": {}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 1}, "page": ""}
+{"dir": "device->bridge", "msg": {"method": "Page.defaultUserPreferencesDidChange", "params": {"preferences": [{"name": "PrefersReducedMotion", "value": "NoPreference"}, {"name": "PrefersContrast", "value": "NoPreference"}, {"name": "PrefersColorScheme", "value": "Light"}]}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 1}, "page": "page-780"}
+{"dir": "editor->bridge", "msg": {"id": 2, "method": "Runtime.enable", "params": {}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 2, "method": "Runtime.enable", "params": {}}, "page": "page-780"}
+{"dir": "bridge->device", "msg": {"id": -1, "method": "Inspector.enable", "params": {}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 2}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 3}, "page": ""}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 430, "type": "normal", "name": "", "frameId": "0.123"}}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 431, "type": "user", "name": "com.apple.LinkPresentation.MetadataProvider", "frameId": "0.123"}}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 432, "type": "internal", "name": "SafariSchemaDataExtractor", "frameId": "0.123"}}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 433, "type": "internal", "name": "SafariQuickWebsiteSearch", "frameId": "0.123"}}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 2}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": -1}, "page": "page-780"}
+{"dir": "editor->bridge", "msg": {"id": 3, "method": "Debugger.enable", "params": {}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 3, "method": "Debugger.enable", "params": {}}, "page": "page-780"}
+{"dir": "bridge->device", "msg": {"id": -3, "method": "Debugger.setPauseOnDebuggerStatements", "params": {"enabled": true}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 5}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 6}, "page": ""}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "2755", "url": "https://example.com/?again", "startLine": 0, "startColumn": 0, "endLine": 2, "endColumn": 6962, "isContentScript": true, "sourceURL": "__InjectedScript_SchemaDataExtractor.js", "module": false}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "2753", "url": "user-script:1", "startLine": 0, "startColumn": 0, "endLine": 3, "endColumn": 2, "isContentScript": true, "sourceURL": "__InjectedScript_OpenSearchURLFinder.js", "module": false}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "2754", "url": "user-script:2", "startLine": 0, "startColumn": 0, "endLine": 3, "endColumn": 2, "isContentScript": true, "sourceURL": "__InjectedScript_QuickWebsiteSearchURLDetector.js", "module": false}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 3}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": -3}, "page": "page-780"}
+{"dir": "editor->bridge", "msg": {"id": 4, "method": "Debugger.setBreakpointsActive", "params": {"active": true}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": -4, "method": "Debugger.setPauseOnDebuggerStatements", "params": {"enabled": true}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 7}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 8}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": -4}, "page": "page-780"}
+{"dir": "editor->bridge", "msg": {"id": 5, "method": "Page.navigate", "params": {"url": "https://example.com/"}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": -5, "method": "Runtime.evaluate", "params": {"expression": "location.href = \"https://example.com/\"\n//# sourceURL=__pymobiledevice3_internal__"}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 9}, "page": ""}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "2780", "url": "", "startLine": 0, "startColumn": 0, "endLine": 1, "endColumn": 42, "isContentScript": false, "sourceURL": "__pymobiledevice3_internal__", "module": false}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 434, "type": "internal", "name": "SafariReaderArticleFinder", "frameId": "0.123"}}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {"result": {"type": "string", "value": "https://example.com/"}, "wasThrown": false}, "id": -5}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Page.frameNavigated", "params": {"frame": {"id": "0.123", "loaderId": "0.260", "url": "https://example.com/", "mimeType": "text/html", "securityOrigin": "https://example.com"}}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.globalObjectCleared"}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 435, "type": "normal", "name": "", "frameId": "0.123"}}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 436, "type": "user", "name": "com.apple.LinkPresentation.MetadataProvider", "frameId": "0.123"}}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 437, "type": "internal", "name": "SafariSchemaDataExtractor", "frameId": "0.123"}}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 438, "type": "internal", "name": "SafariQuickWebsiteSearch", "frameId": "0.123"}}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 439, "type": "internal", "name": "SafariReaderArticleFinder", "frameId": "0.123"}}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "2781", "url": "user-script:1", "startLine": 0, "startColumn": 0, "endLine": 3, "endColumn": 2, "isContentScript": true, "sourceURL": "__InjectedScript_OpenSearchURLFinder.js", "module": false}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "2782", "url": "user-script:2", "startLine": 0, "startColumn": 0, "endLine": 3, "endColumn": 2, "isContentScript": true, "sourceURL": "__InjectedScript_QuickWebsiteSearchURLDetector.js", "module": false}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Page.loadEventFired", "params": {"timestamp": 0.05039612499967916}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Page.domContentEventFired", "params": {"timestamp": 0.05063308333046734}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "2783", "url": "https://example.com/", "startLine": 0, "startColumn": 0, "endLine": 2, "endColumn": 6962, "isContentScript": true, "sourceURL": "__InjectedScript_SchemaDataExtractor.js", "module": false}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 440, "type": "user", "name": "com.apple.LinkPresentation.MetadataProvider", "frameId": "0.123"}}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "2784", "url": "https://example.com/", "startLine": 0, "startColumn": 0, "endLine": 632, "endColumn": 0, "isContentScript": true, "module": false}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "9", "url": "", "startLine": 0, "startColumn": 0, "endLine": 4, "endColumn": 2, "isContentScript": true, "sourceURL": "__InjectedScript_ReaderShared.js", "module": false}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "10", "url": "", "startLine": 0, "startColumn": 0, "endLine": 13, "endColumn": 2, "isContentScript": true, "sourceURL": "__InjectedScript_ReaderArticleFinder.js", "module": false}}, "page": "page-780"}
+{"dir": "editor->bridge", "msg": {"id": 6, "method": "Runtime.evaluate", "params": {"expression": "function stepMe(){\n  var a=1;\n  debugger;\n  var b=2;\n  return a+b;\n}\nsetTimeout(stepMe, 30);", "userGesture": true}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 6, "method": "Runtime.evaluate", "params": {"expression": "function stepMe(){\n  var a=1;\n  debugger;\n  var b=2;\n  return a+b;\n}\nsetTimeout(stepMe, 30);", "emulateUserGesture": true}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 10}, "page": ""}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "2785", "url": "", "startLine": 0, "startColumn": 0, "endLine": 6, "endColumn": 23, "isContentScript": false, "module": false}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {"result": {"type": "number", "value": 1, "description": "1"}, "wasThrown": false}, "id": 6}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.paused", "params": {"callFrames": [{"callFrameId": "{\"ordinal\":0,\"injectedScriptId\":435}", "functionName": "stepMe", "location": {"scriptId": "2785", "lineNumber": 2, "columnNumber": 2}, "scopeChain": [{"object": {"type": "object", "objectId": "{\"injectedScriptId\":435,\"id\":1}", "className": "DebuggerScope", "description": "DebuggerScope"}, "type": "closure", "name": "stepMe", "location": {"scriptId": "2785", "lineNumber": 1, "columnNumber": 16}}, {"object": {"type": "object", "objectId": "{\"injectedScriptId\":435,\"id\":2}", "className": "DebuggerScope", "description": "DebuggerScope"}, "type": "globalLexicalEnvironment", "empty": true}, {"object": {"type": "object", "objectId": "{\"injectedScriptId\":435,\"id\":3}", "className": "Window", "description": "Window"}, "type": "global"}], "this": {"type": "object", "objectId": "{\"injectedScriptId\":435,\"id\":4}", "className": "Window", "description": "Window"}, "isTailDeleted": false}], "reason": "DebuggerStatement"}}, "page": "page-780"}
+{"dir": "editor->bridge", "msg": {"id": 7, "method": "Debugger.stepOver", "params": {}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 7, "method": "Debugger.stepOver", "params": {}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 11}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 7}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.paused", "params": {"callFrames": [{"callFrameId": "{\"ordinal\":0,\"injectedScriptId\":435}", "functionName": "stepMe", "location": {"scriptId": "2785", "lineNumber": 3, "columnNumber": 2}, "scopeChain": [{"object": {"type": "object", "objectId": "{\"injectedScriptId\":435,\"id\":5}", "className": "DebuggerScope", "description": "DebuggerScope"}, "type": "closure", "name": "stepMe", "location": {"scriptId": "2785", "lineNumber": 1, "columnNumber": 16}}, {"object": {"type": "object", "objectId": "{\"injectedScriptId\":435,\"id\":6}", "className": "DebuggerScope", "description": "DebuggerScope"}, "type": "globalLexicalEnvironment", "empty": true}, {"object": {"type": "object", "objectId": "{\"injectedScriptId\":435,\"id\":7}", "className": "Window", "description": "Window"}, "type": "global"}], "this": {"type": "object", "objectId": "{\"injectedScriptId\":435,\"id\":8}", "className": "Window", "description": "Window"}, "isTailDeleted": false}], "reason": "other"}}, "page": "page-780"}
+{"dir": "editor->bridge", "msg": {"id": 8, "method": "Debugger.stepOver", "params": {}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 8, "method": "Debugger.stepOver", "params": {}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 12}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 8}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.paused", "params": {"callFrames": [{"callFrameId": "{\"ordinal\":0,\"injectedScriptId\":435}", "functionName": "stepMe", "location": {"scriptId": "2785", "lineNumber": 4, "columnNumber": 2}, "scopeChain": [{"object": {"type": "object", "objectId": "{\"injectedScriptId\":435,\"id\":9}", "className": "DebuggerScope", "description": "DebuggerScope"}, "type": "closure", "name": "stepMe", "location": {"scriptId": "2785", "lineNumber": 1, "columnNumber": 16}}, {"object": {"type": "object", "objectId": "{\"injectedScriptId\":435,\"id\":10}", "className": "DebuggerScope", "description": "DebuggerScope"}, "type": "globalLexicalEnvironment", "empty": true}, {"object": {"type": "object", "objectId": "{\"injectedScriptId\":435,\"id\":11}", "className": "Window", "description": "Window"}, "type": "global"}], "this": {"type": "object", "objectId": "{\"injectedScriptId\":435,\"id\":12}", "className": "Window", "description": "Window"}, "isTailDeleted": false}], "reason": "other"}}, "page": "page-780"}
+{"dir": "editor->bridge", "msg": {"id": 9, "method": "Debugger.resume", "params": {}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 9, "method": "Debugger.resume", "params": {}}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 13}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 9}, "page": "page-780"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.resumed"}, "page": "page-780"}

--- a/tests/services/test_web_protocol/golden_flow.py
+++ b/tests/services/test_web_protocol/golden_flow.py
@@ -146,3 +146,99 @@ async def replay_flat_session(fixture: list[dict[str, Any]], settle: float = 0.4
         for task in (target._input_task, target._receiving_task):
             task.cancel()
     return emitted
+
+
+async def replay_page_session(fixture: list[dict[str, Any]], settle: float = 0.5) -> list[dict[str, Any]]:
+    """Drive a Target-multiplexed (page) CdpTarget with the fixture and return its editor output.
+
+    A page speaks through WebKit's Target domain: the bridge wraps each request in
+    Target.sendMessageToTarget and the device answers inside Target.dispatchMessageFromTarget. The
+    fixture's device messages are the unwrapped inner ones (as `--trace` records); this re-wraps
+    them. The device request the fixture scripts is matched by method, as on the flat path.
+    """
+    editor, initial_events, turns = _device_turns(fixture)
+    scripted = [turn for turn in turns if turn.method not in AUTO_ACKNOWLEDGED]
+    turn_iter = iter(scripted)
+
+    target_id = "page"
+    for entry in fixture:
+        message = entry["msg"]
+        if entry["dir"] == "device->bridge" and message.get("method") == "Target.targetCreated":
+            target_id = message["params"]["targetInfo"]["targetId"]
+            break
+
+    inspector = WebinspectorService.__new__(WebinspectorService)
+    inspector.wir_events = {}
+    inspector.wir_message_results = {}
+    results = cast(dict[Any, Any], inspector.wir_message_results)
+    session_id = "GOLDEN"
+
+    def deliver_wrapped(inner_messages: list[dict[str, Any]]) -> None:
+        queue = inspector.session_events(session_id)
+        for inner in inner_messages:
+            # The target is adopted up front; a replayed Target.targetCreated would only be
+            # re-announced (and, wrapped, mis-forwarded to the editor).
+            if inner.get("method") == "Target.targetCreated":
+                continue
+            queue.append({
+                "method": "Target.dispatchMessageFromTarget",
+                "params": {"targetId": target_id, "message": json.dumps(inner)},
+            })
+
+    async def send_socket_data(session: str, app_id: str, page_id: int, data: dict[str, Any]) -> None:
+        outer_id = data.get("id")
+        if isinstance(outer_id, int):
+            results[outer_id] = {"id": outer_id, "result": {}}  # ack the Target.sendMessageToTarget envelope
+        if data.get("method") != "Target.sendMessageToTarget":
+            return
+        inner = json.loads(data["params"]["message"])
+        inner_id = inner.get("id")
+        method = inner.get("method", "")
+        if method in AUTO_ACKNOWLEDGED:
+            if isinstance(inner_id, int):
+                deliver_wrapped([{"id": inner_id, "result": {}}])
+            return
+        turn = next(turn_iter, None)
+        if turn is None:
+            return
+        wrapped: list[dict[str, Any]] = []
+        if isinstance(inner_id, int) and turn.reply is not None:
+            wrapped.append({**{k: v for k, v in turn.reply.items() if k != "id"}, "id": inner_id})
+        wrapped.extend(dict(event) for event in turn.events)
+        if wrapped:
+            deliver_wrapped(wrapped)
+
+    inspector.send_socket_data = send_socket_data  # type: ignore[method-assign]
+
+    page = Page.from_page_dictionary({
+        "WIRPageIdentifierKey": 1,
+        "WIRTypeKey": "WIRTypeWeb",
+        "WIRTitleKey": "Example",
+        "WIRURLKey": "https://example.com/",
+    })
+    application = Application(
+        "PID:1", "com.apple.mobilesafari", 1, "MobileSafari", AutomationAvailability.NOT_AVAILABLE, 1, False, True
+    )
+    target = CdpTarget(SessionProtocol(inspector, session_id, application, page, method_prefix=""), target_id)
+    assert not target._flat, "the page replay models the Target-multiplexed path"
+    target._page_targets.add(target_id)
+
+    emitted: list[dict[str, Any]] = []
+
+    async def drain() -> None:
+        while True:
+            emitted.append(await target.receive())
+
+    drain_task = asyncio.ensure_future(drain())
+    try:
+        if initial_events:
+            deliver_wrapped(initial_events)
+        for command in editor:
+            await target.send(dict(command))
+            await asyncio.sleep(0.02)
+        await asyncio.sleep(settle)
+    finally:
+        drain_task.cancel()
+        for task in (target._input_task, target._receiving_task):
+            task.cancel()
+    return emitted

--- a/tests/services/test_web_protocol/protocol_inventory.py
+++ b/tests/services/test_web_protocol/protocol_inventory.py
@@ -234,3 +234,41 @@ def in_events(spec: dict[str, Any], name: str) -> bool:
 def command_params(spec: dict[str, Any], name: str) -> dict[str, Any]:
     d, m = split(name)
     return spec.get(d, {}).get("commands", {}).get(m, {}).get("params", {})
+
+
+def event_params(spec: dict[str, Any], name: str) -> dict[str, Any]:
+    d, m = split(name)
+    return spec.get(d, {}).get("events", {}).get(m, {}).get("params", {})
+
+
+# CDP events the bridge emits that the vendored Chrome protocol has since removed a required field
+# from, or shapes slightly differently than the spec of record; each is kept with the reason it is
+# tolerated so a genuine missing field is still caught.
+EVENT_VALIDATION_ALLOWLIST: dict[str, set[str]] = {
+    # buildId is a recent addition to Debugger.scriptParsed that even node does not send; the hash
+    # and executionContextId the bridge now fills are the fields a client actually keys on.
+    "Debugger.scriptParsed": {"buildId"},
+}
+
+
+def validate_editor_event(spec: dict[str, Any], message: dict[str, Any]) -> list[str]:
+    """Problems with an event the bridge emitted to the editor, against Chrome's protocol.
+
+    Checks the shape a client actually depends on: the event exists, and every required parameter
+    is present. Returns a list of human-readable problems (empty when the event is valid). Replies
+    (id-carrying) are not checked here - the command they answer, and so their expected shape, is
+    not on the message.
+    """
+    method = message.get("method")
+    if not isinstance(method, str) or "id" in message:
+        return []
+    if not in_events(spec, method):
+        return [f"{method}: not a Chrome event"]
+    params = message.get("params") or {}
+    allowed_missing = EVENT_VALIDATION_ALLOWLIST.get(method, set())
+    missing = [
+        name
+        for name, meta in event_params(spec, method).items()
+        if not meta["optional"] and name not in params and name not in allowed_missing
+    ]
+    return [f"{method}: missing required parameter {name!r}" for name in missing]

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -40,7 +40,8 @@ from pymobiledevice3.services.web_protocol.cdp_target import (
 )
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
 from pymobiledevice3.services.webinspector import SAFARI, Application, AutomationAvailability, Page, WebinspectorService
-from tests.services.test_web_protocol.golden_flow import load_fixture, replay_flat_session
+from tests.services.test_web_protocol.golden_flow import load_fixture, replay_flat_session, replay_page_session
+from tests.services.test_web_protocol.protocol_inventory import load_spec, validate_editor_event
 
 TIMEOUT = 30
 
@@ -2887,6 +2888,33 @@ async def test_a_paused_stack_keeps_the_top_frame_even_if_it_looks_native(monkey
         assert [f["callFrameId"] for f in frames] == ["cf0"]
 
 
+async def test_golden_safari_page_stepping_flow() -> None:
+    """Replay a real Safari-page debugging session - the Target-multiplexed path - through the
+    current bridge and assert stepping advances line by line with the paused/resumed alternation
+    editors need, and that every event emitted carries Chrome's required parameters. Guards the
+    page path (most editor use) the way the JSContext golden guards the flat path, without a device."""
+    emitted = await replay_page_session(load_fixture("safari_page_stepping"))
+    methods = [m.get("method", "<reply>") for m in emitted]
+
+    paused = [m for m in emitted if m.get("method") == "Debugger.paused"]
+    assert [p["params"]["callFrames"][0]["location"]["lineNumber"] for p in paused] == [2, 3, 4], (
+        f"the debugger; statement pauses, then two steps advance a line each: {methods}"
+    )
+    for event in paused:
+        for frame in event["params"]["callFrames"]:
+            assert frame["location"]["scriptId"] != "0" and frame["location"]["lineNumber"] >= 0
+
+    paused_at = [i for i, method in enumerate(methods) if method == "Debugger.paused"]
+    for first, second in zip(paused_at, paused_at[1:]):
+        assert "Debugger.resumed" in methods[first + 1 : second], (
+            f"each step must read paused -> resumed -> paused: {methods}"
+        )
+
+    cdp = load_spec("cdp")
+    problems = [problem for message in emitted for problem in validate_editor_event(cdp, message)]
+    assert problems == [], f"emitted events violate Chrome's schema: {sorted(set(problems))}"
+
+
 async def test_golden_webstorm_jscontext_stepping_flow() -> None:
     """Replay a real WebStorm JSContext debugging session (its editor commands and the device's
     responses) through the current bridge and assert the editor-visible behavior the step-over bug
@@ -2917,6 +2945,11 @@ async def test_golden_webstorm_jscontext_stepping_flow() -> None:
     assert not any(
         m.get("method") == "Log.entryAdded" and m["params"]["entry"].get("source") == "javascript" for m in emitted
     ), "engine errors are Runtime.exceptionThrown, not Log entries"
+
+    # Every event the bridge emitted must carry the required parameters of Chrome's protocol.
+    cdp = load_spec("cdp")
+    problems = [problem for message in emitted for problem in validate_editor_event(cdp, message)]
+    assert problems == [], f"emitted events violate Chrome's schema: {sorted(set(problems))}"
 
 
 async def test_javascript_errors_become_runtime_exception_thrown(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Follows the golden-flow PR (#1931) and closes most of the coverage gaps I flagged, in one PR as requested.

## 1. On-the-wire schema validation of emitted events

`protocol_inventory.validate_editor_event` checks an event the bridge emits against Chrome's protocol: the event exists and every required parameter is present. The conformance tests already checked protocol *names* in the source; this checks the *shape* of what actually goes to the editor. Both golden tests now run it over every emitted event, so dropping a Chrome-required field fails offline in CI.

Run over the golden flows, it found two real gaps, both fixed here (verified against `node --inspect`, which sends them):

- `Debugger.scriptParsed` omitted `hash` and `executionContextId`. Now filled: a stable per-script hash and the script's context (the one context on a JSContext, the page's default otherwise). `buildId` is newer and node omits it too, so it is allowlisted.
- `Page.frameNavigated` omitted the required `type`; set to `"Navigation"` (every navigation the bridge sees is an ordinary one).

## 2. Page-path golden flow

The golden harness only replayed the JSContext (flat) path. `replay_page_session` extends it to the Target-multiplexed page path - most editor use - by re-wrapping the fixture's device messages in WebKit's `Target` envelope (the fixture format is unchanged). A real Safari-page stepping session is replayed and asserted to advance line by line (2 -> 3 -> 4) with the `paused -> resumed -> paused` alternation editors need, and every emitted event is schema-checked.

Removing the scriptParsed or frameNavigated fields, or the `resumed` synthesis, makes these tests fail - verified, so they are real guards.

## 3. The `getProperties`-empty item: not a bug

I flagged earlier that JSContext `Runtime.getProperties` returned an empty scope. On the device it does not: closure and global-object scopes return their variables; only WebKit's empty global-lexical scope returns `[]`, which is correct. Dropped from the list; no change.

## Verified

- Full offline web-protocol suite and repo pyright clean.
- Device tests for navigation lifecycle, large-file stepping, JSContext, node inspector events, url breakpoints and per-frame contexts pass unchanged with the scriptParsed and frameNavigated changes.

Remaining gap, not in this PR: more golden fixtures (other editor flows), and full type validation (nested object shapes) rather than required-field presence. The presence check already catches the class that kept biting.
