### PR TITLE
webinspector: Build a page listing from the replies it asked for, not the cache

### DIFF
--- a/pymobiledevice3/services/web_protocol/cdp_server.py
+++ b/pymobiledevice3/services/web_protocol/cdp_server.py
@@ -682,12 +682,13 @@ def version(request: Request):
 
 
 async def refresh_listings() -> None:
-    """Ask every connected application to re-report its pages, without waiting for the replies.
+    """Ask every connected application to re-report its pages, and wait for the replies.
 
     `webinspectord` pushes a fresh listing on its own whenever a page opens, closes or navigates,
-    so the cached state is already live and the answer can be built from it straight away; the
-    request is only a nudge for anything that does not announce itself. Blocking on the replies
-    instead put a fixed half-second on every listing request - the whole cost of serving one.
+    but not the instant an application connects or a page moves to another process - answering
+    from the cache alone then left those out, and an editor that lists targets once attached to
+    whatever was left without offering a choice. The wait is for the replies themselves (a few
+    milliseconds), not a fixed delay; see WebinspectorService.get_open_pages.
     """
     await app.state.inspector.get_open_pages()
 

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -23,6 +23,9 @@ from pymobiledevice3.services.web_protocol.inspector_session import InspectorSes
 from pymobiledevice3.services.web_protocol.session_protocol import SessionProtocol
 
 SAFARI = "com.apple.mobilesafari"
+# How long a page listing waits, at most, for the applications' replies (see get_open_pages). A
+# reply takes a few milliseconds; this only bounds an application that never answers.
+LISTING_REPLY_TIMEOUT = 0.3
 WEBINSPECTORD_DISABLED_NOTIFICATION = "com.apple.webinspectord.disabled"
 
 
@@ -373,18 +376,45 @@ class WebinspectorService(LockdownService):
             wait_target=page.type_ != WirTypes.JAVASCRIPT,
         )
 
-    async def get_open_pages(self) -> dict[str, Any]:
+    async def get_open_pages(self, timeout: float = LISTING_REPLY_TIMEOUT) -> dict[str, Any]:
         """Request and return the currently open pages of all connected applications.
 
