### PR TITLE
webinspector: tolerate a missing WIRAutomationAvailabilityKey (iOS 12)

### DIFF
--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -140,7 +140,9 @@ class Application:
             app_dict["WIRApplicationBundleIdentifierKey"],
             key_to_pid(app_dict["WIRApplicationIdentifierKey"]),
             app_dict["WIRApplicationNameKey"],
-            AutomationAvailability(app_dict["WIRAutomationAvailabilityKey"]),
+            AutomationAvailability(
+                app_dict.get("WIRAutomationAvailabilityKey", AutomationAvailability.UNKNOWN.value)
+            ),
             app_dict["WIRIsApplicationActiveKey"],
             app_dict["WIRIsApplicationProxyKey"],
             app_dict["WIRIsApplicationReadyKey"],
@@ -601,7 +603,7 @@ class WebinspectorService(LockdownService):
         await self.receive_handlers[plist["__selector"]](plist["__argument"])
 
     async def _handle_report_current_state(self, arg: dict[str, Any]):
-        self.state = arg["WIRAutomationAvailabilityKey"]
+        self.state = arg.get("WIRAutomationAvailabilityKey", AutomationAvailability.UNKNOWN.value)
 
     async def _handle_report_connected_application_list(self, arg: dict[str, Any]):
         self.connected_application = {}


### PR DESCRIPTION
On iOS 12 Safari does not include `WIRAutomationAvailabilityKey`, neither in the application dictionary nor in `_rpc_reportCurrentState`. Both `Application.from_application_dictionary` and `WebinspectorService._handle_report_current_state` index it directly, so `webinspector cdp` crashes before serving:

```
File ".../pymobiledevice3/services/webinspector.py", line 143, in from_application_dictionary
    AutomationAvailability(app_dict["WIRAutomationAvailabilityKey"]),
KeyError: 'WIRAutomationAvailabilityKey'
```

Seen on an iPhone 5s running iOS 12.5.8 with v11.12.3. This change treats a missing key as `WIRAutomationAvailabilityUnknown` in both places.

Tested with the patched build: `webinspector cdp` serves and a CDP session attaches on the iOS 12.5.8 device. It still attaches on iOS 13.4.1, 18.7.8, 26.2.1 and 26.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198iqPKbRizWwaM9WTD8PoQ