### PR TITLE
cli: Say Developer Mode applies to iOS 16+, not 15+

### DIFF
--- a/docs/guides/codex-device-operator-skill.md
+++ b/docs/guides/codex-device-operator-skill.md
@@ -98,8 +98,8 @@ For iOS 17+ developer services, the skill routes users through the project tunne
 On iOS 17.4+ no tunnel setup is needed at all: commands that require an RSD
 tunnel establish a no-root in-process userspace tunnel automatically, so the
 skill routes agents straight to the target command. Privileged tunnels
-(`tunneld`, `start-tunnel`) remain the fallback for iOS 17.0-17.3 devices or
-when the userspace path is not viable (e.g. sustained host-to-device
+(`tunneld`, `start-tunnel`) remain the fallback for iOS 17.0-17.3 devices on
+Linux/Windows or when the userspace path is not viable (e.g. sustained host-to-device
 throughput).
 
 For agent-driven `start-tunnel` startup on those fallback paths, the skill

--- a/docs/guides/ios17-tunnels.md
+++ b/docs/guides/ios17-tunnels.md
@@ -11,7 +11,7 @@ python3 -m pymobiledevice3 developer dvt ls /
 ```
 
 A privileged `tunneld` is only needed for specific cases (external tools such as `lldb`, a
-shared/persistent tunnel, or iOS 17.0-17.3.1 — see
+shared/persistent tunnel, or iOS 17.0-17.3.1 on Linux/Windows — see
 [When you still need `tunneld`](#when-you-still-need-a-privileged-tunneld)).
 
 !!! tip "Working from Python?"
@@ -47,24 +47,25 @@ Set `PYMOBILEDEVICE3_DEFAULT_FALLBACK=native|userspace|tunneld` to change which 
 automatic selection prefers (see [Environment variables](environment-variables.md) for every
 variable the CLI honors).
 
-!!! warning "iOS 17.0-17.3.1 uses `tunneld` by default"
+!!! warning "iOS 17.0-17.3.1 needs `tunneld` on Linux/Windows"
     These versions predate the CoreDeviceProxy service, so the userspace tunnel can only reach them
     over the RemotePairing path — which is Wi-Fi-only and, on macOS, races `remoted` (the no-root
     path can't suspend it without root). Rather than depend on that fragile path, pymobiledevice3
-    **routes iOS 17.0-17.3.1 to `tunneld` on every platform**, so keep one running:
+    routes iOS 17.0-17.3.1 to the **native tunnel on macOS** (still no root — `remoted` already
+    reaches these devices) and to **`tunneld` on Linux/Windows**, so keep one running there:
 
     ```shell
     sudo python3 -m pymobiledevice3 remote tunneld
     ```
 
-    You can still force the no-root path with `--userspace` where it applies (a device on Wi-Fi;
+    You can still force the userspace path with `--userspace` where it applies (a device on Wi-Fi;
     unreliable on macOS).
 
 ## Support Notes
 
 | Host OS | iOS 17.0-17.3.1 | iOS 17.4+ |
 | --- | --- | --- |
-| macOS | Uses `tunneld` (root) | Supported (no-root) |
+| macOS | Supported (no-root, native tunnel) | Supported (no-root) |
 | Windows | Uses `tunneld` (root) + additional drivers | Supported (no-root) |
 | Linux | Uses `tunneld` (root) | Supported (no-root) |
 
@@ -80,7 +81,7 @@ below) when:
   to a local port and *does* work over the userspace tunnel).
 - **You want one shared/persistent tunnel** reused across many invocations instead of rebuilding it
   per command.
-- **iOS 17.0-17.3.1** (any host OS) — routed to `tunneld` automatically; see the warning above.
+- **iOS 17.0-17.3.1 on Linux/Windows** — routed to `tunneld` automatically; see the warning above.
 
 ## Running `tunneld`
 
@@ -245,8 +246,9 @@ default applies to `remote browse`: on macOS it lists devices via `remotepairing
 ## Forcing the userspace tunnel (`--userspace`)
 
 The userspace tunnel is already the default, so you rarely need the flag. Pass `--userspace`
-explicitly to **force** the no-root in-process tunnel and skip the automatic `tunneld` fallback
-(iOS 17.0-17.3.1) — any establishment failure is then surfaced as an error rather than masked:
+explicitly to **force** the no-root in-process tunnel and skip the automatic native/`tunneld`
+fallback (iOS 17.0-17.3.1) — any establishment failure is then surfaced as an error rather than
+masked:
 
 ```shell
 python3 -m pymobiledevice3 developer dvt ls / --userspace
@@ -309,8 +311,8 @@ python3 -m pymobiledevice3 syslog live --tunnel ''
 - Most developer commands need no flag — the no-root tunnel is established for you. If one fails to
   establish a tunnel, the two explicit routes are `--tunnel ''` (uses a running `tunneld`) or
   `--userspace` (forces the no-root in-process tunnel and surfaces the real error).
-- iOS 17.0-17.3.1 is routed to `tunneld` on every platform (the no-root path only reaches those
-  over the fragile Wi-Fi RemotePairing route), so start one. `--userspace` can still force that
-  no-root path over Wi-Fi if you prefer.
+- iOS 17.0-17.3.1 is routed to the native tunnel on macOS and to `tunneld` on Linux/Windows (the
+  userspace path only reaches those over the fragile Wi-Fi RemotePairing route), so start one
+  there. `--userspace` can still force the userspace path over Wi-Fi if you prefer.
 - Verify the tunnel process is running and the device is trusted/paired.
 - On Windows for iOS 17.0-17.3.1, ensure required additional drivers are installed.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -115,9 +115,9 @@ it yet. In order:
 
 ### "Unable to connect to Tunneld" (`TunneldConnectionError`)
 
-You passed `--tunnel` (or the automatic fallback chose tunneld — which happens on
-iOS 17.0–17.3, where the userspace tunnel has no reliable transport), but no tunneld daemon is
-running. Start one with root privileges and leave it running:
+You passed `--tunnel` (or the automatic fallback chose tunneld — which happens on Linux/Windows
+with iOS 17.0–17.3, where the userspace tunnel has no reliable transport; macOS serves those devices
+no-root via the native tunnel), but no tunneld daemon is running. Start one with root privileges and leave it running:
 
 ```shell
 sudo pymobiledevice3 remote tunneld

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -97,7 +97,7 @@ if sys.platform == "win32":
 
 INVALID_SERVICE_MESSAGE = """Failed to start service. Possible reasons are:
 - If you were trying to access a developer service (developer subcommand):
-    - If your device iOS version >= 15.0:
+    - If your device iOS version >= 16.0:
         - Make sure you first enabled "Developer Mode" via:
           > python3 -m pymobiledevice3 amfi enable-developer-mode
 

--- a/pymobiledevice3/__main__.py
+++ b/pymobiledevice3/__main__.py
@@ -105,8 +105,10 @@ INVALID_SERVICE_MESSAGE = """Failed to start service. Possible reasons are:
       > python3 -m pymobiledevice3 mounter auto-mount
 
     - If your device iOS version >= 17.0:
-        - Make sure you passed the --rsd option to the subcommand
-          https://github.com/doronz88/pymobiledevice3#working-with-developer-tools-ios--170
+        - An RSD tunnel is established automatically; no flag is needed.
+        - On Linux/Windows with iOS 17.0-17.3, a privileged tunneld must be running:
+          > sudo python3 -m pymobiledevice3 remote tunneld
+          https://doronz88.github.io/pymobiledevice3/guides/ios17-tunnels/
 
 - Apple removed this service, or your iOS version does not support it.
 


### PR DESCRIPTION
Corrections to the "Failed to start service" hint and the matching docs, prompted by #1942:

- Developer Mode applies to iOS 16+, not 15+.
- Drop the advice to pass `--rsd` on iOS 17+: the tunnel is established in-process automatically before this message can print. Only Linux/Windows hosts with iOS 17.0-17.3 still need a privileged `tunneld` (macOS serves those devices no-root via the native tunnel). The README anchor it linked no longer exists, so link the tunnels guide.
- docs: the tunnels guide, its support table and the troubleshooting page said iOS 17.0-17.3.1 needs `tunneld` on every platform; correct them to Linux/Windows only, matching the CLI's routing.