### PR TITLE
web_protocol: Await any thenable a client asks to await, as Chrome does

### DIFF
--- a/docs/guides/webview-debugging.md
+++ b/docs/guides/webview-debugging.md
@@ -276,10 +276,11 @@ Notes worth knowing when scripting against a device:
 - Everything is a USB round-trip, so per-call latency is far higher than against a
   local browser. Prefer a few coarse `evaluate()` calls over many fine-grained ones
   in a hot loop.
-- A page whose framework replaces the global `Promise` and minifies the replacement
-  (Angular with zone.js, for example) reports objects of that class without the
-  `promise` subtype, because the bridge recognises built-ins by their class name.
-  `await` still behaves; only code that inspects the subtype is affected.
+- A page whose framework replaces the global `Promise` with a class of its own (Angular
+  with zone.js, for example) is awaited like any other: a call made with `awaitPromise`
+  follows any thenable, as Chrome's does. Objects of that class carry no `promise`
+  subtype - neither Chrome nor the bridge tags anything but a native promise - so only
+  code that inspects the subtype sees a difference.
 
 ## Attaching before a page or context runs
 

--- a/pymobiledevice3/services/web_protocol/cdp_target.py
+++ b/pymobiledevice3/services/web_protocol/cdp_target.py
@@ -2832,9 +2832,34 @@ class CdpTarget:
         if "userGesture" in params:
             params["emulateUserGesture"] = bool(params.pop("userGesture"))
 
+    @staticmethod
+    def _adopt_thenable_result(function_declaration: str) -> str:
+        """Make a function whose result is any thenable hand WebKit a native promise to await.
+
+        Chrome's `awaitPromise` resolves the result the way `Promise.resolve` does, so a thenable
+        of any kind is followed. WebKit awaits only a native promise (`@isPromise` in
+        InjectedScriptSource.js) and returns anything else as-is - and a page that replaced the
+        global `Promise`, as zone.js does for every Angular app, hands back its own class. A client
+        that relied on the await then read the promise object where the value should be: that is
+        Playwright's `page.screenshot()` failing with `"undefined" is not valid JSON`.
+
+        Adopt the result through an async function: that always produces a native promise, whatever
+        the page did to its `Promise` binding, and settling it follows the thenable's `then`.
+        """
+        return (
+            "function() {"
+            f" const result = ({function_declaration}).apply(this, arguments);"
+            " if (result !== null && (typeof result === 'object' || typeof result === 'function')"
+            " && typeof result.then === 'function') { return (async () => result)(); }"
+            " return result;"
+            "}"
+        )
+
     async def _runtime_call_function_on(self, message: dict[str, Any]):
         params = message.setdefault("params", {})
         self._translate_user_gesture(params)
+        if params.get("awaitPromise") and isinstance(params.get("functionDeclaration"), str):
+            params["functionDeclaration"] = self._adopt_thenable_result(params["functionDeclaration"])
         if "objectId" not in params:
             # Chrome lets callFunctionOn target a bare execution context (executionContextId /
             # uniqueContextId); WebKit requires an object to call the function on. Resolve the

