### PR TITLE
cdp: Reconnect after a device reboot instead of dying

### DIFF
--- a/pymobiledevice3/cli/webinspector.py
+++ b/pymobiledevice3/cli/webinspector.py
@@ -487,6 +487,13 @@ async def cdp(
         app.state.trace = recorder
         app.state.inspector.trace = recorder.device_hook
         typer.echo(f"Recording the protocol trace to {trace}")
+    # Connect before uvicorn owns the failure. The app's lifespan connects too (it is a no-op once
+    # this succeeded), but uvicorn runs the lifespan itself: an exception there is logged and
+    # turned into `sys.exit(3)`, which asyncio re-raises straight out of the event loop. A device
+    # that is rebooting when the bridge starts - exactly what `--reconnect` re-runs into - would
+    # kill the process before the top-level handler ever classified the error. Here it is an
+    # ordinary exception, and `--reconnect` waits for the device and re-runs the command.
+    await app.state.inspector.connect()
     print(f"Web Inspector ready. Open in Google Chrome: http://{host}:{port}/")
     logging.getLogger("uvicorn.access").addFilter(_GetAccessToDebug())
     server = uvicorn.Server(

--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import json
+import time
 import uuid
 from collections import deque
 from collections.abc import Coroutine
@@ -24,6 +25,10 @@ from pymobiledevice3.services.web_protocol.session_protocol import SessionProtoc
 
 SAFARI = "com.apple.mobilesafari"
 WEBINSPECTORD_DISABLED_NOTIFICATION = "com.apple.webinspectord.disabled"
+# How long webinspectord may keep refusing a session before it is taken to mean Web Inspector is
+# disabled, and how long to wait between attempts (see WebinspectorService._handshake).
+HANDSHAKE_RETRY_TIMEOUT = 20
+HANDSHAKE_RETRY_INTERVAL = 1
 
 
 def key_to_pid(key: str) -> int:
@@ -275,39 +280,55 @@ class WebinspectorService(LockdownService):
             if event.get("Name") == WEBINSPECTORD_DISABLED_NOTIFICATION:
                 raise WebInspectorNotEnabledError
 
-    async def _connect_service(self) -> None:
-        """Connect to webinspectord, waiting out the gate it puts on consecutive sessions.
-
-        A new session is admitted only about ten seconds after the previous one started: until
-        then webinspectord accepts the connection but never completes the TLS handshake. That is a
-        hair longer than DEFAULT_SSL_HANDSHAKE_TIMEOUT, so reattaching right after a session ended
-        - restarting the CDP bridge, or opening an automation session once inspection is done -
-        aborted the handshake and, since a disabled device also terminates the connection, was
-        reported as "Web Inspector is disabled". The attempt that timed out has already waited the
-        gate out, so a second one goes through.
-        """
-        try:
-            await super().connect()
-        except ConnectionTerminatedError as e:
-            if not isinstance(e.__cause__, ConnectionAbortedError):
-                # Terminated by the device rather than by our own handshake timeout.
-                raise
-            await super().connect()
-
     async def _connect_or_raise_disabled(self) -> None:
         async with NotificationProxyService(self.lockdown) as notification_proxy:
             await notification_proxy.notify_register_dispatch(WEBINSPECTORD_DISABLED_NOTIFICATION)
             disabled_task = asyncio.create_task(self._wait_for_disabled_notification(notification_proxy))
             try:
-                # Keep the disabled notification watcher active for the full WebInspector handshake. A disabled
-                # device may report either the explicit notification or an abrupt service termination.
-                await self._await_or_raise_disabled(self._connect_service(), disabled_task)
-                await self._await_or_raise_disabled(self._report_identifier(), disabled_task)
-                await self._handle_recv(await self._await_or_raise_disabled(self._recv_message(), disabled_task))
+                await self._handshake(disabled_task)
             finally:
                 disabled_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await disabled_task
+
+    async def _handshake(self, disabled_task: asyncio.Task[None]) -> None:
+        """Run the WebInspector handshake, retrying while webinspectord keeps refusing it.
+
+        webinspectord refuses a session by terminating the connection - accepting it and never
+        completing the TLS handshake, or closing it right after - and does so for three reasons
+        that look identical from here:
+
+        * Web Inspector is disabled on the device.
+        * The gate it puts on consecutive sessions has not elapsed: a new session is admitted only
+          about ten seconds after the previous one started, a hair longer than
+          DEFAULT_SSL_HANDSHAKE_TIMEOUT. Reattaching right after a session ended - restarting the
+          CDP bridge, or opening an automation session once inspection is done - hits this.
+        * It is not up yet because the device is still booting. `--reconnect` re-runs a command the
+          moment lockdownd answers again, which is seconds before webinspectord serves anything.
+
+        Only the first is permanent, so keep trying until the deadline and report the refusal as
+        Web Inspector being disabled only if it outlives it. A device that goes away mid-handshake
+        is reported as the disconnect it is, so that a caller which retries on a disconnect (the
+        CDP bridge under `--reconnect`) does. `disabled_task`, the device's own disabled
+        notification, ends the wait immediately.
+        """
+        deadline = time.monotonic() + HANDSHAKE_RETRY_TIMEOUT
+        while True:
+            try:
+                await self._await_or_raise_disabled(super().connect(), disabled_task)
+                await self._await_or_raise_disabled(self._report_identifier(), disabled_task)
+                await self._handle_recv(await self._await_or_raise_disabled(self._recv_message(), disabled_task))
+            except ConnectionTerminatedError as e:
+                if not await self._device_answers():
+                    raise
+                if time.monotonic() >= deadline:
+                    raise WebInspectorNotEnabledError from e
+            else:
+                return
+            self.logger.debug("webinspectord refused the session; retrying")
+            # Drop the refused connection so the next attempt starts a session of its own.
+            await self.close()
+            await asyncio.sleep(HANDSHAKE_RETRY_INTERVAL)
 
     async def _await_or_raise_disabled(self, coro: Coroutine[Any, Any, Any], disabled_task: asyncio.Task[None]):
         task = asyncio.create_task(coro)
@@ -320,10 +341,19 @@ class WebinspectorService(LockdownService):
             with contextlib.suppress(asyncio.CancelledError):
                 await task
             await disabled_task
+        return await task
+
+    async def _device_answers(self) -> bool:
+        """Whether lockdownd still answers.
+
+        A device that went away and one that refused the session both terminate the WebInspector
+        connection abruptly; only the one that is still there answers.
+        """
         try:
-            return await task
-        except ConnectionTerminatedError as e:
-            raise WebInspectorNotEnabledError from e
+            await self.lockdown.get_date()
+        except Exception:
+            return False
+        return True
 
     async def _receiving_task(self):
         try:

--- a/tests/cli/test_cdp_reconnect.py
+++ b/tests/cli/test_cdp_reconnect.py
@@ -1,0 +1,33 @@
+"""The CDP bridge must fail with the device error it hit, so `--reconnect` can act on it."""
+
+from typing import Any, Optional, cast
+
+import pytest
+
+from pymobiledevice3.cli import webinspector as webinspector_cli
+from pymobiledevice3.exceptions import ConnectionTerminatedError
+
+
+class _RefusingInspector:
+    """A WebinspectorService stand-in that fails to connect the way a rebooting device makes it."""
+
+    def __init__(self, lockdown: Any) -> None:
+        self.on_connection_lost: Optional[Any] = None
+        self.trace: Optional[Any] = None
+
+    async def connect(self) -> None:
+        raise ConnectionTerminatedError
+
+
+async def test_a_device_error_starting_the_bridge_reaches_the_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """uvicorn runs the ASGI lifespan itself and turns a failure there into `sys.exit(3)`, which
+    asyncio re-raises out of the event loop - so a device that is still rebooting when the bridge
+    starts used to kill the process (exit code 3) instead of reaching the top-level handler that
+    `--reconnect` retries from. Connecting to the device happens before uvicorn owns the failure."""
+    monkeypatch.setattr(webinspector_cli, "WebinspectorService", _RefusingInspector)
+    monkeypatch.setattr(webinspector_cli, "find_chrome", lambda chrome: None)
+
+    # `cdp` is the sync wrapper Typer registers; `__wrapped__` is the coroutine underneath.
+    cdp = cast(Any, webinspector_cli.cdp).__wrapped__
+    with pytest.raises(ConnectionTerminatedError):
+        await cdp(cast(Any, None), host="127.0.0.1", port=0)

--- a/tests/services/test_webinspector.py
+++ b/tests/services/test_webinspector.py
@@ -1,3 +1,5 @@
+import asyncio
+import datetime
 import json
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -5,8 +7,10 @@ from typing import Any, cast
 
 import pytest
 
-from pymobiledevice3.exceptions import WebInspectorNotEnabledError
+from pymobiledevice3.exceptions import ConnectionTerminatedError, WebInspectorNotEnabledError
 from pymobiledevice3.lockdown import LockdownClient
+from pymobiledevice3.services import webinspector
+from pymobiledevice3.services.lockdown_service import LockdownService
 from pymobiledevice3.services.webinspector import (
     SAFARI,
     Application,
@@ -188,3 +192,86 @@ async def testp_reattaching_immediately_after_a_session_succeeds(lockdown: Lockd
         assert reattached.connection_id
     finally:
         await reattached.close()
+
+
+class _ProbeableLockdown:
+    """A lockdown stand-in whose liveness probe answers or fails on demand."""
+
+    def __init__(self, answers: bool) -> None:
+        self.answers = answers
+
+    async def get_date(self) -> datetime.datetime:
+        if not self.answers:
+            raise ConnectionTerminatedError
+        return datetime.datetime.now()
+
+
+def _refusing_inspector(
+    monkeypatch: pytest.MonkeyPatch, lockdown: _ProbeableLockdown, refusals: int
+) -> tuple[WebinspectorService, list[int]]:
+    """A service whose handshake webinspectord refuses `refusals` times, with its attempt log."""
+    attempts: list[int] = []
+
+    async def connect(self: Any) -> None:
+        attempts.append(len(attempts))
+        if len(attempts) <= refusals:
+            raise ConnectionTerminatedError
+
+    async def handshake_step(*args: Any) -> None:
+        return None
+
+    monkeypatch.setattr(LockdownService, "connect", connect)
+    monkeypatch.setattr(webinspector, "HANDSHAKE_RETRY_INTERVAL", 0)
+    inspector = WebinspectorService(lockdown=cast(Any, lockdown))
+    monkeypatch.setattr(inspector, "_report_identifier", handshake_step)
+    monkeypatch.setattr(inspector, "_recv_message", handshake_step)
+    monkeypatch.setattr(inspector, "_handle_recv", handshake_step)
+    return inspector, attempts
+
+
+@asynccontextmanager
+async def _never_disabled() -> AsyncGenerator[Any, None]:
+    """The disabled-notification watcher of a device that never posts one."""
+    task = asyncio.create_task(asyncio.Event().wait())
+    try:
+        yield task
+    finally:
+        task.cancel()
+
+
+async def test_a_refused_handshake_is_retried_until_webinspectord_serves_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """webinspectord refuses a session it will not serve yet - the gate on consecutive sessions,
+    or a device that is still booting - exactly as a device with Web Inspector disabled does. Both
+    transient refusals clear within seconds, so the handshake is retried rather than reported."""
+    inspector, attempts = _refusing_inspector(monkeypatch, _ProbeableLockdown(answers=True), refusals=2)
+    async with _never_disabled() as disabled_task:
+        await inspector._handshake(disabled_task)
+    assert len(attempts) == 3
+
+
+async def test_a_refusal_that_outlives_the_deadline_reports_web_inspector_as_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The device is there and keeps refusing: that is Web Inspector being off."""
+    monkeypatch.setattr(webinspector, "HANDSHAKE_RETRY_TIMEOUT", 0)
+    inspector, attempts = _refusing_inspector(monkeypatch, _ProbeableLockdown(answers=True), refusals=1)
+    async with _never_disabled() as disabled_task:
+        with pytest.raises(WebInspectorNotEnabledError) as raised:
+            await inspector._handshake(disabled_task)
+    assert isinstance(raised.value.__cause__, ConnectionTerminatedError)
+    assert len(attempts) == 1
+
+
+async def test_a_disconnect_during_the_handshake_is_not_reported_as_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A device that goes away mid-handshake (a reboot, a cable pull) terminates the connection
+    just like one refusing the session does - but reporting it as disabled stops the callers that
+    would otherwise retry the disconnect (the CDP bridge under `--reconnect`)."""
+    inspector, attempts = _refusing_inspector(monkeypatch, _ProbeableLockdown(answers=False), refusals=1)
+    async with _never_disabled() as disabled_task:
+        with pytest.raises(ConnectionTerminatedError):
+            await inspector._handshake(disabled_task)
+    assert len(attempts) == 1


### PR DESCRIPTION
`pymobiledevice3 --reconnect webinspector cdp` often failed to come back after the device
disconnected. Reproduced by stress-rebooting the device under a running bridge: **3 of 8 reboot
cycles killed it** (plus a cold start that never came up). Two independent defects, both on the
"device comes back" path.

### 1. `sys.exit(3)` bypasses `--reconnect` entirely

The bridge connected to WebInspector from inside the ASGI lifespan, and uvicorn runs the lifespan
itself: an exception there is logged as a traceback and turned into `sys.exit(3)`, which asyncio
re-raises straight out of the event loop. The device error was only *printed* - it never reached
the top-level handler that classifies it, so `--reconnect` never waited for the device and never
re-ran the command. The process died with exit code 3 and `ERROR: Application startup failed.
Exiting.`.

Connecting before the app is handed to uvicorn keeps it an ordinary exception (the lifespan's own
connect is then a no-op).

### 2. A booting device was reported as "Web Inspector is disabled"

`--reconnect` re-invokes the command the moment lockdownd answers - a second or two before
webinspectord serves anything. webinspectord refuses a session by terminating the connection,
exactly as a device with Web Inspector disabled does, and every `ConnectionTerminatedError` during
the handshake was mapped to `WebInspectorNotEnabledError`, which is fatal and not reconnectable.
Measured after a reboot: lockdownd answers, an attach at +1.38s is refused, the next one goes
through ~9s later.

The handshake is now retried while the device is still there, and a refusal is reported as a
disabled Web Inspector only once it outlives the deadline; the device's own disabled notification
still ends the wait immediately. A device that went away mid-handshake is told apart by whether
lockdownd still answers and is reported as the disconnect it is, so `--reconnect` retries it. This
replaces the single retry that waited out the ten-second session gate, which the loop subsumes -
and costs nothing in the genuinely-disabled case, which already took ~20s (two handshake timeouts).

### Verification

- 6 of 6 reboot cycles reconnect cleanly: no tracebacks, a single `Device connected` ->
  `Web Inspector ready`.
- The retry loop is confirmed firing against a real device by the existing session-gate test
  (`testp_reattaching_immediately_after_a_session_succeeds`).
- New tests: three for the refuse / retry / disconnect classification, and a CLI regression test
  that pins the `SystemExit` trap - it fails on the old code with the exact
  "Application startup failed" symptom.
- Full `pytest` run: 862 passed (two pre-existing device failures in afc/backup2, confirmed
  failing without these changes); ruff clean; pyright 0 errors; each commit audited standalone.