### PR TITLE
cdp: Make Puppeteer work and add a chrome-remote-interface golden

### DIFF
--- a/pymobiledevice3/services/web_protocol/cdp_browser.py
+++ b/pymobiledevice3/services/web_protocol/cdp_browser.py
@@ -223,6 +223,7 @@ class CdpBrowser:
             "Target.attachToBrowserTarget": self._target_attach_to_browser_target,
             "Target.setDiscoverTargets": self._target_set_discover_targets,
             "Target.setAutoAttach": self._target_set_auto_attach,
+            "Target.getBrowserContexts": self._target_get_browser_contexts,
             "Target.getTargets": self._target_get_targets,
             "Target.getTargetInfo": self._target_get_target_info,
             "Target.attachToTarget": self._target_attach_to_target,
@@ -411,6 +412,12 @@ class CdpBrowser:
         else:
             await self._stop_waiting_for_new_targets()
         await self._reply(message, {})
+
+    async def _target_get_browser_contexts(self, message: dict[str, Any]) -> None:
+        # Only the default browser context exists (no incognito), and Chrome omits the default from
+        # this list, so it is empty. Puppeteer's connect iterates the result and fails on a missing
+        # array; a bare {} ack is not enough.
+        await self._reply(message, {"browserContextIds": []})
 
     async def _target_get_targets(self, message: dict[str, Any]) -> None:
         await self._refresh_targets()

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -91,7 +91,7 @@ MOUSEMOVE_MIN_INTERVAL = 0.08
 
 # CDP domains WebKit does not implement at all. Any method in these that isn't specially
 # translated is acknowledged with an empty response instead of being forwarded (and erroring).
-NOOP_ABSENT_DOMAINS = frozenset({"Input", "Overlay"})
+NOOP_ABSENT_DOMAINS = frozenset({"Input", "Overlay", "Performance"})
 
 # Events WebKit's Web Inspector emits that have no counterpart in Chrome's protocol. Forwarding
 # them is at best noise (Chrome ignores unknown events) and at worst fatal: an unrecognized event
@@ -2696,8 +2696,38 @@ class CdpTarget:
             params["emulateUserGesture"] = bool(params.pop("userGesture"))
 
     async def _runtime_call_function_on(self, message: dict[str, Any]):
-        self._translate_user_gesture(message.setdefault("params", {}))
+        params = message.setdefault("params", {})
+        self._translate_user_gesture(params)
+        if "objectId" not in params:
+            # Chrome lets callFunctionOn target a bare execution context (executionContextId /
+            # uniqueContextId); WebKit requires an object to call the function on. Resolve the
+            # context's global object and call on it - what Chrome does under the hood, and what
+            # Puppeteer's page.evaluate relies on.
+            object_id = await self._context_global_object_id(params.get("executionContextId"))
+            params.pop("executionContextId", None)
+            params.pop("uniqueContextId", None)
+            if object_id is not None:
+                params["objectId"] = object_id
+            else:
+                await self._error_response(
+                    message, {"code": -32000, "message": "callFunctionOn needs an object or a known execution context"}
+                )
+                return
         await self._send_message_to_target(message)
+
+    async def _context_global_object_id(self, context_id: Optional[int]) -> Optional[str]:
+        """The objectId of the global object of an execution context, for calling a function on it.
+
+        `context_id` absent, or the flat JSContext, means the one/default context."""
+        evaluate: dict[str, Any] = {"expression": "this"}
+        if isinstance(context_id, int):
+            real = self._real_context_id(context_id)
+            if real is not None:
+                evaluate["contextId"] = real
+        response = await self.send_message_with_result("Runtime.evaluate", evaluate)
+        result = response.get("result", {}).get("result", {})
+        object_id = result.get("objectId")
+        return object_id if isinstance(object_id, str) else None
 
     async def _runtime_compile_script(self, message: dict[str, Any]):
         self._script_source_to_context_id[message["params"]["expression"]] = message["params"]["executionContextId"]

