### PR TITLE
cli: exit with nonzero statuscode on failure

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -1,5 +1,6 @@
 import asyncio
 import difflib
+import enum
 import importlib
 import logging
 import os
@@ -150,6 +151,14 @@ CLI_GROUPS = {
 # Set if used the `--reconnect` option
 RECONNECT = False
 _ORIGINAL_SHELLINGHAM_DETECT: Optional[Callable[[], tuple[str, str]]] = None
+
+
+class ExitCode(enum.IntEnum):
+    """Process exit codes returned by `main()`."""
+
+    SUCCESS = 0
+    ERROR = 1
+    ABORTED = 130  # SIGINT convention: 128 + signal number
 
 
 def _detect_shell_for_completion() -> tuple[str, str]:
@@ -321,20 +330,23 @@ def product_version_needs_tunnel(product_version: str) -> bool:
     return Version(product_version) >= Version("17.0")
 
 
-def invoke_cli_with_error_handling() -> bool:
+def invoke_cli_with_error_handling() -> tuple[ExitCode, bool]:
     """
-    Invoke the command line interface and return `True` if the failure reason of the command was that the device was
-    disconnected.
+    Invoke the command line interface once. Returns (exit_code, reconnectable) - reconnectable is
+    True when the failure was that the device disconnected, which keeps the `--reconnect` retry
+    loop alive. A successful command never reaches this function's own return statements: it
+    exits earlier, via the SystemExit that Typer's own `app(...)` call raises.
     """
+    reconnectable = False
     try:
         # Typer apps are callable; this executes the CLI with current sys.argv
         app(args=["--help"] if len(sys.argv) == 1 else None)
     except NoDeviceConnectedError:
         logger.error("Device is not connected")
-        return True
+        reconnectable = True
     except ConnectionTerminatedError:
         logger.error("Connection was terminated abruptly")
-        return True
+        reconnectable = True
     except NotPairedError:
         logger.error("Device is not paired")
     except UserDeniedPairingError:
@@ -353,7 +365,7 @@ def invoke_cli_with_error_handling() -> bool:
         logger.error("Failed to connect to usbmuxd socket. Make sure it's running.")
     except ConnectionFailedError:
         logger.error("Failed to connect to service port.")
-        return True
+        reconnectable = True
     except MessageNotSupportedError:
         logger.error("Message not supported for this iOS version")
         traceback.print_exc()
@@ -374,7 +386,7 @@ def invoke_cli_with_error_handling() -> bool:
         logger.error(str(e))
         # Reconnectable: after a disconnect the target device may still be re-enumerating
         # while other devices are attached, making re-invocation fail with this error.
-        return True
+        reconnectable = True
     except UserspaceTunnelUnavailableError as e:
         logger.error(str(e))
     except DeviceFeatureNotSupportedError as e:
@@ -419,8 +431,11 @@ def invoke_cli_with_error_handling() -> bool:
             # Target the same device the tunnel would otherwise resolve by default.
             if e.identifier and not os.getenv(UDID_ENV_VAR):
                 os.environ[UDID_ENV_VAR] = e.identifier
-            main()
-            return False
+            # main() only returns (rather than raising the SystemExit(0) a successful retry ends
+            # in) when the retried attempt also failed - propagate its actual exit code (e.g.
+            # ExitCode.ABORTED on Ctrl-C) instead of flattening it to a generic error.
+            exit_code = main()
+            return exit_code, False
         logger.error(INVALID_SERVICE_MESSAGE)
     except PasswordRequiredError:
         logger.error("Device is password protected. Please unlock and retry")
@@ -468,7 +483,11 @@ def invoke_cli_with_error_handling() -> bool:
         logger.error(f"File [{e.filename}] not found during afc operation: {e}")
     except AfcException as e:
         logger.error(f"Failed to perform Afc operation: {e}")
-    return False
+    else:
+        # No exception: in practice unreachable, since a real Typer app() raises SystemExit(0) on
+        # success before ever returning here
+        return ExitCode.SUCCESS, False
+    return ExitCode.ERROR, reconnectable
 
 
 def _retarget_reconnect_udid(udid: str) -> None:
@@ -482,13 +501,16 @@ def _retarget_reconnect_udid(udid: str) -> None:
     os.environ[UDID_ENV_VAR] = udid
 
 
-def main() -> None:
-    # Retry to invoke the CLI
-    while invoke_cli_with_error_handling():
-        # If reached here, this means the failure reason was that the device is disconnected
-        if not RECONNECT:
-            # If not invoked with the `--reconnect` option, break here
-            break
+def main() -> ExitCode:
+    """Returns the process exit code. A successful command exits earlier via the SystemExit that
+    Typer's own `app(...)` call raises, from within `invoke_cli_with_error_handling()`; this loop
+    only ever runs again (or returns ExitCode.ABORTED) once that call has already logged an
+    error."""
+    while True:
+        exit_code, reconnectable = invoke_cli_with_error_handling()
+        # Not a reconnectable failure, or not invoked with `--reconnect`: stop here.
+        if not reconnectable or not RECONNECT:
+            return exit_code
         try:
             logger.info("Waiting for the device to be available again")
             # Wait for the device the command targeted, not just any device. The target is the
@@ -517,8 +539,8 @@ def main() -> None:
             asyncio.run(lockdown.close())
         except KeyboardInterrupt:
             print("Aborted.")
-            break
+            return ExitCode.ABORTED
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -60,6 +60,61 @@ def test_cli_from_python_m_with_invalid_option():
     assert "Traceback" not in result.stderr
 
 
+def test_cli_from_python_m_exits_zero_on_success():
+    """A genuinely successful command exits 0 via Typer's own SystemExit(0) on completion - not
+    anything invoke_cli_with_error_handling()/main() decide. `version` needs no device."""
+    result = subprocess.run(
+        [sys.executable, "-m", "pymobiledevice3", "version"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Traceback" not in result.stderr
+
+
+def test_cli_from_python_m_exits_nonzero_on_typer_failure():
+    """A Typer usage error (the package path doesn't exist) is rejected before device resolution
+    is even attempted, and exits 2 - untouched by the invoke_cli_with_error_handling() fix below."""
+    result = subprocess.run(
+        [sys.executable, "-m", "pymobiledevice3", "apps", "install", "/no/such/package.ipa"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "does not exist" in ANSI_ESCAPE.sub("", result.stderr)
+
+
+def test_cli_from_python_m_exits_nonzero_on_logical_failure(tmp_path):
+    """Regression: Commands which failed because of internal CLI processing
+    exited 0, hiding the failure from scripts and CI. We test here that the CLI indicates a nonzero exit code on failure"""
+    package = tmp_path / "dummy.ipa"
+    package.touch()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pymobiledevice3",
+            "apps",
+            "install",
+            str(package),
+            "--developer",
+            "--udid",
+            "no-such-udid-123",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    # The specific handled exception depends on the environment (e.g. no usbmuxd daemon at all on
+    # a bare CI runner raises "Failed to connect to usbmuxd socket" instead of "Device not
+    # found") - what matters here is a clean, logged failure, not which one fired.
+    assert "Traceback" not in result.stderr
+
+
 def test_install_completion_uses_fish_for_xonsh_when_available(monkeypatch, tmp_path):
     monkeypatch.setattr(__main__, "_ORIGINAL_SHELLINGHAM_DETECT", lambda: ("xonsh", "/bin/xonsh"))
     monkeypatch.setattr(__main__.shutil, "which", lambda command: "/usr/bin/fish" if command == "fish" else None)
@@ -223,7 +278,7 @@ def test_reconnect_waits_for_the_target_device(monkeypatch):
 
         return _FakeLockdown()
 
-    invocations = iter([True, False])
+    invocations = iter([(__main__.ExitCode.ERROR, True), (__main__.ExitCode.SUCCESS, False)])
     monkeypatch.setattr(__main__, "invoke_cli_with_error_handling", lambda: next(invocations))
     monkeypatch.setattr(__main__, "RECONNECT", True)
     monkeypatch.setattr(__main__, "retry_create_using_usbmux", fake_retry_create_using_usbmux)
@@ -256,7 +311,7 @@ def test_reconnect_any_accepts_first_available_device(monkeypatch, caplog):
 
         return _FakeLockdown()
 
-    invocations = iter([True, False])
+    invocations = iter([(__main__.ExitCode.ERROR, True), (__main__.ExitCode.SUCCESS, False)])
     monkeypatch.setattr(__main__, "invoke_cli_with_error_handling", lambda: next(invocations))
     monkeypatch.setattr(__main__, "RECONNECT", True)
     monkeypatch.setattr(__main__, "retry_create_using_usbmux", fake_retry_create_using_usbmux)
@@ -287,7 +342,30 @@ def test_device_not_found_is_a_reconnectable_failure(monkeypatch):
         raise DeviceNotFoundError("TARGET-UDID")
 
     monkeypatch.setattr(__main__, "app", raise_not_found)
-    assert __main__.invoke_cli_with_error_handling() is True
+    assert __main__.invoke_cli_with_error_handling() == (__main__.ExitCode.ERROR, True)
+
+
+def test_non_reconnectable_error_fails_the_process(monkeypatch):
+    """A handled exception that isn't itself reconnectable (falls through to the bottom of
+    invoke_cli_with_error_handling()) must also fail the process, not just log a one-liner."""
+    from pymobiledevice3.exceptions import NotPairedError
+
+    def raise_not_paired(*args, **kwargs):
+        raise NotPairedError()
+
+    monkeypatch.setattr(__main__, "app", raise_not_paired)
+    monkeypatch.setattr(__main__, "RECONNECT", False)
+
+    assert __main__.main() == __main__.ExitCode.ERROR
+
+
+def test_app_returning_without_raising_is_a_success(monkeypatch):
+    """A command that returns without raising (a real Typer app instead exits earlier via its
+    own SystemExit(0)) must still resolve to ExitCode.SUCCESS."""
+    monkeypatch.setattr(__main__, "app", lambda *args, **kwargs: None)
+    monkeypatch.setattr(__main__, "RECONNECT", False)
+
+    assert __main__.main() == __main__.ExitCode.SUCCESS
 
 
 def test_tunneld_device_not_found_names_the_tunneld_instance(monkeypatch):
@@ -332,7 +410,7 @@ def test_native_tunnel_device_not_found_is_reconnectable(monkeypatch):
         )
 
     monkeypatch.setattr(__main__, "app", raise_not_found)
-    assert __main__.invoke_cli_with_error_handling() is True
+    assert __main__.invoke_cli_with_error_handling() == (__main__.ExitCode.ERROR, True)
 
 
 def test_reconnect_reuses_interactively_selected_device(monkeypatch):
@@ -355,7 +433,7 @@ def test_reconnect_reuses_interactively_selected_device(monkeypatch):
 
         return _FakeLockdown()
 
-    invocations = iter([True, False])
+    invocations = iter([(__main__.ExitCode.ERROR, True), (__main__.ExitCode.SUCCESS, False)])
     monkeypatch.setattr(__main__, "invoke_cli_with_error_handling", lambda: next(invocations))
     monkeypatch.setattr(__main__, "RECONNECT", True)
     monkeypatch.setattr(__main__, "retry_create_using_usbmux", fake_retry_create_using_usbmux)


### PR DESCRIPTION
## Summary

Every handled exception in `invoke_cli_with_error_handling()` (`NoDeviceConnectedError`, `ConnectionTerminatedError`, `NotPairedError`, `DeviceNotFoundError`, ...) was logged as a one-liner and then `main()` returned normally, so the process exited 0. Scripts and CI could not detect the failure. This has been the behavior since the handler was introduced in v1.13.0.

`main()` now returns an `ExitCode` and the process exits with it (`sys.exit(main())` from both `__main__` and the console script):

- handled error: 1
- Ctrl-C while waiting in `--reconnect`: 130
- success: unchanged, Typer's own `SystemExit(0)`
- usage errors: unchanged, Typer's own exit 2

The implicit-tunnel retry propagates the retried attempt's code instead of flattening it.

Fixes the exit-code part of #1682 (the iOS 17+ tunneld fallback part is separate). Supersedes #1817.

## Testing

- CI matrix green (3.9-3.15 on ubuntu/macos/windows, pyright).
- Locally on macOS with a device attached: `pytest tests/cli/test_cli.py` 109 passed; `pymobiledevice3 lockdown info --udid nope` exits 1 (0 on master); `pymobiledevice3 usbmux list` exits 0.

## AI Assistance

Not stated by the author. Body filled in by the maintainer.
