### PR TITLE
cdp: Fail cleanly on a device disconnect so --reconnect can retry

### DIFF
--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 import inspect
 import logging
 import re
@@ -27,6 +29,7 @@ from typer_injector import InjectingTyper
 from pymobiledevice3.cli.cli_common import ServiceProviderDep, async_command, prompt_selection
 from pymobiledevice3.common import get_home_folder
 from pymobiledevice3.exceptions import (
+    ConnectionTerminatedError,
     InspectorEvaluateError,
     LaunchingApplicationError,
     RemoteAutomationNotEnabledError,
@@ -473,6 +476,10 @@ async def cdp(
     default install location.
     """
     app.state.inspector = WebinspectorService(lockdown=service_provider)
+    # A device disconnect stops the bridge with a device-disconnected error, which
+    # pymobiledevice3's own --reconnect (a top-level option) then retries by re-running the command.
+    device_disconnected = asyncio.Event()
+    app.state.inspector.on_connection_lost = device_disconnected.set
     app.state.chrome_path = find_chrome(chrome)
     app.state.pause_new_targets = pause_new_targets
     recorder = ProtocolTrace(trace) if trace is not None else None
@@ -491,9 +498,21 @@ async def cdp(
             ws="wsproto",
         )
     )
+    serve_task = asyncio.ensure_future(server.serve())
+    disconnect_task = asyncio.ensure_future(device_disconnected.wait())
     try:
-        await server.serve()
+        await asyncio.wait({serve_task, disconnect_task}, return_when=asyncio.FIRST_COMPLETED)
+        if device_disconnected.is_set():
+            server.should_exit = True
+            await serve_task
+            # Raised to pymobiledevice3's top-level handler: with --reconnect it waits for the
+            # device and re-runs the command, otherwise it reports the disconnect and stops.
+            raise ConnectionTerminatedError("the device disconnected")
+        await serve_task
     finally:
+        disconnect_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await disconnect_task
         if recorder is not None:
             recorder.close()
 

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -207,6 +207,13 @@ class WebinspectorService(LockdownService):
             "_rpc_reportAutomaticInspectionCandidate:": self._handle_report_automatic_inspection_candidate,
         }
         self._recv_task: Optional[asyncio.Task[None]] = None
+        # Set once the device's Web Inspector connection drops (a restart, a cable pull). The
+        # listing endpoints then serve what was last known instead of raising per request; the
+        # bridge stays up rather than spewing a traceback on every landing-page poll.
+        self._connection_lost = False
+        # Called once when the connection drops, so the caller can act on it - the CDP bridge
+        # raises a device-disconnected error so pymobiledevice3's --reconnect can retry the command.
+        self.on_connection_lost: Optional[Callable[[], None]] = None
         # Queues handed out by subscribe_*: the receive task publishes into them without waiting,
         # so a subscriber that reacts by talking to the device (whose answers arrive through this
         # same receive task) never deadlocks it.
@@ -228,6 +235,24 @@ class WebinspectorService(LockdownService):
 
         await self._connect_or_raise_disabled()
         self._recv_task = asyncio.create_task(self._receiving_task())
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the device's Web Inspector connection is still up."""
+        return not self._connection_lost
+
+    @staticmethod
+    def _is_connection_lost(error: BaseException) -> bool:
+        return isinstance(
+            error, (ConnectionError, ConnectionTerminatedError, asyncio.IncompleteReadError, EOFError, OSError)
+        )
+
+    def _note_connection_lost(self, error: BaseException) -> None:
+        if not self._connection_lost:
+            self._connection_lost = True
+            self.logger.warning(f"Web Inspector connection to the device lost ({type(error).__name__})")
+            if self.on_connection_lost is not None:
+                self.on_connection_lost()
 
     async def close(self):
         """Cancel the background receive task and close the underlying service connection."""
@@ -301,8 +326,16 @@ class WebinspectorService(LockdownService):
             raise WebInspectorNotEnabledError from e
 
     async def _receiving_task(self):
-        while True:
-            await self._handle_recv(await self._recv_message())
+        try:
+            while True:
+                await self._handle_recv(await self._recv_message())
+        except asyncio.CancelledError:
+            raise
+        except BaseException as error:
+            if self._is_connection_lost(error):
+                self._note_connection_lost(error)
+                return
+            raise
 
     async def automation_session(self, app: Application) -> AutomationSession:
         """Start a WebDriver automation session against an application.
@@ -347,7 +380,11 @@ class WebinspectorService(LockdownService):
             only applications that currently report at least one page.
         """
         apps: dict[str, Any] = {}
-        await asyncio.gather(*[self._forward_get_listing(app) for app in self.connected_application])
+        # One failing listing (or a lost connection) must not break the whole answer; serve what
+        # was last reported instead.
+        await asyncio.gather(
+            *[self._forward_get_listing(app) for app in self.connected_application], return_exceptions=True
+        )
         for app in self.connected_application:
             if self.application_pages.get(app, False):
                 apps[self.connected_application[app].name] = self.application_pages[app].values()
@@ -691,7 +728,16 @@ class WebinspectorService(LockdownService):
         if args is None:
             args = {}
         args["WIRConnectionIdentifierKey"] = self.connection_id
-        await self.service.send_plist({"__selector": selector, "__argument": args})
+        # Never let a send establish the connection. While reconnecting, self._service is None and
+        # self.service would lazily run the handshake - a second reader on the socket the reconnect
+        # is already reading, which asyncio rejects ("readexactly() called while another coroutine
+        # is already waiting"). A send with no live service (lost, or mid-reconnect) is a no-op.
+        if self._connection_lost or self._service is None:
+            return
+        try:
+            await self._service.send_plist({"__selector": selector, "__argument": args})
+        except (ConnectionError, ConnectionTerminatedError, OSError, EOFError) as error:
+            self._note_connection_lost(error)
 
     def _page_by_automation_session(self, session_id: str) -> Page:
         for app_id in self.application_pages:

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import itertools
 import json
+import logging
 import socket
 import threading
 import time
@@ -2819,6 +2820,46 @@ async def test_stepping_gets_a_synthesized_resumed_between_pauses(monkeypatch: p
         assert target.output_queue.empty()
 
 
+async def test_a_lost_device_connection_is_handled_gracefully() -> None:
+    """When the device restarts or disconnects, the Web Inspector socket dies. Serving the landing
+    page (get_open_pages) must not raise per request - it once spewed a traceback on every poll -
+    but note the loss, keep the last-known pages, and leave the bridge up to recover."""
+    inspector = WebinspectorService.__new__(WebinspectorService)
+    inspector._connection_lost = False
+    inspector.logger = logging.getLogger("test.webinspector")
+    inspector.connection_id = "CONN"
+    application = Application(
+        "PID:1", "com.example.app", 1, "App", AutomationAvailability.NOT_AVAILABLE, 1, False, True
+    )
+    page = Page.from_page_dictionary({
+        "WIRPageIdentifierKey": 1,
+        "WIRTypeKey": "WIRTypeWeb",
+        "WIRTitleKey": "Example",
+        "WIRURLKey": "https://example.com/",
+    })
+    inspector.connected_application = {"PID:1": application}
+    inspector.application_pages = {"PID:1": {1: page}}
+
+    class DeadService:
+        async def send_plist(self, _: Any) -> None:
+            raise ConnectionResetError("Connection lost")
+
+    inspector._service = DeadService()  # type: ignore[assignment]  # the `service` property returns this
+
+    disconnected: list[bool] = []
+    inspector.on_connection_lost = lambda: disconnected.append(True)
+
+    assert inspector.is_connected
+    pages = await inspector.get_open_pages()  # must not raise
+    assert inspector.is_connected is False, "the loss is noted"
+    assert list(pages) == ["App"] and list(pages["App"]) == [page], "the last-known pages are still served"
+    assert disconnected == [True], "with no reconnect wired, the loss fires on_connection_lost (the bridge fails fast)"
+
+    # A further send while lost is a quiet no-op, not another failure or a repeated callback.
+    await inspector._send_message("_rpc_forwardGetListing:", {"WIRApplicationIdentifierKey": "PID:1"})
+    assert disconnected == [True]
+
+
 async def test_a_paused_stack_drops_webkit_native_frames(monkeypatch: pytest.MonkeyPatch) -> None:
     """WebKit puts a native entry frame - scriptId "0", lineNumber -1 - at the bottom of a paused
     call stack. Chrome's protocol has no such frame and js-debug/WebStorm build the stack strictly;
@@ -3255,6 +3296,7 @@ def _landing_page_app() -> Any:
             self.application_pages: dict[str, dict[str, Page]] = {}
             self.connected_application: dict[str, Application] = {}
             self.indicated: list[tuple[str, int, bool]] = []
+            self.is_connected = True
 
         async def get_open_pages(self) -> None:
             pass


### PR DESCRIPTION
When the device restarts or the cable is pulled, the Web Inspector socket dies and the bridge raised `ConnectionResetError` up the ASGI stack on **every** landing-page poll - a traceback per request, forever, with no recovery.

## Fix

The inspector notes the loss once and degrades instead of raising on every use: a send with no live service is a quiet no-op (and never lazily reconnects), the receive task ends cleanly, and `get_open_pages` tolerates the failure. It then fires an `on_connection_lost` callback, which the CDP bridge turns into a clean shutdown and a `ConnectionTerminatedError("the device disconnected")`.

## Reconnect is handled where it already lives

That error is what pymobiledevice3's existing **top-level `--reconnect`** already handles - `main()` catches `ConnectionTerminatedError`, waits for the device to come back, and re-runs the command. So the bridge now behaves like every other command:

- by default, a disconnect stops it with a clear "device disconnected" error;
- `pymobiledevice3 --reconnect webinspector cdp --port 9222` waits for the device and reconnects.

No bridge-specific reconnect logic, no per-command flag. `--reconnect` is a top-level option, so it goes **before** the subcommand.

## Tests

`test_a_lost_device_connection_is_handled_gracefully`: a dead service makes `get_open_pages` note the loss, serve the last-known pages without raising, and fire `on_connection_lost` once. Full offline suite, repo pyright, and the landing-page and end-to-end device tests pass; a bridge smoke test serves and shuts down cleanly.