--- a/tests/services/test_web_protocol/golden/README.md
+++ b/tests/services/test_web_protocol/golden/README.md
@@ -28,7 +28,10 @@ output, not the recording.
 `golden_flow` models both paths: `replay_flat_session` for the un-multiplexed JSContext path and
 `replay_page_session` for the Target-multiplexed page path (the fixture is the same unwrapped form
 either way; the page replay re-wraps device messages in the Target envelope). Fixtures:
-`webstorm_jscontext_stepping.jsonl` and `safari_page_stepping.jsonl`.
+
+- `webstorm_jscontext_stepping.jsonl` - WebStorm on a JSContext.
+- `safari_page_stepping.jsonl` - a Safari page.
+- `chrome_remote_interface_stepping.jsonl` - the raw chrome-remote-interface client on a page.
 
 Each golden test also runs `protocol_inventory.validate_editor_event` over every emitted event, so
 a missing required parameter of Chrome's protocol fails the test.

--- a/tests/services/test_web_protocol/golden/chrome_remote_interface_stepping.jsonl
+++ b/tests/services/test_web_protocol/golden/chrome_remote_interface_stepping.jsonl
@@ -1,0 +1,74 @@
+{"dir": "device->bridge", "msg": {"method": "Target.targetCreated", "params": {"targetInfo": {"targetId": "page-30", "type": "page"}}}, "page": ""}
+{"dir": "editor->bridge", "msg": {"id": 1, "method": "Page.enable", "params": {}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 1, "method": "Page.enable", "params": {}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Target.targetCreated", "params": {"targetInfo": {"targetId": "frame-8589934593", "type": "frame"}}}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 1}, "page": ""}
+{"dir": "device->bridge", "msg": {"method": "Page.defaultUserPreferencesDidChange", "params": {"preferences": [{"name": "PrefersReducedMotion", "value": "NoPreference"}, {"name": "PrefersContrast", "value": "NoPreference"}, {"name": "PrefersColorScheme", "value": "Light"}]}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 1}, "page": "page-30"}
+{"dir": "editor->bridge", "msg": {"id": 2, "method": "Runtime.enable", "params": {}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 2, "method": "Runtime.enable", "params": {}}, "page": "page-30"}
+{"dir": "bridge->device", "msg": {"id": -1, "method": "Inspector.enable", "params": {}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 2}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 3}, "page": ""}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 2, "type": "normal", "name": "", "frameId": "0.1"}}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 2}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": -1}, "page": "page-30"}
+{"dir": "editor->bridge", "msg": {"id": 3, "method": "Debugger.enable", "params": {}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 3, "method": "Debugger.enable", "params": {}}, "page": "page-30"}
+{"dir": "bridge->device", "msg": {"id": -3, "method": "Debugger.setPauseOnDebuggerStatements", "params": {"enabled": true}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 5}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 6}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 3}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": -3}, "page": "page-30"}
+{"dir": "editor->bridge", "msg": {"id": 4, "method": "Debugger.setBreakpointsActive", "params": {"active": true}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": -4, "method": "Debugger.setPauseOnDebuggerStatements", "params": {"enabled": true}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 7}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 8}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": -4}, "page": "page-30"}
+{"dir": "editor->bridge", "msg": {"id": 5, "method": "Page.navigate", "params": {"url": "https://example.com/"}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": -5, "method": "Runtime.evaluate", "params": {"expression": "location.href = \"https://example.com/\"\n//# sourceURL=__pymobiledevice3_internal__"}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 9}, "page": ""}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "2", "url": "", "startLine": 0, "startColumn": 0, "endLine": 1, "endColumn": 42, "isContentScript": false, "sourceURL": "__pymobiledevice3_internal__", "module": false}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {"result": {"type": "string", "value": "https://example.com/"}, "wasThrown": false}, "id": -5}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Page.frameNavigated", "params": {"frame": {"id": "0.1", "loaderId": "0.2", "url": "https://example.com/", "mimeType": "text/html", "securityOrigin": "https://example.com"}}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.globalObjectCleared"}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 3, "type": "normal", "name": "", "frameId": "0.1"}}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 4, "type": "internal", "name": "SafariQuickWebsiteSearch", "frameId": "0.1"}}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "3", "url": "user-script:1", "startLine": 0, "startColumn": 0, "endLine": 3, "endColumn": 2, "isContentScript": true, "sourceURL": "__InjectedScript_OpenSearchURLFinder.js", "module": false}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "4", "url": "user-script:2", "startLine": 0, "startColumn": 0, "endLine": 3, "endColumn": 2, "isContentScript": true, "sourceURL": "__InjectedScript_QuickWebsiteSearchURLDetector.js", "module": false}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Page.loadEventFired", "params": {"timestamp": 0.1394632083331544}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Page.domContentEventFired", "params": {"timestamp": 0.1399493750000147}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 5, "type": "internal", "name": "SafariSchemaDataExtractor", "frameId": "0.1"}}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "5", "url": "https://example.com/", "startLine": 0, "startColumn": 0, "endLine": 2, "endColumn": 6962, "isContentScript": true, "sourceURL": "__InjectedScript_SchemaDataExtractor.js", "module": false}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 6, "type": "internal", "name": "SafariReaderArticleFinder", "frameId": "0.1"}}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "6", "url": "", "startLine": 0, "startColumn": 0, "endLine": 4, "endColumn": 2, "isContentScript": true, "sourceURL": "__InjectedScript_ReaderShared.js", "module": false}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "7", "url": "", "startLine": 0, "startColumn": 0, "endLine": 13, "endColumn": 2, "isContentScript": true, "sourceURL": "__InjectedScript_ReaderArticleFinder.js", "module": false}}, "page": "page-30"}
+{"dir": "editor->bridge", "msg": {"id": 6, "method": "Runtime.evaluate", "params": {"expression": "function crStep(){\n  var a=1;\n  debugger;\n  var b=2;\n  return a+b;\n}\nsetTimeout(crStep, 30);", "userGesture": true}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 6, "method": "Runtime.evaluate", "params": {"expression": "function crStep(){\n  var a=1;\n  debugger;\n  var b=2;\n  return a+b;\n}\nsetTimeout(crStep, 30);", "emulateUserGesture": true}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 10}, "page": ""}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "8", "url": "", "startLine": 0, "startColumn": 0, "endLine": 6, "endColumn": 23, "isContentScript": false, "module": false}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {"result": {"type": "number", "value": 1, "description": "1"}, "wasThrown": false}, "id": 6}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.paused", "params": {"callFrames": [{"callFrameId": "{\"ordinal\":0,\"injectedScriptId\":3}", "functionName": "crStep", "location": {"scriptId": "8", "lineNumber": 2, "columnNumber": 2}, "scopeChain": [{"object": {"type": "object", "objectId": "{\"injectedScriptId\":3,\"id\":1}", "className": "DebuggerScope", "description": "DebuggerScope"}, "type": "closure", "name": "crStep", "location": {"scriptId": "8", "lineNumber": 1, "columnNumber": 16}}, {"object": {"type": "object", "objectId": "{\"injectedScriptId\":3,\"id\":2}", "className": "DebuggerScope", "description": "DebuggerScope"}, "type": "globalLexicalEnvironment", "empty": true}, {"object": {"type": "object", "objectId": "{\"injectedScriptId\":3,\"id\":3}", "className": "Window", "description": "Window"}, "type": "global"}], "this": {"type": "object", "objectId": "{\"injectedScriptId\":3,\"id\":4}", "className": "Window", "description": "Window"}, "isTailDeleted": false}], "reason": "DebuggerStatement"}}, "page": "page-30"}
+{"dir": "editor->bridge", "msg": {"id": 7, "method": "Debugger.stepOver", "params": {}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 7, "method": "Debugger.stepOver", "params": {}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 11}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 7}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.paused", "params": {"callFrames": [{"callFrameId": "{\"ordinal\":0,\"injectedScriptId\":3}", "functionName": "crStep", "location": {"scriptId": "8", "lineNumber": 3, "columnNumber": 2}, "scopeChain": [{"object": {"type": "object", "objectId": "{\"injectedScriptId\":3,\"id\":5}", "className": "DebuggerScope", "description": "DebuggerScope"}, "type": "closure", "name": "crStep", "location": {"scriptId": "8", "lineNumber": 1, "columnNumber": 16}}, {"object": {"type": "object", "objectId": "{\"injectedScriptId\":3,\"id\":6}", "className": "DebuggerScope", "description": "DebuggerScope"}, "type": "globalLexicalEnvironment", "empty": true}, {"object": {"type": "object", "objectId": "{\"injectedScriptId\":3,\"id\":7}", "className": "Window", "description": "Window"}, "type": "global"}], "this": {"type": "object", "objectId": "{\"injectedScriptId\":3,\"id\":8}", "className": "Window", "description": "Window"}, "isTailDeleted": false}], "reason": "other"}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Runtime.executionContextCreated", "params": {"context": {"id": 7, "type": "internal", "name": "SafariReaderArticleFinder", "frameId": "0.1"}}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "6", "url": "", "startLine": 0, "startColumn": 0, "endLine": 4, "endColumn": 2, "isContentScript": true, "sourceURL": "__InjectedScript_ReaderShared.js", "module": false}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "7", "url": "", "startLine": 0, "startColumn": 0, "endLine": 13, "endColumn": 2, "isContentScript": true, "sourceURL": "__InjectedScript_ReaderArticleFinder.js", "module": false}}, "page": "page-30"}
+{"dir": "editor->bridge", "msg": {"id": 8, "method": "Debugger.stepOver", "params": {}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 8, "method": "Debugger.stepOver", "params": {}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 12}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 8}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.paused", "params": {"callFrames": [{"callFrameId": "{\"ordinal\":0,\"injectedScriptId\":3}", "functionName": "crStep", "location": {"scriptId": "8", "lineNumber": 4, "columnNumber": 2}, "scopeChain": [{"object": {"type": "object", "objectId": "{\"injectedScriptId\":3,\"id\":9}", "className": "DebuggerScope", "description": "DebuggerScope"}, "type": "closure", "name": "crStep", "location": {"scriptId": "8", "lineNumber": 1, "columnNumber": 16}}, {"object": {"type": "object", "objectId": "{\"injectedScriptId\":3,\"id\":10}", "className": "DebuggerScope", "description": "DebuggerScope"}, "type": "globalLexicalEnvironment", "empty": true}, {"object": {"type": "object", "objectId": "{\"injectedScriptId\":3,\"id\":11}", "className": "Window", "description": "Window"}, "type": "global"}], "this": {"type": "object", "objectId": "{\"injectedScriptId\":3,\"id\":12}", "className": "Window", "description": "Window"}, "isTailDeleted": false}], "reason": "other"}}, "page": "page-30"}
+{"dir": "editor->bridge", "msg": {"id": 9, "method": "Runtime.evaluate", "params": {"expression": "6*7", "returnByValue": true}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 9, "method": "Runtime.evaluate", "params": {"expression": "6*7", "returnByValue": true}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 13}, "page": ""}
+{"dir": "device->bridge", "msg": {"method": "Debugger.scriptParsed", "params": {"scriptId": "9", "url": "", "startLine": 0, "startColumn": 0, "endLine": 0, "endColumn": 3, "isContentScript": false, "module": false}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {"result": {"type": "number", "value": 42, "description": "42"}, "wasThrown": false}, "id": 9}, "page": "page-30"}
+{"dir": "editor->bridge", "msg": {"id": 10, "method": "Debugger.resume", "params": {}}, "page": "1"}
+{"dir": "bridge->device", "msg": {"id": 10, "method": "Debugger.resume", "params": {}}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 14}, "page": ""}
+{"dir": "device->bridge", "msg": {"result": {}, "id": 10}, "page": "page-30"}
+{"dir": "device->bridge", "msg": {"method": "Debugger.resumed"}, "page": "page-30"}

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -229,6 +229,26 @@ class CdpBrowserWebsocketClient(CdpWebsocketClient):
         return await asyncio.wait_for(wait_for_response(), TIMEOUT)
 
 
