### PR TITLE
syslog: Fix UnicodeEncodeError on non-UTF-8 consoles

### DIFF
--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -501,11 +501,26 @@ def _retarget_reconnect_udid(udid: str) -> None:
     os.environ[UDID_ENV_VAR] = udid
 
 
+def tolerate_unencodable_output() -> None:
+    """Escape, instead of crash on, characters the console encoding cannot represent.
+
+    Device-supplied text (syslog lines, process names, bundle names, ...) can carry any code point,
+    while a Windows console frequently hands Python a cp1252 stdout. With the default
+    `errors="strict"` a single emoji in a syslog line raises UnicodeEncodeError from inside print()
+    (issue #1942). `backslashreplace` keeps the character recoverable (`\\U0001f600`) rather than
+    dropping it, and matches what Python already does for stderr."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(errors="backslashreplace")
+
+
 def main() -> ExitCode:
     """Returns the process exit code. A successful command exits earlier via the SystemExit that
     Typer's own `app(...)` call raises, from within `invoke_cli_with_error_handling()`; this loop
     only ever runs again (or returns ExitCode.ABORTED) once that call has already logged an
     error."""
+    tolerate_unencodable_output()
     while True:
         exit_code, reconnectable = invoke_cli_with_error_handling()
         # Not a reconnectable failure, or not invoked with `--reconnect`: stop here.

--- a/pymobiledevice3/cli/syslog.py
+++ b/pymobiledevice3/cli/syslog.py
@@ -459,7 +459,7 @@ async def cli_syslog_live(
 ) -> None:
     """view live syslog lines"""
 
-    with out.open("wt") if out else nullcontext() as out_file:
+    with out.open("wt", encoding="utf-8") if out else nullcontext() as out_file:
         await syslog_live(
             service_provider,
             out_file,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,3 +1,4 @@
+import io
 import re
 import subprocess
 import sys
@@ -481,3 +482,24 @@ def test_lockdown_on_off_state_is_a_positional_argument(command):
     output = " ".join(ANSI_ESCAPE.sub("", result.output).replace("│", " ").split())
     assert "Arguments" in output
     assert "--state" not in output
+
+
+def test_main_escapes_characters_the_console_encoding_cannot_represent(monkeypatch):
+    # Windows consoles frequently expose a cp1252 stdout; device-supplied text (syslog lines,
+    # process names) can carry code points outside it. Strict encoding turned that into a
+    # UnicodeEncodeError deep inside print() (issue #1942).
+    stdout_bytes = io.BytesIO()
+    stderr_bytes = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", io.TextIOWrapper(stdout_bytes, encoding="cp1252", errors="strict"))
+    monkeypatch.setattr(sys, "stderr", io.TextIOWrapper(stderr_bytes, encoding="cp1252", errors="strict"))
+
+    __main__.tolerate_unencodable_output()
+
+    print("syslog \U0001f600 line")
+    print("stderr ✅ line", file=sys.stderr)
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    # Windows text streams write \r\n; the line ending is not what this test is about.
+    assert stdout_bytes.getvalue().replace(b"\r\n", b"\n") == b"syslog \\U0001f600 line\n"
+    assert stderr_bytes.getvalue().replace(b"\r\n", b"\n") == b"stderr \\u2705 line\n"

--- a/tests/cli/test_syslog.py
+++ b/tests/cli/test_syslog.py
@@ -628,3 +628,23 @@ async def test_syslog_live_subsystem_filter_json(monkeypatch, capsys):
     obj = json.loads(printed_lines[0])
     assert obj["message"] == "keep"
     assert obj["label"]["subsystem"] == "com.apple.WebKit.Network"
+
+
+def test_cli_syslog_live_out_file_is_utf8_regardless_of_locale(monkeypatch, tmp_path):
+    # The --out file must not depend on the host locale encoding (cp1252 on Windows before
+    # Python 3.15), otherwise the same line that crashed stdout in issue #1942 also crashes
+    # the file write.
+    out_path = tmp_path / "syslog.log"
+    seen_encoding: list[str] = []
+
+    async def fake_syslog_live(service_provider, out, *args, **kwargs):
+        seen_encoding.append(out.encoding)
+        print("syslog \U0001f600 line", file=out)
+
+    monkeypatch.setattr(syslog_module, "syslog_live", fake_syslog_live)
+
+    syslog_module.cli_syslog_live(service_provider=_FAKE_SERVICE_PROVIDER, out=out_path)
+
+    assert [encoding.lower().replace("-", "") for encoding in seen_encoding] == ["utf8"]
+    # Windows text streams write \r\n; the line ending is not what this test is about.
+    assert out_path.read_bytes().replace(b"\r\n", b"\n") == "syslog \U0001f600 line\n".encode()


### PR DESCRIPTION
Fixes #1942.

On Windows, `syslog live` crashed with `UnicodeEncodeError: 'charmap' codec can't encode characters` once a syslog line contained a character outside cp1252 (an emoji, an arrow, CJK text). The console stream was strict cp1252, so `print()` raised.

- `cli`: reconfigure stdout/stderr with `errors="backslashreplace"` at the CLI entry point. Unencodable characters print as `\U0001f600` escapes instead of killing the command. This covers every command that prints device-supplied text, not just `syslog live`.
- `syslog`: open the `--out` file as UTF-8 instead of the locale encoding (cp1252 on Windows before Python 3.15), so the tee file does not hit the same crash.

Verified against a device with `PYTHONIOENCODING=cp1252:strict` while launching a bogus bundle id containing an emoji: stdout shows `com.pmd3.\U0001f600→中`, the `--out` file keeps the raw UTF-8 text, no traceback.