### PR TITLE
webinspector: tolerate a missing WIRAutomationAvailabilityKey (iOS 12)

### DIFF
--- a/pymobiledevice3/services/webinspector.py
+++ b/pymobiledevice3/services/webinspector.py
@@ -140,7 +140,7 @@ class Application:
             app_dict["WIRApplicationBundleIdentifierKey"],
             key_to_pid(app_dict["WIRApplicationIdentifierKey"]),
             app_dict["WIRApplicationNameKey"],
-            AutomationAvailability(app_dict["WIRAutomationAvailabilityKey"]),
+            AutomationAvailability(app_dict.get("WIRAutomationAvailabilityKey", AutomationAvailability.UNKNOWN.value)),
             app_dict["WIRIsApplicationActiveKey"],
             app_dict["WIRIsApplicationProxyKey"],
             app_dict["WIRIsApplicationReadyKey"],
@@ -601,7 +601,7 @@ class WebinspectorService(LockdownService):
         await self.receive_handlers[plist["__selector"]](plist["__argument"])
 
     async def _handle_report_current_state(self, arg: dict[str, Any]):
-        self.state = arg["WIRAutomationAvailabilityKey"]
+        self.state = arg.get("WIRAutomationAvailabilityKey", AutomationAvailability.UNKNOWN.value)
 
     async def _handle_report_connected_application_list(self, arg: dict[str, Any]):
         self.connected_application = {}


### PR DESCRIPTION
Carries #1945 by @LeaveMyYard with a `ruff format` fix applied on top. The fork is org-owned, so I couldn't push the lint fix to the PR branch directly. Authorship of the commit is preserved.

On iOS 12 Safari does not include `WIRAutomationAvailabilityKey`, neither in the application dictionary nor in `_rpc_reportCurrentState`, so `webinspector cdp` crashed with a `KeyError` before serving. A missing key is now treated as `WIRAutomationAvailabilityUnknown` in both places.

Supersedes #1945.