+async def testp_cdp_browser_endpoint_answers_puppeteer_connect(lockdown: LockdownClient) -> None:
+    """Puppeteer's connect() over the browser endpoint calls Target.getBrowserContexts and iterates
+    the result; a bare {} ack made it throw "contextIds is not iterable" before it saw a page. The
+    endpoint must return the (empty) browser-context list Chrome does."""
+    async with cdp_server_with_safari_page(lockdown) as (port, _):
+        version = await http_get_json(port, "/json/version/")
+        browser_id = urlsplit(version["webSocketDebuggerUrl"]).path.rsplit("/", 1)[1]
+        client = CdpBrowserWebsocketClient(port, browser_id)
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        ids = itertools.count(1)
+        try:
+            await client.command(next(ids), "Target.attachToBrowserTarget", {})
+            contexts = await client.command(next(ids), "Target.getBrowserContexts", {})
+            assert isinstance(contexts["result"].get("browserContextIds"), list), (
+                f"Target.getBrowserContexts must return a browserContextIds array: {contexts}"
+            )
+        finally:
+            await client.close()
+
+
 async def testp_cdp_browser_endpoint_announces_targets_after_get_targets(lockdown: LockdownClient) -> None:
     """
     VS Code's js-debug builds its target picker by calling Target.getTargets first and then
@@ -2665,6 +2685,33 @@ async def test_a_page_target_takes_over_the_session(monkeypatch: pytest.MonkeyPa
         assert target.output_queue.get_nowait()["method"] == "Target.targetInfoChanged"
 
 
+async def test_call_function_on_without_object_id_targets_the_context_global(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Chrome lets Runtime.callFunctionOn target a bare execution context; WebKit requires an
+    object. Puppeteer's page.evaluate relies on the former. The bridge resolves the context's
+    global object (evaluate `this`) and calls the function on it."""
+    with offline_cdp_target(monkeypatch) as (target, sent):
+        target._flat = True  # a JSContext: the one, default context
+
+        async def fake_result(method: str, params: dict[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
+            assert method == "Runtime.evaluate" and params["expression"] == "this"
+            return {"result": {"result": {"type": "object", "objectId": "GLOBAL"}}}
+
+        monkeypatch.setattr(target, "send_message_with_result", fake_result)
+        await target._runtime_call_function_on({
+            "id": 1,
+            "method": "Runtime.callFunctionOn",
+            "params": {
+                "functionDeclaration": "function () { return 6 * 7; }",
+                "executionContextId": 5,
+                "returnByValue": True,
+            },
+        })
+        forwarded = sent[-1]  # the flat path sends the raw message (no Target envelope)
+        assert forwarded["method"] == "Runtime.callFunctionOn"
+        assert forwarded["params"]["objectId"] == "GLOBAL", "the call targets the resolved global object"
+        assert "executionContextId" not in forwarded["params"], "WebKit takes no execution context here"
+
+
 async def test_user_preference_overrides_are_translated_and_replayed(monkeypatch: pytest.MonkeyPatch) -> None:
     """Chrome's dark-mode emulation - Emulation.setAutoDarkModeOverride and the media features of
     Emulation.setEmulatedMedia - maps onto WebKit's Page.overrideUserPreference (the command that
@@ -2886,6 +2933,25 @@ async def test_a_paused_stack_keeps_the_top_frame_even_if_it_looks_native(monkey
         })
         frames = target.output_queue.get_nowait()["params"]["callFrames"]
         assert [f["callFrameId"] for f in frames] == ["cf0"]
+
+
+async def test_golden_chrome_remote_interface_stepping_flow() -> None:
+    """Replay a real chrome-remote-interface debugging session - a raw CDP client that speaks the
+    protocol with almost no abstraction - and assert stepping advances with the paused/resumed
+    alternation and every emitted event matches Chrome's schema. A different client than WebStorm
+    or js-debug over the same page path."""
+    emitted = await replay_page_session(load_fixture("chrome_remote_interface_stepping"))
+    methods = [m.get("method", "<reply>") for m in emitted]
+    paused = [m for m in emitted if m.get("method") == "Debugger.paused"]
+    assert [p["params"]["callFrames"][0]["location"]["lineNumber"] for p in paused] == [2, 3, 4], methods
+    paused_at = [i for i, method in enumerate(methods) if method == "Debugger.paused"]
+    for first, second in zip(paused_at, paused_at[1:]):
+        assert "Debugger.resumed" in methods[first + 1 : second], (
+            f"each step must read paused -> resumed -> paused: {methods}"
+        )
+    cdp = load_spec("cdp")
+    problems = [problem for message in emitted for problem in validate_editor_event(cdp, message)]
+    assert problems == [], f"emitted events violate Chrome's schema: {sorted(set(problems))}"
 
 
 async def test_golden_safari_page_stepping_flow() -> None:


### PR DESCRIPTION
You asked to test the bridge with two more well-known CDP clients - Puppeteer and chrome-remote-interface - and add golden fixtures. Both turned up real bugs, now fixed.

## Puppeteer did not work; three gaps fixed

Puppeteer's `connect()` failed before it saw a page, and `page.evaluate` failed after. Each is a genuine bridge gap:

- **`Target.getBrowserContexts`** was answered with a bare `{}`; Puppeteer iterates the result and threw `contextIds is not iterable`. It now returns the browser-context list Chrome does (empty, since only the default context exists).
- **`Performance` domain** - Puppeteer enables it on every page; WebKit has none, and the raw forward errored `'Performance' domain was not found`. Now acknowledged as a no-op, like Input and Overlay.
- **`Runtime.callFunctionOn` targeting a bare execution context** (no `objectId`), which `page.evaluate` uses, was rejected by WebKit (which requires an object). The bridge now resolves the context's global object (evaluate `this`) and calls the function on it, as Chrome does under the hood.

Verified end to end with `puppeteer-core` against a device: `connect`, `goto`, `page.title()` and `page.evaluate()` all work.

## chrome-remote-interface: a new golden flow

CRI is a raw CDP client - almost no abstraction, so it exposes shapes a polished client hides. It worked against the bridge once pointed at a page endpoint, and a real CRI stepping session now replays **offline in CI** through the page harness, asserting the `paused -> resumed -> paused` alternation and schema validity, alongside the WebStorm and Safari-page goldens.

## Tests

- Offline: `test_golden_chrome_remote_interface_stepping_flow`, `test_call_function_on_without_object_id_targets_the_context_global`.
- Device: `testp_cdp_browser_endpoint_answers_puppeteer_connect`.
- Full offline suite, repo pyright, and the Playwright and evaluate device tests pass unchanged (the callFunctionOn change only triggers when `objectId` is absent).

## Scope note

CRI is captured as an **offline golden** (it attaches to a page endpoint - a plain session). Puppeteer drives the **browser endpoint** (target discovery + flatten), whose offline replay needs a browser-endpoint harness; that is a follow-up. Puppeteer's advanced `createCDPSession` and `$eval` have further gaps not addressed here - core automation is what this makes work.