--- a/tests/services/test_web_protocol/test_cdp_server.py
+++ b/tests/services/test_web_protocol/test_cdp_server.py
@@ -716,6 +716,91 @@ async def testp_cdp_server_reports_remote_object_subtypes(lockdown: LockdownClie
             await client.close()
 
 
+async def testp_cdp_server_awaits_a_thenable_for_a_client(lockdown: LockdownClient) -> None:
+    """
+    Chrome's awaitPromise follows any thenable, the way Promise.resolve does. WebKit awaits only a
+    native promise and hands anything else back unresolved - so a page that replaced the global
+    Promise with a class of its own (zone.js does, on every Angular app) answered a client's
+    awaited call with the promise object where the value should be. That is how Playwright's
+    page.screenshot() failed with `"undefined" is not valid JSON` (#1904).
+    """
+    # A stand-in for zone.js's ZoneAwarePromise: a class of the page's own, not a native promise
+    # (nor a subclass of one, whose instances would be), installed as the global Promise under a
+    # minified name. Parked on window so the page can be handed its real Promise back afterwards.
+    install_page_promise = (
+        "(() => {"
+        "  const Native = window.__pmd3NativePromise = window.Promise;"
+        "  class R {"
+        "    constructor(executor) { this._native = new Native(executor); }"
+        "    then(onFulfilled, onRejected) {"
+        "      return new R((resolve, reject) => this._native.then(onFulfilled, onRejected).then(resolve, reject));"
+        "    }"
+        "    static resolve(value) { return new R(resolve => resolve(value)); }"
+        "    static reject(reason) { return new R((_, reject) => reject(reason)); }"
+        "    get [Symbol.toStringTag]() { return 'Promise'; }"
+        "  }"
+        "  window.Promise = R;"
+        "  return Promise.name;"
+        "})()"
+    )
+    async with cdp_server_with_safari_page(lockdown) as (port, targets):
+        client = CdpWebsocketClient(port, targets[0]["id"])
+        await asyncio.wait_for(client.connect(), TIMEOUT)
+        message_ids = itertools.count(1)
+
+        async def evaluate(expression: str) -> dict[str, Any]:
+            response = await client.command(
+                next(message_ids), "Runtime.evaluate", {"expression": expression, "returnByValue": True}
+            )
+            return response["result"]["result"]
+
+        try:
+            assert (await evaluate(install_page_promise)).get("value") == "R"
+            global_object = await client.command(next(message_ids), "Runtime.evaluate", {"expression": "this"})
+            object_id = global_object["result"]["result"]["objectId"]
+
+            async def call_awaited(function_declaration: str) -> dict[str, Any]:
+                response = await client.command(
+                    next(message_ids),
+                    "Runtime.callFunctionOn",
+                    {
+                        "functionDeclaration": function_declaration,
+                        "objectId": object_id,
+                        "awaitPromise": True,
+                        "returnByValue": True,
+                    },
+                )
+                return response["result"]
+
+            awaited = await call_awaited("function() { return Promise.resolve(42); }")
+            assert awaited["result"].get("value") == 42, f"a thenable must be awaited like a promise: {awaited}"
+            rejected = await call_awaited("function() { return Promise.reject(new Error('boom')); }")
+            assert rejected.get("wasThrown") is True, f"a rejected thenable must throw: {rejected}"
+            assert "boom" in rejected["result"].get("description", ""), rejected
+            # What WebKit already awaited, and what needs no awaiting, must come back unchanged.
+            native = await call_awaited("function() { return (async () => 43)(); }")
+            assert native["result"].get("value") == 43, native
+            plain = await call_awaited("function() { return 44; }")
+            assert plain["result"].get("value") == 44, plain
+            # `this` and the arguments must still reach the function as the client passed them.
+            response = await client.command(
+                next(message_ids),
+                "Runtime.callFunctionOn",
+                {
+                    "functionDeclaration": "function(a, b) { return Promise.resolve(this === window && a + b); }",
+                    "objectId": object_id,
+                    "arguments": [{"value": 20}, {"value": 22}],
+                    "awaitPromise": True,
+                    "returnByValue": True,
+                },
+            )
+            assert response["result"]["result"].get("value") == 42, response
+        finally:
+            with suppress(Exception):
+                await evaluate("window.Promise = window.__pmd3NativePromise; Promise.name")
+            await client.close()
+
+
 async def testp_cdp_server_types_text_into_the_page(lockdown: LockdownClient) -> None:
     """
     WebKit has no Input domain, so the bridge types in-page. Two shapes have to work, because a


### PR DESCRIPTION
Follow-up to #1904 (comment: https://github.com/doronz88/pymobiledevice3/issues/1904#issuecomment-5603309080). `page.screenshot()` fails again on Angular/zone.js pages with `"undefined" is not valid JSON`.

## Root cause

Not the `subtype: "promise"` tagging - Playwright never dispatches on it. It sends `Runtime.callFunctionOn` with `awaitPromise: true` and reads the value. WebKit's injected script awaits only a native promise (`@isPromise`), while Chrome's `awaitPromise` follows any thenable, the way `Promise.resolve` does. zone.js's `ZoneAwarePromise` is a standalone class, not a `Promise` subclass, so WebKit returned it unawaited and the client read `undefined`.

The #1906 validation rig mimicked zone.js with `class R extends Promise {}`, whose instances are still native promises - which is why it could not reproduce this.

## Fix

When a client passes `awaitPromise`, wrap the function declaration so a thenable result is returned through an async function. That always yields a native promise regardless of what the page did to its `Promise` binding, and WebKit then awaits it. Non-thenable results are untouched; no round-trip is added.

## Verification

Against a physical device (iOS 26.4), with the real zone.js 0.15.0 and Playwright 1.54.1 (the reporter's version):

| | before | after |
|---|---|---|
| `callFunctionOn` + `awaitPromise` on a zone promise | returned `{__zone_symbol__state, __zone_symbol__value}` | `42` |
| `page.screenshot()` | `"undefined" is not valid JSON` | ok |
| `evaluateHandle(() => Promise.resolve(5))` | handle to `ZoneAwarePromise` | `5` |
| rejected thenable | unawaited object | thrown |

- New device test `testp_cdp_server_awaits_a_thenable_for_a_client` fails without the fix and passes with it.
- Full `test_cdp_server.py` device suite: 63 passed, 3 skipped. Non-device web_protocol: 126 passed. ruff and pyright clean.
- The guide claimed `await` still behaved on such pages; corrected.

## Not in this PR

Two pre-existing gaps found on the way, confirmed on the unpatched bridge too:

- `Runtime.evaluate` + `awaitPromise` is ignored entirely (WebKit's evaluate has no such parameter; even a native promise returns `{}` by value).
- WebKit's `wasThrown` is forwarded without translation to Chrome's `exceptionDetails`, so `page.evaluate(() => { throw ... })` resolves to `undefined` instead of rejecting.
