### PR TITLE
lockdown: Map common errors to dedicated exceptions

### DIFF
--- a/pymobiledevice3/exceptions.py
+++ b/pymobiledevice3/exceptions.py
@@ -40,6 +40,7 @@ __all__ = [
     "InvalidServiceError",
     "LaunchingApplicationError",
     "LockdownError",
+    "MCProtectedError",
     "MessageNotSupportedError",
     "MissingValueError",
     "MuxException",
@@ -64,6 +65,7 @@ __all__ = [
     "RemoteAutomationNotEnabledError",
     "RemotePairingCompletedError",
     "ScreencastUnavailableError",
+    "SessionActiveError",
     "SetProhibitedError",
     "StartServiceError",
     "SysdiagnoseTimeoutError",
@@ -383,6 +385,18 @@ class InvalidConnectionError(LockdownError):
 
 class PasscodeRequiredError(LockdownError):
     """passcode must be present for this action"""
+
+    pass
+
+
+class MCProtectedError(LockdownError):
+    """mobile configuration policy prohibits this action"""
+
+    pass
+
+
+class SessionActiveError(LockdownError):
+    """a lockdown session is already active"""
 
     pass
 

--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -43,14 +43,17 @@ from pymobiledevice3.exceptions import (
     InvalidHostIDError,
     InvalidServiceError,
     LockdownError,
+    MCProtectedError,
     MissingValueError,
     MuxException,
     NoDeviceConnectedError,
     NotPairedError,
     PairingDialogResponsePendingError,
     PairingError,
+    PasscodeRequiredError,
     PasswordRequiredError,
     PyMobileDevice3Exception,
+    SessionActiveError,
     SetProhibitedError,
     StartServiceError,
     UserDeniedPairingError,
@@ -1057,6 +1060,9 @@ class LockdownClient(ABC, LockdownServiceProvider):
                 "MissingValue": MissingValueError,
                 "InvalidService": InvalidServiceError,
                 "InvalidConnection": InvalidConnectionError,
+                "MCProtected": MCProtectedError,
+                "PasscodeRequired": PasscodeRequiredError,
+                "SessionActive": SessionActiveError,
             }
             raise exception_errors.get(error, LockdownError)(error, self.identifier, self.product_version)
 

--- a/tests/services/test_lockdown.py
+++ b/tests/services/test_lockdown.py
@@ -2,9 +2,31 @@ import asyncio
 
 import pytest
 
-from pymobiledevice3.lockdown import LockdownClient
+from pymobiledevice3.exceptions import LockdownError, MCProtectedError, PasscodeRequiredError, SessionActiveError
+from pymobiledevice3.lockdown import LockdownClient, UsbmuxLockdownClient
 
 LOCKDOWND_SOCKET_SELECT_TIMEOUT = 60
+
+
+@pytest.mark.parametrize(
+    ("error", "exception_type"),
+    [
+        ("MCProtected", MCProtectedError),
+        ("PasscodeRequired", PasscodeRequiredError),
+        ("SessionActive", SessionActiveError),
+    ],
+)
+def test_lockdown_error_mapping(error: str, exception_type: type[LockdownError]) -> None:
+    lockdown = object.__new__(UsbmuxLockdownClient)
+    lockdown.identifier = "test-device"
+    lockdown.all_values = {"ProductVersion": "18.0"}
+
+    with pytest.raises(exception_type) as exc_info:
+        lockdown._verify_request_response("Test", {"Request": "Test", "Error": error})
+
+    assert str(exc_info.value) == error
+    assert exc_info.value.identifier == "test-device"
+    assert exc_info.value.product_version == "18.0"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Lockdown currently maps `MCProtected`, `PasscodeRequired`, and `SessionActive` responses to the generic `LockdownError`, even though callers can recover differently from each condition. For example, `MCProtected` indicates a mobile configuration policy restriction, while `SessionActive` can be handled as a pairing/session lifecycle conflict.

Add dedicated public exceptions for `MCProtected` and `SessionActive`, and connect the existing `PasscodeRequiredError` to its wire response. Each exception preserves the original error text, device identifier, and product version from `LockdownError`.

Fixes #708.

Validation:

- `python -m pytest tests/services/test_lockdown.py -q`: 3 passed, 1 device-dependent test skipped
- `ruff format` and `ruff check` on all changed files: passed
- `pyright --venvpath .` on all changed files: 0 errors, 0 warnings

The complete test suite reached device-dependent DVT coverage and failed with `ConnectionTerminatedError: No route to host`; no device protocol code is changed here.
