### PR TITLE
readme: Add TestingBot to sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ A huge thank you to our sponsors for supporting this project! 💖
 </a>
 <!-- markdownlint-enable MD013 -->
 
+[![TestingBot](https://github.com/testingbot.png?size=48)](https://testingbot.com) [**TestingBot**](https://testingbot.com)
+
 [![SmartDust](https://github.com/smartdust-me.png?size=48)](https://smartdust.me) [**SmartDust**](https://smartdust.me)
 
 [![AnNEDoMini](https://github.com/AnNEDoMini.png?size=48)](https://github.com/AnNEDoMini) [**AnNEDoMini**](https://github.com/AnNEDoMini)


### PR DESCRIPTION
Adds [TestingBot](https://github.com/testingbot) to the sponsors list, listed second (right after the TestMu AI logo), using the same avatar + name style as the other entries.