+        The answer is built from the listings the applications reply with, not from whatever was
+        cached before the request: answering straight after asking left out any page the device
+        had not reported yet - an application that had only just connected, a process a page had
+        just moved to - and an editor that lists targets once attached to whatever was left
+        without offering a choice. A reply takes a few milliseconds; `timeout` bounds the wait
+        for an application that never answers.
+
+        :param timeout: Seconds to wait, at most, for the applications' listings.
         :returns: A mapping of application name to the collection of its `Page` objects, including
             only applications that currently report at least one page.
         """
         apps: dict[str, Any] = {}
-        # One failing listing (or a lost connection) must not break the whole answer; serve what
-        # was last reported instead.
-        await asyncio.gather(
-            *[self._forward_get_listing(app) for app in self.connected_application], return_exceptions=True
-        )
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + timeout
+        # Subscribed before asking, so that no reply can slip by between the two.
+        listings = self.subscribe_listings()
+        try:
+            # Right after connecting, even the application list may still be on its way.
+            while not self.connected_application and not self._connection_lost and loop.time() < deadline:
+                await asyncio.sleep(0.01)
+            pending = set(self.connected_application)
+            # One failing listing (or a lost connection) must not break the whole answer; serve what
+            # was last reported instead.
+            await asyncio.gather(*[self._forward_get_listing(app) for app in pending], return_exceptions=True)
+            while pending and not self._connection_lost:
+                # An application that went away meanwhile will not answer.
+                pending &= set(self.connected_application)
+                remaining = deadline - loop.time()
+                if not pending or remaining <= 0:
+                    break
+                try:
+                    pending.discard(await asyncio.wait_for(listings.get(), remaining))
+                except asyncio.TimeoutError:
+                    break
+        finally:
+            self.unsubscribe_listings(listings)
         for app in self.connected_application:
             if self.application_pages.get(app, False):
                 apps[self.connected_application[app].name] = self.application_pages[app].values()
@@ -622,6 +652,9 @@ class WebinspectorService(LockdownService):
     async def _handle_application_connected(self, arg: dict[str, Any]):
         app = Application.from_application_dictionary(arg)
         self.connected_application[app.id_] = app
+        # Ask for its pages right away rather than waiting for the device to volunteer them (it
+        # does, but some hundred milliseconds later), so a listing served meanwhile has them.
+        await self._forward_get_listing(app.id_)
 
     async def _handle_application_sent_data(self, arg: dict[str, Any]):
         response = json.loads(arg["WIRMessageDataKey"])

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -2839,6 +2839,7 @@ async def test_a_lost_device_connection_is_handled_gracefully() -> None:
     })
     inspector.connected_application = {"PID:1": application}
     inspector.application_pages = {"PID:1": {1: page}}
+    inspector._listing_subscribers = []
 
     class DeadService:
         async def send_plist(self, _: Any) -> None:
@@ -3743,3 +3744,76 @@ async def testp_cdp_server_binds_url_breakpoints_set_before_a_jscontext_script(l
             assert not [e for e in events if e["method"] == "Debugger.paused"], "removed breakpoints must not hit"
         finally:
             await client.close()
+
+
+async def test_a_listing_waits_for_the_replies_it_asked_for() -> None:
+    """get_open_pages answers from the listings the applications reply with, not from the cache
+    as it was before asking: an application that had only just connected had no pages cached, so
+    an editor listing targets right then saw a shorter list than the truth and attached to what
+    was left without offering a choice. The wait is for the replies, bounded for one that never
+    comes."""
+    inspector = WebinspectorService.__new__(WebinspectorService)
+    inspector._connection_lost = False
+    inspector.logger = logging.getLogger("test.webinspector")
+    inspector.connection_id = "CONN"
+    inspector._listing_subscribers = []
+    inspector.connected_application = {
+        "PID:1": Application(
+            "PID:1", "com.example.app", 1, "App", AutomationAvailability.NOT_AVAILABLE, 1, False, True
+        ),
+        "PID:2": Application(
+            "PID:2", "com.example.new", 2, "New", AutomationAvailability.NOT_AVAILABLE, 1, False, True
+        ),
+    }
+    inspector.application_pages = {"PID:1": {}, "PID:2": {}}
+    asked: list[str] = []
+
+    async def reply_later(app_id: str) -> None:
+        await asyncio.sleep(0.02)
+        await inspector._handle_application_sent_listing({
+            "WIRApplicationIdentifierKey": app_id,
+            "WIRListingKey": {
+                "1": {
+                    "WIRPageIdentifierKey": 1,
+                    "WIRTypeKey": "WIRTypeWeb",
+                    "WIRTitleKey": app_id,
+                    "WIRURLKey": "https://e/",
+                }
+            },
+        })
+
+    async def send_message(selector: str, args: Optional[dict[str, Any]] = None) -> None:
+        if selector == "_rpc_forwardGetListing:":
+            app_id = cast(dict[str, Any], args)["WIRApplicationIdentifierKey"]
+            asked.append(app_id)
+            if app_id != "PID:2":
+                asyncio.get_event_loop().create_task(reply_later(app_id))
+
+    inspector._send_message = send_message  # type: ignore[method-assign]
+
+    started = asyncio.get_event_loop().time()
+    pages = await inspector.get_open_pages(timeout=0.3)
+    elapsed = asyncio.get_event_loop().time() - started
+    assert sorted(asked) == ["PID:1", "PID:2"]
+    assert "App" in pages, "the reply that arrived after the request is in the answer"
+    assert elapsed >= 0.3 - 0.05, "an application that never answers is waited for up to the bound"
+
+    asked.clear()
+    started = asyncio.get_event_loop().time()
+    inspector.connected_application.pop("PID:2")
+    pages = await inspector.get_open_pages(timeout=0.3)
+    elapsed = asyncio.get_event_loop().time() - started
+    assert asked == ["PID:1"] and "App" in pages
+    assert elapsed < 0.2, "with every reply in, the answer does not wait out the bound"
+    assert inspector._listing_subscribers == [], "the wait's subscription is released"
+
+
+async def testp_cdp_server_lists_an_application_the_moment_it_connects(lockdown: LockdownClient) -> None:
+    """The listing an editor fetches right after an application connected includes that
+    application's pages. It once answered from the cache, which webinspectord fills a hundred
+    milliseconds or so later, so the list came back without them - and an editor that saw a single
+    target attached to it without asking."""
+    async with cdp_server(lockdown) as (port, inspector):
+        await inspector.open_app(SAFARI)
+        targets = [target for target in await http_get_json(port, "/json/list") if target["type"] == "page"]
+        assert targets, "the freshly connected Safari's page is listed straight away"


### PR DESCRIPTION
## Summary

`get_open_pages` sent every application a listing request and answered straight away from what was cached *before* the request, so anything the device had not reported yet was missing: an application that had only just connected (webinspectord volunteers its listing about 100 ms later), a page whose process just changed. An editor that lists targets once when attaching - WebStorm fetches `/json/list` and offers a chooser only when it sees more than one target - then attached to whatever was listed, without asking, which looks random.

This waits for the replies themselves, bounded by `LISTING_REPLY_TIMEOUT` (0.3 s) for an application that never answers. A reply takes a few milliseconds on the device, so the listing costs what it always did (this is not the old fixed half-second wait). The subscription is taken before asking so no reply is missed, an application that disconnects meanwhile is dropped from the wait, and a newly connected application is asked for its pages right away instead of waiting for the device to volunteer them.

## Verification

On an iPhone (iOS 26.6.1): `/json/list` fetched right after `open_app(Safari)` returned listed **0** targets before and **1** (Safari's page) after; 1 s later both list 1. The explicit listing round-trip for three connected applications is 5 ms.

WebStorm's own traces from this machine show it uses only `/json/list` (and `/json/version`) and then a page websocket, never the browser session, and the listing fields have not changed since v11.9.0 - this is the only bridge-side way I found for it to see a shorter list than the truth. If the chooser still gets skipped after this, please run the bridge with `-v` and attach the log around the attach; it may be on WebStorm's side.

Added `test_a_listing_waits_for_the_replies_it_asked_for` (offline) and `testp_cdp_server_lists_an_application_the_moment_it_connects` (device). Offline `web_protocol` suite passes (93), the webinspector device tests pass, ruff and pyright clean.
